### PR TITLE
feat: implement PDH-based GPU usage monitoring

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,7 @@ windows = { version = "0.62.2", features = [
     "Data_Xml_Dom",
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_Performance",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/src-tauri/src/commands/hardware.rs
+++ b/src-tauri/src/commands/hardware.rs
@@ -83,7 +83,7 @@ pub fn get_memory_usage(state: tauri::State<'_, HardwareMonitorState>) -> i32 {
 /// ## Get GPU usage (%)
 ///
 /// Returns the GPU usage percentage together with the data-source
-/// identifier (e.g. "NVAPI", "ADL", "WMI", "DRM (AMD)", "IOKit").
+/// identifier (e.g. "NVAPI", "ADL", "PDH", "DRM (AMD)", "IOKit").
 ///
 #[command]
 #[specta::specta]

--- a/src-tauri/src/infrastructure/providers/windows/mod.rs
+++ b/src-tauri/src/infrastructure/providers/windows/mod.rs
@@ -1,4 +1,5 @@
 pub mod adl_provider;
 pub mod directx;
 pub mod nvapi_provider;
+pub mod pdh_provider;
 pub mod wmi_provider;

--- a/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
@@ -11,13 +11,14 @@
 use crate::{log_debug, log_error, log_internal};
 use std::collections::HashMap;
 use std::error::Error;
+use std::mem::{self, MaybeUninit};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 use tokio::task::spawn_blocking;
 use windows::Win32::System::Performance::{
-  PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE, PDH_HCOUNTER, PDH_HQUERY,
-  PdhAddEnglishCounterW, PdhCloseQuery, PdhCollectQueryData,
-  PdhGetFormattedCounterArrayW, PdhOpenQueryW,
+  PDH_CSTATUS_NEW_DATA, PDH_CSTATUS_VALID_DATA, PDH_FMT_COUNTERVALUE_ITEM_W,
+  PDH_FMT_DOUBLE, PDH_HCOUNTER, PDH_HQUERY, PdhAddEnglishCounterW, PdhCloseQuery,
+  PdhCollectQueryData, PdhGetFormattedCounterArrayW, PdhOpenQueryW,
 };
 use windows::core::PCWSTR;
 
@@ -79,15 +80,9 @@ struct PdhState {
   query: PDH_HQUERY,
   counter: PDH_HCOUNTER,
   /// Reusable buffer for `PdhGetFormattedCounterArrayW`.
-  /// Uses `u64` instead of `u8` to guarantee 8-byte alignment, which
-  /// `PDH_FMT_COUNTERVALUE_ITEM_W` (contains pointers and `f64`) requires.
-  buf: Vec<u64>,
-  /// Whether at least one successful collect has been performed.
-  /// The first collect after `AddCounter` is a baseline; we need a
-  /// second one for meaningful data from rate-based counters.
-  /// GPU Utilisation Percentage is a gauge, but some drivers still
-  /// return 0 on the very first sample, so we prime on init.
-  primed: bool,
+  /// Typed as `MaybeUninit<PDH_FMT_COUNTERVALUE_ITEM_W>` to guarantee
+  /// correct alignment regardless of the struct's actual `align_of`.
+  buf: Vec<MaybeUninit<PDH_FMT_COUNTERVALUE_ITEM_W>>,
   /// Per-engine-type max utilisation (0.0–1.0) from the last collect.
   /// Populated for *all* known engine types in a single pass so that
   /// concurrent queries for different engine types don't each trigger a
@@ -109,8 +104,10 @@ impl Drop for PdhState {
   }
 }
 
-/// Lazy-initialised global state.
-static PDH_STATE: OnceLock<Mutex<PdhState>> = OnceLock::new();
+/// Lazy-initialised global state.  Stores `Err(message)` if PDH
+/// initialisation failed so subsequent calls return the error instead of
+/// panicking.
+static PDH_STATE: OnceLock<Result<Mutex<PdhState>, String>> = OnceLock::new();
 
 /// Initialise the persistent query (called once under the lock).
 fn init_pdh_state() -> Result<PdhState, Box<dyn Error + Send>> {
@@ -136,12 +133,23 @@ fn init_pdh_state() -> Result<PdhState, Box<dyn Error + Send>> {
       )));
     }
 
-    // Prime: first collect establishes the baseline.
+    // Prime: collect baseline → sleep → collect again so rate-based
+    // counters and drivers that return 0 on the first sample are ready.
     let status = PdhCollectQueryData(query);
     if status != 0 {
       PdhCloseQuery(query);
       return Err(pdh_err(format!(
-        "PdhCollectQueryData (prime) failed: 0x{status:08X}"
+        "PdhCollectQueryData (prime 1) failed: 0x{status:08X}"
+      )));
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let status = PdhCollectQueryData(query);
+    if status != 0 {
+      PdhCloseQuery(query);
+      return Err(pdh_err(format!(
+        "PdhCollectQueryData (prime 2) failed: 0x{status:08X}"
       )));
     }
 
@@ -149,7 +157,6 @@ fn init_pdh_state() -> Result<PdhState, Box<dyn Error + Send>> {
       query,
       counter,
       buf: Vec::new(),
-      primed: false,
       cache: HashMap::new(),
       cache_time: Instant::now(),
     })
@@ -184,18 +191,23 @@ pub async fn query_gpu_usage_by_device_and_engine(
 // ---------------------------------------------------------------------------
 
 fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + Send>> {
-  let mut guard = PDH_STATE
-    .get_or_init(|| match init_pdh_state() {
-      Ok(state) => Mutex::new(state),
-      Err(e) => {
-        log_error!(
-          "init_error",
-          "pdh_provider::collect_and_read",
-          Some(e.to_string())
-        );
-        panic!("Failed to initialize PDH state: {}", e);
-      }
-    })
+  let init_result = PDH_STATE.get_or_init(|| match init_pdh_state() {
+    Ok(state) => Ok(Mutex::new(state)),
+    Err(e) => {
+      log_error!(
+        "init_error",
+        "pdh_provider::collect_and_read",
+        Some(e.to_string())
+      );
+      Err(e.to_string())
+    }
+  });
+
+  let mtx = init_result
+    .as_ref()
+    .map_err(|e| pdh_err(format!("PDH init failed: {e}")))?;
+
+  let mut guard = mtx
     .lock()
     .map_err(|e| pdh_err(format!("PDH_STATE lock poisoned: {e}")))?;
 
@@ -206,13 +218,6 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
     && let Some(&v) = state.cache.get(&engine_type)
   {
     return Ok(v);
-  }
-
-  // If this is the first real poll after init, sleep briefly so the
-  // second collect gives a non-trivial delta for any smoothed counters.
-  if !state.primed {
-    std::thread::sleep(std::time::Duration::from_millis(200));
-    state.primed = true;
   }
 
   unsafe {
@@ -241,10 +246,11 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
       )));
     }
 
-    // Grow reusable buffer if necessary (convert byte count → u64 count, round up)
-    let needed = (buf_size as usize).div_ceil(8);
+    // Grow reusable buffer if necessary (convert byte count → item count, round up)
+    let item_size = mem::size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>();
+    let needed = (buf_size as usize).div_ceil(item_size);
     if needed > state.buf.len() {
-      state.buf.resize(needed, 0u64);
+      state.buf.resize_with(needed, MaybeUninit::uninit);
     }
 
     // --- fetch data into aligned buffer ---
@@ -253,7 +259,7 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
       PDH_FMT_DOUBLE,
       &mut buf_size,
       &mut item_count,
-      Some(state.buf.as_mut_ptr() as *mut PDH_FMT_COUNTERVALUE_ITEM_W),
+      Some(state.buf.as_mut_ptr().cast::<PDH_FMT_COUNTERVALUE_ITEM_W>()),
     );
     if status != 0 {
       return Err(pdh_err(format!(
@@ -263,7 +269,7 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
 
     // --- walk all instances, build per-engine-type cache ---
     let items = std::slice::from_raw_parts(
-      state.buf.as_ptr() as *const PDH_FMT_COUNTERVALUE_ITEM_W,
+      state.buf.as_ptr().cast::<PDH_FMT_COUNTERVALUE_ITEM_W>(),
       item_count as usize,
     );
 
@@ -271,11 +277,25 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
     let engtype_tag = "engtype_";
 
     for item in items {
+      // Skip items with invalid CStatus.
+      let cstatus = item.FmtValue.CStatus;
+      if cstatus != PDH_CSTATUS_VALID_DATA && cstatus != PDH_CSTATUS_NEW_DATA {
+        continue;
+      }
+
+      let raw = item.FmtValue.Anonymous.doubleValue;
+
+      // Skip non-finite or out-of-range values.
+      if !raw.is_finite() || !(0.0..=100.0).contains(&raw) {
+        continue;
+      }
+
       let name = pwstr_to_string(item.szName.0);
-      if let Some(pos) = name.find(engtype_tag) {
-        let suffix = &name[pos + engtype_tag.len()..];
+      if let Some(pos) = name.rfind(engtype_tag) {
+        let mut suffix = &name[pos + engtype_tag.len()..];
+        suffix = suffix.split('_').next().unwrap_or(suffix);
         if let Some(etype) = GpuEngineType::from_pdh_suffix(suffix) {
-          let value = item.FmtValue.Anonymous.doubleValue as f32 / 100.0;
+          let value = (raw as f32 / 100.0).clamp(0.0, 1.0);
           let entry = state.cache.entry(etype).or_insert(0.0f32);
           if value > *entry {
             *entry = value;

--- a/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
@@ -1,0 +1,330 @@
+///
+/// PDH-based GPU engine utilization provider.
+///
+/// Replaces the WMI-based `Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine`
+/// query with a direct PDH counter query for lower overhead and no COM dependency.
+///
+/// The PDH query handle and counter handle are initialised once (on the first
+/// call) and reused across subsequent polls so that only `CollectQueryData` +
+/// `GetFormattedCounterArrayW` run on each tick.
+///
+use crate::{log_debug, log_error, log_internal};
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+use tokio::task::spawn_blocking;
+use windows::Win32::System::Performance::{
+  PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE, PDH_HCOUNTER, PDH_HQUERY,
+  PdhAddEnglishCounterW, PdhCloseQuery, PdhCollectQueryData,
+  PdhGetFormattedCounterArrayW, PdhOpenQueryW,
+};
+use windows::core::PCWSTR;
+
+/// `PdhGetFormattedCounterArrayW` returns this when the caller-supplied buffer
+/// is too small and needs to be grown (normal sizing flow).
+const PDH_MORE_DATA: u32 = 0x800007D2;
+
+/// How long cached results remain valid.  When multiple engine types are
+/// queried within the same monitoring tick, only the first call triggers an
+/// actual PDH collect; the rest are served from cache.
+const CACHE_TTL: std::time::Duration = std::time::Duration::from_millis(100);
+
+// ---------------------------------------------------------------------------
+// GPU engine type
+// ---------------------------------------------------------------------------
+
+/// WDDM GPU engine types exposed by the PDH `GPU Engine` counter set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GpuEngineType {
+  Graphics3D,
+  Copy,
+  VideoDecode,
+  VideoEncode,
+  VideoProcessing,
+}
+
+impl GpuEngineType {
+  /// The suffix that appears in PDH instance names (e.g. `engtype_3D`).
+  fn as_pdh_suffix(&self) -> &'static str {
+    match self {
+      Self::Graphics3D => "3D",
+      Self::Copy => "Copy",
+      Self::VideoDecode => "VideoDecode",
+      Self::VideoEncode => "VideoEncode",
+      Self::VideoProcessing => "VideoProcessing",
+    }
+  }
+
+  /// Parse a PDH engine-type suffix back into the enum.
+  fn from_pdh_suffix(s: &str) -> Option<Self> {
+    match s {
+      "3D" => Some(Self::Graphics3D),
+      "Copy" => Some(Self::Copy),
+      "VideoDecode" => Some(Self::VideoDecode),
+      "VideoEncode" => Some(Self::VideoEncode),
+      "VideoProcessing" => Some(Self::VideoProcessing),
+      _ => None,
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persistent query state
+// ---------------------------------------------------------------------------
+
+/// Holds the PDH query and counter handles that survive across polls.
+/// Created once, closed when the process exits (or on `Drop`).
+struct PdhState {
+  query: PDH_HQUERY,
+  counter: PDH_HCOUNTER,
+  /// Reusable buffer for `PdhGetFormattedCounterArrayW`.
+  /// Uses `u64` instead of `u8` to guarantee 8-byte alignment, which
+  /// `PDH_FMT_COUNTERVALUE_ITEM_W` (contains pointers and `f64`) requires.
+  buf: Vec<u64>,
+  /// Whether at least one successful collect has been performed.
+  /// The first collect after `AddCounter` is a baseline; we need a
+  /// second one for meaningful data from rate-based counters.
+  /// GPU Utilisation Percentage is a gauge, but some drivers still
+  /// return 0 on the very first sample, so we prime on init.
+  primed: bool,
+  /// Per-engine-type max utilisation (0.0–1.0) from the last collect.
+  /// Populated for *all* known engine types in a single pass so that
+  /// concurrent queries for different engine types don't each trigger a
+  /// PDH collect.
+  cache: HashMap<GpuEngineType, f32>,
+  /// When `cache` was last populated.
+  cache_time: Instant,
+}
+
+// SAFETY: PDH handles are *not* thread-safe, but we guarantee exclusive
+// access through a Mutex and always call PDH from `spawn_blocking`.
+unsafe impl Send for PdhState {}
+
+impl Drop for PdhState {
+  fn drop(&mut self) {
+    unsafe {
+      PdhCloseQuery(self.query);
+    }
+  }
+}
+
+/// Lazy-initialised global state.
+static PDH_STATE: OnceLock<Mutex<PdhState>> = OnceLock::new();
+
+/// Initialise the persistent query (called once under the lock).
+fn init_pdh_state() -> Result<PdhState, Box<dyn Error + Send>> {
+  unsafe {
+    let mut query: PDH_HQUERY = PDH_HQUERY::default();
+    let status = PdhOpenQueryW(PCWSTR::null(), 0, &mut query);
+    if status != 0 {
+      return Err(pdh_err(format!("PdhOpenQueryW failed: 0x{status:08X}")));
+    }
+
+    let counter_path = "\\GPU Engine(*)\\Utilization Percentage";
+    let wide: Vec<u16> = counter_path
+      .encode_utf16()
+      .chain(std::iter::once(0))
+      .collect();
+
+    let mut counter: PDH_HCOUNTER = PDH_HCOUNTER::default();
+    let status = PdhAddEnglishCounterW(query, PCWSTR(wide.as_ptr()), 0, &mut counter);
+    if status != 0 {
+      PdhCloseQuery(query);
+      return Err(pdh_err(format!(
+        "PdhAddEnglishCounterW failed: 0x{status:08X}"
+      )));
+    }
+
+    // Prime: first collect establishes the baseline.
+    let status = PdhCollectQueryData(query);
+    if status != 0 {
+      PdhCloseQuery(query);
+      return Err(pdh_err(format!(
+        "PdhCollectQueryData (prime) failed: 0x{status:08X}"
+      )));
+    }
+
+    Ok(PdhState {
+      query,
+      counter,
+      buf: Vec::new(),
+      primed: false,
+      cache: HashMap::new(),
+      cache_time: Instant::now(),
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Query GPU engine utilization for the specified engine type using PDH.
+///
+/// Returns the **maximum** utilisation percentage (as 0.0–1.0) across all
+/// instances whose name contains `engtype_<engine_type>`.
+pub async fn query_gpu_usage_by_device_and_engine(
+  engine_type: GpuEngineType,
+) -> Result<f32, Box<dyn Error + Send>> {
+  spawn_blocking(move || collect_and_read(engine_type))
+    .await
+    .map_err(|e| {
+      log_error!(
+        "join_error",
+        "pdh_provider::query_gpu_usage_by_device_and_engine",
+        Some(e.to_string())
+      );
+      pdh_err("PDH query task panicked".to_string())
+    })?
+}
+
+// ---------------------------------------------------------------------------
+// Core collection logic (runs inside `spawn_blocking`)
+// ---------------------------------------------------------------------------
+
+fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + Send>> {
+  let mut guard = PDH_STATE
+    .get_or_init(|| match init_pdh_state() {
+      Ok(state) => Mutex::new(state),
+      Err(e) => {
+        log_error!(
+          "init_error",
+          "pdh_provider::collect_and_read",
+          Some(e.to_string())
+        );
+        panic!("Failed to initialize PDH state: {}", e);
+      }
+    })
+    .lock()
+    .map_err(|e| pdh_err(format!("PDH_STATE lock poisoned: {e}")))?;
+
+  let state = &mut *guard;
+
+  // Return cached value if the last collect is recent enough.
+  if state.cache_time.elapsed() < CACHE_TTL
+    && let Some(&v) = state.cache.get(&engine_type)
+  {
+    return Ok(v);
+  }
+
+  // If this is the first real poll after init, sleep briefly so the
+  // second collect gives a non-trivial delta for any smoothed counters.
+  if !state.primed {
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    state.primed = true;
+  }
+
+  unsafe {
+    // Collect fresh sample
+    let status = PdhCollectQueryData(state.query);
+    if status != 0 {
+      return Err(pdh_err(format!(
+        "PdhCollectQueryData failed: 0x{status:08X}"
+      )));
+    }
+
+    // --- size the buffer ---
+    let mut buf_size: u32 = 0;
+    let mut item_count: u32 = 0;
+
+    let status = PdhGetFormattedCounterArrayW(
+      state.counter,
+      PDH_FMT_DOUBLE,
+      &mut buf_size,
+      &mut item_count,
+      None,
+    );
+    if status != PDH_MORE_DATA {
+      return Err(pdh_err(format!(
+        "PdhGetFormattedCounterArrayW (sizing) failed: 0x{status:08X}"
+      )));
+    }
+
+    // Grow reusable buffer if necessary (convert byte count → u64 count, round up)
+    let needed = (buf_size as usize).div_ceil(8);
+    if needed > state.buf.len() {
+      state.buf.resize(needed, 0u64);
+    }
+
+    // --- fetch data into aligned buffer ---
+    let status = PdhGetFormattedCounterArrayW(
+      state.counter,
+      PDH_FMT_DOUBLE,
+      &mut buf_size,
+      &mut item_count,
+      Some(state.buf.as_mut_ptr() as *mut PDH_FMT_COUNTERVALUE_ITEM_W),
+    );
+    if status != 0 {
+      return Err(pdh_err(format!(
+        "PdhGetFormattedCounterArrayW (data) failed: 0x{status:08X}"
+      )));
+    }
+
+    // --- walk all instances, build per-engine-type cache ---
+    let items = std::slice::from_raw_parts(
+      state.buf.as_ptr() as *const PDH_FMT_COUNTERVALUE_ITEM_W,
+      item_count as usize,
+    );
+
+    state.cache.clear();
+    let engtype_tag = "engtype_";
+
+    for item in items {
+      let name = pwstr_to_string(item.szName.0);
+      if let Some(pos) = name.find(engtype_tag) {
+        let suffix = &name[pos + engtype_tag.len()..];
+        if let Some(etype) = GpuEngineType::from_pdh_suffix(suffix) {
+          let value = item.FmtValue.Anonymous.doubleValue as f32 / 100.0;
+          let entry = state.cache.entry(etype).or_insert(0.0f32);
+          if value > *entry {
+            *entry = value;
+          }
+        }
+      }
+    }
+
+    state.cache_time = Instant::now();
+  }
+
+  let suffix = engine_type.as_pdh_suffix();
+  match state.cache.get(&engine_type) {
+    Some(&v) => {
+      log_debug!(
+        &format!("PDH GPU usage for engtype_{suffix}: {v}"),
+        "pdh_provider::collect_and_read",
+        None::<&str>
+      );
+      Ok(v)
+    }
+    None => Err(pdh_err(format!(
+      "No PDH GPU engine data for engtype_{suffix}"
+    ))),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Read a null-terminated wide string from a raw `*const u16` pointer.
+///
+/// # Safety
+/// The caller must guarantee that `ptr` points to a valid, null-terminated
+/// UTF-16 string.
+unsafe fn pwstr_to_string(ptr: *const u16) -> String {
+  if ptr.is_null() {
+    return String::new();
+  }
+  unsafe {
+    let mut len = 0;
+    while *ptr.add(len) != 0 {
+      len += 1;
+    }
+    String::from_utf16_lossy(std::slice::from_raw_parts(ptr, len))
+  }
+}
+
+fn pdh_err(msg: String) -> Box<dyn Error + Send> {
+  Box::new(std::io::Error::other(msg))
+}

--- a/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/pdh_provider.rs
@@ -187,6 +187,47 @@ pub async fn query_gpu_usage_by_device_and_engine(
 }
 
 // ---------------------------------------------------------------------------
+// Pure helper functions (testable without PDH handles)
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when `raw` is finite and within the 0–100 range expected
+/// from PDH utilisation counters.
+fn is_valid_pdh_value(raw: f64) -> bool {
+  raw.is_finite() && (0.0..=100.0).contains(&raw)
+}
+
+/// Extract the [`GpuEngineType`] from a PDH instance name such as
+/// `pid_1234_luid_0x00_0x0000_phys_0_eng_1_engtype_3D`.
+///
+/// Uses `rfind` so that only the **last** `engtype_` tag is considered.
+fn parse_engine_type_from_instance(name: &str) -> Option<GpuEngineType> {
+  let engtype_tag = "engtype_";
+  let pos = name.rfind(engtype_tag)?;
+  let suffix = &name[pos + engtype_tag.len()..];
+  let suffix = suffix.split('_').next().unwrap_or(suffix);
+  GpuEngineType::from_pdh_suffix(suffix)
+}
+
+/// Aggregate a slice of `(engine_type, raw_percentage)` pairs into `cache`.
+///
+/// For each engine type the **maximum** raw value is kept, normalised from
+/// the 0–100 PDH range to 0.0–1.0.  The cache is cleared before aggregation
+/// so stale entries from a previous collection do not leak through.
+fn aggregate_engine_usage(
+  cache: &mut HashMap<GpuEngineType, f32>,
+  entries: &[(GpuEngineType, f64)],
+) {
+  cache.clear();
+  for &(etype, raw) in entries {
+    let value = (raw as f32 / 100.0).clamp(0.0, 1.0);
+    let entry = cache.entry(etype).or_insert(0.0f32);
+    if value > *entry {
+      *entry = value;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Core collection logic (runs inside `spawn_blocking`)
 // ---------------------------------------------------------------------------
 
@@ -273,36 +314,22 @@ fn collect_and_read(engine_type: GpuEngineType) -> Result<f32, Box<dyn Error + S
       item_count as usize,
     );
 
-    state.cache.clear();
-    let engtype_tag = "engtype_";
-
+    let mut valid_entries: Vec<(GpuEngineType, f64)> = Vec::new();
     for item in items {
-      // Skip items with invalid CStatus.
       let cstatus = item.FmtValue.CStatus;
       if cstatus != PDH_CSTATUS_VALID_DATA && cstatus != PDH_CSTATUS_NEW_DATA {
         continue;
       }
-
       let raw = item.FmtValue.Anonymous.doubleValue;
-
-      // Skip non-finite or out-of-range values.
-      if !raw.is_finite() || !(0.0..=100.0).contains(&raw) {
+      if !is_valid_pdh_value(raw) {
         continue;
       }
-
       let name = pwstr_to_string(item.szName.0);
-      if let Some(pos) = name.rfind(engtype_tag) {
-        let mut suffix = &name[pos + engtype_tag.len()..];
-        suffix = suffix.split('_').next().unwrap_or(suffix);
-        if let Some(etype) = GpuEngineType::from_pdh_suffix(suffix) {
-          let value = (raw as f32 / 100.0).clamp(0.0, 1.0);
-          let entry = state.cache.entry(etype).or_insert(0.0f32);
-          if value > *entry {
-            *entry = value;
-          }
-        }
+      if let Some(etype) = parse_engine_type_from_instance(&name) {
+        valid_entries.push((etype, raw));
       }
     }
+    aggregate_engine_usage(&mut state.cache, &valid_entries);
 
     state.cache_time = Instant::now();
   }
@@ -347,4 +374,327 @@ unsafe fn pwstr_to_string(ptr: *const u16) -> String {
 
 fn pdh_err(msg: String) -> Box<dyn Error + Send> {
   Box::new(std::io::Error::other(msg))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // -----------------------------------------------------------------------
+  // GpuEngineType::as_pdh_suffix
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn as_pdh_suffix_graphics3d() {
+    assert_eq!(GpuEngineType::Graphics3D.as_pdh_suffix(), "3D");
+  }
+
+  #[test]
+  fn as_pdh_suffix_copy() {
+    assert_eq!(GpuEngineType::Copy.as_pdh_suffix(), "Copy");
+  }
+
+  #[test]
+  fn as_pdh_suffix_video_decode() {
+    assert_eq!(GpuEngineType::VideoDecode.as_pdh_suffix(), "VideoDecode");
+  }
+
+  #[test]
+  fn as_pdh_suffix_video_encode() {
+    assert_eq!(GpuEngineType::VideoEncode.as_pdh_suffix(), "VideoEncode");
+  }
+
+  #[test]
+  fn as_pdh_suffix_video_processing() {
+    assert_eq!(
+      GpuEngineType::VideoProcessing.as_pdh_suffix(),
+      "VideoProcessing"
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // GpuEngineType::from_pdh_suffix
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn from_pdh_suffix_3d() {
+    assert_eq!(
+      GpuEngineType::from_pdh_suffix("3D"),
+      Some(GpuEngineType::Graphics3D)
+    );
+  }
+
+  #[test]
+  fn from_pdh_suffix_copy() {
+    assert_eq!(
+      GpuEngineType::from_pdh_suffix("Copy"),
+      Some(GpuEngineType::Copy)
+    );
+  }
+
+  #[test]
+  fn from_pdh_suffix_video_decode() {
+    assert_eq!(
+      GpuEngineType::from_pdh_suffix("VideoDecode"),
+      Some(GpuEngineType::VideoDecode)
+    );
+  }
+
+  #[test]
+  fn from_pdh_suffix_video_encode() {
+    assert_eq!(
+      GpuEngineType::from_pdh_suffix("VideoEncode"),
+      Some(GpuEngineType::VideoEncode)
+    );
+  }
+
+  #[test]
+  fn from_pdh_suffix_video_processing() {
+    assert_eq!(
+      GpuEngineType::from_pdh_suffix("VideoProcessing"),
+      Some(GpuEngineType::VideoProcessing)
+    );
+  }
+
+  #[test]
+  fn from_pdh_suffix_unknown_returns_none() {
+    assert_eq!(GpuEngineType::from_pdh_suffix("Compute"), None);
+  }
+
+  #[test]
+  fn from_pdh_suffix_empty_returns_none() {
+    assert_eq!(GpuEngineType::from_pdh_suffix(""), None);
+  }
+
+  #[test]
+  fn from_pdh_suffix_wrong_case_returns_none() {
+    assert_eq!(GpuEngineType::from_pdh_suffix("3d"), None);
+    assert_eq!(GpuEngineType::from_pdh_suffix("copy"), None);
+  }
+
+  // -----------------------------------------------------------------------
+  // Roundtrip: as_pdh_suffix → from_pdh_suffix
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn roundtrip_all_variants() {
+    let variants = [
+      GpuEngineType::Graphics3D,
+      GpuEngineType::Copy,
+      GpuEngineType::VideoDecode,
+      GpuEngineType::VideoEncode,
+      GpuEngineType::VideoProcessing,
+    ];
+    for variant in variants {
+      assert_eq!(
+        GpuEngineType::from_pdh_suffix(variant.as_pdh_suffix()),
+        Some(variant),
+        "roundtrip failed for {variant:?}"
+      );
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // is_valid_pdh_value
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn valid_pdh_value_zero() {
+    assert!(is_valid_pdh_value(0.0));
+  }
+
+  #[test]
+  fn valid_pdh_value_mid() {
+    assert!(is_valid_pdh_value(50.0));
+  }
+
+  #[test]
+  fn valid_pdh_value_hundred() {
+    assert!(is_valid_pdh_value(100.0));
+  }
+
+  #[test]
+  fn invalid_pdh_value_below_range() {
+    assert!(!is_valid_pdh_value(-0.001));
+  }
+
+  #[test]
+  fn invalid_pdh_value_above_range() {
+    assert!(!is_valid_pdh_value(100.001));
+  }
+
+  #[test]
+  fn invalid_pdh_value_nan() {
+    assert!(!is_valid_pdh_value(f64::NAN));
+  }
+
+  #[test]
+  fn invalid_pdh_value_infinity() {
+    assert!(!is_valid_pdh_value(f64::INFINITY));
+    assert!(!is_valid_pdh_value(f64::NEG_INFINITY));
+  }
+
+  // -----------------------------------------------------------------------
+  // parse_engine_type_from_instance
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn parse_instance_3d() {
+    let name = "pid_1234_luid_0x00_0x0000_phys_0_eng_0_engtype_3D";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::Graphics3D)
+    );
+  }
+
+  #[test]
+  fn parse_instance_copy() {
+    let name = "pid_5678_luid_0x00_0x0001_phys_0_eng_1_engtype_Copy";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::Copy)
+    );
+  }
+
+  #[test]
+  fn parse_instance_video_decode() {
+    let name = "pid_9999_luid_0x00_0x0002_phys_0_eng_2_engtype_VideoDecode";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::VideoDecode)
+    );
+  }
+
+  #[test]
+  fn parse_instance_video_encode() {
+    let name = "pid_1111_luid_0x00_0x0003_phys_0_eng_3_engtype_VideoEncode";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::VideoEncode)
+    );
+  }
+
+  #[test]
+  fn parse_instance_video_processing() {
+    let name = "pid_2222_luid_0x00_0x0004_phys_0_eng_4_engtype_VideoProcessing";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::VideoProcessing)
+    );
+  }
+
+  #[test]
+  fn parse_instance_no_engtype_tag() {
+    assert_eq!(parse_engine_type_from_instance("pid_1234_luid_0x00"), None);
+  }
+
+  #[test]
+  fn parse_instance_empty_string() {
+    assert_eq!(parse_engine_type_from_instance(""), None);
+  }
+
+  #[test]
+  fn parse_instance_unknown_engine_type() {
+    let name = "pid_1234_luid_0x00_phys_0_eng_0_engtype_Compute";
+    assert_eq!(parse_engine_type_from_instance(name), None);
+  }
+
+  #[test]
+  fn parse_instance_with_trailing_suffix() {
+    // engtype_ followed by additional underscore-separated parts
+    let name = "pid_1234_luid_0x00_phys_0_eng_0_engtype_3D_extra";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::Graphics3D)
+    );
+  }
+
+  #[test]
+  fn parse_instance_multiple_engtype_uses_last() {
+    // Two engtype_ tags — rfind should pick the last one
+    let name = "engtype_Copy_something_engtype_VideoDecode";
+    assert_eq!(
+      parse_engine_type_from_instance(name),
+      Some(GpuEngineType::VideoDecode)
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // aggregate_engine_usage
+  // -----------------------------------------------------------------------
+
+  #[test]
+  fn aggregate_empty_input() {
+    let mut cache = HashMap::new();
+    aggregate_engine_usage(&mut cache, &[]);
+    assert!(cache.is_empty());
+  }
+
+  #[test]
+  fn aggregate_single_entry() {
+    let mut cache = HashMap::new();
+    let entries = [(GpuEngineType::Graphics3D, 50.0)];
+    aggregate_engine_usage(&mut cache, &entries);
+    assert_eq!(cache.get(&GpuEngineType::Graphics3D), Some(&0.5));
+  }
+
+  #[test]
+  fn aggregate_same_engine_keeps_max() {
+    let mut cache = HashMap::new();
+    let entries = [
+      (GpuEngineType::Copy, 20.0),
+      (GpuEngineType::Copy, 80.0),
+      (GpuEngineType::Copy, 50.0),
+    ];
+    aggregate_engine_usage(&mut cache, &entries);
+    assert_eq!(cache.get(&GpuEngineType::Copy), Some(&0.8));
+  }
+
+  #[test]
+  fn aggregate_multiple_engine_types() {
+    let mut cache = HashMap::new();
+    let entries = [
+      (GpuEngineType::Graphics3D, 60.0),
+      (GpuEngineType::VideoDecode, 30.0),
+    ];
+    aggregate_engine_usage(&mut cache, &entries);
+    assert_eq!(cache.len(), 2);
+    assert_eq!(cache.get(&GpuEngineType::Graphics3D), Some(&0.6));
+    assert_eq!(cache.get(&GpuEngineType::VideoDecode), Some(&0.3));
+  }
+
+  #[test]
+  fn aggregate_normalizes_hundred_to_one() {
+    let mut cache = HashMap::new();
+    let entries = [(GpuEngineType::VideoEncode, 100.0)];
+    aggregate_engine_usage(&mut cache, &entries);
+    assert_eq!(cache.get(&GpuEngineType::VideoEncode), Some(&1.0));
+  }
+
+  #[test]
+  fn aggregate_normalizes_zero_to_zero() {
+    let mut cache = HashMap::new();
+    let entries = [(GpuEngineType::VideoProcessing, 0.0)];
+    aggregate_engine_usage(&mut cache, &entries);
+    assert_eq!(cache.get(&GpuEngineType::VideoProcessing), Some(&0.0));
+  }
+
+  #[test]
+  fn aggregate_clears_existing_cache() {
+    let mut cache = HashMap::new();
+    cache.insert(GpuEngineType::Graphics3D, 0.99);
+    cache.insert(GpuEngineType::Copy, 0.5);
+
+    let entries = [(GpuEngineType::VideoDecode, 40.0)];
+    aggregate_engine_usage(&mut cache, &entries);
+
+    assert_eq!(cache.len(), 1);
+    assert!(!cache.contains_key(&GpuEngineType::Graphics3D));
+    assert!(!cache.contains_key(&GpuEngineType::Copy));
+    assert_eq!(cache.get(&GpuEngineType::VideoDecode), Some(&0.4));
+  }
 }

--- a/src-tauri/src/infrastructure/providers/windows/wmi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/wmi_provider.rs
@@ -3,10 +3,8 @@ use crate::utils;
 use crate::utils::formatter;
 use crate::{log_debug, log_error, log_internal};
 
-use regex::Regex;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
-use std::error::Error;
 use std::net::IpAddr;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
@@ -65,52 +63,6 @@ pub async fn query_memory_info() -> Result<MemoryInfo, String> {
   };
 
   Ok(memory_info)
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "PascalCase")]
-struct GpuEngineLoadInfo {
-  name: String,
-  utilization_percentage: Option<u16>,
-}
-
-///
-/// Get GPU engine usage for specified engine type (using WMI)
-///
-pub async fn query_gpu_usage_by_device_and_engine(
-  engine_type: &str,
-) -> Result<f32, Box<dyn Error>> {
-  // Get GPU engine information
-  let results: Vec<GpuEngineLoadInfo>  = wmi_query_in_thread(
-      "SELECT Name, UtilizationPercentage FROM Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine".to_string(),
-  )?;
-
-  log_debug!(
-    &format!("GPU engine usage data: {results:?}"),
-    "get_gpu_usage_by_device_and_engine",
-    None::<&str>
-  );
-
-  // Extract `engtype_xxx` part using regex
-  let re = Regex::new(r"engtype_(\w+)").unwrap();
-
-  results
-    .iter()
-    .find_map(|engine| {
-      re.captures(&engine.name)
-        .and_then(|captures| captures.get(1))
-        .filter(|engine_name| engine_name.as_str() == engine_type)
-        .and_then(|_| {
-          engine
-            .utilization_percentage
-            .map(|load| load as f32 / 100.0)
-        })
-    })
-    .ok_or_else(|| {
-      let message = format!("No usage data available for engine type: {engine_type}");
-      Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, message))
-        as Box<dyn Error>
-    })
 }
 
 #[derive(Deserialize, Debug)]

--- a/src-tauri/src/platform/windows/gpu.rs
+++ b/src-tauri/src/platform/windows/gpu.rs
@@ -20,19 +20,20 @@ pub async fn get_gpu_usage() -> Result<(f32, String), String> {
     log_warn!(
       "adl_fallback",
       "get_gpu_usage",
-      Some("ADL usage query failed, falling back to WMI")
+      Some("ADL usage query failed, falling back to PDH")
     );
   }
 
-  // 3. WMI (generic fallback)
-  match infrastructure::providers::wmi_provider::query_gpu_usage_by_device_and_engine(
-    "3D",
+  // 3. PDH (generic fallback using Windows Performance Counters)
+  use infrastructure::providers::pdh_provider::GpuEngineType;
+  match infrastructure::providers::pdh_provider::query_gpu_usage_by_device_and_engine(
+    GpuEngineType::Graphics3D,
   )
   .await
   {
-    Ok(usage) => Ok(((usage * 100.0).round(), "WMI".to_string())),
+    Ok(usage) => Ok(((usage * 100.0).round(), "PDH".to_string())),
     Err(e) => Err(format!(
-      "Failed to get GPU usage from NVIDIA API, AMD ADL, and WMI: {e:?}"
+      "Failed to get GPU usage from NVIDIA API, AMD ADL, and PDH: {e:?}"
     )),
   }
 }

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -87,7 +87,7 @@ async getMemoryUsage() : Promise<number> {
  * ## Get GPU usage (%)
  * 
  * Returns the GPU usage percentage together with the data-source
- * identifier (e.g. "NVAPI", "ADL", "WMI", "DRM (AMD)", "IOKit").
+ * identifier (e.g. "NVAPI", "ADL", "PDH", "DRM (AMD)", "IOKit").
  * 
  */
 async getGpuUsage() : Promise<Result<GpuUsageResult, string>> {


### PR DESCRIPTION
This pull request introduces a new Windows GPU usage provider based on PDH (Performance Data Helper), replacing the previous WMI-based fallback for GPU engine utilization. The main motivation is to reduce overhead and remove the dependency on COM, resulting in more efficient and reliable GPU usage queries. The WMI-based implementation is removed, and the fallback logic and documentation are updated to reference PDH instead of WMI.

**Windows GPU usage provider modernization:**

- Added a new `pdh_provider` module that uses PDH performance counters to query GPU engine utilization, caching results for efficiency and eliminating the need for COM or WMI. This includes robust error handling and a persistent query state for performance. [[1]](diffhunk://#diff-0ff698fea6d8df9daca0d62054a57e5ce948076ae482adfdf698f830a90c8afcR1-R350) [[2]](diffhunk://#diff-40ba83013f912c03ecea174b1307d703d97b643d445a561f57f88e714fe9b173R4) [[3]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39R99)
- Removed the old WMI-based GPU engine usage code from `wmi_provider.rs`, including associated data structures and logic. [[1]](diffhunk://#diff-2de113ba2654ac2dfe944d64e1fb42d58e732a1d57270b9c1db1157d8fbb484dL70-L115) [[2]](diffhunk://#diff-2de113ba2654ac2dfe944d64e1fb42d58e732a1d57270b9c1db1157d8fbb484dL6-L9)

**Platform and API integration:**

- Updated the Windows GPU usage fallback logic in `platform/windows/gpu.rs` to use the new PDH provider instead of WMI, and updated log/error messages accordingly.
- Updated documentation and comments in both Rust and TypeScript bindings to reference "PDH" as the fallback data source instead of "WMI". [[1]](diffhunk://#diff-6bbfaf16bb0b1a931ff04a37115db25153f08990876f766d49da9c2416d6f7d4L90-R90) [[2]](diffhunk://#diff-6af4ad61680560261d27d365c019bbed7b7c78fa8c0ff8349a02341554b164e6L86-R86)