### PR TITLE
Add missing unit tests

### DIFF
--- a/src/test/unit/lib/array.test.ts
+++ b/src/test/unit/lib/array.test.ts
@@ -1,0 +1,21 @@
+import { transpose } from "@/lib/array";
+import { describe, expect, it } from "vitest";
+
+describe("transpose", () => {
+  it("should return an empty array when given an empty matrix", () => {
+    expect(transpose([])).toEqual([]);
+  });
+
+  it("should transpose a matrix", () => {
+    const matrix = [
+      [1, 2, 3],
+      [4, 5, 6],
+    ];
+    const result = transpose(matrix);
+    expect(result).toEqual([
+      [1, 4],
+      [2, 5],
+      [3, 6],
+    ]);
+  });
+});

--- a/src/test/unit/lib/formatter.test.ts
+++ b/src/test/unit/lib/formatter.test.ts
@@ -1,0 +1,25 @@
+import { formatBytes, formatDuration } from "@/lib/formatter";
+import { describe, expect, it } from "vitest";
+
+describe("formatBytes", () => {
+  it("should return [0,'B'] for invalid numbers", () => {
+    expect(formatBytes(-1)).toEqual([0, "B"]);
+    expect(formatBytes(Number.NaN)).toEqual([0, "B"]);
+  });
+
+  it("should convert bytes to appropriate units", () => {
+    expect(formatBytes(1024)).toEqual([1, "KB"]);
+    expect(formatBytes(1024 ** 2)).toEqual([1, "MB"]);
+    expect(formatBytes(1024 ** 3)).toEqual([1, "GB"]);
+  });
+});
+
+describe("formatDuration", () => {
+  it("should format duration in English", () => {
+    expect(formatDuration(3661, "en-US")).toBe("1hour 1minute 1second");
+  });
+
+  it("should format duration in Japanese", () => {
+    expect(formatDuration(90061, "ja-JP")).toBe("1日 1時間 1分 1秒");
+  });
+});

--- a/src/test/unit/lib/utils.test.ts
+++ b/src/test/unit/lib/utils.test.ts
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+import { describe, expect, it } from "vitest";
+
+describe("cn", () => {
+  it("should merge class names and remove duplicates", () => {
+    const result = cn("bg-red-500", "text-white", "bg-red-500");
+    const classes = result.split(/\s+/).sort();
+    expect(classes).toEqual(["bg-red-500", "text-white"]);
+  });
+
+  it("should handle conditional class names", () => {
+    const result = cn("foo", { bar: true, baz: false }, [
+      "qux",
+      { quux: true },
+    ]);
+    // Order of classes should match clsx/twMerge behavior
+    expect(result).toBe("foo bar qux quux");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for array helper `transpose`
- test formatter helpers
- test util `cn`

## Testing
- `npx vitest run`
- `npm run test:unit-cov`

------
https://chatgpt.com/codex/tasks/task_e_6843fe2861148332883571aeae55b843