### PR TITLE
Fix: resolve AMD GPU name mismatch between dashboard and monitoring via PCI BDF

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,37 @@
+# Rust coding instructions (HardwareVisualizer)
+
+These instructions apply to all Rust code under `src-tauri/`.
+
+## Macro imports — `log_internal` is required
+
+The logging macros (`log_debug!`, `log_info!`, `log_warn!`, `log_error!`) are defined in `src-tauri/src/utils/logger.rs` and internally expand to `log_internal!`.
+
+Because `log_internal!` is a `#[macro_export]` macro, any file that uses one of the convenience macros **must** import it:
+
+```rust
+use crate::{log_debug, log_internal};
+```
+
+`log_internal` will appear unused to the compiler and linters (including `clippy`), but removing it causes a compilation error. **Do not remove `log_internal` imports.**
+
+## Backend architecture
+
+Follow the one-way dependency chain: **Commands → Services → Platform (Factory) → Infrastructure / OS APIs**.
+
+- `src-tauri/src/commands/` — Tauri command handlers (UI boundary)
+- `src-tauri/src/services/` — Business logic
+- `src-tauri/src/platform/` — OS-specific trait implementations
+- `src-tauri/src/infrastructure/` — Providers (GPU APIs, DB, WMI, etc.)
+
+See `docs/ARCHITECTURE/BACKEND_ARCHITECTURE.md` for details.
+
+## Platform-conditional code
+
+- Use `#[cfg(target_os = "windows")]`, `#[cfg(target_os = "linux")]`, `#[cfg(target_os = "macos")]` for OS-specific code.
+- Pure helper functions used only by platform-gated callers should use `#[cfg(any(target_os = "...", test))]` to keep them available for unit tests across all platforms.
+
+## Testing
+
+- Run Rust tests: `cargo tauri-test` (CI parity) or `cargo test --lib` (quick local check).
+- Place tests in inline `#[cfg(test)] mod tests { ... }` at the bottom of each file.
+- Prefer testing pure functions. Extract platform-dependent logic into pure helpers where practical.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code Instructions
+
+Read and follow these project-specific instruction files:
+
+- `.github/copilot-instructions.md` — Project overview, architecture, dev workflows, conventions
+- `.github/instructions/rust.instructions.md` — Rust coding rules (macro imports, platform-conditional code, testing)
+- `.github/instructions/documentation.instructions.md` — Documentation update rules

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,7 +91,7 @@ custom-protocol = ["tauri/custom-protocol"]
 [target.'cfg(windows)'.dependencies]
 wmi = "0.18.3"
 dxgi = "0.1.7"
-winapi = { version = "0.3", features = ["dxgi"] }
+winapi = { version = "0.3", features = ["dxgi", "setupapi", "devguid"] }
 windows = { version = "0.62.2", features = [
     "Data_Xml_Dom",
     "Win32_Foundation",

--- a/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
@@ -933,8 +933,8 @@ pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<AdlAdapterMetric>, St
 ///
 /// Returns [`AdlAdapterMetric`] (name + BDF + temperature_celsius) for each
 /// active AMD adapter, using the best available temperature source (Core/Edge sensor).
-pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<AdlAdapterMetric>, String>
-{
+pub async fn get_amd_gpu_temperatures_per_adapter()
+-> Result<Vec<AdlAdapterMetric>, String> {
   spawn_blocking(|| {
     let adl = get_adl().ok_or("AMD ADL library not available")?;
     let adapters = enumerate_adapters(adl);

--- a/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/adl_provider.rs
@@ -378,6 +378,9 @@ fn get_adl() -> Option<&'static AdlLibrary> {
 struct AdapterState {
   adapter_index: i32,
   adapter_name: String,
+  bus_number: i32,
+  device_number: i32,
+  function_number: i32,
   overdrive_level: i32, // 5, 6, 7, 8, or -1
   overdrive_supported: bool,
 }
@@ -445,6 +448,9 @@ fn enumerate_adapters(adl: &AdlLibrary) -> Vec<AdapterState> {
       result.push(AdapterState {
         adapter_index: info.adapter_index,
         adapter_name,
+        bus_number: info.bus_number,
+        device_number: info.device_number,
+        function_number: info.function_number,
         overdrive_level: od_level,
         overdrive_supported: od_supported,
       });
@@ -858,10 +864,19 @@ pub fn is_available() -> bool {
   get_adl().is_some()
 }
 
+/// Per-adapter metric with PCI BDF for cross-API GPU identification.
+pub struct AdlAdapterMetric {
+  pub adapter_name: String,
+  pub bus: i32,
+  pub device: i32,
+  pub function: i32,
+  pub value: f32,
+}
+
 /// Get per-adapter GPU core usage for monitoring/archiving.
 ///
-/// Returns `(adapter_name, usage%)` for each active AMD adapter.
-pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<(String, f32)>, String> {
+/// Returns [`AdlAdapterMetric`] (name + BDF + usage%) for each active AMD adapter.
+pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<AdlAdapterMetric>, String> {
   spawn_blocking(|| {
     let adl = get_adl().ok_or("AMD ADL library not available")?;
     let adapters = enumerate_adapters(adl);
@@ -870,7 +885,7 @@ pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<(String, f32)>, Strin
       return Err("No active AMD GPU adapters found".to_string());
     }
 
-    let mut results: Vec<(String, f32)> = Vec::new();
+    let mut results: Vec<AdlAdapterMetric> = Vec::new();
 
     for adapter in &adapters {
       let idx = adapter.adapter_index;
@@ -887,7 +902,13 @@ pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<(String, f32)>, Strin
       }
 
       if let Some(u) = usage {
-        results.push((adapter.adapter_name.clone(), u));
+        results.push(AdlAdapterMetric {
+          adapter_name: adapter.adapter_name.clone(),
+          bus: adapter.bus_number,
+          device: adapter.device_number,
+          function: adapter.function_number,
+          value: u,
+        });
       }
     }
 
@@ -910,9 +931,9 @@ pub async fn get_amd_gpu_usage_per_adapter() -> Result<Vec<(String, f32)>, Strin
 
 /// Get per-adapter GPU core temperature for monitoring/archiving.
 ///
-/// Returns `(adapter_name, temperature_celsius)` for each active AMD adapter,
-/// using the best available temperature source (Core/Edge sensor).
-pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<(String, f32)>, String>
+/// Returns [`AdlAdapterMetric`] (name + BDF + temperature_celsius) for each
+/// active AMD adapter, using the best available temperature source (Core/Edge sensor).
+pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<AdlAdapterMetric>, String>
 {
   spawn_blocking(|| {
     let adl = get_adl().ok_or("AMD ADL library not available")?;
@@ -922,7 +943,7 @@ pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<(String, f32)>
       return Err("No active AMD GPU adapters found".to_string());
     }
 
-    let mut results: Vec<(String, f32)> = Vec::new();
+    let mut results: Vec<AdlAdapterMetric> = Vec::new();
 
     for adapter in &adapters {
       let idx = adapter.adapter_index;
@@ -950,7 +971,13 @@ pub async fn get_amd_gpu_temperatures_per_adapter() -> Result<Vec<(String, f32)>
       }
 
       if let Some(t) = temp {
-        results.push((adapter.adapter_name.clone(), t as f32));
+        results.push(AdlAdapterMetric {
+          adapter_name: adapter.adapter_name.clone(),
+          bus: adapter.bus_number,
+          device: adapter.device_number,
+          function: adapter.function_number,
+          value: t as f32,
+        });
       }
     }
 

--- a/src-tauri/src/infrastructure/providers/windows/mod.rs
+++ b/src-tauri/src/infrastructure/providers/windows/mod.rs
@@ -2,4 +2,5 @@ pub mod adl_provider;
 pub mod directx;
 pub mod nvapi_provider;
 pub mod pdh_provider;
+pub mod setupdi_provider;
 pub mod wmi_provider;

--- a/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -25,6 +25,8 @@ pub struct DisplayAdapterBdf {
 pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
   use winapi::shared::devguid::GUID_DEVCLASS_DISPLAY;
   use winapi::shared::minwindef::{BYTE, DWORD, FALSE};
+  use winapi::shared::winerror::ERROR_NO_MORE_ITEMS;
+  use winapi::um::errhandlingapi::GetLastError;
   use winapi::um::setupapi::{
     DIGCF_PRESENT, SP_DEVINFO_DATA, SPDRP_ADDRESS, SPDRP_BUSNUMBER, SPDRP_DEVICEDESC,
     SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
@@ -56,32 +58,32 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
       dev_info_data.cbSize = std::mem::size_of::<SP_DEVINFO_DATA>() as DWORD;
 
       if SetupDiEnumDeviceInfo(dev_info, index, &mut dev_info_data) == FALSE {
+        let err = GetLastError();
+        if err != ERROR_NO_MORE_ITEMS {
+          log_debug!(
+            &format!("SetupDiEnumDeviceInfo failed at index {index}: error {err}"),
+            "setupdi_provider",
+            None::<&str>
+          );
+        }
         break;
       }
       index += 1;
 
       // --- Device description (= DXGI adapter name) ---
-      let mut desc_buf = [0u16; 256];
-      let mut reg_type: DWORD = 0;
-      let mut required_size: DWORD = 0;
-      if SetupDiGetDeviceRegistryPropertyW(
+      let description = match read_registry_string(
         dev_info,
         &mut dev_info_data,
         SPDRP_DEVICEDESC,
-        &mut reg_type,
-        desc_buf.as_mut_ptr() as *mut BYTE,
-        (desc_buf.len() * std::mem::size_of::<u16>()) as DWORD,
-        &mut required_size,
-      ) == FALSE
-      {
-        continue;
-      }
-      let description = String::from_utf16_lossy(&desc_buf)
-        .trim_end_matches('\0')
-        .to_string();
+      ) {
+        Some(s) => s,
+        None => continue,
+      };
 
       // --- PCI bus number ---
       let mut bus: DWORD = 0;
+      let mut reg_type: DWORD = 0;
+      let mut required_size: DWORD = 0;
       if SetupDiGetDeviceRegistryPropertyW(
         dev_info,
         &mut dev_info_data,
@@ -131,4 +133,64 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
 
     result
   }
+}
+
+/// Read a REG_SZ registry property from a SetupDi device, dynamically
+/// allocating a buffer based on `required_size` when the initial attempt
+/// with a stack buffer fails due to insufficient space.
+unsafe fn read_registry_string(
+  dev_info: winapi::um::setupapi::HDEVINFO,
+  dev_info_data: &mut winapi::um::setupapi::SP_DEVINFO_DATA,
+  property: winapi::shared::minwindef::DWORD,
+) -> Option<String> {
+  use winapi::shared::minwindef::{BYTE, DWORD, FALSE};
+  use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
+  use winapi::um::errhandlingapi::GetLastError;
+  use winapi::um::setupapi::SetupDiGetDeviceRegistryPropertyW;
+
+  let mut reg_type: DWORD = 0;
+  let mut required_size: DWORD = 0;
+
+  // First attempt: stack buffer (covers almost all device descriptions).
+  let mut buf = [0u16; 256];
+  if SetupDiGetDeviceRegistryPropertyW(
+    dev_info,
+    dev_info_data,
+    property,
+    &mut reg_type,
+    buf.as_mut_ptr() as *mut BYTE,
+    (buf.len() * std::mem::size_of::<u16>()) as DWORD,
+    &mut required_size,
+  ) != FALSE
+  {
+    let s = String::from_utf16_lossy(&buf)
+      .trim_end_matches('\0')
+      .to_string();
+    return Some(s);
+  }
+
+  // Retry with a dynamically sized buffer if the stack buffer was too small.
+  if GetLastError() != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
+    return None;
+  }
+
+  let elements = (required_size as usize + 1) / std::mem::size_of::<u16>();
+  let mut dyn_buf = vec![0u16; elements];
+  if SetupDiGetDeviceRegistryPropertyW(
+    dev_info,
+    dev_info_data,
+    property,
+    &mut reg_type,
+    dyn_buf.as_mut_ptr() as *mut BYTE,
+    required_size,
+    std::ptr::null_mut(),
+  ) == FALSE
+  {
+    return None;
+  }
+
+  let s = String::from_utf16_lossy(&dyn_buf)
+    .trim_end_matches('\0')
+    .to_string();
+  Some(s)
 }

--- a/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -1,0 +1,130 @@
+///
+/// Windows SetupDi provider — enumerates display adapters with PCI bus location.
+///
+/// Uses `SetupDiGetClassDevs` / `SetupDiEnumDeviceInfo` /
+/// `SetupDiGetDeviceRegistryProperty` to retrieve each display adapter's
+/// human-readable description together with its PCI Bus/Device/Function
+/// address.  The description returned by `SPDRP_DEVICEDESC` matches the
+/// string reported by DXGI (`DXGI_ADAPTER_DESC.Description`), so the
+/// result can be used to correlate DXGI names with ADL names via BDF.
+///
+use crate::{log_debug, log_internal};
+
+/// PCI Bus/Device/Function together with the Windows device description
+/// (which matches the DXGI adapter name).
+#[derive(Debug, Clone)]
+pub struct DisplayAdapterBdf {
+  pub description: String,
+  pub bus: i32,
+  pub device: i32,
+  pub function: i32,
+}
+
+/// Enumerate all *present* display adapters and return their device
+/// description and PCI BDF address.
+pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
+  use winapi::shared::devguid::GUID_DEVCLASS_DISPLAY;
+  use winapi::shared::minwindef::{BYTE, DWORD, FALSE};
+  use winapi::um::setupapi::{
+    SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
+    SetupDiGetDeviceRegistryPropertyW, DIGCF_PRESENT, SPDRP_ADDRESS, SPDRP_BUSNUMBER,
+    SPDRP_DEVICEDESC, SP_DEVINFO_DATA,
+  };
+
+  unsafe {
+    let dev_info = SetupDiGetClassDevsW(
+      &GUID_DEVCLASS_DISPLAY,
+      std::ptr::null(),
+      std::ptr::null_mut(),
+      DIGCF_PRESENT,
+    );
+
+    if dev_info.is_null() || dev_info == winapi::um::handleapi::INVALID_HANDLE_VALUE {
+      log_debug!("SetupDiGetClassDevsW failed", "setupdi_provider", None::<&str>);
+      return Vec::new();
+    }
+
+    let mut result = Vec::new();
+    let mut index: DWORD = 0;
+
+    loop {
+      let mut dev_info_data: SP_DEVINFO_DATA = std::mem::zeroed();
+      dev_info_data.cbSize = std::mem::size_of::<SP_DEVINFO_DATA>() as DWORD;
+
+      if SetupDiEnumDeviceInfo(dev_info, index, &mut dev_info_data) == FALSE {
+        break;
+      }
+      index += 1;
+
+      // --- Device description (= DXGI adapter name) ---
+      let mut desc_buf = [0u16; 256];
+      let mut reg_type: DWORD = 0;
+      let mut required_size: DWORD = 0;
+      if SetupDiGetDeviceRegistryPropertyW(
+        dev_info,
+        &mut dev_info_data,
+        SPDRP_DEVICEDESC,
+        &mut reg_type,
+        desc_buf.as_mut_ptr() as *mut BYTE,
+        (desc_buf.len() * std::mem::size_of::<u16>()) as DWORD,
+        &mut required_size,
+      ) == FALSE
+      {
+        continue;
+      }
+      let description = String::from_utf16_lossy(&desc_buf)
+        .trim_end_matches('\0')
+        .to_string();
+
+      // --- PCI bus number ---
+      let mut bus: DWORD = 0;
+      if SetupDiGetDeviceRegistryPropertyW(
+        dev_info,
+        &mut dev_info_data,
+        SPDRP_BUSNUMBER,
+        &mut reg_type,
+        &mut bus as *mut DWORD as *mut BYTE,
+        std::mem::size_of::<DWORD>() as DWORD,
+        &mut required_size,
+      ) == FALSE
+      {
+        continue;
+      }
+
+      // --- PCI address (device << 16 | function) ---
+      let mut address: DWORD = 0;
+      if SetupDiGetDeviceRegistryPropertyW(
+        dev_info,
+        &mut dev_info_data,
+        SPDRP_ADDRESS,
+        &mut reg_type,
+        &mut address as *mut DWORD as *mut BYTE,
+        std::mem::size_of::<DWORD>() as DWORD,
+        &mut required_size,
+      ) == FALSE
+      {
+        continue;
+      }
+
+      let device_num = (address >> 16) as i32;
+      let function_num = (address & 0xFFFF) as i32;
+
+      result.push(DisplayAdapterBdf {
+        description,
+        bus: bus as i32,
+        device: device_num,
+        function: function_num,
+      });
+    }
+
+    SetupDiDestroyDeviceInfoList(dev_info);
+
+    log_debug!(
+      &format!("enumerated {} display adapters", result.len()),
+      "setupdi_provider",
+      None::<&str>
+    );
+
+    result
+  }
+}

--- a/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -150,15 +150,18 @@ unsafe fn read_registry_string(
 
   // First attempt: stack buffer (covers almost all device descriptions).
   let mut buf = [0u16; 256];
-  if SetupDiGetDeviceRegistryPropertyW(
-    dev_info,
-    dev_info_data,
-    property,
-    &mut reg_type,
-    buf.as_mut_ptr() as *mut BYTE,
-    (buf.len() * std::mem::size_of::<u16>()) as DWORD,
-    &mut required_size,
-  ) != FALSE
+  // SAFETY: All pointers are valid and lifetimes are bounded by this function.
+  if unsafe {
+    SetupDiGetDeviceRegistryPropertyW(
+      dev_info,
+      dev_info_data,
+      property,
+      &mut reg_type,
+      buf.as_mut_ptr() as *mut BYTE,
+      (buf.len() * std::mem::size_of::<u16>()) as DWORD,
+      &mut required_size,
+    )
+  } != FALSE
   {
     let s = String::from_utf16_lossy(&buf)
       .trim_end_matches('\0')
@@ -167,21 +170,25 @@ unsafe fn read_registry_string(
   }
 
   // Retry with a dynamically sized buffer if the stack buffer was too small.
-  if GetLastError() != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
+  // SAFETY: No preconditions beyond being called after a Win32 API call.
+  if unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
     return None;
   }
 
   let elements = (required_size as usize + 1) / std::mem::size_of::<u16>();
   let mut dyn_buf = vec![0u16; elements];
-  if SetupDiGetDeviceRegistryPropertyW(
-    dev_info,
-    dev_info_data,
-    property,
-    &mut reg_type,
-    dyn_buf.as_mut_ptr() as *mut BYTE,
-    required_size,
-    std::ptr::null_mut(),
-  ) == FALSE
+  // SAFETY: `dyn_buf` is large enough for `required_size` bytes.
+  if unsafe {
+    SetupDiGetDeviceRegistryPropertyW(
+      dev_info,
+      dev_info_data,
+      property,
+      &mut reg_type,
+      dyn_buf.as_mut_ptr() as *mut BYTE,
+      required_size,
+      std::ptr::null_mut(),
+    )
+  } == FALSE
   {
     return None;
   }

--- a/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -71,14 +71,11 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
       index += 1;
 
       // --- Device description (= DXGI adapter name) ---
-      let description = match read_registry_string(
-        dev_info,
-        &mut dev_info_data,
-        SPDRP_DEVICEDESC,
-      ) {
-        Some(s) => s,
-        None => continue,
-      };
+      let description =
+        match read_registry_string(dev_info, &mut dev_info_data, SPDRP_DEVICEDESC) {
+          Some(s) => s,
+          None => continue,
+        };
 
       // --- PCI bus number ---
       let mut bus: DWORD = 0;

--- a/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/src-tauri/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -26,9 +26,9 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
   use winapi::shared::devguid::GUID_DEVCLASS_DISPLAY;
   use winapi::shared::minwindef::{BYTE, DWORD, FALSE};
   use winapi::um::setupapi::{
+    DIGCF_PRESENT, SP_DEVINFO_DATA, SPDRP_ADDRESS, SPDRP_BUSNUMBER, SPDRP_DEVICEDESC,
     SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo, SetupDiGetClassDevsW,
-    SetupDiGetDeviceRegistryPropertyW, DIGCF_PRESENT, SPDRP_ADDRESS, SPDRP_BUSNUMBER,
-    SPDRP_DEVICEDESC, SP_DEVINFO_DATA,
+    SetupDiGetDeviceRegistryPropertyW,
   };
 
   unsafe {
@@ -40,7 +40,11 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
     );
 
     if dev_info.is_null() || dev_info == winapi::um::handleapi::INVALID_HANDLE_VALUE {
-      log_debug!("SetupDiGetClassDevsW failed", "setupdi_provider", None::<&str>);
+      log_debug!(
+        "SetupDiGetClassDevsW failed",
+        "setupdi_provider",
+        None::<&str>
+      );
       return Vec::new();
     }
 

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -197,7 +197,12 @@ async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
   for metric in &usages {
     let bdf = (metric.bus, metric.device, metric.function);
     let temperature = temp_map.get(&bdf).copied();
-    let name = resolve_gpu_name(&metric.adapter_name, metric.bus, metric.device, metric.function);
+    let name = resolve_gpu_name(
+      &metric.adapter_name,
+      metric.bus,
+      metric.device,
+      metric.function,
+    );
     // VRAM usage is not available via ADL
     gpu_metrics.push(GpuSample {
       name,

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -169,6 +169,7 @@ async fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32
 {
   use crate::infrastructure::providers::setupdi_provider;
   use crate::log_error;
+  use crate::log_internal;
 
   static MAP: tokio::sync::OnceCell<std::collections::HashMap<(i32, i32, i32), String>> =
     tokio::sync::OnceCell::const_new();

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -174,7 +174,12 @@ async fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32
 /// Resolve the canonical (DXGI) name for an ADL adapter via its PCI BDF.
 /// Falls back to the ADL adapter name when no SetupDi entry matches.
 #[cfg(target_os = "windows")]
-async fn resolve_gpu_name(adl_name: &str, bus: i32, device: i32, function: i32) -> String {
+async fn resolve_gpu_name(
+  adl_name: &str,
+  bus: i32,
+  device: i32,
+  function: i32,
+) -> String {
   bdf_to_dxgi_name()
     .await
     .get(&(bus, device, function))

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -145,28 +145,38 @@ pub async fn sample_gpu(resources: &MonitorResources) -> Vec<GpuSample> {
 /// canonical GPU name used by `get_gpu_info` / `GraphicInfo`).
 ///
 /// The table is computed once via SetupDi and cached for the lifetime of
-/// the process.
+/// the process.  Because SetupDi calls are blocking Win32 APIs, the first
+/// invocation offloads them to the Tokio blocking thread pool so we never
+/// stall an async worker thread.
 #[cfg(target_os = "windows")]
-fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32), String> {
+async fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32), String>
+{
   use crate::infrastructure::providers::setupdi_provider;
 
-  static MAP: std::sync::OnceLock<std::collections::HashMap<(i32, i32, i32), String>> =
-    std::sync::OnceLock::new();
+  static MAP: tokio::sync::OnceCell<std::collections::HashMap<(i32, i32, i32), String>> =
+    tokio::sync::OnceCell::const_new();
 
-  MAP.get_or_init(|| {
-    let adapters = setupdi_provider::enumerate_display_adapters();
-    adapters
-      .into_iter()
-      .map(|a| ((a.bus, a.device, a.function), a.description))
-      .collect()
-  })
+  MAP
+    .get_or_init(|| async {
+      tokio::task::spawn_blocking(|| {
+        let adapters = setupdi_provider::enumerate_display_adapters();
+        adapters
+          .into_iter()
+          .map(|a| ((a.bus, a.device, a.function), a.description))
+          .collect()
+      })
+      .await
+      .unwrap_or_default()
+    })
+    .await
 }
 
 /// Resolve the canonical (DXGI) name for an ADL adapter via its PCI BDF.
 /// Falls back to the ADL adapter name when no SetupDi entry matches.
 #[cfg(target_os = "windows")]
-fn resolve_gpu_name(adl_name: &str, bus: i32, device: i32, function: i32) -> String {
+async fn resolve_gpu_name(adl_name: &str, bus: i32, device: i32, function: i32) -> String {
   bdf_to_dxgi_name()
+    .await
     .get(&(bus, device, function))
     .cloned()
     .unwrap_or_else(|| adl_name.to_string())
@@ -202,7 +212,8 @@ async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
       metric.bus,
       metric.device,
       metric.function,
-    );
+    )
+    .await;
     // VRAM usage is not available via ADL
     gpu_metrics.push(GpuSample {
       name,

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -141,6 +141,22 @@ pub async fn sample_gpu(resources: &MonitorResources) -> Vec<GpuSample> {
   gpu_metrics
 }
 
+/// Resolve a GPU's canonical name using a pre-built BDF→name lookup table.
+/// Returns the mapped name on hit, or the original `adl_name` on miss.
+#[cfg(any(target_os = "windows", test))]
+fn resolve_gpu_name_from_map(
+  bdf_map: &std::collections::HashMap<(i32, i32, i32), String>,
+  adl_name: &str,
+  bus: i32,
+  device: i32,
+  function: i32,
+) -> String {
+  bdf_map
+    .get(&(bus, device, function))
+    .cloned()
+    .unwrap_or_else(|| adl_name.to_string())
+}
+
 /// Build a lookup table that maps PCI BDF → DXGI device description (= the
 /// canonical GPU name used by `get_gpu_info` / `GraphicInfo`).
 ///
@@ -152,13 +168,14 @@ pub async fn sample_gpu(resources: &MonitorResources) -> Vec<GpuSample> {
 async fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32), String>
 {
   use crate::infrastructure::providers::setupdi_provider;
+  use crate::log_error;
 
   static MAP: tokio::sync::OnceCell<std::collections::HashMap<(i32, i32, i32), String>> =
     tokio::sync::OnceCell::const_new();
 
   MAP
     .get_or_init(|| async {
-      tokio::task::spawn_blocking(|| {
+      match tokio::task::spawn_blocking(|| {
         let adapters = setupdi_provider::enumerate_display_adapters();
         adapters
           .into_iter()
@@ -166,25 +183,19 @@ async fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32
           .collect()
       })
       .await
-      .unwrap_or_default()
+      {
+        Ok(map) => map,
+        Err(e) => {
+          log_error!(
+            &format!("SetupDi enumeration task failed: {e}"),
+            "monitoring_service::bdf_to_dxgi_name",
+            None::<&str>
+          );
+          std::collections::HashMap::new()
+        }
+      }
     })
     .await
-}
-
-/// Resolve the canonical (DXGI) name for an ADL adapter via its PCI BDF.
-/// Falls back to the ADL adapter name when no SetupDi entry matches.
-#[cfg(target_os = "windows")]
-async fn resolve_gpu_name(
-  adl_name: &str,
-  bus: i32,
-  device: i32,
-  function: i32,
-) -> String {
-  bdf_to_dxgi_name()
-    .await
-    .get(&(bus, device, function))
-    .cloned()
-    .unwrap_or_else(|| adl_name.to_string())
 }
 
 /// Collect AMD GPU usage and temperature via ADL.
@@ -209,16 +220,19 @@ async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
     .map(|m| ((m.bus, m.device, m.function), m.value))
     .collect();
 
+  // Fetch the BDF→DXGI name map once, not per-adapter
+  let bdf_map = bdf_to_dxgi_name().await;
+
   for metric in &usages {
     let bdf = (metric.bus, metric.device, metric.function);
     let temperature = temp_map.get(&bdf).copied();
-    let name = resolve_gpu_name(
+    let name = resolve_gpu_name_from_map(
+      bdf_map,
       &metric.adapter_name,
       metric.bus,
       metric.device,
       metric.function,
-    )
-    .await;
+    );
     // VRAM usage is not available via ADL
     gpu_metrics.push(GpuSample {
       name,
@@ -788,5 +802,55 @@ mod tests {
 
     let cpu_h = resources.process_cpu_histories.lock().unwrap();
     assert_eq!(cpu_h.get(&pid).unwrap().len(), HARDWARE_HISTORY_BUFFER_SIZE);
+  }
+
+  // ── resolve_gpu_name_from_map ──
+
+  #[test]
+  fn resolve_gpu_name_returns_dxgi_name_on_bdf_hit() {
+    let mut map = HashMap::new();
+    map.insert((3, 0, 0), "AMD Radeon RX 7900 XTX".to_string());
+    let result = resolve_gpu_name_from_map(&map, "Radeon RX 7900 XTX", 3, 0, 0);
+    assert_eq!(result, "AMD Radeon RX 7900 XTX");
+  }
+
+  #[test]
+  fn resolve_gpu_name_falls_back_to_adl_name_on_miss() {
+    let map = HashMap::new(); // empty map
+    let result = resolve_gpu_name_from_map(&map, "Radeon RX 7900 XTX", 3, 0, 0);
+    assert_eq!(result, "Radeon RX 7900 XTX");
+  }
+
+  #[test]
+  fn resolve_gpu_name_distinguishes_by_bdf() {
+    let mut map = HashMap::new();
+    map.insert((3, 0, 0), "GPU on bus 3".to_string());
+    map.insert((6, 0, 0), "GPU on bus 6".to_string());
+
+    assert_eq!(
+      resolve_gpu_name_from_map(&map, "fallback", 3, 0, 0),
+      "GPU on bus 3"
+    );
+    assert_eq!(
+      resolve_gpu_name_from_map(&map, "fallback", 6, 0, 0),
+      "GPU on bus 6"
+    );
+    // Different BDF not in map → fallback
+    assert_eq!(
+      resolve_gpu_name_from_map(&map, "fallback", 9, 0, 0),
+      "fallback"
+    );
+  }
+
+  #[test]
+  fn resolve_gpu_name_handles_duplicate_bdf() {
+    let mut map = HashMap::new();
+    // Last insert wins (HashMap behavior)
+    map.insert((3, 0, 0), "First".to_string());
+    map.insert((3, 0, 0), "Second".to_string());
+    assert_eq!(
+      resolve_gpu_name_from_map(&map, "fallback", 3, 0, 0),
+      "Second"
+    );
   }
 }

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -141,32 +141,67 @@ pub async fn sample_gpu(resources: &MonitorResources) -> Vec<GpuSample> {
   gpu_metrics
 }
 
+/// Build a lookup table that maps PCI BDF → DXGI device description (= the
+/// canonical GPU name used by `get_gpu_info` / `GraphicInfo`).
+///
+/// The table is computed once via SetupDi and cached for the lifetime of
+/// the process.
+#[cfg(target_os = "windows")]
+fn bdf_to_dxgi_name() -> &'static std::collections::HashMap<(i32, i32, i32), String> {
+  use crate::infrastructure::providers::setupdi_provider;
+
+  static MAP: std::sync::OnceLock<std::collections::HashMap<(i32, i32, i32), String>> =
+    std::sync::OnceLock::new();
+
+  MAP.get_or_init(|| {
+    let adapters = setupdi_provider::enumerate_display_adapters();
+    adapters
+      .into_iter()
+      .map(|a| ((a.bus, a.device, a.function), a.description))
+      .collect()
+  })
+}
+
+/// Resolve the canonical (DXGI) name for an ADL adapter via its PCI BDF.
+/// Falls back to the ADL adapter name when no SetupDi entry matches.
+#[cfg(target_os = "windows")]
+fn resolve_gpu_name(adl_name: &str, bus: i32, device: i32, function: i32) -> String {
+  bdf_to_dxgi_name()
+    .get(&(bus, device, function))
+    .cloned()
+    .unwrap_or_else(|| adl_name.to_string())
+}
+
 /// Collect AMD GPU usage and temperature via ADL.
 /// VRAM usage is not available via ADL.
 #[cfg(target_os = "windows")]
 async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::adl_provider;
 
-  // Usage per adapter
-  let usages: Vec<(String, f32)> = adl_provider::get_amd_gpu_usage_per_adapter()
+  // Usage per adapter (with BDF)
+  let usages = adl_provider::get_amd_gpu_usage_per_adapter()
     .await
     .unwrap_or_default();
 
-  // Temperature per adapter
-  let temps: Vec<(String, f32)> = adl_provider::get_amd_gpu_temperatures_per_adapter()
+  // Temperature per adapter (with BDF)
+  let temps = adl_provider::get_amd_gpu_temperatures_per_adapter()
     .await
     .unwrap_or_default();
 
-  // Build a temp lookup by adapter name
-  let temp_map: std::collections::HashMap<&str, f32> =
-    temps.iter().map(|(n, t)| (n.as_str(), *t)).collect();
+  // Build a temp lookup by BDF (more reliable than name matching)
+  let temp_map: std::collections::HashMap<(i32, i32, i32), f32> = temps
+    .iter()
+    .map(|m| ((m.bus, m.device, m.function), m.value))
+    .collect();
 
-  for (name, usage) in &usages {
-    let temperature = temp_map.get(name.as_str()).copied();
+  for metric in &usages {
+    let bdf = (metric.bus, metric.device, metric.function);
+    let temperature = temp_map.get(&bdf).copied();
+    let name = resolve_gpu_name(&metric.adapter_name, metric.bus, metric.device, metric.function);
     // VRAM usage is not available via ADL
     gpu_metrics.push(GpuSample {
-      name: name.clone(),
-      usage: Some(*usage),
+      name,
+      usage: Some(metric.value),
       temperature,
       dedicated_memory_kb: None,
       cooler_level: None,

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -210,6 +210,10 @@ async fn sample_amd_gpu(gpu_metrics: &mut Vec<GpuSample>) {
     .await
     .unwrap_or_default();
 
+  if usages.is_empty() {
+    // No usage metrics; skip temperature queries and SetupDi enumeration
+    return;
+  }
   // Temperature per adapter (with BDF)
   let temps = adl_provider::get_amd_gpu_temperatures_per_adapter()
     .await

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -87,7 +87,11 @@ export const GPUInfo = () => {
   const os = useMemo(() => platform(), []);
 
   const getTargetInfo = (data: NameValues) => {
-    if (!hardwareInfo.gpus || hardwareInfo.gpus.length === 0 || data.length === 0)
+    if (
+      !hardwareInfo.gpus ||
+      hardwareInfo.gpus.length === 0 ||
+      data.length === 0
+    )
       return undefined;
     // Exact match first; fall back to first entry as a safety net
     // (the backend resolves ADL names to DXGI names via PCI BDF,

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -87,12 +87,13 @@ export const GPUInfo = () => {
   const os = useMemo(() => platform(), []);
 
   const getTargetInfo = (data: NameValues) => {
-    if (!hardwareInfo.gpus || data.length === 0) return undefined;
+    if (!hardwareInfo.gpus || hardwareInfo.gpus.length === 0 || data.length === 0)
+      return undefined;
     // Exact match first; fall back to first entry as a safety net
     // (the backend resolves ADL names to DXGI names via PCI BDF,
     // so exact match should always succeed).
     return (
-      data.find((x) => x.name === hardwareInfo.gpus?.[0].name)?.value ??
+      data.find((x) => x.name === hardwareInfo.gpus?.[0]?.name)?.value ??
       data[0]?.value
     );
   };

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -94,9 +94,7 @@ export const GPUInfo = () => {
     )
       return undefined;
     // Prefer an exact name match for the primary GPU.
-    const matched = data.find(
-      (x) => x.name === hardwareInfo.gpus?.[0]?.name,
-    );
+    const matched = data.find((x) => x.name === hardwareInfo.gpus?.[0]?.name);
     if (matched) return matched.value;
     // If there is exactly one GPU and one metric entry, allow a safe fallback.
     if (hardwareInfo.gpus.length === 1 && data.length === 1) {

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -87,9 +87,14 @@ export const GPUInfo = () => {
   const os = useMemo(() => platform(), []);
 
   const getTargetInfo = (data: NameValues) => {
-    return data.find(
-      (x) => hardwareInfo.gpus && x.name === hardwareInfo.gpus[0].name,
-    )?.value;
+    if (!hardwareInfo.gpus || data.length === 0) return undefined;
+    // Exact match first; fall back to first entry as a safety net
+    // (the backend resolves ADL names to DXGI names via PCI BDF,
+    // so exact match should always succeed).
+    return (
+      data.find((x) => x.name === hardwareInfo.gpus?.[0].name)?.value ??
+      data[0]?.value
+    );
   };
 
   const targetTemperature = getTargetInfo(gpuTemp);

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -93,13 +93,17 @@ export const GPUInfo = () => {
       data.length === 0
     )
       return undefined;
-    // Exact match first; fall back to first entry as a safety net
-    // (the backend resolves ADL names to DXGI names via PCI BDF,
-    // so exact match should always succeed).
-    return (
-      data.find((x) => x.name === hardwareInfo.gpus?.[0]?.name)?.value ??
-      data[0]?.value
+    // Prefer an exact name match for the primary GPU.
+    const matched = data.find(
+      (x) => x.name === hardwareInfo.gpus?.[0]?.name,
     );
+    if (matched) return matched.value;
+    // If there is exactly one GPU and one metric entry, allow a safe fallback.
+    if (hardwareInfo.gpus.length === 1 && data.length === 1) {
+      return data[0]?.value;
+    }
+    // Otherwise, avoid showing potentially incorrect metrics.
+    return undefined;
   };
 
   const targetTemperature = getTargetInfo(gpuTemp);


### PR DESCRIPTION
## Summary

On Windows AMD systems, the dashboard GPU info names come from DXGI (e.g. "AMD Radeon RX 7900 XTX") while monitoring event names come from ADL (e.g. "Radeon RX 7900 XTX"). This name mismatch caused GPU temperature to not display on the dashboard, even though Insights (which uses ADL names consistently) showed it correctly.

Introduce a SetupDi-based provider that enumerates display adapters with their PCI Bus/Device/Function addresses and device descriptions (which match DXGI names). ADL adapters now expose BDF alongside their metrics, enabling reliable cross-API GPU identification. The ADL name is resolved to the canonical DXGI name via BDF lookup at the monitoring boundary, so names are consistent throughout the entire data flow.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors
