### PR TITLE
Update GitHub Community Support link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: GitHub Community Support
-    url: https://github.com/orgs/community/discussions
-    about: Please ask and answer questions here.
+    url: https://github.com/shm11C3/HardwareVisualizer/discussions
+    about: Feel free to ask questions, share ideas, or drop your feedback here.
   - name: Security Vulnerability
     url: mailto:m11c3.sh@gmail.com
     about: Do not open a public issue for security vulnerabilities. Contact the maintainer directly.


### PR DESCRIPTION
## Summary

Update the GitHub Community Support link in the issue template to direct users to the appropriate discussions page for asking questions, sharing ideas, or providing feedback.

## Related Issues

<!-- No related issues -->

## Type of Change

- [x] Other (`chore/` branch)

## Screenshots / Videos

<!-- No screenshots or videos applicable -->

## Test Plan

- [x] Manual testing

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the issue template configuration to direct users to the repository's dedicated Discussions page for community support inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->