### PR TITLE
Avoid forking lspci on every GPU monitoring cycle

### DIFF
--- a/src-tauri/src/infrastructure/providers/linux/lspci.rs
+++ b/src-tauri/src/infrastructure/providers/linux/lspci.rs
@@ -1,7 +1,5 @@
-/// Look up a GPU name from `lspci -nn` output by PCI BDF (bus:device.function).
-///
-/// Returns the full lspci line for the VGA/Display controller at the given slot.
-pub fn get_gpu_name_from_lspci_by_bdf(bdf: &str) -> Option<String> {
+/// Run `lspci -nn` and return the raw stdout.
+pub fn get_lspci_nn_output() -> Option<String> {
   use std::process::Command;
 
   let output = Command::new("lspci").arg("-nn").output().ok()?;
@@ -10,7 +8,16 @@ pub fn get_gpu_name_from_lspci_by_bdf(bdf: &str) -> Option<String> {
     return None;
   }
 
-  let stdout = String::from_utf8_lossy(&output.stdout);
+  Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Look up a GPU name from `lspci -nn` output by PCI BDF (bus:device.function).
+///
+/// Returns the full lspci line for the VGA/Display controller at the given slot.
+/// Note: forks `lspci` on each call. For hot loops, prefer calling
+/// [`get_lspci_nn_output`] once and then [`parse_gpu_name_by_bdf`] per card.
+pub fn get_gpu_name_from_lspci_by_bdf(bdf: &str) -> Option<String> {
+  let stdout = get_lspci_nn_output()?;
   parse_gpu_name_by_bdf(&stdout, bdf)
 }
 

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -353,9 +353,13 @@ pub async fn sample_gpu(resources: &MonitorResources) -> Vec<GpuSample> {
 async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
   use crate::infrastructure::providers::drm_sys;
   use crate::infrastructure::providers::hwmon;
+  use crate::infrastructure::providers::lspci;
 
   let mut metrics: Vec<GpuSample> = Vec::new();
   let card_ids = drm_sys::get_all_card_ids();
+
+  // Fetch lspci output once for all cards (avoids forking per card per second)
+  let lspci_output = lspci::get_lspci_nn_output();
 
   for card_id in card_ids {
     let vendor = drm_sys::detect_gpu_vendor(card_id);
@@ -364,7 +368,9 @@ async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
       drm_sys::GpuVendor::Amd => {
         let name = drm_sys::get_card_bdf(card_id)
           .and_then(|bdf| {
-            crate::infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
+            lspci_output
+              .as_deref()
+              .and_then(|out| lspci::parse_gpu_name_by_bdf(out, &bdf))
           })
           .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
         let usage = drm_sys::get_amd_gpu_usage(card_id as u32)

--- a/src-tauri/src/services/monitoring_service.rs
+++ b/src-tauri/src/services/monitoring_service.rs
@@ -358,17 +358,19 @@ async fn collect_linux_gpu_metrics() -> Vec<GpuSample> {
   let mut metrics: Vec<GpuSample> = Vec::new();
   let card_ids = drm_sys::get_all_card_ids();
 
-  // Fetch lspci output once for all cards (avoids forking per card per second)
-  let lspci_output = lspci::get_lspci_nn_output();
+  // Lazily fetched on first AMD card (avoids forking lspci on Intel-only systems
+  // while still fetching only once when multiple AMD cards are present)
+  let mut lspci_output: Option<Option<String>> = None;
 
   for card_id in card_ids {
     let vendor = drm_sys::detect_gpu_vendor(card_id);
 
     let (name, usage, temperature, source) = match vendor {
       drm_sys::GpuVendor::Amd => {
+        let cached = lspci_output.get_or_insert_with(lspci::get_lspci_nn_output);
         let name = drm_sys::get_card_bdf(card_id)
           .and_then(|bdf| {
-            lspci_output
+            cached
               .as_deref()
               .and_then(|out| lspci::parse_gpu_name_by_bdf(out, &bdf))
           })


### PR DESCRIPTION
collect_linux_gpu_metrics() called get_gpu_name_from_lspci_by_bdf() inside the per-card loop, forking lspci once per AMD card per second. Extract get_lspci_nn_output() and call it once before the loop, then use parse_gpu_name_by_bdf() directly for each card.

## Summary

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved GPU monitoring efficiency on Linux systems by reducing redundant system queries when detecting and monitoring AMD GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->