### PR TITLE
Revert "Chore: Exclude bindings.ts from frontend labeler configuration"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,6 @@ frontend:
   - changed-files:
       - any-glob-to-any-file:
           - "src/**"
-          - "!src/rspc/bindings.ts"
           - "index.html"
           - "package.json"
 


### PR DESCRIPTION
Reverts shm11C3/HardwareVisualizer#1052