### PR TITLE
(feat) Support AMD GPU for Insights

### DIFF
--- a/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
@@ -857,3 +857,116 @@ pub async fn get_amd_gpu_usage() -> Result<f32, String> {
 pub fn is_available() -> bool {
   get_adl().is_some()
 }
+
+/// Get per-adapter GPU core usage for monitoring/archiving.
+///
+/// Returns `(adapter_name, usage%)` for each active AMD adapter.
+pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<(String, f32)>, String> {
+  spawn_blocking(|| {
+    let adl = get_adl().ok_or("AMD ADL library not available")?;
+    let adapters = enumerate_adapters(adl);
+
+    if adapters.is_empty() {
+      return Err("No active AMD GPU adapters found".to_string());
+    }
+
+    let mut results: Vec<(String, f32)> = Vec::new();
+
+    for adapter in &adapters {
+      let idx = adapter.adapter_index;
+      let mut usage: Option<f32> = None;
+
+      if adapter.overdrive_supported {
+        usage = read_od5_activity(adl, idx);
+      }
+
+      if (adapter.overdrive_level >= 8 || !adapter.overdrive_supported || usage.is_none())
+        && let Some(v) = read_od8_usage(adl, idx)
+      {
+        usage = Some(v);
+      }
+
+      if let Some(u) = usage {
+        results.push((adapter.adapter_name.clone(), u));
+      }
+    }
+
+    if results.is_empty() {
+      Err("AMD ADL: no per-adapter usage data collected".to_string())
+    } else {
+      Ok(results)
+    }
+  })
+  .await
+  .map_err(|e| {
+    log_error!(
+      "join_error",
+      "adl_provider::get_amd_gpu_usage_per_adapter",
+      Some(e.to_string())
+    );
+    "AMD GPU per-adapter usage retrieval failed".to_string()
+  })?
+}
+
+/// Get per-adapter GPU core temperature for monitoring/archiving.
+///
+/// Returns `(adapter_name, temperature_celsius)` for each active AMD adapter,
+/// using the best available temperature source (Core/Edge sensor).
+pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<(String, f32)>, String>
+{
+  spawn_blocking(|| {
+    let adl = get_adl().ok_or("AMD ADL library not available")?;
+    let adapters = enumerate_adapters(adl);
+
+    if adapters.is_empty() {
+      return Err("No active AMD GPU adapters found".to_string());
+    }
+
+    let mut results: Vec<(String, f32)> = Vec::new();
+
+    for adapter in &adapters {
+      let idx = adapter.adapter_index;
+      let mut temp: Option<i32> = None;
+
+      // Phase 1: OD5 baseline (Core temperature)
+      if adapter.overdrive_supported {
+        temp = read_od5_temperature(adl, idx);
+      }
+
+      // Phase 2: ODN override (OD ≥ 7) — Edge sensor
+      if adapter.overdrive_supported
+        && adapter.overdrive_level >= 7
+        && let Some(v) = read_odn_temperature(adl, idx, ODNT_EDGE)
+      {
+        temp = Some(v);
+      }
+
+      // Phase 3: PMLog / OD8 supplement
+      let has_gap = temp.is_none();
+      if (adapter.overdrive_level >= 8 || !adapter.overdrive_supported || has_gap)
+        && let Some(v) = read_od8_sensor_value(adl, idx, PMLOG_TEMPERATURE_EDGE)
+      {
+        temp = Some(v);
+      }
+
+      if let Some(t) = temp {
+        results.push((adapter.adapter_name.clone(), t as f32));
+      }
+    }
+
+    if results.is_empty() {
+      Err("AMD ADL: no per-adapter temperature data collected".to_string())
+    } else {
+      Ok(results)
+    }
+  })
+  .await
+  .map_err(|e| {
+    log_error!(
+      "join_error",
+      "adl_provider::get_amd_gpu_temperatures_per_adapter",
+      Some(e.to_string())
+    );
+    "AMD GPU per-adapter temperature retrieval failed".to_string()
+  })?
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,9 +42,9 @@ pub fn run() {
   let gpu_history = Arc::new(Mutex::new(VecDeque::with_capacity(60)));
   let process_cpu_histories = Arc::new(Mutex::new(HashMap::new()));
   let process_memory_histories = Arc::new(Mutex::new(HashMap::new()));
-  let nv_gpu_usage_histories = Arc::new(Mutex::new(HashMap::new()));
-  let nv_gpu_temperature_histories = Arc::new(Mutex::new(HashMap::new()));
-  let nv_gpu_dedicated_memory_histories = Arc::new(Mutex::new(HashMap::new()));
+  let gpu_usage_histories = Arc::new(Mutex::new(HashMap::new()));
+  let gpu_temperature_histories = Arc::new(Mutex::new(HashMap::new()));
+  let gpu_dedicated_memory_histories = Arc::new(Mutex::new(HashMap::new()));
 
   let state = models::hardware::HardwareMonitorState {
     system: Arc::clone(&system),
@@ -53,8 +53,8 @@ pub fn run() {
     gpu_history: Arc::clone(&gpu_history),
     process_cpu_histories: Arc::clone(&process_cpu_histories),
     process_memory_histories: Arc::clone(&process_memory_histories),
-    nv_gpu_usage_histories: Arc::clone(&nv_gpu_usage_histories),
-    nv_gpu_temperature_histories: Arc::clone(&nv_gpu_temperature_histories),
+    gpu_usage_histories: Arc::clone(&gpu_usage_histories),
+    gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
   };
 
   let settings = app_state.settings.lock().unwrap().clone();
@@ -143,11 +143,9 @@ pub fn run() {
           memory_history: Arc::clone(&memory_history),
           process_cpu_histories: Arc::clone(&process_cpu_histories),
           process_memory_histories: Arc::clone(&process_memory_histories),
-          nv_gpu_usage_histories: Arc::clone(&nv_gpu_usage_histories),
-          nv_gpu_temperature_histories: Arc::clone(&nv_gpu_temperature_histories),
-          nv_gpu_dedicated_memory_histories: Arc::clone(
-            &nv_gpu_dedicated_memory_histories,
-          ),
+          gpu_usage_histories: Arc::clone(&gpu_usage_histories),
+          gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
+          gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
         },
       );
       {
@@ -164,11 +162,9 @@ pub fn run() {
             memory_history: Arc::clone(&memory_history),
             process_cpu_histories: Arc::clone(&process_cpu_histories),
             process_memory_histories: Arc::clone(&process_memory_histories),
-            nv_gpu_usage_histories: Arc::clone(&nv_gpu_usage_histories),
-            nv_gpu_temperature_histories: Arc::clone(&nv_gpu_temperature_histories),
-            nv_gpu_dedicated_memory_histories: Arc::clone(
-              &nv_gpu_dedicated_memory_histories,
-            ),
+            gpu_usage_histories: Arc::clone(&gpu_usage_histories),
+            gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
+            gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
           },
         );
         {

--- a/src-tauri/src/models/hardware.rs
+++ b/src-tauri/src/models/hardware.rs
@@ -13,9 +13,9 @@ pub struct HardwareMonitorState {
   pub process_cpu_histories: Arc<Mutex<HashMap<sysinfo::Pid, VecDeque<f32>>>>,
   pub process_memory_histories: Arc<Mutex<HashMap<sysinfo::Pid, VecDeque<f32>>>>,
   #[allow(dead_code)]
-  pub nv_gpu_usage_histories: Arc<Mutex<HashMap<String, VecDeque<f32>>>>,
+  pub gpu_usage_histories: Arc<Mutex<HashMap<String, VecDeque<f32>>>>,
   #[allow(dead_code)]
-  pub nv_gpu_temperature_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
+  pub gpu_temperature_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
 }
 
 #[derive(Serialize, Deserialize, Type, Clone)]

--- a/src-tauri/src/models/hardware_archive.rs
+++ b/src-tauri/src/models/hardware_archive.rs
@@ -11,9 +11,9 @@ pub struct MonitorResources {
   pub memory_history: Arc<Mutex<VecDeque<f32>>>,
   pub process_cpu_histories: Arc<Mutex<HashMap<sysinfo::Pid, VecDeque<f32>>>>,
   pub process_memory_histories: Arc<Mutex<HashMap<sysinfo::Pid, VecDeque<f32>>>>,
-  pub nv_gpu_usage_histories: Arc<Mutex<HashMap<String, VecDeque<f32>>>>,
-  pub nv_gpu_temperature_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
-  pub nv_gpu_dedicated_memory_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
+  pub gpu_usage_histories: Arc<Mutex<HashMap<String, VecDeque<f32>>>>,
+  pub gpu_temperature_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
+  pub gpu_dedicated_memory_histories: Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]

--- a/src-tauri/src/services/archive_service.rs
+++ b/src-tauri/src/services/archive_service.rs
@@ -70,9 +70,9 @@ impl ArchiveService {
   ) {
     let hardware_data = Self::collect_hardware_metrics(resources);
     let gpu_data = GpuMetricsCollector::new(
-      &resources.nv_gpu_usage_histories,
-      &resources.nv_gpu_temperature_histories,
-      &resources.nv_gpu_dedicated_memory_histories,
+      &resources.gpu_usage_histories,
+      &resources.gpu_temperature_histories,
+      &resources.gpu_dedicated_memory_histories,
     )
     .collect_all();
     let process_stats = ProcessStatsCollector::new(
@@ -230,9 +230,9 @@ impl<'a> GpuMetricsCollector<'a> {
     &self,
     gpu_name: &str,
   ) -> models::hardware_archive::GpuData {
-    let usage_stats = self.calculate_usage_stats();
-    let temperature_stats = self.calculate_temperature_stats();
-    let memory_stats = self.calculate_memory_stats();
+    let usage_stats = self.calculate_usage_stats(gpu_name);
+    let temperature_stats = self.calculate_temperature_stats(gpu_name);
+    let memory_stats = self.calculate_memory_stats(gpu_name);
 
     models::hardware_archive::GpuData {
       gpu_name: gpu_name.to_string(),
@@ -248,46 +248,55 @@ impl<'a> GpuMetricsCollector<'a> {
     }
   }
 
-  fn calculate_usage_stats(&self) -> (Option<f32>, Option<f32>, Option<f32>) {
-    let values = self.flatten_f32_histories(self.usage_histories);
+  fn calculate_usage_stats(
+    &self,
+    gpu_name: &str,
+  ) -> (Option<f32>, Option<f32>, Option<f32>) {
+    let values = self.get_f32_history_for_gpu(self.usage_histories, gpu_name);
     StatsCalculator::compute_f32_aggregates(&values)
   }
 
-  fn calculate_temperature_stats(&self) -> (Option<f32>, Option<i32>, Option<i32>) {
-    let values = self.flatten_i32_histories(self.temperature_histories);
+  fn calculate_temperature_stats(
+    &self,
+    gpu_name: &str,
+  ) -> (Option<f32>, Option<i32>, Option<i32>) {
+    let values = self.get_i32_history_for_gpu(self.temperature_histories, gpu_name);
     StatsCalculator::compute_i32_aggregates(&values)
   }
 
-  fn calculate_memory_stats(&self) -> (Option<i32>, Option<i32>, Option<i32>) {
-    let values = self.flatten_i32_histories(self.memory_histories);
+  fn calculate_memory_stats(
+    &self,
+    gpu_name: &str,
+  ) -> (Option<i32>, Option<i32>, Option<i32>) {
+    let values = self.get_i32_history_for_gpu(self.memory_histories, gpu_name);
     let (avg_f32, max, min) = StatsCalculator::compute_i32_aggregates(&values);
     (avg_f32.map(|v| v as i32), max, min)
   }
 
-  fn flatten_f32_histories(
+  fn get_f32_history_for_gpu(
     &self,
     histories: &Arc<Mutex<HashMap<String, VecDeque<f32>>>>,
+    gpu_name: &str,
   ) -> Vec<f32> {
     histories
       .lock()
       .unwrap()
-      .values()
-      .flat_map(|v| v.iter())
-      .cloned()
-      .collect()
+      .get(gpu_name)
+      .map(|v| v.iter().cloned().collect())
+      .unwrap_or_default()
   }
 
-  fn flatten_i32_histories(
+  fn get_i32_history_for_gpu(
     &self,
     histories: &Arc<Mutex<HashMap<String, VecDeque<i32>>>>,
+    gpu_name: &str,
   ) -> Vec<i32> {
     histories
       .lock()
       .unwrap()
-      .values()
-      .flat_map(|v| v.iter())
-      .cloned()
-      .collect()
+      .get(gpu_name)
+      .map(|v| v.iter().cloned().collect())
+      .unwrap_or_default()
   }
 }
 

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -72,11 +72,14 @@ fn update_process_histories(
 }
 
 #[cfg(target_os = "windows")]
-pub fn sample_gpu(resources: &MonitorResources) {
+pub async fn sample_gpu(resources: &MonitorResources) {
   use crate::infrastructure::providers::nvapi_provider;
   use nvapi::PhysicalGpu;
 
-  if let Some(gpu_metrics) = PhysicalGpu::enumerate().ok().map(|gpus| {
+  let mut gpu_metrics: Vec<(String, f32, f32, f32)> = Vec::new();
+
+  // ── NVIDIA GPUs via NVAPI ──
+  if let Some(nvapi_metrics) = PhysicalGpu::enumerate().ok().map(|gpus| {
     gpus
       .iter()
       .map(|gpu| {
@@ -90,18 +93,109 @@ pub fn sample_gpu(resources: &MonitorResources) {
       })
       .collect::<Vec<_>>()
   }) {
+    gpu_metrics.extend(nvapi_metrics);
+  }
+
+  // ── AMD GPUs via ADL ──
+  if crate::infrastructure::providers::adl_provider::is_available() {
+    sample_amd_gpu(&mut gpu_metrics).await;
+  }
+
+  if !gpu_metrics.is_empty() {
     update_gpu_histories(resources, &gpu_metrics);
   }
 }
 
+/// Collect AMD GPU usage and temperature via ADL.
+/// VRAM usage is out of scope for now.
 #[cfg(target_os = "windows")]
+async fn sample_amd_gpu(gpu_metrics: &mut Vec<(String, f32, f32, f32)>) {
+  use crate::infrastructure::providers::adl_provider;
+
+  // Usage per adapter
+  let usages: Vec<(String, f32)> = adl_provider::get_amd_gpu_usage_per_adapter()
+    .await
+    .unwrap_or_default();
+
+  // Temperature per adapter
+  let temps: Vec<(String, f32)> = adl_provider::get_amd_gpu_temperatures_per_adapter()
+    .await
+    .unwrap_or_default();
+
+  // Build a temp lookup by adapter name
+  let temp_map: std::collections::HashMap<&str, f32> =
+    temps.iter().map(|(n, t)| (n.as_str(), *t)).collect();
+
+  for (name, usage) in &usages {
+    let temperature = temp_map.get(name.as_str()).copied().unwrap_or(0.0);
+    // VRAM usage is not available via ADL; default to 0
+    gpu_metrics.push((name.clone(), *usage, temperature, 0.0));
+  }
+}
+
+#[cfg(target_os = "linux")]
+pub async fn sample_gpu(resources: &MonitorResources) {
+  let gpu_metrics = collect_linux_gpu_metrics().await;
+
+  if !gpu_metrics.is_empty() {
+    update_gpu_histories(resources, &gpu_metrics);
+  }
+}
+
+/// Collect GPU metrics on Linux using the existing platform layer
+/// (DRM/sysfs for AMD, DRM for Intel).
+#[cfg(target_os = "linux")]
+async fn collect_linux_gpu_metrics() -> Vec<(String, f32, f32, f32)> {
+  use crate::infrastructure::providers::drm_sys;
+  use crate::infrastructure::providers::hwmon;
+
+  let mut metrics: Vec<(String, f32, f32, f32)> = Vec::new();
+  let card_ids = drm_sys::get_all_card_ids();
+
+  for card_id in card_ids {
+    let vendor = drm_sys::detect_gpu_vendor(card_id);
+
+    let (name, usage, temperature) = match vendor {
+      drm_sys::GpuVendor::Amd => {
+        let name =
+          crate::infrastructure::providers::lspci::get_gpu_name_from_lspci_by_vendor_id(
+            "1002",
+          )
+          .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
+        let usage = drm_sys::get_amd_gpu_usage(card_id as u32)
+          .await
+          .map(|u| (u * 100.0) as f32)
+          .unwrap_or(0.0);
+        let temperature = hwmon::read_hwmon_temperatures(card_id)
+          .ok()
+          .and_then(|temps| temps.first().map(|t| t.value as f32))
+          .unwrap_or(0.0);
+        (name, usage, temperature)
+      }
+      drm_sys::GpuVendor::Intel => {
+        let usage = drm_sys::get_intel_gpu_usage()
+          .await
+          .map(|u| (u * 100.0) as f32)
+          .unwrap_or(0.0);
+        (format!("Intel GPU (card{})", card_id), usage, 0.0)
+      }
+      _ => continue,
+    };
+
+    // VRAM usage is out of scope for now
+    metrics.push((name, usage, temperature, 0.0));
+  }
+
+  metrics
+}
+
 fn update_gpu_histories(
   resources: &MonitorResources,
   gpu_metrics: &[(String, f32, f32, f32)],
 ) {
-  let mut usage_histories = resources.nv_gpu_usage_histories.lock().unwrap();
-  let mut temp_histories = resources.nv_gpu_temperature_histories.lock().unwrap();
-  let mut mem_histories = resources.nv_gpu_dedicated_memory_histories.lock().unwrap();
+  let mut usage_histories = resources.gpu_usage_histories.lock().unwrap();
+  let mut temp_histories = resources.gpu_temperature_histories.lock().unwrap();
+  let mut mem_histories = resources.gpu_dedicated_memory_histories.lock().unwrap();
 
   gpu_metrics
     .iter()

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -193,7 +193,7 @@ async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
   metrics
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(not(target_os = "macos"))]
 fn update_gpu_histories(resources: &MonitorResources, gpu_metrics: &[GpuSample]) {
   let mut usage_histories = resources.gpu_usage_histories.lock().unwrap();
   let mut temp_histories = resources.gpu_temperature_histories.lock().unwrap();

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -9,6 +9,7 @@ use crate::models::hardware_archive::MonitorResources;
 
 /// A single GPU sample: (name, usage%, temperature°C, dedicated_memory_usage%).
 /// `None` means the metric is unavailable for this GPU vendor/platform.
+#[cfg(not(target_os = "macos"))]
 type GpuSample = (String, Option<f32>, Option<f32>, Option<f32>);
 
 /// System sampling for one cycle (CPU/memory/process)
@@ -192,6 +193,7 @@ async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
   metrics
 }
 
+#[cfg(target_os = "windows")]
 fn update_gpu_histories(resources: &MonitorResources, gpu_metrics: &[GpuSample]) {
   let mut usage_histories = resources.gpu_usage_histories.lock().unwrap();
   let mut temp_histories = resources.gpu_temperature_histories.lock().unwrap();

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -7,6 +7,10 @@ use crate::constants::{
 use crate::models::hardware::HardwareMonitorState;
 use crate::models::hardware_archive::MonitorResources;
 
+/// A single GPU sample: (name, usage%, temperature°C, dedicated_memory_usage%).
+/// `None` means the metric is unavailable for this GPU vendor/platform.
+type GpuSample = (String, Option<f32>, Option<f32>, Option<f32>);
+
 /// System sampling for one cycle (CPU/memory/process)
 pub fn sample_system(resources: &MonitorResources) {
   if let Some((cpu_usage, memory_usage, process_metrics)) =
@@ -76,7 +80,7 @@ pub async fn sample_gpu(resources: &MonitorResources) {
   use crate::infrastructure::providers::nvapi_provider;
   use nvapi::PhysicalGpu;
 
-  let mut gpu_metrics: Vec<(String, f32, f32, f32)> = Vec::new();
+  let mut gpu_metrics: Vec<GpuSample> = Vec::new();
 
   // ── NVIDIA GPUs via NVAPI ──
   if let Some(nvapi_metrics) = PhysicalGpu::enumerate().ok().map(|gpus| {
@@ -89,7 +93,7 @@ pub async fn sample_gpu(resources: &MonitorResources) {
           nvapi_provider::get_gpu_temperature_from_physical_gpu(gpu) as f32;
         let memory_usage =
           nvapi_provider::get_gpu_dedicated_memory_usage_from_physical_gpu(gpu) as f32;
-        (name, usage, temperature, memory_usage)
+        (name, Some(usage), Some(temperature), Some(memory_usage))
       })
       .collect::<Vec<_>>()
   }) {
@@ -107,9 +111,9 @@ pub async fn sample_gpu(resources: &MonitorResources) {
 }
 
 /// Collect AMD GPU usage and temperature via ADL.
-/// VRAM usage is out of scope for now.
+/// VRAM usage is not available via ADL.
 #[cfg(target_os = "windows")]
-async fn sample_amd_gpu(gpu_metrics: &mut Vec<(String, f32, f32, f32)>) {
+async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::adl_provider;
 
   // Usage per adapter
@@ -127,9 +131,9 @@ async fn sample_amd_gpu(gpu_metrics: &mut Vec<(String, f32, f32, f32)>) {
     temps.iter().map(|(n, t)| (n.as_str(), *t)).collect();
 
   for (name, usage) in &usages {
-    let temperature = temp_map.get(name.as_str()).copied().unwrap_or(0.0);
-    // VRAM usage is not available via ADL; default to 0
-    gpu_metrics.push((name.clone(), *usage, temperature, 0.0));
+    let temperature = temp_map.get(name.as_str()).copied();
+    // VRAM usage is not available via ADL
+    gpu_metrics.push((name.clone(), Some(*usage), temperature, None));
   }
 }
 
@@ -145,11 +149,11 @@ pub async fn sample_gpu(resources: &MonitorResources) {
 /// Collect GPU metrics on Linux using the existing platform layer
 /// (DRM/sysfs for AMD, DRM for Intel).
 #[cfg(target_os = "linux")]
-async fn collect_linux_gpu_metrics() -> Vec<(String, f32, f32, f32)> {
+async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
   use crate::infrastructure::providers::drm_sys;
   use crate::infrastructure::providers::hwmon;
 
-  let mut metrics: Vec<(String, f32, f32, f32)> = Vec::new();
+  let mut metrics: Vec<GpuSample> = Vec::new();
   let card_ids = drm_sys::get_all_card_ids();
 
   for card_id in card_ids {
@@ -165,34 +169,30 @@ async fn collect_linux_gpu_metrics() -> Vec<(String, f32, f32, f32)> {
         let usage = drm_sys::get_amd_gpu_usage(card_id as u32)
           .await
           .map(|u| (u * 100.0) as f32)
-          .unwrap_or(0.0);
+          .ok();
         let temperature = hwmon::read_hwmon_temperatures(card_id)
           .ok()
-          .and_then(|temps| temps.first().map(|t| t.value as f32))
-          .unwrap_or(0.0);
+          .and_then(|temps| temps.first().map(|t| t.value as f32));
         (name, usage, temperature)
       }
       drm_sys::GpuVendor::Intel => {
         let usage = drm_sys::get_intel_gpu_usage()
           .await
           .map(|u| (u * 100.0) as f32)
-          .unwrap_or(0.0);
-        (format!("Intel GPU (card{})", card_id), usage, 0.0)
+          .ok();
+        (format!("Intel GPU (card{})", card_id), usage, None)
       }
       _ => continue,
     };
 
-    // VRAM usage is out of scope for now
-    metrics.push((name, usage, temperature, 0.0));
+    // VRAM usage is not available on Linux
+    metrics.push((name, usage, temperature, None));
   }
 
   metrics
 }
 
-fn update_gpu_histories(
-  resources: &MonitorResources,
-  gpu_metrics: &[(String, f32, f32, f32)],
-) {
+fn update_gpu_histories(resources: &MonitorResources, gpu_metrics: &[GpuSample]) {
   let mut usage_histories = resources.gpu_usage_histories.lock().unwrap();
   let mut temp_histories = resources.gpu_temperature_histories.lock().unwrap();
   let mut mem_histories = resources.gpu_dedicated_memory_histories.lock().unwrap();
@@ -200,21 +200,27 @@ fn update_gpu_histories(
   gpu_metrics
     .iter()
     .for_each(|(name, usage, temperature, memory_usage)| {
-      let usage_history = usage_histories.entry(name.clone()).or_default();
-      if usage_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
-        usage_history.pop_front();
+      if let Some(usage) = usage {
+        let usage_history = usage_histories.entry(name.clone()).or_default();
+        if usage_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
+          usage_history.pop_front();
+        }
+        usage_history.push_back(*usage);
       }
-      usage_history.push_back(*usage);
-      let temp_history = temp_histories.entry(name.clone()).or_default();
-      if temp_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
-        temp_history.pop_front();
+      if let Some(temperature) = temperature {
+        let temp_history = temp_histories.entry(name.clone()).or_default();
+        if temp_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
+          temp_history.pop_front();
+        }
+        temp_history.push_back(*temperature as i32);
       }
-      temp_history.push_back(*temperature as i32);
-      let mem_history = mem_histories.entry(name.clone()).or_default();
-      if mem_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
-        mem_history.pop_front();
+      if let Some(memory_usage) = memory_usage {
+        let mem_history = mem_histories.entry(name.clone()).or_default();
+        if mem_history.len() >= HARDWARE_HISTORY_BUFFER_SIZE {
+          mem_history.pop_front();
+        }
+        mem_history.push_back(*memory_usage as i32);
       }
-      mem_history.push_back(*memory_usage as i32);
     });
 }
 

--- a/src-tauri/src/workers/system_monitor.rs
+++ b/src-tauri/src/workers/system_monitor.rs
@@ -33,11 +33,12 @@ impl SystemMonitorController {
         #[cfg(target_os = "windows")]
         {
           monitoring_service::sample_system(&resources);
-          monitoring_service::sample_gpu(&resources);
+          monitoring_service::sample_gpu(&resources).await;
         }
         #[cfg(target_os = "linux")]
         {
           monitoring_service::sample_system(&resources);
+          monitoring_service::sample_gpu(&resources).await;
         }
         #[cfg(target_os = "macos")]
         {
@@ -52,11 +53,12 @@ impl SystemMonitorController {
               #[cfg(target_os = "windows")]
               {
                 monitoring_service::sample_system(&resources);
-                monitoring_service::sample_gpu(&resources);
+                monitoring_service::sample_gpu(&resources).await;
               }
               #[cfg(target_os = "linux")]
               {
                 monitoring_service::sample_system(&resources);
+                monitoring_service::sample_gpu(&resources).await;
               }
               #[cfg(target_os = "macos")]
               {

--- a/src/features/hardware/insights/components/InsightChart.tsx
+++ b/src/features/hardware/insights/components/InsightChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { SingleLineChart } from "@/components/charts/LineChart";
 import type { ChartConfig } from "@/components/ui/chart";
@@ -74,17 +74,19 @@ export const GpuInsightChart = ({
   dataStats,
   offset,
   gpuName,
+  onDataAvailabilityChange,
 }: {
   dataType: GpuDataType;
   period: (typeof archivePeriods)[number];
   dataStats: DataStats;
   offset: number;
   gpuName: string;
+  onDataAvailabilityChange?: (hasData: boolean) => void;
 }) => {
   const { t } = useTranslation();
   const { settings } = useSettingsAtom();
   const { hardwareInfo } = useHardwareInfoAtom();
-  const { labels, chartData } = useInsightChart({
+  const { labels, chartData, hasData } = useInsightChart({
     hardwareType: "gpu",
     dataStats,
     dataType,
@@ -92,6 +94,10 @@ export const GpuInsightChart = ({
     offset,
     gpuName,
   });
+
+  useEffect(() => {
+    onDataAvailabilityChange?.(hasData);
+  }, [hasData, onDataAvailabilityChange]);
 
   const chartConfig: Record<GpuDataType, { label: string; color: string }> = {
     usage: {
@@ -139,6 +145,16 @@ export const GpuInsightChart = ({
     // Round up the maximum value to the nearest integer to ensure proper grid alignment in the chart.
     return Math.ceil(max);
   }, [hardwareInfo.gpus]);
+
+  if (chartData.every((v) => v == null)) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <span className="text-muted-foreground">
+          {t("pages.insights.noDataForPeriod")}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full">

--- a/src/features/hardware/insights/hooks/useInsightChart.ts
+++ b/src/features/hardware/insights/hooks/useInsightChart.ts
@@ -328,5 +328,7 @@ export const useInsightChart = (
     dateFormatter,
   ]);
 
-  return { labels: filledLabels, chartData: filledChartData };
+  const hasData = filledChartData.some((v) => v != null);
+
+  return { labels: filledLabels, chartData: filledChartData, hasData };
 };

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -151,7 +151,8 @@
       },
       "snapshot": {
         "title": "Snapshot"
-      }
+      },
+      "noDataForPeriod": "No data found for the selected period"
     },
     "settings": {
       "name": "Settings",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -151,7 +151,8 @@
       },
       "snapshot": {
         "title": "スナップショット"
-      }
+      },
+      "noDataForPeriod": "選択された期間のデータは見つかりませんでした"
     },
     "settings": {
       "name": "設定",


### PR DESCRIPTION
This pull request introduces cross-vendor GPU monitoring support, refactoring the GPU metrics collection and storage system to be vendor-agnostic and adding AMD and Linux GPU metrics collection. It also updates the data pipeline and UI to handle the new structure and improves data availability feedback in the insights chart.

**GPU Monitoring Refactor and Vendor-Agnostic Support:**

* Replaces NVIDIA-specific GPU history fields (`nv_gpu_*_histories`) with generic `gpu_*_histories` in state and resource models, and updates all usages throughout the backend to use the new generic fields. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL45-R47) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL56-R57) [[3]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL146-R148) [[4]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL167-R167) [[5]](diffhunk://#diff-256394c2d3e1c02fbdbf67999c869586982c7a28f1db9321b2987809f8694258L16-R18) [[6]](diffhunk://#diff-a7bc2bccbbd4c01e6271c61e29d648267886d355ee9130c6ded4b031490c6ab3L14-R16) [[7]](diffhunk://#diff-cc69c958a375ce5cd187c548ba4f30687fa0539d0b866010c204b1287a6bb9cdL73-R75)
* Refactors the GPU metrics collection pipeline to aggregate per-GPU metrics (usage, temperature, memory) for both NVIDIA and AMD on Windows, and for AMD/Intel on Linux, using a new `GpuSample` type. [[1]](diffhunk://#diff-63a11154cb47837c96be409caa2562af6293d6d6d2a84a817c81e51722d8cdc2R10-R13) [[2]](diffhunk://#diff-63a11154cb47837c96be409caa2562af6293d6d6d2a84a817c81e51722d8cdc2L75-R86) [[3]](diffhunk://#diff-63a11154cb47837c96be409caa2562af6293d6d6d2a84a817c81e51722d8cdc2L89-R223)

**AMD and Linux GPU Metrics Collection:**

* Implements async AMD GPU usage and temperature collection via ADL on Windows, exposing new async functions `get_amd_gpu_usage_per_adapter` and `get_amd_gpu_temperatures_per_adapter`.
* Adds Linux GPU metrics collection for AMD and Intel using DRM/sysfs/hwmon, including vendor detection and per-card sampling, with fallback for missing VRAM metrics.

**Data Pipeline and Stats Calculation Updates:**

* Updates the archive and stats calculation logic to use the new vendor-agnostic GPU histories, ensuring per-GPU stats are computed for the correct device by name. [[1]](diffhunk://#diff-cc69c958a375ce5cd187c548ba4f30687fa0539d0b866010c204b1287a6bb9cdL233-R235) [[2]](diffhunk://#diff-cc69c958a375ce5cd187c548ba4f30687fa0539d0b866010c204b1287a6bb9cdL251-R299)

**Frontend Improvements:**

* Enhances the GPU insight chart to detect and display when no data is available for the selected period, using a new `onDataAvailabilityChange` callback and a fallback UI message. [[1]](diffhunk://#diff-030664ba2f31ce492d216d2d45ef99baa1b48eb97f4048f7cd211854918fa2f9L1-R1) [[2]](diffhunk://#diff-030664ba2f31ce492d216d2d45ef99baa1b48eb97f4048f7cd211854918fa2f9R77-R89) [[3]](diffhunk://#diff-030664ba2f31ce492d216d2d45ef99baa1b48eb97f4048f7cd211854918fa2f9R98-R101) [[4]](diffhunk://#diff-030664ba2f31ce492d216d2d45ef99baa1b48eb97f4048f7cd211854918fa2f9R149-R158)

**Async Monitoring Pipeline:**

* Updates the system monitor worker and monitoring service to call the async GPU sampling function for both Windows and Linux, ensuring non-blocking and correct vendor support. [[1]](diffhunk://#diff-d79922deecf239e77dad8cf6656c80ea6b7d3adfd1d110c96d4e48f7a0ea0343L36-R41) [[2]](diffhunk://#diff-d79922deecf239e77dad8cf6656c80ea6b7d3adfd1d110c96d4e48f7a0ea0343L55-R61)

These changes lay the groundwork for unified GPU monitoring across vendors and platforms, improve code maintainability, and enhance the user experience when data is unavailable.