### PR TITLE
Fix GPU name collision for multi-AMD GPU systems on Linux (#1297)

### DIFF
--- a/src-tauri/src/infrastructure/providers/linux/drm_sys.rs
+++ b/src-tauri/src/infrastructure/providers/linux/drm_sys.rs
@@ -130,3 +130,82 @@ pub fn detect_gpu_vendor(card_id: u8) -> GpuVendor {
     Err(_) => GpuVendor::Unknown,
   }
 }
+
+/// Read the PCI BDF (bus:device.function) for a DRM card by following the
+/// `/sys/class/drm/card{N}/device` symlink.
+///
+/// Returns e.g. `"03:00.0"`.
+pub fn get_card_bdf(card_id: u8) -> Option<String> {
+  let link = fs::read_link(format!("/sys/class/drm/card{card_id}/device")).ok()?;
+  let target = link.to_string_lossy().to_string();
+  parse_bdf_from_device_link(&target)
+}
+
+/// Pure parsing function: extract the BDF portion (e.g. `"03:00.0"`) from a
+/// sysfs device symlink target like `"../../0000:03:00.0"` or an absolute path
+/// like `"/sys/devices/pci0000:00/0000:00:08.1/0000:0a:00.0"`.
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_bdf_from_device_link(symlink_target: &str) -> Option<String> {
+  // PCI address format: DDDD:BB:DD.F (e.g. "0000:03:00.0")
+  // Extract the last path segment, then strip the domain prefix.
+  let segment = symlink_target.rsplit('/').next().unwrap_or(symlink_target);
+
+  // Expect "DDDD:BB:DD.F" — split on first ':' to remove domain
+  let (_, bdf) = segment.split_once(':')?;
+
+  // Validate BDF looks like "XX:XX.X"
+  if !bdf.contains(':') || !bdf.contains('.') {
+    return None;
+  }
+
+  Some(bdf.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── parse_bdf_from_device_link ──
+
+  #[test]
+  fn parse_bdf_standard_pci_address() {
+    assert_eq!(
+      parse_bdf_from_device_link("../../0000:03:00.0"),
+      Some("03:00.0".to_string())
+    );
+  }
+
+  #[test]
+  fn parse_bdf_different_domain() {
+    assert_eq!(
+      parse_bdf_from_device_link("../../0001:0a:00.0"),
+      Some("0a:00.0".to_string())
+    );
+  }
+
+  #[test]
+  fn parse_bdf_non_zero_function() {
+    assert_eq!(
+      parse_bdf_from_device_link("../../0000:06:00.1"),
+      Some("06:00.1".to_string())
+    );
+  }
+
+  #[test]
+  fn parse_bdf_absolute_path() {
+    assert_eq!(
+      parse_bdf_from_device_link("/sys/devices/pci0000:00/0000:00:08.1/0000:0a:00.0"),
+      Some("0a:00.0".to_string())
+    );
+  }
+
+  #[test]
+  fn parse_bdf_empty_string() {
+    assert!(parse_bdf_from_device_link("").is_none());
+  }
+
+  #[test]
+  fn parse_bdf_invalid_format() {
+    assert!(parse_bdf_from_device_link("../../invalid").is_none());
+  }
+}

--- a/src-tauri/src/infrastructure/providers/linux/lspci.rs
+++ b/src-tauri/src/infrastructure/providers/linux/lspci.rs
@@ -1,4 +1,7 @@
-pub fn get_gpu_name_from_lspci_by_vendor_id(vendor_id: &str) -> Option<String> {
+/// Look up a GPU name from `lspci -nn` output by PCI BDF (bus:device.function).
+///
+/// Returns the full lspci line for the VGA/Display controller at the given slot.
+pub fn get_gpu_name_from_lspci_by_bdf(bdf: &str) -> Option<String> {
   use std::process::Command;
 
   let output = Command::new("lspci").arg("-nn").output().ok()?;
@@ -8,13 +11,70 @@ pub fn get_gpu_name_from_lspci_by_vendor_id(vendor_id: &str) -> Option<String> {
   }
 
   let stdout = String::from_utf8_lossy(&output.stdout);
+  parse_gpu_name_by_bdf(&stdout, bdf)
+}
 
-  for line in stdout.lines() {
-    if line.contains("VGA") && line.contains(vendor_id) {
-      // Example: "03:00.0 VGA compatible controller [0300]: AMD/ATI Renoir [1002:1636]"
+/// Pure parsing function: extract the GPU name line from lspci output matching
+/// the given BDF slot. Matches lines containing "VGA" or "Display controller".
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_gpu_name_by_bdf(lspci_output: &str, bdf: &str) -> Option<String> {
+  for line in lspci_output.lines() {
+    // BDF must be followed by a space (e.g. "06:00.0 VGA ...")
+    if !line.starts_with(bdf) || line.as_bytes().get(bdf.len()) != Some(&b' ') {
+      continue;
+    }
+    if line.contains("VGA") || line.contains("Display controller") {
       return Some(line.trim().to_string());
     }
   }
-
   None
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── parse_gpu_name_by_bdf ──
+
+  #[test]
+  fn parse_gpu_name_by_bdf_matches_exact_slot() {
+    let output = "\
+06:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Navi 31 [Radeon RX 7900 XTX] [1002:744c]
+0a:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Renoir [Radeon Vega Series] [1002:1636]";
+    assert!(
+      parse_gpu_name_by_bdf(output, "06:00.0")
+        .unwrap()
+        .contains("Navi 31")
+    );
+    assert!(
+      parse_gpu_name_by_bdf(output, "0a:00.0")
+        .unwrap()
+        .contains("Renoir")
+    );
+  }
+
+  #[test]
+  fn parse_gpu_name_by_bdf_no_match() {
+    let output = "06:00.0 VGA compatible controller [0300]: AMD/ATI Navi 31 [1002:744c]";
+    assert!(parse_gpu_name_by_bdf(output, "0a:00.0").is_none());
+  }
+
+  #[test]
+  fn parse_gpu_name_by_bdf_ignores_non_vga() {
+    let output = "06:00.1 Audio device [0403]: AMD/ATI Navi 31 HDMI Audio [1002:ab30]";
+    assert!(parse_gpu_name_by_bdf(output, "06:00.1").is_none());
+  }
+
+  #[test]
+  fn parse_gpu_name_by_bdf_display_controller() {
+    let output = "06:00.0 Display controller [0380]: Advanced Micro Devices, Inc. [AMD/ATI] Renoir [1002:1636]";
+    assert!(parse_gpu_name_by_bdf(output, "06:00.0").is_some());
+  }
+
+  #[test]
+  fn parse_gpu_name_by_bdf_no_prefix_false_positive() {
+    // "06:00.0" should NOT match a line starting with "06:00.00"
+    let output = "06:00.00 VGA compatible controller [0300]: Fake GPU [ffff:0000]";
+    assert!(parse_gpu_name_by_bdf(output, "06:00.0").is_none());
+  }
 }

--- a/src-tauri/src/platform/linux/gpu.rs
+++ b/src-tauri/src/platform/linux/gpu.rs
@@ -66,11 +66,11 @@ pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, String
 async fn get_amd_graphic_info(
   card_id: u8,
 ) -> Result<models::hardware::GraphicInfo, String> {
-  const VENDOR_ID: &str = "1002";
-
-  let name =
-    infrastructure::providers::lspci::get_gpu_name_from_lspci_by_vendor_id(VENDOR_ID)
-      .unwrap_or_else(|| "Unknown AMD GPU".to_string());
+  let name = infrastructure::providers::drm_sys::get_card_bdf(card_id)
+    .and_then(|bdf| {
+      infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
+    })
+    .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
 
   let clock = infrastructure::providers::kernel::read_pm_info_sclk(card_id).unwrap_or(0);
   let memory_total =

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -362,10 +362,10 @@ async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
 
     let (name, usage, temperature, source) = match vendor {
       drm_sys::GpuVendor::Amd => {
-        let name =
-          crate::infrastructure::providers::lspci::get_gpu_name_from_lspci_by_vendor_id(
-            "1002",
-          )
+        let name = drm_sys::get_card_bdf(card_id)
+          .and_then(|bdf| {
+            crate::infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
+          })
           .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
         let usage = drm_sys::get_amd_gpu_usage(card_id as u32)
           .await
@@ -842,6 +842,44 @@ mod tests {
 
     let cpu_h = resources.process_cpu_histories.lock().unwrap();
     assert_eq!(cpu_h.get(&pid).unwrap().len(), HARDWARE_HISTORY_BUFFER_SIZE);
+  }
+
+  // ── resolve_gpu_name_from_map ──
+
+  // ── update_gpu_histories: multi-AMD GPU name collision regression ──
+
+  #[test]
+  fn update_gpu_histories_two_amd_gpus_separate_entries() {
+    let resources = create_test_resources();
+    let samples = vec![
+      GpuSample {
+        name: "06:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Navi 31 [Radeon RX 7900 XTX] [1002:744c]".to_string(),
+        usage: Some(80.0),
+        temperature: Some(65.0),
+        dedicated_memory_kb: None,
+        cooler_level: None,
+        source: "DRM (AMD)".to_string(),
+      },
+      GpuSample {
+        name: "0a:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Renoir [Radeon Vega Series] [1002:1636]".to_string(),
+        usage: Some(15.0),
+        temperature: Some(45.0),
+        dedicated_memory_kb: None,
+        cooler_level: None,
+        source: "DRM (AMD)".to_string(),
+      },
+    ];
+    update_gpu_histories(&resources, &samples);
+
+    let usage = resources.gpu_usage_histories.lock().unwrap();
+    assert_eq!(
+      usage.len(),
+      2,
+      "Two AMD GPUs must have separate history entries"
+    );
+
+    let temp = resources.gpu_temperature_histories.lock().unwrap();
+    assert_eq!(temp.len(), 2);
   }
 
   // ── resolve_gpu_name_from_map ──


### PR DESCRIPTION
Replace vendor-ID-based lspci lookup with BDF-based resolution so that each GPU gets a unique name even when multiple AMD GPUs share vendor 0x1002. This prevents history HashMap overwrites and archive DB collisions.

- Add get_card_bdf() to extract PCI BDF from sysfs symlink
- Add get_gpu_name_from_lspci_by_bdf() to match by PCI slot
- Update collect_linux_gpu_metrics() and get_amd_graphic_info()
- Fall back to "AMD GPU (card{N})" when BDF resolution fails
- Remove unused get_gpu_name_from_lspci_by_vendor_id()