### PR TITLE
Reapply missing branch coverage for useTauriDialog and useMenu

### DIFF
--- a/src/features/menu/hooks/useMenu.test.ts
+++ b/src/features/menu/hooks/useMenu.test.ts
@@ -10,9 +10,9 @@ vi.mock("@/hooks/useTauriStore", () => ({
   useTauriStore: vi
     .fn()
     .mockImplementation((key: string, defaultValue: unknown) => {
-      if (key === "sideMenuOpen") return [defaultValue, mockSetMenuOpen];
-      if (key === "display") return [defaultValue, mockSetDisplayTarget];
-      return [defaultValue, vi.fn()];
+      if (key === "sideMenuOpen") return [defaultValue, mockSetMenuOpen, false];
+      if (key === "display") return [defaultValue, mockSetDisplayTarget, false];
+      return [defaultValue, vi.fn(), false];
     }),
 }));
 
@@ -21,13 +21,15 @@ import { useMenu } from "@/features/menu/hooks/useMenu";
 describe("useMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useTauriStore).mockImplementation(
-      (key: string, defaultValue: unknown) => {
-        if (key === "sideMenuOpen") return [defaultValue, mockSetMenuOpen];
-        if (key === "display") return [defaultValue, mockSetDisplayTarget];
-        return [defaultValue, vi.fn()];
-      },
-    );
+    vi
+      .mocked(useTauriStore)
+      .mockImplementation((key: string, defaultValue: unknown) => {
+        if (key === "sideMenuOpen")
+          return [defaultValue, mockSetMenuOpen, false];
+        if (key === "display")
+          return [defaultValue, mockSetDisplayTarget, false];
+        return [defaultValue, vi.fn(), false];
+      }) as unknown as typeof useTauriStore;
   });
 
   it("returns initial state with isOpen=false and displayTarget=dashboard", () => {
@@ -61,10 +63,10 @@ describe("useMenu", () => {
 
   it("useEffect: does not call setDisplayTargetAtom when displayTarget is null", () => {
     vi.mocked(useTauriStore).mockImplementation((key: string) => {
-      if (key === "sideMenuOpen") return [false, mockSetMenuOpen];
-      if (key === "display") return [null, mockSetDisplayTarget];
-      return [null, vi.fn()];
-    });
+      if (key === "sideMenuOpen") return [false, mockSetMenuOpen, false];
+      if (key === "display") return [null, mockSetDisplayTarget, true];
+      return [null, vi.fn(), true];
+    }) as unknown as typeof useTauriStore;
     const { result } = renderHook(() => useMenu(), { wrapper: Provider });
 
     expect(result.current.displayTarget).toBeNull();

--- a/src/features/menu/hooks/useMenu.test.ts
+++ b/src/features/menu/hooks/useMenu.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { Provider } from "jotai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTauriStore } from "@/hooks/useTauriStore";
 
 const mockSetMenuOpen = vi.fn();
 const mockSetDisplayTarget = vi.fn();
@@ -20,6 +21,13 @@ import { useMenu } from "@/features/menu/hooks/useMenu";
 describe("useMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useTauriStore).mockImplementation(
+      (key: string, defaultValue: unknown) => {
+        if (key === "sideMenuOpen") return [defaultValue, mockSetMenuOpen];
+        if (key === "display") return [defaultValue, mockSetDisplayTarget];
+        return [defaultValue, vi.fn()];
+      },
+    );
   });
 
   it("returns initial state with isOpen=false and displayTarget=dashboard", () => {
@@ -49,6 +57,17 @@ describe("useMenu", () => {
     });
 
     expect(mockSetDisplayTarget).toHaveBeenCalledWith("settings");
+  });
+
+  it("useEffect: does not call setDisplayTargetAtom when displayTarget is null", () => {
+    vi.mocked(useTauriStore).mockImplementation((key: string) => {
+      if (key === "sideMenuOpen") return [false, mockSetMenuOpen];
+      if (key === "display") return [null, mockSetDisplayTarget];
+      return [null, vi.fn()];
+    });
+    const { result } = renderHook(() => useMenu(), { wrapper: Provider });
+
+    expect(result.current.displayTarget).toBeNull();
   });
 
   it("handleMenuClick: can switch between different display targets", () => {

--- a/src/hooks/useTauriDialog.test.ts
+++ b/src/hooks/useTauriDialog.test.ts
@@ -81,6 +81,23 @@ describe("useTauriDialog", () => {
     expect(res).toBe(true);
   });
 
+  it("confirm: When title is not specified, title becomes undefined", async () => {
+    const { result } = renderHook(() => useTauriDialog());
+    (showConfirm as Mock).mockResolvedValue(false);
+
+    const dialog = result.current;
+    const res = await dialog.confirm({
+      message: "Continue?",
+      kind: "info",
+    });
+
+    expect(showConfirm).toHaveBeenCalledWith("Continue?", {
+      title: undefined,
+      kind: "info",
+    });
+    expect(res).toBe(false);
+  });
+
   it("message: When title is specified, calls showMessage with translated title", async () => {
     const { result } = renderHook(() => useTauriDialog());
     (showMessage as Mock).mockResolvedValue(undefined);
@@ -94,6 +111,22 @@ describe("useTauriDialog", () => {
 
     expect(showMessage).toHaveBeenCalledWith("Operation completed", {
       title: "error.title.success",
+      kind: "info",
+    });
+  });
+
+  it("message: When title is not specified, title becomes undefined", async () => {
+    const { result } = renderHook(() => useTauriDialog());
+    (showMessage as Mock).mockResolvedValue(undefined);
+
+    const dialog = result.current;
+    await dialog.message({
+      message: "Hello",
+      kind: "info",
+    });
+
+    expect(showMessage).toHaveBeenCalledWith("Hello", {
+      title: undefined,
       kind: "info",
     });
   });


### PR DESCRIPTION
Reapply the changes to add missing branch coverage for the `useTauriDialog` and `useMenu` hooks. Fix a build error encountered during the process.