### PR TITLE
feat(backend): graceful handling of DB schema version mismatch on downgrade

### DIFF
--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -1,5 +1,14 @@
 use tauri_plugin_sql::{Migration, MigrationKind};
 
+pub fn get_max_migration_version() -> i64 {
+  get_migrations()
+    .iter()
+    .filter(|m| matches!(m.kind, MigrationKind::Up))
+    .map(|m| m.version)
+    .max()
+    .unwrap_or(0)
+}
+
 pub fn get_migrations() -> Vec<Migration> {
   vec![
     // Up Migrations
@@ -60,6 +69,11 @@ mod tests {
       .expect("Version 5 up migration must exist");
     assert!(v5.sql.contains("gpu_id TEXT"));
     assert!(v5.sql.contains("GPU_DATA_ARCHIVE"));
+  }
+
+  #[test]
+  fn max_migration_version() {
+    assert_eq!(get_max_migration_version(), 5);
   }
 
   #[test]

--- a/src-tauri/src/infrastructure/database/mod.rs
+++ b/src-tauri/src/infrastructure/database/mod.rs
@@ -2,4 +2,5 @@ pub mod db;
 pub mod gpu_archive;
 pub mod hardware_archive;
 pub mod migration;
+pub mod preflight;
 pub mod process_stats;

--- a/src-tauri/src/infrastructure/database/preflight.rs
+++ b/src-tauri/src/infrastructure/database/preflight.rs
@@ -1,0 +1,235 @@
+use crate::utils;
+use sqlx::Row;
+use sqlx::sqlite::SqlitePool;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbStartupError {
+  IncompatibleVersion {
+    db_max_version: i64,
+    app_max_version: i64,
+  },
+  Other(String),
+}
+
+/// Check if the database schema is compatible with this app version.
+///
+/// Returns `None` if the database is compatible or doesn't exist yet.
+/// Returns `Some(DbStartupError)` if the database schema is incompatible.
+pub fn check_db_compatibility() -> Option<DbStartupError> {
+  let db_path = utils::file::get_app_data_dir("hv-database.db");
+  let app_max_version = super::migration::get_max_migration_version();
+  check_db_compatibility_at(&db_path, app_max_version)
+}
+
+fn check_db_compatibility_at(db_path: &Path, app_max_version: i64) -> Option<DbStartupError> {
+  if !db_path.exists() {
+    return None;
+  }
+
+  let database_url = format!("sqlite:{}", db_path.to_string_lossy());
+
+  let result = tauri::async_runtime::block_on(async {
+    query_max_migration_version(&database_url).await
+  });
+
+  match result {
+    Ok(Some(db_max_version)) if db_max_version > app_max_version => {
+      Some(DbStartupError::IncompatibleVersion {
+        db_max_version,
+        app_max_version,
+      })
+    }
+    Ok(_) => None,
+    Err(e) => {
+      let err_msg = e.to_string();
+      // Table doesn't exist yet — first migration hasn't run
+      if err_msg.contains("no such table") {
+        None
+      } else {
+        Some(DbStartupError::Other(err_msg))
+      }
+    }
+  }
+}
+
+async fn query_max_migration_version(
+  database_url: &str,
+) -> Result<Option<i64>, sqlx::Error> {
+  let pool = SqlitePool::connect(database_url).await?;
+  let row = sqlx::query(
+    "SELECT MAX(version) as max_version FROM _sqlx_migrations WHERE success = 1",
+  )
+  .fetch_optional(&pool)
+  .await;
+  pool.close().await;
+
+  match row {
+    Ok(Some(r)) => Ok(r.get("max_version")),
+    Ok(None) => Ok(None),
+    Err(e) => Err(e),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use sqlx::sqlite::SqlitePool;
+  use tempfile::NamedTempFile;
+
+  async fn create_test_db(path: &Path) -> SqlitePool {
+    let url = format!("sqlite:{}", path.to_string_lossy());
+    let pool = SqlitePool::connect(&url).await.unwrap();
+    sqlx::query(
+      "CREATE TABLE _sqlx_migrations (
+        version BIGINT PRIMARY KEY,
+        description TEXT NOT NULL,
+        installed_on TEXT NOT NULL DEFAULT (datetime('now')),
+        success BOOLEAN NOT NULL,
+        checksum BLOB NOT NULL,
+        execution_time BIGINT NOT NULL
+      )",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool
+  }
+
+  async fn insert_migration(pool: &SqlitePool, version: i64, success: bool) {
+    sqlx::query(
+      "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
+       VALUES (?, 'test', ?, X'00', 0)",
+    )
+    .bind(version)
+    .bind(success)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  #[tokio::test]
+  async fn query_returns_none_when_no_migration_table() {
+    let tmp = NamedTempFile::new().unwrap();
+    let url = format!("sqlite:{}", tmp.path().to_string_lossy());
+    // Create an empty DB (no _sqlx_migrations table)
+    let _pool = SqlitePool::connect(&url).await.unwrap();
+
+    let result = query_max_migration_version(&url).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("no such table"));
+  }
+
+  #[tokio::test]
+  async fn query_returns_none_when_table_empty() {
+    let tmp = NamedTempFile::new().unwrap();
+    let pool = create_test_db(tmp.path()).await;
+    pool.close().await;
+
+    let url = format!("sqlite:{}", tmp.path().to_string_lossy());
+    let result = query_max_migration_version(&url).await.unwrap();
+    // MAX() on empty table returns NULL → None
+    assert_eq!(result, None);
+  }
+
+  #[tokio::test]
+  async fn query_returns_max_successful_version() {
+    let tmp = NamedTempFile::new().unwrap();
+    let pool = create_test_db(tmp.path()).await;
+    insert_migration(&pool, 1, true).await;
+    insert_migration(&pool, 2, true).await;
+    insert_migration(&pool, 3, true).await;
+    pool.close().await;
+
+    let url = format!("sqlite:{}", tmp.path().to_string_lossy());
+    let result = query_max_migration_version(&url).await.unwrap();
+    assert_eq!(result, Some(3));
+  }
+
+  #[tokio::test]
+  async fn query_ignores_failed_migrations() {
+    let tmp = NamedTempFile::new().unwrap();
+    let pool = create_test_db(tmp.path()).await;
+    insert_migration(&pool, 1, true).await;
+    insert_migration(&pool, 2, true).await;
+    insert_migration(&pool, 3, false).await; // failed
+    pool.close().await;
+
+    let url = format!("sqlite:{}", tmp.path().to_string_lossy());
+    let result = query_max_migration_version(&url).await.unwrap();
+    assert_eq!(result, Some(2));
+  }
+
+  #[test]
+  fn compatible_when_db_file_does_not_exist() {
+    let path = Path::new("/nonexistent/path/to/db.sqlite");
+    assert_eq!(check_db_compatibility_at(path, 5), None);
+  }
+
+  #[test]
+  fn compatible_when_db_version_equals_app_version() {
+    let tmp = NamedTempFile::new().unwrap();
+    tauri::async_runtime::block_on(async {
+      let pool = create_test_db(tmp.path()).await;
+      insert_migration(&pool, 1, true).await;
+      insert_migration(&pool, 5, true).await;
+      pool.close().await;
+    });
+
+    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+  }
+
+  #[test]
+  fn compatible_when_db_version_lower_than_app() {
+    let tmp = NamedTempFile::new().unwrap();
+    tauri::async_runtime::block_on(async {
+      let pool = create_test_db(tmp.path()).await;
+      insert_migration(&pool, 1, true).await;
+      insert_migration(&pool, 3, true).await;
+      pool.close().await;
+    });
+
+    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+  }
+
+  #[test]
+  fn incompatible_when_db_version_higher_than_app() {
+    let tmp = NamedTempFile::new().unwrap();
+    tauri::async_runtime::block_on(async {
+      let pool = create_test_db(tmp.path()).await;
+      insert_migration(&pool, 1, true).await;
+      insert_migration(&pool, 6, true).await;
+      pool.close().await;
+    });
+
+    assert_eq!(
+      check_db_compatibility_at(tmp.path(), 5),
+      Some(DbStartupError::IncompatibleVersion {
+        db_max_version: 6,
+        app_max_version: 5,
+      })
+    );
+  }
+
+  #[test]
+  fn compatible_when_no_migration_table() {
+    let tmp = NamedTempFile::new().unwrap();
+    tauri::async_runtime::block_on(async {
+      let url = format!("sqlite:{}", tmp.path().to_string_lossy());
+      let _pool = SqlitePool::connect(&url).await.unwrap();
+    });
+
+    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+  }
+
+  #[test]
+  fn compatible_when_migration_table_empty() {
+    let tmp = NamedTempFile::new().unwrap();
+    tauri::async_runtime::block_on(async {
+      let pool = create_test_db(tmp.path()).await;
+      pool.close().await;
+    });
+
+    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+  }
+}

--- a/src-tauri/src/infrastructure/database/preflight.rs
+++ b/src-tauri/src/infrastructure/database/preflight.rs
@@ -22,7 +22,10 @@ pub fn check_db_compatibility() -> Option<DbStartupError> {
   check_db_compatibility_at(&db_path, app_max_version)
 }
 
-fn check_db_compatibility_at(db_path: &Path, app_max_version: i64) -> Option<DbStartupError> {
+fn check_db_compatibility_at(
+  db_path: &Path,
+  app_max_version: i64,
+) -> Option<DbStartupError> {
   if !db_path.exists() {
     return None;
   }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,9 @@ pub fn run() {
 
   let settings = app_state.settings.lock().unwrap().clone();
 
+  let db_error = infrastructure::database::preflight::check_db_compatibility();
+  let is_db_ok = db_error.is_none();
+
   let migrations = infrastructure::database::migration::get_migrations();
 
   let builder = Builder::<tauri::Wry>::new()
@@ -124,7 +127,7 @@ pub fn run() {
     )
     .expect("Failed to export typescript bindings");
 
-  tauri::Builder::<Wry>::default()
+  let mut tauri_builder = tauri::Builder::<Wry>::default()
     .invoke_handler(builder.invoke_handler())
     .setup(move |app| {
       let path_resolver = app.path();
@@ -132,33 +135,13 @@ pub fn run() {
       // Initialize logger
       utils::logger::init(path_resolver.app_log_dir().unwrap());
 
-      // Initialize UI
-      commands::ui::init(app);
+      if is_db_ok {
+        // Initialize UI
+        commands::ui::init(app);
 
-      builder.mount_events(app);
+        builder.mount_events(app);
 
-      let monitor = workers::system_monitor::SystemMonitorController::setup(
-        models::hardware_archive::MonitorResources {
-          system: Arc::clone(&system),
-          cpu_history: Arc::clone(&cpu_history),
-          memory_history: Arc::clone(&memory_history),
-          process_cpu_histories: Arc::clone(&process_cpu_histories),
-          process_memory_histories: Arc::clone(&process_memory_histories),
-          gpu_usage_histories: Arc::clone(&gpu_usage_histories),
-          gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
-          gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
-          gpu_name_map: Arc::clone(&gpu_name_map),
-        },
-        app.handle().clone(),
-      );
-      {
-        let ws = app.state::<workers::WorkersState>();
-        ws.monitor.lock().unwrap().replace(monitor);
-      }
-
-      // Start hardware archive service
-      if settings.hardware_archive.enabled {
-        let hw_archive = workers::hardware_archive::HardwareArchiveController::setup(
+        let monitor = workers::system_monitor::SystemMonitorController::setup(
           models::hardware_archive::MonitorResources {
             system: Arc::clone(&system),
             cpu_history: Arc::clone(&cpu_history),
@@ -170,18 +153,58 @@ pub fn run() {
             gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
             gpu_name_map: Arc::clone(&gpu_name_map),
           },
+          app.handle().clone(),
         );
         {
           let ws = app.state::<workers::WorkersState>();
-          ws.hw_archive.lock().unwrap().replace(hw_archive);
+          ws.monitor.lock().unwrap().replace(monitor);
         }
-      }
 
-      // Start scheduled data deletion
-      if settings.hardware_archive.scheduled_data_deletion {
-        tauri::async_runtime::spawn(workers::hardware_archive::batch_delete_old_data(
-          settings.hardware_archive.refresh_interval_days,
-        ));
+        // Start hardware archive service
+        if settings.hardware_archive.enabled {
+          let hw_archive = workers::hardware_archive::HardwareArchiveController::setup(
+            models::hardware_archive::MonitorResources {
+              system: Arc::clone(&system),
+              cpu_history: Arc::clone(&cpu_history),
+              memory_history: Arc::clone(&memory_history),
+              process_cpu_histories: Arc::clone(&process_cpu_histories),
+              process_memory_histories: Arc::clone(&process_memory_histories),
+              gpu_usage_histories: Arc::clone(&gpu_usage_histories),
+              gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
+              gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
+              gpu_name_map: Arc::clone(&gpu_name_map),
+            },
+          );
+          {
+            let ws = app.state::<workers::WorkersState>();
+            ws.hw_archive.lock().unwrap().replace(hw_archive);
+          }
+        }
+
+        // Start scheduled data deletion
+        if settings.hardware_archive.scheduled_data_deletion {
+          tauri::async_runtime::spawn(workers::hardware_archive::batch_delete_old_data(
+            settings.hardware_archive.refresh_interval_days,
+          ));
+        }
+      } else {
+        // Database schema is incompatible — show error dialog
+        if let Some(window) = app.get_webview_window("main") {
+          let _ = window.hide();
+        }
+
+        let handle = app.handle().clone();
+        let db_err = db_error.expect("db_error must be Some when is_db_ok is false");
+        std::thread::spawn(move || {
+          use services::db_startup_service::{self, StartupErrorAction};
+          match db_startup_service::prompt_startup_error(&handle, db_err) {
+            StartupErrorAction::ResetAndRestart => {
+              db_startup_service::reset_database_and_restart(&handle);
+            }
+            StartupErrorAction::ContinueAnyway => {}
+            StartupErrorAction::Exit => handle.exit(1),
+          }
+        });
       }
 
       Ok(())
@@ -205,11 +228,6 @@ pub fn run() {
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_window_state::Builder::default().build())
     .plugin(tauri_plugin_shell::init())
-    .plugin(
-      tauri_plugin_sql::Builder::new()
-        .add_migrations("sqlite:hv-database.db", migrations)
-        .build(),
-    )
     .plugin(tauri_plugin_autostart::init(
       MacosLauncher::LaunchAgent,
       Some(vec![]),
@@ -220,7 +238,17 @@ pub fn run() {
     .manage(state)
     .manage(app_state)
     .manage(workers::WorkersState::default())
-    .manage(app_updates::PendingUpdate(Mutex::new(None)))
+    .manage(app_updates::PendingUpdate(Mutex::new(None)));
+
+  if is_db_ok {
+    tauri_builder = tauri_builder.plugin(
+      tauri_plugin_sql::Builder::new()
+        .add_migrations("sqlite:hv-database.db", migrations)
+        .build(),
+    );
+  }
+
+  tauri_builder
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,32 +135,31 @@ pub fn run() {
       // Initialize logger
       utils::logger::init(path_resolver.app_log_dir().unwrap());
 
+      // Initialize UI and real-time monitoring (independent of DB)
+      commands::ui::init(app);
+      builder.mount_events(app);
+
+      let monitor = workers::system_monitor::SystemMonitorController::setup(
+        models::hardware_archive::MonitorResources {
+          system: Arc::clone(&system),
+          cpu_history: Arc::clone(&cpu_history),
+          memory_history: Arc::clone(&memory_history),
+          process_cpu_histories: Arc::clone(&process_cpu_histories),
+          process_memory_histories: Arc::clone(&process_memory_histories),
+          gpu_usage_histories: Arc::clone(&gpu_usage_histories),
+          gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
+          gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
+          gpu_name_map: Arc::clone(&gpu_name_map),
+        },
+        app.handle().clone(),
+      );
+      {
+        let ws = app.state::<workers::WorkersState>();
+        ws.monitor.lock().unwrap().replace(monitor);
+      }
+
       if is_db_ok {
-        // Initialize UI
-        commands::ui::init(app);
-
-        builder.mount_events(app);
-
-        let monitor = workers::system_monitor::SystemMonitorController::setup(
-          models::hardware_archive::MonitorResources {
-            system: Arc::clone(&system),
-            cpu_history: Arc::clone(&cpu_history),
-            memory_history: Arc::clone(&memory_history),
-            process_cpu_histories: Arc::clone(&process_cpu_histories),
-            process_memory_histories: Arc::clone(&process_memory_histories),
-            gpu_usage_histories: Arc::clone(&gpu_usage_histories),
-            gpu_temperature_histories: Arc::clone(&gpu_temperature_histories),
-            gpu_dedicated_memory_histories: Arc::clone(&gpu_dedicated_memory_histories),
-            gpu_name_map: Arc::clone(&gpu_name_map),
-          },
-          app.handle().clone(),
-        );
-        {
-          let ws = app.state::<workers::WorkersState>();
-          ws.monitor.lock().unwrap().replace(monitor);
-        }
-
-        // Start hardware archive service
+        // Start DB-dependent archive services
         if settings.hardware_archive.enabled {
           let hw_archive = workers::hardware_archive::HardwareArchiveController::setup(
             models::hardware_archive::MonitorResources {
@@ -181,7 +180,6 @@ pub fn run() {
           }
         }
 
-        // Start scheduled data deletion
         if settings.hardware_archive.scheduled_data_deletion {
           tauri::async_runtime::spawn(workers::hardware_archive::batch_delete_old_data(
             settings.hardware_archive.refresh_interval_days,
@@ -189,6 +187,7 @@ pub fn run() {
         }
       } else {
         // Database schema is incompatible — show error dialog
+        // Hide window while dialog is shown, then restore based on user choice
         if let Some(window) = app.get_webview_window("main") {
           let _ = window.hide();
         }
@@ -201,7 +200,12 @@ pub fn run() {
             StartupErrorAction::ResetAndRestart => {
               db_startup_service::reset_database_and_restart(&handle);
             }
-            StartupErrorAction::ContinueAnyway => {}
+            StartupErrorAction::ContinueAnyway => {
+              // Show the main window — app runs without DB-backed features
+              if let Some(window) = handle.get_webview_window("main") {
+                let _ = window.show();
+              }
+            }
             StartupErrorAction::Exit => handle.exit(1),
           }
         });

--- a/src-tauri/src/services/db_startup_service.rs
+++ b/src-tauri/src/services/db_startup_service.rs
@@ -1,7 +1,9 @@
 use crate::infrastructure::database::preflight::DbStartupError;
 use crate::utils;
 use std::path::Path;
-use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult};
+use tauri_plugin_dialog::{
+  DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
+};
 
 const RESET_LABEL: &str = "Reset and Restart";
 const CONTINUE_LABEL: &str = "Continue Anyway";
@@ -36,8 +38,8 @@ pub fn prompt_startup_error(
     ))
     .blocking_show_with_result();
 
-  let is_reset =
-    result == MessageDialogResult::Yes || result == MessageDialogResult::Custom(RESET_LABEL.into());
+  let is_reset = result == MessageDialogResult::Yes
+    || result == MessageDialogResult::Custom(RESET_LABEL.into());
   let is_continue = result == MessageDialogResult::No
     || result == MessageDialogResult::Custom(CONTINUE_LABEL.into());
 

--- a/src-tauri/src/services/db_startup_service.rs
+++ b/src-tauri/src/services/db_startup_service.rs
@@ -56,24 +56,29 @@ pub fn prompt_startup_error(
 pub fn reset_database_and_restart(handle: &tauri::AppHandle) {
   let db_path = utils::file::get_app_data_dir("hv-database.db");
   if let Err(e) = delete_database_files(&db_path) {
-    handle
-      .dialog()
-      .message(format!("Failed to delete database file: {e}"))
-      .title("Error")
-      .kind(MessageDialogKind::Error)
-      .buttons(MessageDialogButtons::Ok)
-      .blocking_show();
+    show_error_dialog(handle, &format!("Failed to delete database file: {e}"));
     handle.exit(1);
     return;
   }
 
-  let exe_path = std::env::current_exe().expect("Failed to obtain executable path");
+  let exe_path = match std::env::current_exe() {
+    Ok(path) => path,
+    Err(e) => {
+      show_error_dialog(handle, &format!("Failed to obtain executable path: {e}"));
+      handle.exit(1);
+      return;
+    }
+  };
   let args: Vec<String> = std::env::args().collect();
   #[allow(clippy::zombie_processes)]
-  std::process::Command::new(exe_path)
+  if let Err(e) = std::process::Command::new(exe_path)
     .args(&args[1..])
     .spawn()
-    .expect("Failed to restart process");
+  {
+    show_error_dialog(handle, &format!("Failed to restart process: {e}"));
+    handle.exit(1);
+    return;
+  }
   handle.exit(0);
 }
 
@@ -88,6 +93,16 @@ pub(crate) fn delete_database_files(db_path: &Path) -> std::io::Result<()> {
   let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
   let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
   Ok(())
+}
+
+fn show_error_dialog(handle: &tauri::AppHandle, message: &str) {
+  handle
+    .dialog()
+    .message(message.to_string())
+    .title("Error")
+    .kind(MessageDialogKind::Error)
+    .buttons(MessageDialogButtons::Ok)
+    .blocking_show();
 }
 
 fn build_message(error: &DbStartupError) -> String {

--- a/src-tauri/src/services/db_startup_service.rs
+++ b/src-tauri/src/services/db_startup_service.rs
@@ -1,0 +1,178 @@
+use crate::infrastructure::database::preflight::DbStartupError;
+use crate::utils;
+use std::path::Path;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult};
+
+const RESET_LABEL: &str = "Reset and Restart";
+const CONTINUE_LABEL: &str = "Continue Anyway";
+const EXIT_LABEL: &str = "Exit";
+
+/// User's chosen action from the DB startup error dialog.
+pub enum StartupErrorAction {
+  /// User chose to delete DB and restart.
+  ResetAndRestart,
+  /// User chose to continue without the database.
+  ContinueAnyway,
+  /// User chose to exit.
+  Exit,
+}
+
+/// Show a dialog for a DB startup error and return the user's chosen action.
+pub fn prompt_startup_error(
+  handle: &tauri::AppHandle,
+  error: DbStartupError,
+) -> StartupErrorAction {
+  let message = build_message(&error);
+
+  let result = handle
+    .dialog()
+    .message(message)
+    .title("Data Compatibility Issue")
+    .kind(MessageDialogKind::Warning)
+    .buttons(MessageDialogButtons::YesNoCancelCustom(
+      RESET_LABEL.into(),
+      CONTINUE_LABEL.into(),
+      EXIT_LABEL.into(),
+    ))
+    .blocking_show_with_result();
+
+  let is_reset =
+    result == MessageDialogResult::Yes || result == MessageDialogResult::Custom(RESET_LABEL.into());
+  let is_continue = result == MessageDialogResult::No
+    || result == MessageDialogResult::Custom(CONTINUE_LABEL.into());
+
+  if is_reset {
+    StartupErrorAction::ResetAndRestart
+  } else if is_continue {
+    StartupErrorAction::ContinueAnyway
+  } else {
+    StartupErrorAction::Exit
+  }
+}
+
+/// Delete the database file (and WAL/SHM companions), then restart the app.
+pub fn reset_database_and_restart(handle: &tauri::AppHandle) {
+  let db_path = utils::file::get_app_data_dir("hv-database.db");
+  if let Err(e) = delete_database_files(&db_path) {
+    handle
+      .dialog()
+      .message(format!("Failed to delete database file: {e}"))
+      .title("Error")
+      .kind(MessageDialogKind::Error)
+      .buttons(MessageDialogButtons::Ok)
+      .blocking_show();
+    handle.exit(1);
+    return;
+  }
+
+  let exe_path = std::env::current_exe().expect("Failed to obtain executable path");
+  let args: Vec<String> = std::env::args().collect();
+  #[allow(clippy::zombie_processes)]
+  std::process::Command::new(exe_path)
+    .args(&args[1..])
+    .spawn()
+    .expect("Failed to restart process");
+  handle.exit(0);
+}
+
+/// Delete the database file and its WAL/SHM companions.
+///
+/// Returns `Ok(())` if the main DB file was successfully deleted (or didn't exist).
+/// WAL/SHM deletion errors are silently ignored since they are optional files.
+pub(crate) fn delete_database_files(db_path: &Path) -> std::io::Result<()> {
+  if db_path.exists() {
+    std::fs::remove_file(db_path)?;
+  }
+  let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+  let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+  Ok(())
+}
+
+fn build_message(error: &DbStartupError) -> String {
+  match error {
+    DbStartupError::IncompatibleVersion {
+      db_max_version,
+      app_max_version,
+    } => {
+      format!(
+        "This version of HardwareVisualizer is not compatible with the existing data.\n\
+         This usually happens when reverting to an older version of the app.\n\n\
+         You can reset the data to continue using this version, \
+         or update to the latest version to keep your data.\n\n\
+         * Resetting will delete all archived hardware monitoring history.\n\n\
+         [Details: data schema v{db_max_version}, app supports up to v{app_max_version}]"
+      )
+    }
+    DbStartupError::Other(msg) => {
+      format!(
+        "HardwareVisualizer could not read the existing data.\n\n\
+         You can reset the data to continue using the app.\n\n\
+         * Resetting will delete all archived hardware monitoring history.\n\n\
+         [Details: {msg}]"
+      )
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+  use tempfile::TempDir;
+
+  #[test]
+  fn build_message_incompatible_version_contains_versions() {
+    let msg = build_message(&DbStartupError::IncompatibleVersion {
+      db_max_version: 6,
+      app_max_version: 5,
+    });
+    assert!(msg.contains("v6"));
+    assert!(msg.contains("v5"));
+    assert!(msg.contains("not compatible"));
+    assert!(msg.contains("older version"));
+  }
+
+  #[test]
+  fn build_message_other_contains_detail() {
+    let msg = build_message(&DbStartupError::Other("disk I/O error".into()));
+    assert!(msg.contains("disk I/O error"));
+    assert!(msg.contains("could not read"));
+  }
+
+  #[test]
+  fn delete_database_files_removes_all_files() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let wal_path = dir.path().join("test.db-wal");
+    let shm_path = dir.path().join("test.db-shm");
+
+    fs::write(&db_path, b"db").unwrap();
+    fs::write(&wal_path, b"wal").unwrap();
+    fs::write(&shm_path, b"shm").unwrap();
+
+    delete_database_files(&db_path).unwrap();
+
+    assert!(!db_path.exists());
+    assert!(!wal_path.exists());
+    assert!(!shm_path.exists());
+  }
+
+  #[test]
+  fn delete_database_files_ok_when_no_file() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("nonexistent.db");
+
+    assert!(delete_database_files(&db_path).is_ok());
+  }
+
+  #[test]
+  fn delete_database_files_ok_without_wal_shm() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    fs::write(&db_path, b"db").unwrap();
+
+    delete_database_files(&db_path).unwrap();
+
+    assert!(!db_path.exists());
+  }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod archive_service;
 pub mod background_image_service;
 pub mod cpu_service;
+pub mod db_startup_service;
 pub mod gpu_service;
 pub mod hardware_service;
 pub mod language_service;


### PR DESCRIPTION
## Summary

When a user downgrades the app, the SQLite database may have a newer schema than the older app expects, causing a panic on startup. This adds a pre-flight schema compatibility check before Tauri starts, and shows a native dialog offering to reset the database, continue anyway, or exit — instead of crashing silently.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [x] Manual testing
- [x] Unit tests

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App performs a database compatibility check at startup and defers DB-dependent initialization until the check completes.

* **Bug Fixes**
  * When an incompatible database is detected, the app shows a clear “Data Compatibility Issue” dialog with options to reset & restart, continue anyway, or exit. The main window is hidden while the issue is handled to prevent crashes.

* **Tests**
  * Expanded test suite covering many database compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->