### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   # Lint Frontend
   #
   lint-frontend:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +61,8 @@ jobs:
   # Lint Backend
   #
   lint-backend:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -101,6 +105,8 @@ jobs:
   # Testing Backend
   #
   unit-test-backend:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -184,6 +190,9 @@ jobs:
   # Test Frontend
   #
   unit-test-frontend:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -192,10 +201,6 @@ jobs:
             args: ""
 
     runs-on: ${{ matrix.platform }}
-
-    permissions:
-      contents: read
-      pull-requests: write
 
     steps:
       - name: Set git to use LF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
   # Test Build Frontend
   #
   test-build-frontend:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -59,10 +59,6 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Azure Code Signing
-        run: |
-          cargo install trusted-signing-cli
-
       - name: Install frontend dependencies
         run: npm ci
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,6 +14,8 @@ jobs:
   # Test Build
   #
   test-build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/shm11C3/HardwareVisualizer/security/code-scanning/16](https://github.com/shm11C3/HardwareVisualizer/security/code-scanning/16)

To fix the issue, we will add a `permissions` block to the `test-build-frontend` job. Based on the job's steps, it only needs to read the repository's contents (e.g., for checking out the code and installing dependencies). Therefore, we will set `contents: read` as the minimal required permission. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
