### PR TITLE
feat: add license management features

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -188,6 +188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+dependencies = [
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.6.0",
+]
+
+[[package]]
 name = "async-global-executor"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +273,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite 2.6.0",
+ "rustix 1.0.3",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +299,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.44",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1927,6 +1974,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
  "tauri-plugin-sql",
@@ -5486,6 +5534,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-opener"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecee219f11cdac713ab32959db5d0cceec4810ba4f4458da992292ecf9660321"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.0",
+ "open",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-os"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7415,8 +7485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 2.4.0",
+ "async-lock 3.4.0",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener 5.4.0",
  "futures-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ sqlx = { version = "0.8.6", features = [
 dirs = "6.0.0"
 tauri-plugin-os = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-opener = "2"
 
 [dependencies.uuid]
 version = "1.18.0"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": [
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "$RESOURCE"
+        }
+      ]
+    }
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,9 @@ pub fn run() {
     settings::commands::set_hardware_archive_enabled,
     settings::commands::set_hardware_archive_interval,
     settings::commands::set_hardware_archive_scheduled_data_deletion,
+    settings::commands::read_license_file,
+    settings::commands::read_third_party_notices_file,
+    settings::commands::open_license_file_path,
     background_image::get_background_image,
     background_image::get_background_images,
     background_image::save_background_image,
@@ -191,6 +194,7 @@ pub fn run() {
     ))
     .plugin(tauri_plugin_clipboard_manager::init())
     .plugin(tauri_plugin_os::init())
+    .plugin(tauri_plugin_opener::init())
     .manage(state)
     .manage(app_state)
     .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,10 @@
       "providerShortName": null,
       "signingIdentity": null
     },
-    "resources": [],
+    "resources": {
+      "../LICENSE": "LICENSE",
+      "../THIRD_PARTY_NOTICES.md": "THIRD_PARTY_NOTICES.md"
+    },
     "shortDescription": "",
     "linux": {
       "deb": {

--- a/src/features/settings/Settings.tsx
+++ b/src/features/settings/Settings.tsx
@@ -41,10 +41,10 @@ import {
   type ChartDataType,
   chartHardwareTypes,
 } from "@/features/hardware/types/hardwareDataType";
+import { LicensePage } from "@/features/settings/components/LicensePage";
 import { PreviewChart } from "@/features/settings/components/Preview";
 import { BackgroundImageList } from "@/features/settings/components/SelectBackgroundImage";
 import { UploadImage } from "@/features/settings/components/UploadImage";
-import { LicensePage } from "@/features/settings/components/LicensePage";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import type { Settings as SettingTypes } from "@/features/settings/types/settingsType";
 import { useTauriDialog } from "@/hooks/useTauriDialog";

--- a/src/features/settings/Settings.tsx
+++ b/src/features/settings/Settings.tsx
@@ -44,6 +44,7 @@ import {
 import { PreviewChart } from "@/features/settings/components/Preview";
 import { BackgroundImageList } from "@/features/settings/components/SelectBackgroundImage";
 import { UploadImage } from "@/features/settings/components/UploadImage";
+import { LicensePage } from "@/features/settings/components/LicensePage";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import type { Settings as SettingTypes } from "@/features/settings/types/settingsType";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
@@ -679,7 +680,7 @@ const SetNumberOfDaysInsightDataRetains = () => {
   );
 };
 
-const About = () => {
+const About = ({ onShowLicense }: { onShowLicense: () => void }) => {
   const { t } = useTranslation();
   const [version, setVersion] = useState("");
 
@@ -720,15 +721,11 @@ const About = () => {
           <ArrowSquareOutIcon size={16} />
         </Button>
         <Button
-          onClick={() =>
-            openURL(
-              "https://github.com/shm11C3/HardwareVisualizer?tab=MIT-1-ov-file#readme",
-            )
-          }
+          onClick={onShowLicense}
+          variant="outline"
           className="rounded-full text-sm"
         >
-          <span className="px-1">{t("pages.settings.about.license")}</span>
-          <ArrowSquareOutIcon size={16} />
+          {t("pages.settings.about.license")}
         </Button>
       </div>
     </div>
@@ -751,6 +748,11 @@ const About = () => {
  */
 export const Settings = () => {
   const { t } = useTranslation();
+  const [showLicensePage, setShowLicensePage] = useState(false);
+
+  if (showLicensePage) {
+    return <LicensePage onBack={() => setShowLicensePage(false)} />;
+  }
 
   return (
     <>
@@ -836,7 +838,7 @@ export const Settings = () => {
         <h3 className="py-3 font-bold text-2xl">
           {t("pages.settings.about.name")}
         </h3>
-        <About />
+        <About onShowLicense={() => setShowLicensePage(true)} />
       </div>
     </>
   );

--- a/src/features/settings/components/LicensePage.tsx
+++ b/src/features/settings/components/LicensePage.tsx
@@ -1,0 +1,159 @@
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTauriDialog } from "@/hooks/useTauriDialog";
+import { commands } from "@/rspc/bindings";
+import { isError, isOk } from "@/types/result";
+
+interface LicensePageProps {
+  onBack: () => void;
+}
+
+export const LicensePage = ({ onBack }: LicensePageProps) => {
+  const { t } = useTranslation();
+  const { error } = useTauriDialog();
+  const [licenseContent, setLicenseContent] = useState("");
+  const [thirdPartyContent, setThirdPartyContent] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // ファイルが存在するディレクトリを開く
+  const openLicenseInExplorer = async () => {
+    try {
+      const result = await commands.openLicenseFilePath();
+      if (isError(result)) {
+        error(`Failed to open LICENSE file in explorer: ${result.error}`);
+      }
+    } catch (e) {
+      error(`Failed to open LICENSE file in explorer: ${e}`);
+    }
+  };
+
+  useEffect(() => {
+    const loadLicenseFiles = async () => {
+      setIsLoading(true);
+      try {
+        const [licenseResult, thirdPartyResult] = await Promise.all([
+          commands.readLicenseFile(),
+          commands.readThirdPartyNoticesFile(),
+        ]);
+
+        if (isOk(licenseResult)) {
+          setLicenseContent(licenseResult.data);
+        } else {
+          error(`Failed to load license file: ${licenseResult.error}`);
+        }
+
+        if (isOk(thirdPartyResult)) {
+          setThirdPartyContent(thirdPartyResult.data);
+        } else {
+          error(
+            `Failed to load third party notices file: ${thirdPartyResult.error}`,
+          );
+        }
+      } catch (e) {
+        error(`Failed to load license files: ${e}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadLicenseFiles();
+  }, [error]);
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {/* Header with back button */}
+      <div className="flex items-center justify-between border-b py-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={onBack} className="gap-2">
+            <ArrowLeft size={24} />
+          </Button>
+          <h1 className="font-bold text-2xl">
+            {t("pages.settings.about.license")}
+          </h1>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 p-6">
+        <Tabs defaultValue="license" className="flex h-full w-full flex-col">
+          <TabsList className="grid w-full max-w-md grid-cols-2">
+            <TabsTrigger value="license">
+              {t("pages.settings.license.applicationLicense")}
+            </TabsTrigger>
+            <TabsTrigger value="third-party">
+              {t("pages.settings.license.thirdPartyLicenses")}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="license" className="mt-6 flex-1">
+            <div className="h-full rounded-lg border bg-card">
+              <div className="flex items-center justify-between border-b p-4">
+                <h3 className="font-semibold">
+                  {t("pages.settings.license.applicationLicense")}
+                </h3>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={openLicenseInExplorer}
+                  className="gap-2"
+                >
+                  <ExternalLink size={16} />
+                  {t("shared.showInExplorer")}
+                </Button>
+              </div>
+              <ScrollArea className="h-[calc(100vh-340px)] p-6">
+                {isLoading ? (
+                  <div className="flex h-32 items-center justify-center">
+                    <p className="text-muted-foreground">
+                      {t("shared.loading")}
+                    </p>
+                  </div>
+                ) : (
+                  <pre className="whitespace-pre-wrap font-mono text-foreground text-sm leading-relaxed">
+                    {licenseContent}
+                  </pre>
+                )}
+              </ScrollArea>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="third-party" className="mt-6 flex-1">
+            <div className="h-full rounded-lg border bg-card">
+              <div className="flex items-center justify-between border-b p-4">
+                <h3 className="font-semibold">
+                  {t("pages.settings.license.thirdPartyLicenses")}
+                </h3>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={openLicenseInExplorer}
+                  className="gap-2"
+                >
+                  <ExternalLink size={16} />
+                  {t("shared.showInExplorer")}
+                </Button>
+              </div>
+              <ScrollArea className="h-[calc(100vh-340px)] p-6">
+                {isLoading ? (
+                  <div className="flex h-32 items-center justify-center">
+                    <p className="text-muted-foreground">
+                      {t("shared.loading")}
+                    </p>
+                  </div>
+                ) : (
+                  <pre className="whitespace-pre-wrap font-mono text-foreground text-sm leading-relaxed">
+                    {thirdPartyContent}
+                  </pre>
+                )}
+              </ScrollArea>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -92,7 +92,10 @@
       "noDataMessage": "No processes found matching the specified criteria",
       "adjustFiltersHint": "Try adjusting the filter conditions"
     },
-    "other": "Other"
+    "other": "Other",
+    "loading": "Loading...",
+    "back": "Back",
+    "showInExplorer": "Show in Explorer"
   },
 
   "pages": {
@@ -205,6 +208,10 @@
         "checkGitHub": "Check GitHub",
         "checkLatestVersion": "Check Latest Version",
         "author": "Author: {{author}}"
+      },
+      "license": {
+        "applicationLicense": "Application License",
+        "thirdPartyLicenses": "Third-Party Licenses"
       }
     }
   },

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1,5 +1,6 @@
 {
   "shared": {
+    "loading": "読み込み中...",
     "usage": "使用率",
     "usageValue": "使用量",
     "cpuUsage": "CPU 使用率",
@@ -92,7 +93,9 @@
       "noDataMessage": "指定した条件に一致するプロセスが見つかりませんでした",
       "adjustFiltersHint": "フィルター条件を緩めてみてください"
     },
-    "other": "その他"
+    "other": "その他",
+    "back": "戻る",
+    "showInExplorer": "エクスプローラで表示"
   },
 
   "pages": {
@@ -205,6 +208,10 @@
         "checkGitHub": "GitHub",
         "checkLatestVersion": "最新バージョンを確認する",
         "author": "作者：{{author}}"
+      },
+      "license": {
+        "applicationLicense": "アプリケーションライセンス",
+        "thirdPartyLicenses": "サードパーティライセンス"
       }
     }
   },

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -295,6 +295,30 @@ async setHardwareArchiveScheduledDataDeletion(newValue: boolean) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
+async readLicenseFile() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_license_file") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async readThirdPartyNoticesFile() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_third_party_notices_file") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async openLicenseFilePath() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_license_file_path") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * 背景画像を取得
  * 


### PR DESCRIPTION
- Introduced commands to read license and third-party notices files.
- Added a new LicensePage component for displaying license information.
- Updated settings to include a button for showing the license page.
- Added support for opening the license file path in the file explorer.