### PR TITLE
Change auto-merge strategy to squash for Bot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Enable auto-merge for Bot PRs
         if: github.event.pull_request.user.login == 'hardwarevisualizerappmanager[bot]' || (github.event.pull_request.user.login == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-patch')
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow for auto-merging pull requests. The merge strategy for bot PRs has been switched from a regular merge to a squash merge. This means that when a PR is auto-merged by the bot, all commits will be squashed into a single commit on the target branch.