### PR TITLE
chore: enable blank issues and add GitHub Community Support link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/orgs/community/discussions
+    about: Please ask and answer questions here.
   - name: Security Vulnerability
     url: mailto:m11c3.sh@gmail.com
     about: Do not open a public issue for security vulnerabilities. Contact the maintainer directly.


### PR DESCRIPTION
## Summary

This pull request updates the issue template configuration to make it easier for users to submit blank issues and access community support. The most important changes are:

Improvements to issue submission and support:

* Enabled blank issues by setting `blank_issues_enabled` to `true` in `.github/ISSUE_TEMPLATE/config.yml`, allowing users to submit issues without using a template.
* Added a "GitHub Community Support" contact link to direct users to the GitHub Community Discussions page for questions and answers.

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors
