### PR TITLE
refactor(dashboard): Add React 19 Suspense support with Jotai Promise atoms

### DIFF
--- a/src/features/hardware/dashboard/Dashboard.tsx
+++ b/src/features/hardware/dashboard/Dashboard.tsx
@@ -15,13 +15,15 @@ import {
   NetworkIcon,
 } from "@phosphor-icons/react";
 import type { JSX } from "react";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DashboardItemSelector } from "@/features/hardware/dashboard/components/DashboardItemSelector";
 import { ProcessesTable } from "@/features/hardware/dashboard/components/ProcessTable";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
-import { useHardwareInfoAtom } from "../hooks/useHardwareInfoAtom";
+import { useRefreshHardwareInfo } from "../hooks/useHardwareInfoAtom";
 import {
   CPUInfo,
   GPUInfo,
@@ -32,6 +34,7 @@ import {
 } from "./components/DashboardItems";
 import { ExportHardwareInfo } from "./components/ExportHardwareInfo";
 import { SortableItem } from "./components/SortableItem";
+import { WidgetErrorFallback } from "./components/WidgetErrorFallback";
 import { useDashboardSelector } from "./hooks/useDashboardSelector";
 import { useSortableDashboard } from "./hooks/useSortableDashboard";
 import type { DashboardItemType } from "./types/dashboardItem";
@@ -46,12 +49,12 @@ type DataTypeKey =
   | "motherboard";
 
 export const Dashboard = () => {
-  const { hardwareInfo } = useHardwareInfoAtom();
   const { dashboardItemMap, handleDragOver } = useSortableDashboard();
   const { settings } = useSettingsAtom();
   const { t } = useTranslation();
   const sensors = useSensors(useSensor(PointerSensor));
   const { visibleItems, toggleItem } = useDashboardSelector();
+  const refreshHardwareInfo = useRefreshHardwareInfo();
 
   const dataAreaKey2Title: Partial<Record<DataTypeKey, string>> = {
     cpu: "CPU",
@@ -77,10 +80,7 @@ export const Dashboard = () => {
           color={`rgb(${settings.lineGraphColor.gpu})`}
         />
       ),
-      component:
-        hardwareInfo.gpus != null && hardwareInfo.gpus.length > 0 ? (
-          <GPUInfo />
-        ) : null,
+      component: <GPUInfo />,
     },
     memory: {
       icon: (
@@ -153,7 +153,18 @@ export const Dashboard = () => {
                       title={dataAreaKey2Title[key]}
                       icon={dashboardItemKeyToItems[key].icon}
                     >
-                      {dashboardItemKeyToItems[key].component}
+                      <ErrorBoundary
+                        FallbackComponent={WidgetErrorFallback}
+                        onReset={refreshHardwareInfo}
+                      >
+                        <Suspense
+                          fallback={
+                            <Skeleton className="h-[188px] w-full rounded-md" />
+                          }
+                        >
+                          {dashboardItemKeyToItems[key].component}
+                        </Suspense>
+                      </ErrorBoundary>
                     </DataArea>
                   ) : (
                     <div className="p-4">

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -1,6 +1,6 @@
 import { platform } from "@tauri-apps/plugin-os";
 import { useAtom } from "jotai";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import {
@@ -18,7 +18,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { minOpacity } from "@/consts/style";
-import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
+import {
+  useFetchMemoryInfoDetail,
+  useHardwareInfoSuspense,
+  useNetworkInfoSuspense,
+} from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuUsageHistoryAtom,
   gpuTempAtom,
@@ -42,7 +46,7 @@ import { MiniLineChart } from "./MiniLineChart";
 export const CPUInfo = () => {
   const { t } = useTranslation();
   const [cpuUsageHistory] = useAtom(cpuUsageHistoryAtom);
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const hardwareInfo = useHardwareInfoSuspense();
   const processes = useProcessInfo();
   const [processorsUsageHistory] = useAtom(processorsUsageHistoryAtom);
 
@@ -57,21 +61,18 @@ export const CPUInfo = () => {
         <MiniLineChart hardwareType="cpu" usage={cpuUsageHistory} />
       </div>
 
-      {hardwareInfo.cpu ? (
-        <InfoTable
-          data={{
-            [t("shared.name")]: hardwareInfo.cpu.name,
-            [t("shared.vendor")]: hardwareInfo.cpu.vendor,
-            [t("shared.coreCount")]: hardwareInfo.cpu.coreCount,
-            [t("shared.threadCount")]: processorsUsageHistory[0]?.length || 0,
-            [t("shared.defaultClockSpeed")]:
-              `${hardwareInfo.cpu.clock} ${hardwareInfo.cpu.clockUnit}`,
-            [t("shared.processCount")]: processes.length,
-          }}
-        />
-      ) : (
-        <Skeleton className="h-[188px] w-full rounded-md" />
-      )}
+      <InfoTable
+        data={{
+          [t("shared.name")]: hardwareInfo.cpu?.name ?? "N/A",
+          [t("shared.vendor")]: hardwareInfo.cpu?.vendor ?? "N/A",
+          [t("shared.coreCount")]: hardwareInfo.cpu?.coreCount ?? "N/A",
+          [t("shared.threadCount")]: processorsUsageHistory[0]?.length || 0,
+          [t("shared.defaultClockSpeed")]: hardwareInfo.cpu
+            ? `${hardwareInfo.cpu.clock} ${hardwareInfo.cpu.clockUnit}`
+            : "N/A",
+          [t("shared.processCount")]: processes.length,
+        }}
+      />
     </>
   );
 };
@@ -80,7 +81,7 @@ export const GPUInfo = () => {
   const { t } = useTranslation();
   const [graphicUsageHistory] = useAtom(graphicUsageHistoryAtom);
   const [gpuTemp] = useAtom(gpuTempAtom);
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const hardwareInfo = useHardwareInfoSuspense();
   const { isBreak } = useWindowSize();
   const [gpuMemoryUsage, setGpuMemoryUsage] = useState<GpuMemoryUsage | null>(
     null,
@@ -194,7 +195,7 @@ export const GPUInfo = () => {
 export const MemoryInfo = () => {
   const { t } = useTranslation();
   const [memoryUsageHistory] = useAtom(memoryUsageHistoryAtom);
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const hardwareInfo = useHardwareInfoSuspense();
   const os = platform();
 
   const {
@@ -291,17 +292,17 @@ export const MemoryInfo = () => {
 
 export const FetchDetailButton = () => {
   const { t } = useTranslation();
-  const [loading, setLoading] = useState(false);
-  const { fetchMemoryInfoDetail } = useHardwareInfoAtom();
+  const [isPending, startTransition] = useTransition();
+  const fetchDetail = useFetchMemoryInfoDetail();
 
-  const handleLoadDetail = async () => {
-    setLoading(true);
-    await fetchMemoryInfoDetail();
-    setLoading(false);
+  const handleLoadDetail = () => {
+    startTransition(async () => {
+      await fetchDetail();
+    });
   };
 
   return (
-    <Button onClick={handleLoadDetail} disabled={loading}>
+    <Button onClick={handleLoadDetail} disabled={isPending}>
       {t("shared.loadDetailedInfo")}
     </Button>
   );
@@ -319,7 +320,7 @@ const storageDataInfoGridVariants = tv({
 
 export const StorageDataInfo = () => {
   const { t } = useTranslation();
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const hardwareInfo = useHardwareInfoSuspense();
   const os = useMemo(() => platform(), []);
 
   // Sort by drive name
@@ -398,7 +399,7 @@ export const StorageDataInfo = () => {
 
 export const MotherboardDataInfo = () => {
   const { t } = useTranslation();
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const hardwareInfo = useHardwareInfoSuspense();
 
   if (!hardwareInfo.motherboard) {
     return <Skeleton className="h-[188px] w-full rounded-md" />;
@@ -424,12 +425,7 @@ export const MotherboardDataInfo = () => {
 export const NetworkInfo = () => {
   const { t } = useTranslation();
   const { settings } = useSettingsAtom();
-  const { networkInfo, initNetwork } = useHardwareInfoAtom();
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `initNetwork` is a stable function
-  useEffect(() => {
-    initNetwork();
-  }, []);
+  const networkInfo = useNetworkInfoSuspense();
 
   return (
     <>

--- a/src/features/hardware/dashboard/components/WidgetErrorFallback.tsx
+++ b/src/features/hardware/dashboard/components/WidgetErrorFallback.tsx
@@ -1,0 +1,37 @@
+import { AlertCircle, RotateCcw } from "lucide-react";
+import type { FallbackProps } from "react-error-boundary";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Compact error fallback rendered inside individual dashboard widgets.
+ * Displays the error message with a retry button so that a single widget
+ * failure does not take down the entire dashboard.
+ */
+export const WidgetErrorFallback = ({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-md border border-destructive/30 bg-destructive/5 p-6 text-center">
+      <AlertCircle className="size-8 text-destructive" />
+      <p className="font-medium text-destructive text-sm">
+        {t("pages.dashboard.widgetError.title")}
+      </p>
+      <p className="max-w-xs text-muted-foreground text-xs">
+        {error instanceof Error ? error.message : String(error)}
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={resetErrorBoundary}
+        className="gap-1.5"
+      >
+        <RotateCcw className="size-3.5" />
+        {t("pages.dashboard.widgetError.retry")}
+      </Button>
+    </div>
+  );
+};

--- a/src/features/hardware/dashboard/hooks/useSortableDashboard.ts
+++ b/src/features/hardware/dashboard/hooks/useSortableDashboard.ts
@@ -1,12 +1,9 @@
 import type { DragEndEvent } from "@dnd-kit/core";
 import { arraySwap } from "@dnd-kit/sortable";
-import { useEffect } from "react";
 import { useTauriStore } from "@/hooks/useTauriStore";
-import { useHardwareInfoAtom } from "../../hooks/useHardwareInfoAtom";
 import type { DashboardItemType } from "../types/dashboardItem";
 
 export const useSortableDashboard = () => {
-  const { init } = useHardwareInfoAtom();
   const [dashboardItemMap, setDashboardItemMap] = useTauriStore<
     DashboardItemType[]
   >("dashboardItem", [
@@ -29,10 +26,6 @@ export const useSortableDashboard = () => {
 
     setDashboardItemMap(arraySwap(dashboardItemMap, oldIndex, newIndex));
   };
-
-  useEffect(() => {
-    init();
-  }, [init]);
 
   return {
     dashboardItemMap,

--- a/src/features/hardware/hooks/useHardwareInfoAtom.test.ts
+++ b/src/features/hardware/hooks/useHardwareInfoAtom.test.ts
@@ -1,5 +1,6 @@
-import { act, renderHook } from "@testing-library/react";
-import { Provider } from "jotai";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { createElement, Suspense } from "react";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 /**
@@ -12,24 +13,66 @@ vi.mock("@/hooks/useTauriDialog", () => ({
   }),
 }));
 
-// Mock getHardwareInfo, getNetworkInfo in commands
+// Mock getHardwareInfo, getNetworkInfo, getMemoryInfoDetail in commands.
+// Default values are needed because the module-level Promise atoms call
+// fetchHardwareInfo / fetchNetworkInfo on import.
 vi.mock("@/rspc/bindings", () => ({
   commands: {
-    getHardwareInfo: vi.fn(),
-    getNetworkInfo: vi.fn(),
+    getHardwareInfo: vi.fn().mockResolvedValue({
+      data: {
+        cpu: null,
+        memory: null,
+        gpus: null,
+        storage: [],
+        motherboard: null,
+      },
+    }),
+    getNetworkInfo: vi.fn().mockResolvedValue({ data: [] }),
+    getMemoryInfoDetail: vi.fn(),
   },
 }));
 
 /**
  * Import hook to test
  */
-import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
+import {
+  hardwareInfoPromiseAtom,
+  networkInfoPromiseAtom,
+  useHardwareInfoAtom,
+  useHardwareInfoSuspense,
+  useNetworkInfoSuspense,
+} from "@/features/hardware/hooks/useHardwareInfoAtom";
 import { commands } from "@/rspc/bindings";
+
+/**
+ * Helper: create a wrapper with Jotai Provider + Suspense for testing
+ * Suspense-based hooks with pre-set Promise atom values.
+ */
+const createSuspenseWrapper = (
+  hardwarePromise: Promise<unknown>,
+  networkPromise?: Promise<unknown>,
+) => {
+  const store = createStore();
+  store.set(hardwareInfoPromiseAtom, hardwarePromise as Promise<never>);
+  if (networkPromise) {
+    store.set(networkInfoPromiseAtom, networkPromise as Promise<never>);
+  }
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(
+      Provider,
+      { store },
+      createElement(
+        Suspense,
+        { fallback: createElement("div", null, "loading") },
+        children,
+      ),
+    );
+};
 
 /**
  * Test execution
  */
-describe("useHardwareInfoAtom", () => {
+describe("useHardwareInfoAtom (legacy)", () => {
   beforeEach(() => {
     // Reset mock state before each test execution
     vi.clearAllMocks();
@@ -132,5 +175,52 @@ describe("useHardwareInfoAtom", () => {
     expect(result.current.networkInfo).toEqual([]);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe("useHardwareInfoPromise (Suspense)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves hardware info through use()", async () => {
+    const hwData = {
+      cpu: { name: "Intel" },
+      memory: null,
+      gpus: null,
+      storage: [],
+      motherboard: null,
+    };
+
+    const wrapper = createSuspenseWrapper(Promise.resolve(hwData));
+
+    const { result } = renderHook(() => useHardwareInfoSuspense(), { wrapper });
+
+    // The hook returns a promise — in a Suspense context it suspends until resolved.
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
+  });
+
+  it("resolves network info through use()", async () => {
+    const netData = [{ macAddress: "AA:BB" }];
+    const hwData = {
+      cpu: null,
+      memory: null,
+      gpus: null,
+      storage: [],
+      motherboard: null,
+    };
+
+    const wrapper = createSuspenseWrapper(
+      Promise.resolve(hwData),
+      Promise.resolve(netData),
+    );
+
+    const { result } = renderHook(() => useNetworkInfoSuspense(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
   });
 });

--- a/src/features/hardware/hooks/useHardwareInfoAtom.ts
+++ b/src/features/hardware/hooks/useHardwareInfoAtom.ts
@@ -1,4 +1,4 @@
-import { atom, useAtom } from "jotai";
+import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { commands, type NetworkInfo, type SysInfo } from "@/rspc/bindings";
 import { isError } from "@/types/result";
@@ -12,6 +12,88 @@ const hardInfoAtom = atom<SysInfo>({
 });
 
 const networkInfoAtom = atom<NetworkInfo[]>([]);
+
+const fetchHardwareInfo = async (): Promise<SysInfo> => {
+  const result = await commands.getHardwareInfo();
+  if (!result || isError(result)) {
+    const errorMsg =
+      result && isError(result)
+        ? result.error
+        : "Failed to fetch hardware info";
+    console.error("Failed to fetch hardware info:", result);
+    throw new Error(
+      typeof errorMsg === "string" ? errorMsg : "Failed to fetch hardware info",
+    );
+  }
+  return result.data;
+};
+
+const fetchNetworkInfo = async (): Promise<NetworkInfo[]> => {
+  const result = await commands.getNetworkInfo();
+  if (!result || isError(result)) {
+    const errorMsg =
+      result && isError(result) ? result.error : "Failed to fetch network info";
+    console.error("Failed to fetch network info:", result);
+    throw new Error(
+      typeof errorMsg === "string" ? errorMsg : "Failed to fetch network info",
+    );
+  }
+  return result.data;
+};
+
+// ---------------------------------------------------------------------------
+// Lazy-initialized writable atoms.
+// The read function kicks off the fetch on first access, so there is no
+// module-level side-effect (important for tests where Tauri is not available).
+// Subsequent writes (e.g. from useRefreshHardwareInfo) replace the Promise.
+// ---------------------------------------------------------------------------
+
+let hardwareInfoInitPromise: Promise<SysInfo> | null = null;
+
+export const hardwareInfoPromiseAtom = atom(
+  (get) => {
+    // The stored value is only meaningful after the first write.
+    // On the very first read we bootstrap the fetch ourselves.
+    const stored = get(hardwareInfoPromiseWritableAtom);
+    if (stored) return stored;
+    // Lazily start the first fetch (cached so concurrent reads share it)
+    if (!hardwareInfoInitPromise) {
+      hardwareInfoInitPromise = fetchHardwareInfo();
+    }
+    return hardwareInfoInitPromise;
+  },
+  (_get, set, promise: Promise<SysInfo>) => {
+    set(hardwareInfoPromiseWritableAtom, promise);
+  },
+);
+
+/** Internal backing atom – holds the latest Promise after the first write. */
+const hardwareInfoPromiseWritableAtom = atom<Promise<SysInfo> | null>(null);
+
+let networkInfoInitPromise: Promise<NetworkInfo[]> | null = null;
+
+export const networkInfoPromiseAtom = atom(
+  (get) => {
+    const stored = get(networkInfoPromiseWritableAtom);
+    if (stored) return stored;
+    if (!networkInfoInitPromise) {
+      networkInfoInitPromise = fetchNetworkInfo();
+    }
+    return networkInfoInitPromise;
+  },
+  (_get, set, promise: Promise<NetworkInfo[]>) => {
+    set(networkInfoPromiseWritableAtom, promise);
+  },
+);
+
+const networkInfoPromiseWritableAtom = atom<Promise<NetworkInfo[]> | null>(
+  null,
+);
+
+export const useRefreshHardwareInfo = () => {
+  const setPromise = useSetAtom(hardwareInfoPromiseAtom);
+  return () => setPromise(fetchHardwareInfo());
+};
 
 export const useHardwareInfoAtom = () => {
   const [hardwareInfo, setHardInfo] = useAtom(hardInfoAtom);
@@ -62,5 +144,38 @@ export const useHardwareInfoAtom = () => {
     init,
     initNetwork,
     fetchMemoryInfoDetail,
+  };
+};
+
+export const useHardwareInfoSuspense = () => {
+  return useAtomValue(hardwareInfoPromiseAtom);
+};
+
+export const useNetworkInfoSuspense = () => {
+  return useAtomValue(networkInfoPromiseAtom);
+};
+
+export const useFetchMemoryInfoDetail = () => {
+  const setPromise = useSetAtom(hardwareInfoPromiseAtom);
+
+  return () => {
+    const promise = (async (): Promise<SysInfo> => {
+      // Fetch current hardware info first to preserve other fields
+      const currentResult = await commands.getHardwareInfo();
+      if (isError(currentResult)) {
+        throw new Error(currentResult.error);
+      }
+
+      const detailResult = await commands.getMemoryInfoDetail();
+      if (isError(detailResult)) {
+        console.error("Failed to fetch memory info detail:", detailResult);
+        throw new Error(detailResult.error);
+      }
+
+      return { ...currentResult.data, memory: detailResult.data };
+    })();
+
+    setPromise(promise);
+    return promise;
   };
 };

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -133,7 +133,11 @@
     "dashboard": {
       "name": "Dashboard",
       "visibleItems": "Visible Items",
-      "selectItems": "Select items to display on the dashboard"
+      "selectItems": "Select items to display on the dashboard",
+      "widgetError": {
+        "title": "Failed to load data",
+        "retry": "Retry"
+      }
     },
     "usage": {
       "name": "Usage"

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -133,7 +133,11 @@
     "dashboard": {
       "name": "ダッシュボード",
       "visibleItems": "表示項目",
-      "selectItems": "表示する項目を選択してください"
+      "selectItems": "表示する項目を選択してください",
+      "widgetError": {
+        "title": "データの読み込みに失敗しました",
+        "retry": "再試行"
+      }
     },
     "usage": {
       "name": "ハードウェア使用率"


### PR DESCRIPTION
- Migrate dashboard widgets to Suspense-based data fetching using Jotai atoms
- Add per-widget error boundaries and progressive loading with Skeleton fallback
- Replace useState + manual loading state with useTransition in FetchDetailButton
- Add lazy-initialized Promise atoms to avoid test-breaking module-level effects
- Maintain backward compatibility with legacy useHardwareInfoAtom hook
- Add widget error UI component and i18n translations

Improves data loading UX with progressive widget rendering and error isolation.