### PR TITLE
chore: add PostToolUse hook for Rust file formatting and linting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo $f | grep -qE '\\.rs$' || exit 0; cargo fmt --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings; }",
+            "timeout": 120,
+            "statusMessage": "Running cargo fmt & clippy..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo $f | grep -qE '\\.rs$' || exit 0; cargo fmt --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings; }",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo $f | grep -qE '\\.rs$' || exit 0; cargo tauri-fmt && cargo tauri-lint; }",
             "timeout": 120,
             "statusMessage": "Running cargo fmt & clippy..."
           }

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ licenses.json
 *.njsproj
 *.sln
 *.sw?
-.claude
 .mcp.json
 
 # Rust files


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors
