### PR TITLE
Add support for listing previously used GPU names

### DIFF
--- a/src/features/hardware/hooks/useGpuNames.ts
+++ b/src/features/hardware/hooks/useGpuNames.ts
@@ -8,7 +8,7 @@ export const useGpuNames = () => {
     const fetchGpuNames = async () => {
       const db = await sqlitePromise;
       const result = await db.load<{ gpu_name: string }>(
-        "SELECT DISTINCT gpu_name FROM GPU_DATA_ARCHIVE WHERE gpu_name IS NOT NULL",
+        "SELECT DISTINCT gpu_name FROM GPU_DATA_ARCHIVE WHERE gpu_name IS NOT NULL AND gpu_name != 'Unknown'",
       );
       setGpuNames(result.map((row) => row.gpu_name));
     };

--- a/src/features/hardware/hooks/useGpuNames.ts
+++ b/src/features/hardware/hooks/useGpuNames.ts
@@ -1,0 +1,20 @@
+import { sqlitePromise } from "@/lib/sqlite";
+import { useEffect, useState } from "react";
+
+export const useGpuNames = () => {
+  const [gpuNames, setGpuNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchGpuNames = async () => {
+      const db = await sqlitePromise;
+      const result = await db.load<{ gpu_name: string }>(
+        "SELECT DISTINCT gpu_name FROM GPU_DATA_ARCHIVE WHERE gpu_name IS NOT NULL",
+      );
+      setGpuNames(result.map((row) => row.gpu_name));
+    };
+
+    fetchGpuNames();
+  }, []);
+
+  return gpuNames;
+};

--- a/src/features/hardware/insights/Insights.tsx
+++ b/src/features/hardware/insights/Insights.tsx
@@ -454,14 +454,12 @@ export const Insights = () => {
   }[] = [
     { key: "main", element: <MainInsights /> },
     ...(gpuNames.length
-      ? gpuNames
-          .filter((v) => v !== "Unknown")
-          .map((v) => {
-            return {
-              key: v,
-              element: <GPUInsights gpuName={v} />,
-            };
-          })
+      ? gpuNames.map((v) => {
+          return {
+            key: v,
+            element: <GPUInsights gpuName={v} />,
+          };
+        })
       : []),
     { key: "process", element: <ProcessInsight /> },
   ];

--- a/src/features/hardware/insights/Insights.tsx
+++ b/src/features/hardware/insights/Insights.tsx
@@ -15,6 +15,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { type JSX, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
+import { useGpuNames } from "../hooks/useGpuNames";
 import { SelectPeriod } from "./components/SelectPeriod";
 import { ProcessInsight } from "./process/ProcessInsight";
 
@@ -436,7 +437,7 @@ const GPUInsights = ({ gpuName }: { gpuName: string }) => {
 
 export const Insights = () => {
   const { t } = useTranslation();
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const gpuNames = useGpuNames();
   const { init } = useHardwareInfoAtom();
   const [displayTarget, setDisplayTarget, isPending] = useTauriStore<string>(
     "insightDisplayTarget",
@@ -452,17 +453,15 @@ export const Insights = () => {
     element: JSX.Element;
   }[] = [
     { key: "main", element: <MainInsights /> },
-    ...(hardwareInfo.gpus
-      ? hardwareInfo.gpus
+    ...(gpuNames.length
+      ? gpuNames
+          .filter((v) => v !== "Unknown")
           .map((v) => {
-            return v.vendorName === "NVIDIA"
-              ? {
-                  key: v.name,
-                  element: <GPUInsights gpuName={v.name} />,
-                }
-              : undefined;
+            return {
+              key: v,
+              element: <GPUInsights gpuName={v} />,
+            };
           })
-          .filter((v): v is NonNullable<typeof v> => Boolean(v))
       : []),
     { key: "process", element: <ProcessInsight /> },
   ];


### PR DESCRIPTION
Implemented functionality to retrieve a distinct list of GPU names from the GPU_DATA_ARCHIVE table, enabling access to records of previously used GPUs.

- Added SQL query using DISTINCT to eliminate duplicates
- Created useGpuNames React hook to fetch and expose GPU names
- Hook executes on initial mount to populate the list for display