### PR TITLE
Fix(macos): Use frequency-weighted GPU usage calculation

### DIFF
--- a/docs/ARCHITECTURE/macos-gpu-usage-algorithm.md
+++ b/docs/ARCHITECTURE/macos-gpu-usage-algorithm.md
@@ -1,0 +1,153 @@
+# macOS GPU Usage Algorithm
+
+## Overview
+
+On macOS (Apple Silicon), GPU usage is measured via Apple's private **IOReport** framework.
+The reported value represents the fraction of the GPU's maximum computational capacity
+currently in use, matching the metric shown by tools such as [macmon](https://github.com/vladkens/macmon).
+
+## Data Sources
+
+### 1. GPUPH Channel (IOReport)
+
+IOReport exposes a channel under:
+
+- **Group:** `GPU Stats`
+- **Subgroup:** `GPU Performance States`
+- **Channel:** `GPUPH`
+
+This channel reports **residency** (time in nanoseconds) for each GPU power state:
+
+| State        | Meaning                          |
+| ------------ | -------------------------------- |
+| `OFF`        | GPU is powered off (idle)        |
+| `P1`         | Lowest active frequency          |
+| `P2` – `P15` | Progressively higher frequencies |
+
+A background thread samples this channel every 1 second via `IOReportCreateSamplesDelta`,
+which yields per-state residency deltas for the interval.
+
+### 2. GPU DVFS Frequency Table (IOKit Device Registry)
+
+Each P-state corresponds to a specific clock frequency.
+The mapping is read once at startup from the **PMGR** (Power Manager) IOKit node:
+
+| Key | Value |
+|-----|-------|
+| IOKit service class | `AppleARMIODevice` |
+| Registry entry name | `pmgr` |
+| Property | `voltage-states9` |
+
+`voltage-states9` is a packed binary blob of 8-byte records:
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 4 bytes | Frequency (little-endian, Hz) |
+| 4 | 4 bytes | Voltage (little-endian) |
+
+Frequencies are in Hz. Index 0 is the OFF state; indices 1–N map to P1–PN.
+
+## Calculation
+
+### Formula
+
+```math
+usage = (avg\_active\_freq \times active\_ratio) / max\_freq
+```
+
+Where:
+
+- **active_ratio** = `Σ active_residency / Σ all_residency`
+  - Active states: everything except OFF, IDLE, DOWN
+- **avg_active_freq** = `Σ(residency_i × freq_i) / Σ active_residency`
+  - Time-weighted average frequency across active P-states
+- **max_freq** = highest frequency in the DVFS table (last entry)
+
+### Why Frequency Weighting Matters
+
+Without weighting, simple active-time ratio (`active_time / total_time`) significantly
+overestimates GPU usage because:
+
+- macOS keeps the GPU in **P1** (minimum frequency) for display compositing even when idle
+- P1 occupies 40–60% of total time during normal desktop use
+- Simple ratio reports this as 40–60% GPU usage
+
+With frequency weighting, P1 time is scaled by `P1_freq / max_freq` (e.g., ~0.28 on M4),
+producing a value that reflects actual computational load.
+
+| Metric                                   | Idle Desktop | Light Workload |
+| ---------------------------------------- | ------------ | -------------- |
+| Simple active ratio                      | 40–60%       | 60–80%         |
+| Frequency-weighted (this implementation) | 5–15%        | 15–30%         |
+
+### Pseudocode
+
+```text
+residencies = IOReport_delta("GPUPH")
+# → [(OFF, r0), (P1, r1), (P2, r2), ..., (P15, r15)]
+
+dvfs_freqs = read_voltage_states9("pmgr")
+# → [freq_off, freq_p1, freq_p2, ..., freq_p15]
+
+active_freqs = dvfs_freqs[1:]   # skip OFF entry
+offset = first index where state not in {OFF, IDLE, DOWN}
+
+total     = sum(all residencies)
+active    = sum(residencies[offset:])
+avg_freq  = sum(residencies[i+offset] * active_freqs[i] for i in range(N)) / active
+max_freq  = active_freqs[-1]
+
+usage = clamp((max(avg_freq, min_freq) * active / total) / max_freq, 0.0, 1.0)
+```
+
+## Implementation Details
+
+### Files
+
+| File                                                  | Role                                                     |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| `infrastructure/providers/macos/io_kit/io_report.rs`  | IOReport subscription, sampling, and usage computation   |
+| `infrastructure/providers/macos/io_kit/iokit_info.rs` | `read_gpu_dvfs_freqs_mhz()` — reads DVFS table from PMGR |
+| `infrastructure/providers/macos/gpu.rs`               | Background sampler thread; caches result in `AtomicU32`  |
+| `services/monitoring_service.rs`                      | Reads cached value and converts 0.0–1.0 → 0–100%         |
+
+### Sampling Architecture
+
+```mermaid
+flowchart TD
+    subgraph sampler["gpu-usage-sampler thread"]
+        init["GpuUsageIOReport::new()"]
+        sub["IOReport subscription"]
+        dvfs["Read DVFS freq table"]
+        init --> sub
+        init --> dvfs
+
+        loop["loop (every 1s)"]
+        s1["IOReportCreateSamples"]
+        s2["IOReportCreateSamplesDelta"]
+        s3["compute_usage_freq_weighted"]
+        store["Store result in AtomicU32"]
+
+        loop --> s1 --> s2 --> s3 --> store
+    end
+
+    store -- "read_gpu_usage_cached()" --> mon
+
+    subgraph mon["monitoring_service"]
+        calc["usage = cached_value × 100"]
+        out["GpuSample { usage, ... }"]
+        calc --> out
+    end
+```
+
+### Fallback
+
+If the DVFS frequency table cannot be read (e.g., non-Apple-Silicon Mac or
+missing PMGR node), the implementation falls back to simple active-time ratio.
+
+## References
+
+- [macmon](https://github.com/vladkens/macmon) (MIT) — Referenced for the
+  frequency-weighted approach. No code copied; independently reimplemented.
+- Apple IOReport framework (private API, no public documentation)
+- Apple IOKit device registry

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -363,3 +363,130 @@ fn is_idle_state(name: &str) -> bool {
 
   false
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── is_idle_state ──
+
+  #[test]
+  fn is_idle_state_classification() {
+    // Idle states (OFF observed on M4; IDLE/DOWN on M2/M3 Max per macmon)
+    for name in ["OFF", "off", "IDLE", "idle", "IDLE_OFF", "DOWN", "down", "  OFF  "] {
+      assert!(is_idle_state(name), "{name:?} should be idle");
+    }
+    // Active P-states
+    for name in ["P1", "P15", "PERF"] {
+      assert!(!is_idle_state(name), "{name:?} should not be idle");
+    }
+  }
+
+  // ── compute_usage_unweighted ──
+
+  #[test]
+  fn unweighted_all_off() {
+    let resid = vec![("OFF".into(), 1000i64)];
+    let usage = compute_usage_unweighted(&resid).unwrap();
+    assert_eq!(usage, 0.0);
+  }
+
+  #[test]
+  fn unweighted_all_active() {
+    let resid = vec![("OFF".into(), 0i64), ("P1".into(), 1000)];
+    let usage = compute_usage_unweighted(&resid).unwrap();
+    assert!((usage - 1.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn unweighted_half_active() {
+    let resid = vec![("OFF".into(), 500i64), ("P1".into(), 500)];
+    let usage = compute_usage_unweighted(&resid).unwrap();
+    assert!((usage - 0.5).abs() < 1e-6);
+  }
+
+  #[test]
+  fn unweighted_empty_returns_zero() {
+    let resid: Vec<(String, i64)> = vec![];
+    let usage = compute_usage_unweighted(&resid).unwrap();
+    assert_eq!(usage, 0.0);
+  }
+
+  // ── compute_usage_freq_weighted ──
+
+  fn m4_resid(off: i64, p1: i64, p2: i64, p3: i64) -> Vec<(String, i64)> {
+    vec![
+      ("OFF".into(), off),
+      ("P1".into(), p1),
+      ("P2".into(), p2),
+      ("P3".into(), p3),
+    ]
+  }
+
+  // Frequencies in MHz: P1=396, P2=720, P3=1398
+  fn m4_freqs() -> Vec<u32> {
+    vec![396, 720, 1398]
+  }
+
+  #[test]
+  fn freq_weighted_all_off() {
+    let resid = m4_resid(1000, 0, 0, 0);
+    let usage = compute_usage_freq_weighted(&resid, &m4_freqs()).unwrap();
+    assert_eq!(usage, 0.0);
+  }
+
+  #[test]
+  fn freq_weighted_all_p1() {
+    // 100% active at P1 (396 MHz), max = 1398 MHz
+    // usage = (396 * 1.0) / 1398 ≈ 0.283
+    let resid = m4_resid(0, 1000, 0, 0);
+    let usage = compute_usage_freq_weighted(&resid, &m4_freqs()).unwrap();
+    assert!((usage - 396.0 / 1398.0).abs() < 0.01);
+  }
+
+  #[test]
+  fn freq_weighted_all_max() {
+    // 100% active at P3 (1398 MHz) → usage = 1.0
+    let resid = m4_resid(0, 0, 0, 1000);
+    let usage = compute_usage_freq_weighted(&resid, &m4_freqs()).unwrap();
+    assert!((usage - 1.0).abs() < 0.01);
+  }
+
+  #[test]
+  fn freq_weighted_half_off_half_p1() {
+    // 50% active at P1 (396 MHz)
+    // usage = (396 * 0.5) / 1398 ≈ 0.142
+    let resid = m4_resid(500, 500, 0, 0);
+    let usage = compute_usage_freq_weighted(&resid, &m4_freqs()).unwrap();
+    let expected = (396.0 * 0.5) / 1398.0;
+    assert!((usage - expected as f32).abs() < 0.01);
+  }
+
+  #[test]
+  fn freq_weighted_realistic_idle_desktop() {
+    // Typical idle: OFF=10M, P1=13M, P2=0.5M, P3=0.5M
+    let resid = m4_resid(10_000_000, 13_000_000, 500_000, 500_000);
+    let usage = compute_usage_freq_weighted(&resid, &m4_freqs()).unwrap();
+    // Should be in the 10-20% range, not 50-60%
+    assert!(usage > 0.05 && usage < 0.25, "usage={usage}");
+  }
+
+  #[test]
+  fn freq_weighted_empty_freqs_returns_err() {
+    let resid = m4_resid(500, 500, 0, 0);
+    // Empty freqs → no active P-states to match
+    let result = compute_usage_freq_weighted(&resid, &[]);
+    // offset finds P1, but count = min(0, 3) = 0, so avg_freq stays 0
+    // max_freq from empty slice is 1 (unwrap_or(&1)), so usage ≈ 0
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn freq_weighted_clamped_to_one() {
+    // Edge case: should never exceed 1.0
+    let resid = vec![("OFF".into(), 0i64), ("P1".into(), 1000)];
+    let freqs = vec![2000]; // freq > max_freq (they're the same here)
+    let usage = compute_usage_freq_weighted(&resid, &freqs).unwrap();
+    assert!(usage <= 1.0);
+  }
+}

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -1,7 +1,7 @@
 /*
 Inspired by macmon (MIT): https://github.com/vladkens/macmon
 Referenced for IOReport sampling and frequency-weighted GPU usage calculation.
-No code copied; independently reimplemented from the same public Apple APIs.
+No code copied; independently reimplemented from the same Apple APIs (private/unstable).
 
 Copyright (c) 2024 vladkens
 Licensed under the MIT License. See THIRD_PARTY_NOTICES.md for the full text.
@@ -301,20 +301,26 @@ fn compute_usage_freq_weighted(resid: &[(String, i64)], freqs: &[u32]) -> WithEr
     .ok_or("no active P-states found")?;
 
   let total: f64 = resid.iter().map(|(_, v)| *v as f64).sum();
-  let active: f64 = resid.iter().skip(offset).map(|(_, v)| *v as f64).sum();
-
-  if total <= 0.0 || active <= 0.0 {
+  if total <= 0.0 {
     return Ok(0.0);
   }
 
-  // Compute the time-weighted average frequency across active P-states.
+  // Only consider P-states that have a matching frequency entry so that
+  // active and avg_freq are computed over the same set of states.
   let count = freqs.len().min(resid.len() - offset);
-  let mut avg_freq = 0.0_f64;
+  let mut active = 0.0_f64;
+  let mut weighted_freq = 0.0_f64;
   for i in 0..count {
-    let frac = resid[i + offset].1 as f64 / active;
-    avg_freq += frac * freqs[i] as f64;
+    let r = resid[i + offset].1 as f64;
+    active += r;
+    weighted_freq += r * freqs[i] as f64;
   }
 
+  if active <= 0.0 {
+    return Ok(0.0);
+  }
+
+  let avg_freq = weighted_freq / active;
   let active_ratio = active / total;
   let min_freq = *freqs.first().unwrap_or(&1) as f64;
   let max_freq = *freqs.last().unwrap_or(&1) as f64;

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -182,7 +182,13 @@ impl GpuUsageIOReport {
     // The first entry (index 0) is the OFF/idle state — skip it so that
     // gpu_freqs[0] = P1 frequency, gpu_freqs[1] = P2 frequency, etc.
     let gpu_freqs = super::iokit_info::read_gpu_dvfs_freqs_mhz()
-      .map(|f| if f.len() > 1 { f[1..].to_vec() } else { Vec::new() })
+      .map(|f| {
+        if f.len() > 1 {
+          f[1..].to_vec()
+        } else {
+          Vec::new()
+        }
+      })
       .unwrap_or_default();
 
     Ok(Self {
@@ -287,10 +293,7 @@ fn compute_gpu_usage_from_delta(
 /// where `avg_active_freq` is the time-weighted average of active P-state
 /// frequencies, and `active_ratio` is the fraction of total time spent
 /// in any active state.
-fn compute_usage_freq_weighted(
-  resid: &[(String, i64)],
-  freqs: &[u32],
-) -> WithError<f32> {
+fn compute_usage_freq_weighted(resid: &[(String, i64)], freqs: &[u32]) -> WithError<f32> {
   // Find the first active (non-idle) state index.
   let offset = resid
     .iter()

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -480,21 +480,21 @@ mod tests {
   }
 
   #[test]
-  fn freq_weighted_empty_freqs_returns_err() {
+  fn freq_weighted_empty_freqs_returns_zero() {
     let resid = m4_resid(500, 500, 0, 0);
-    // Empty freqs → no active P-states to match
-    let result = compute_usage_freq_weighted(&resid, &[]);
-    // offset finds P1, but count = min(0, 3) = 0, so avg_freq stays 0
-    // max_freq from empty slice is 1 (unwrap_or(&1)), so usage ≈ 0
-    assert!(result.is_ok());
+    let usage = compute_usage_freq_weighted(&resid, &[]).unwrap();
+    assert_eq!(usage, 0.0);
   }
 
   #[test]
-  fn freq_weighted_clamped_to_one() {
-    // Edge case: should never exceed 1.0
-    let resid = vec![("OFF".into(), 0i64), ("P1".into(), 1000)];
-    let freqs = vec![2000]; // freq > max_freq (they're the same here)
+  fn freq_weighted_result_never_exceeds_one() {
+    // Two active states but only one freq entry → matched count is 1.
+    // P1 freq (2000) > max_freq (2000), active_ratio = 0.5 (P2 unmatched).
+    // raw = 2000 * 0.5 / 2000 = 0.5, so clamp doesn't fire here but
+    // the contract (usage ≤ 1.0) still holds.
+    let resid = vec![("OFF".into(), 0i64), ("P1".into(), 500), ("P2".into(), 500)];
+    let freqs = vec![2000];
     let usage = compute_usage_freq_weighted(&resid, &freqs).unwrap();
-    assert!(usage <= 1.0);
+    assert!(usage <= 1.0, "usage={usage}");
   }
 }

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -373,7 +373,9 @@ mod tests {
   #[test]
   fn is_idle_state_classification() {
     // Idle states (OFF observed on M4; IDLE/DOWN on M2/M3 Max per macmon)
-    for name in ["OFF", "off", "IDLE", "idle", "IDLE_OFF", "DOWN", "down", "  OFF  "] {
+    for name in [
+      "OFF", "off", "IDLE", "idle", "IDLE_OFF", "DOWN", "down", "  OFF  ",
+    ] {
       assert!(is_idle_state(name), "{name:?} should be idle");
     }
     // Active P-states

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -1,6 +1,7 @@
 /*
 Inspired by macmon (MIT): https://github.com/vladkens/macmon
-Referenced for IOReport sampling. No code copied.
+Referenced for IOReport sampling and frequency-weighted GPU usage calculation.
+No code copied; independently reimplemented from the same public Apple APIs.
 
 Copyright (c) 2024 vladkens
 Licensed under the MIT License. See THIRD_PARTY_NOTICES.md for the full text.
@@ -167,16 +168,28 @@ pub struct GpuUsageIOReport {
   subs: IOReportSubscriptionRef,
   chan: CFMutableDictionaryRef,
   prev: Option<(CFDictionaryRef, Instant)>,
+  /// GPU DVFS frequencies for active P-states (P1, P2, …, PN) in MHz.
+  /// Empty if the frequency table could not be read from PMGR.
+  gpu_freqs: Vec<u32>,
 }
 
 impl GpuUsageIOReport {
   pub fn new() -> WithError<Self> {
     let chan = build_channels_gpu_only()?;
     let subs = create_subscription(chan)?;
+
+    // Read the GPU frequency table from the PMGR IOKit node.
+    // The first entry (index 0) is the OFF/idle state — skip it so that
+    // gpu_freqs[0] = P1 frequency, gpu_freqs[1] = P2 frequency, etc.
+    let gpu_freqs = super::iokit_info::read_gpu_dvfs_freqs_mhz()
+      .map(|f| if f.len() > 1 { f[1..].to_vec() } else { Vec::new() })
+      .unwrap_or_default();
+
     Ok(Self {
       subs,
       chan,
       prev: None,
+      gpu_freqs,
     })
   }
 
@@ -206,7 +219,7 @@ impl GpuUsageIOReport {
     self.prev = Some(next);
 
     // Find GPU Perf States in the delta dictionary and compute usage.
-    let usage = compute_gpu_usage_from_delta(delta)?;
+    let usage = compute_gpu_usage_from_delta(delta, &self.gpu_freqs)?;
     unsafe { CFRelease(delta as _) };
     Ok(usage)
   }
@@ -224,7 +237,19 @@ impl Drop for GpuUsageIOReport {
   }
 }
 
-fn compute_gpu_usage_from_delta(delta: CFDictionaryRef) -> WithError<f32> {
+/// Compute GPU usage from the GPUPH channel in the IOReport delta.
+///
+/// When a GPU frequency table is available, the usage is computed as:
+///   `(avg_active_freq × active_ratio) / max_freq`
+/// This weights lower P-states (e.g. P1 at minimum frequency for display
+/// compositing) proportionally less than higher P-states, matching the
+/// approach used by macmon.
+///
+/// Without frequencies, falls back to simple active-time ratio.
+fn compute_gpu_usage_from_delta(
+  delta: CFDictionaryRef,
+  gpu_freqs: &[u32],
+) -> WithError<f32> {
   let arr = dict_get(delta, "IOReportChannels").ok_or("delta has no IOReportChannels")?
     as CFArrayRef;
 
@@ -247,25 +272,75 @@ fn compute_gpu_usage_from_delta(delta: CFDictionaryRef) -> WithError<f32> {
       return Ok(0.0);
     }
 
-    let mut total: i64 = 0;
-    let mut idle: i64 = 0;
-    for (name, v) in &resid {
-      if *v <= 0 {
-        continue;
-      }
-      total += *v;
-      if is_idle_state(name) {
-        idle += *v;
-      }
+    if gpu_freqs.is_empty() {
+      return compute_usage_unweighted(&resid);
     }
-    if total <= 0 {
-      return Ok(0.0);
-    }
-    let usage = ((total - idle) as f32) / (total as f32);
-    return Ok(usage.clamp(0.0, 1.0));
+    return compute_usage_freq_weighted(&resid, gpu_freqs);
   }
 
   Err("GPU Performance States channel not found".into())
+}
+
+/// Frequency-weighted GPU usage (matches macmon's approach).
+///
+/// Formula: `usage = (avg_active_freq × active_ratio) / max_freq`
+/// where `avg_active_freq` is the time-weighted average of active P-state
+/// frequencies, and `active_ratio` is the fraction of total time spent
+/// in any active state.
+fn compute_usage_freq_weighted(
+  resid: &[(String, i64)],
+  freqs: &[u32],
+) -> WithError<f32> {
+  // Find the first active (non-idle) state index.
+  let offset = resid
+    .iter()
+    .position(|(name, _)| !is_idle_state(name))
+    .ok_or("no active P-states found")?;
+
+  let total: f64 = resid.iter().map(|(_, v)| *v as f64).sum();
+  let active: f64 = resid.iter().skip(offset).map(|(_, v)| *v as f64).sum();
+
+  if total <= 0.0 || active <= 0.0 {
+    return Ok(0.0);
+  }
+
+  // Compute the time-weighted average frequency across active P-states.
+  let count = freqs.len().min(resid.len() - offset);
+  let mut avg_freq = 0.0_f64;
+  for i in 0..count {
+    let frac = resid[i + offset].1 as f64 / active;
+    avg_freq += frac * freqs[i] as f64;
+  }
+
+  let active_ratio = active / total;
+  let min_freq = *freqs.first().unwrap_or(&1) as f64;
+  let max_freq = *freqs.last().unwrap_or(&1) as f64;
+  if max_freq <= 0.0 {
+    return Ok(0.0);
+  }
+
+  let usage = (avg_freq.max(min_freq) * active_ratio) / max_freq;
+  Ok((usage as f32).clamp(0.0, 1.0))
+}
+
+/// Simple unweighted fallback: fraction of time in any active P-state.
+fn compute_usage_unweighted(resid: &[(String, i64)]) -> WithError<f32> {
+  let mut total: i64 = 0;
+  let mut idle: i64 = 0;
+  for (name, v) in resid {
+    if *v <= 0 {
+      continue;
+    }
+    total += *v;
+    if is_idle_state(name) {
+      idle += *v;
+    }
+  }
+  if total <= 0 {
+    return Ok(0.0);
+  }
+  let usage = ((total - idle) as f32) / (total as f32);
+  Ok(usage.clamp(0.0, 1.0))
 }
 
 fn is_idle_state(name: &str) -> bool {

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
@@ -489,9 +489,8 @@ pub fn read_gpu_dvfs_freqs_mhz() -> Option<Vec<u32>> {
   }
 
   let mut iter: IoIterator = 0;
-  let kr = unsafe {
-    IOServiceGetMatchingServices(K_IOMASTER_PORT_DEFAULT, matching, &mut iter)
-  };
+  let kr =
+    unsafe { IOServiceGetMatchingServices(K_IOMASTER_PORT_DEFAULT, matching, &mut iter) };
   if kr != KERN_SUCCESS {
     return None;
   }
@@ -518,7 +517,12 @@ pub fn read_gpu_dvfs_freqs_mhz() -> Option<Vec<u32>> {
     // Packed as 8-byte entries: 4-byte freq (LE, Hz) + 4-byte voltage (LE).
     let key = CFString::new("voltage-states9");
     let prop = unsafe {
-      IORegistryEntryCreateCFProperty(entry, key.as_concrete_TypeRef(), kCFAllocatorDefault, 0)
+      IORegistryEntryCreateCFProperty(
+        entry,
+        key.as_concrete_TypeRef(),
+        kCFAllocatorDefault,
+        0,
+      )
     };
     unsafe { IOObjectRelease(entry) };
 

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
@@ -45,6 +45,8 @@ unsafe extern "C" {
     plane: CFStringRef,
     parent: *mut IoRegistryEntry,
   ) -> KernReturn;
+
+  fn IORegistryEntryGetName(entry: IoRegistryEntry, name: *mut i8) -> KernReturn;
 }
 
 #[link(name = "CoreFoundation", kind = "framework")]
@@ -470,4 +472,81 @@ fn cfdata_to_string(d: CFTypeRef) -> String {
   let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
   let end = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
   String::from_utf8_lossy(&bytes[..end]).to_string()
+}
+
+/// Read GPU DVFS frequency table from the PMGR IOKit node.
+///
+/// Returns the full list of frequencies in MHz (index 0 = OFF/idle state,
+/// index 1 = P1, index 2 = P2, …).
+/// Returns `None` if the PMGR node or `voltage-states9` property is not found.
+pub fn read_gpu_dvfs_freqs_mhz() -> Option<Vec<u32>> {
+  let class_cstr = CString::new("AppleARMIODevice").ok()?;
+
+  // IOServiceGetMatchingServices consumes the matching dictionary.
+  let matching = unsafe { IOServiceMatching(class_cstr.as_ptr()) };
+  if matching.is_null() {
+    return None;
+  }
+
+  let mut iter: IoIterator = 0;
+  let kr = unsafe {
+    IOServiceGetMatchingServices(K_IOMASTER_PORT_DEFAULT, matching, &mut iter)
+  };
+  if kr != KERN_SUCCESS {
+    return None;
+  }
+
+  let mut result: Option<Vec<u32>> = None;
+  loop {
+    let entry = unsafe { IOIteratorNext(iter) };
+    if entry == 0 {
+      break;
+    }
+
+    let mut name_buf = [0i8; 128];
+    if unsafe { IORegistryEntryGetName(entry, name_buf.as_mut_ptr()) } != KERN_SUCCESS {
+      unsafe { IOObjectRelease(entry) };
+      continue;
+    }
+    let name = unsafe { std::ffi::CStr::from_ptr(name_buf.as_ptr()) }.to_string_lossy();
+    if name != "pmgr" {
+      unsafe { IOObjectRelease(entry) };
+      continue;
+    }
+
+    // Read "voltage-states9" (GPU DVFS table).
+    // Packed as 8-byte entries: 4-byte freq (LE, Hz) + 4-byte voltage (LE).
+    let key = CFString::new("voltage-states9");
+    let prop = unsafe {
+      IORegistryEntryCreateCFProperty(entry, key.as_concrete_TypeRef(), kCFAllocatorDefault, 0)
+    };
+    unsafe { IOObjectRelease(entry) };
+
+    if prop.is_null() {
+      continue;
+    }
+
+    let type_id = unsafe { CFGetTypeID(prop) };
+    if type_id != unsafe { CFDataGetTypeID() } {
+      unsafe { CFRelease(prop as _) };
+      continue;
+    }
+
+    let len = unsafe { CFDataGetLength(prop) } as usize;
+    let ptr = unsafe { CFDataGetBytePtr(prop) };
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+
+    let mut freqs = Vec::with_capacity(len / 8);
+    for chunk in bytes.chunks_exact(8) {
+      let freq_hz = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+      freqs.push(freq_hz / 1_000_000); // Hz → MHz
+    }
+
+    unsafe { CFRelease(prop as _) };
+    result = Some(freqs);
+    break;
+  }
+
+  unsafe { IOObjectRelease(iter) };
+  result
 }

--- a/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
+++ b/src-tauri/src/infrastructure/providers/macos/io_kit/iokit_info.rs
@@ -538,6 +538,13 @@ pub fn read_gpu_dvfs_freqs_mhz() -> Option<Vec<u32>> {
 
     let len = unsafe { CFDataGetLength(prop) } as usize;
     let ptr = unsafe { CFDataGetBytePtr(prop) };
+
+    // Guard against null pointer, empty data, and truncated records.
+    if ptr.is_null() || len == 0 || !len.is_multiple_of(8) {
+      unsafe { CFRelease(prop as _) };
+      continue;
+    }
+
     let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
 
     let mut freqs = Vec::with_capacity(len / 8);


### PR DESCRIPTION
## Summary

The previous GPUPH-based calculation reported raw P-state residency (time in any active state), which significantly overestimated GPU usage (e.g. 50-60% at idle) because macOS keeps the GPU clocked at P1 for display compositing.

Now reads the DVFS frequency table from the PMGR IOKit node and applies the formula: (avg_active_freq × active_ratio) / max_freq, matching the approach used by macmon. Falls back to unweighted calculation if the frequency table is unavailable.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [x] Manual testing
- [x] Unit tests

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors
