### PR TITLE
feat(frontend): redesign atoms and event listener for multi-GPU (#1299)

### DIFF
--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -9,7 +9,9 @@ import {
   gpuDedicatedMemoryKbAtom,
   gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedAtom,
+  gpuFanSpeedMapAtom,
   gpuTempAtom,
+  gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   gpuUsageSourceAtom,
   gpuUsageSourcesAtom,
@@ -531,7 +533,42 @@ describe("useHardwareEventListener", () => {
       expect(history[history.length - 1]).toBe(42);
     });
 
-    it("collects temperature from all GPUs", () => {
+    it("stores temperature per GPU in gpuTempMapAtom", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [map] = useAtom(gpuTempMapAtom);
+          return map;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuName: "GPU A",
+                gpuTemperature: 60,
+              }),
+              makeGpu({
+                gpuId: "nvapi:1",
+                gpuName: "GPU B",
+                gpuTemperature: 75,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual({
+        "nvapi:0": { name: "GPU A", value: 60 },
+        "nvapi:1": { name: "GPU B", value: 75 },
+      });
+    });
+
+    it("derives gpuTempAtom as NameValues from all GPUs", () => {
       const { result } = renderHook(
         () => {
           useHardwareEventListener();
@@ -566,7 +603,42 @@ describe("useHardwareEventListener", () => {
       ]);
     });
 
-    it("collects fan speed from all GPUs", () => {
+    it("stores fan speed per GPU in gpuFanSpeedMapAtom", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [map] = useAtom(gpuFanSpeedMapAtom);
+          return map;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuName: "GPU A",
+                gpuCoolerLevel: 40,
+              }),
+              makeGpu({
+                gpuId: "nvapi:1",
+                gpuName: "GPU B",
+                gpuCoolerLevel: 65,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual({
+        "nvapi:0": { name: "GPU A", value: 40 },
+        "nvapi:1": { name: "GPU B", value: 65 },
+      });
+    });
+
+    it("derives gpuFanSpeedAtom as NameValues from all GPUs", () => {
       const { result } = renderHook(
         () => {
           useHardwareEventListener();

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -7,12 +7,16 @@ import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareE
 import {
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbAtom,
+  gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedAtom,
   gpuTempAtom,
+  gpuUsageHistoriesAtom,
   gpuUsageSourceAtom,
+  gpuUsageSourcesAtom,
   graphicUsageHistoryAtom,
   memoryUsageHistoryAtom,
   processorsUsageHistoryAtom,
+  selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import type { GpuMonitorData, HardwareMonitorUpdate } from "@/rspc/bindings";
 
@@ -429,5 +433,232 @@ describe("useHardwareEventListener", () => {
     expect(cpu).toHaveLength(chartConfig.historyLengthSec);
     expect(cpu.slice(-3)).toEqual([10, 30, 50]);
     expect(mem.slice(-3)).toEqual([20, 40, 60]);
+  });
+
+  // ── Multi-GPU ──
+
+  describe("multi-GPU support", () => {
+    it("tracks separate usage histories per GPU", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [histories] = useAtom(gpuUsageHistoriesAtom);
+          return histories;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0", gpuUsage: 50 }),
+              makeGpu({ gpuId: "nvapi:1", gpuUsage: 80 }),
+            ],
+          }),
+        ),
+      );
+
+      const histories = result.current;
+      expect(histories["nvapi:0"][histories["nvapi:0"].length - 1]).toBe(50);
+      expect(histories["nvapi:1"][histories["nvapi:1"].length - 1]).toBe(80);
+    });
+
+    it("auto-selects first GPU ID when selectedGpuIdAtom is null", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [id] = useAtom(selectedGpuIdAtom);
+          return id;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0" }),
+              makeGpu({ gpuId: "nvapi:1" }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toBe("nvapi:0");
+    });
+
+    it("does not change selectedGpuIdAtom once set", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [id] = useAtom(selectedGpuIdAtom);
+          return id;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() => {
+        emit(makePayload({ gpus: [makeGpu({ gpuId: "nvapi:0" })] }));
+        emit(makePayload({ gpus: [makeGpu({ gpuId: "nvapi:1" })] }));
+      });
+
+      expect(result.current).toBe("nvapi:0");
+    });
+
+    it("graphicUsageHistoryAtom resolves to selected GPU history", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [history] = useAtom(graphicUsageHistoryAtom);
+          return history;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0", gpuUsage: 42 }),
+              makeGpu({ gpuId: "nvapi:1", gpuUsage: 99 }),
+            ],
+          }),
+        ),
+      );
+
+      const history = result.current;
+      expect(history[history.length - 1]).toBe(42);
+    });
+
+    it("collects temperature from all GPUs", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [temp] = useAtom(gpuTempAtom);
+          return temp;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuName: "GPU A",
+                gpuTemperature: 60,
+              }),
+              makeGpu({
+                gpuId: "nvapi:1",
+                gpuName: "GPU B",
+                gpuTemperature: 75,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual([
+        { name: "GPU A", value: 60 },
+        { name: "GPU B", value: 75 },
+      ]);
+    });
+
+    it("collects fan speed from all GPUs", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [fan] = useAtom(gpuFanSpeedAtom);
+          return fan;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuName: "GPU A",
+                gpuCoolerLevel: 40,
+              }),
+              makeGpu({
+                gpuId: "nvapi:1",
+                gpuName: "GPU B",
+                gpuCoolerLevel: 65,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual([
+        { name: "GPU A", value: 40 },
+        { name: "GPU B", value: 65 },
+      ]);
+    });
+
+    it("tracks usage sources for all GPUs", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [sources] = useAtom(gpuUsageSourcesAtom);
+          return sources;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0", gpuSource: "NVAPI" }),
+              makeGpu({ gpuId: "nvapi:1", gpuSource: "D3DKMT" }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual({
+        "nvapi:0": "NVAPI",
+        "nvapi:1": "D3DKMT",
+      });
+    });
+
+    it("tracks dedicated memory for all GPUs", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [map] = useAtom(gpuDedicatedMemoryKbMapAtom);
+          return map;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuDedicatedMemoryUsageKb: 2048,
+              }),
+              makeGpu({
+                gpuId: "nvapi:1",
+                gpuDedicatedMemoryUsageKb: 4096,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual({
+        "nvapi:0": 2048,
+        "nvapi:1": 4096,
+      });
+    });
   });
 });

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -77,8 +77,11 @@ export const useHardwareEventListener = () => {
       // Temperature from all GPUs
       setGpuTemp(
         gpus
-          .filter((g) => g.gpuName != null && g.gpuTemperature != null)
-          .map((g) => ({ name: g.gpuName, value: g.gpuTemperature as number })),
+          .filter(
+            (g): g is typeof g & { gpuTemperature: number } =>
+              g.gpuTemperature != null,
+          )
+          .map((g) => ({ name: g.gpuName, value: g.gpuTemperature })),
       );
 
       // Usage sources from all GPUs
@@ -102,8 +105,11 @@ export const useHardwareEventListener = () => {
       // Fan speed from all GPUs
       setGpuFanSpeed(
         gpus
-          .filter((g) => g.gpuName != null && g.gpuCoolerLevel != null)
-          .map((g) => ({ name: g.gpuName, value: g.gpuCoolerLevel as number })),
+          .filter(
+            (g): g is typeof g & { gpuCoolerLevel: number } =>
+              g.gpuCoolerLevel != null,
+          )
+          .map((g) => ({ name: g.gpuName, value: g.gpuCoolerLevel })),
       );
 
       // Auto-select first GPU if none selected

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -3,13 +3,14 @@ import { useCallback, useEffect } from "react";
 import { chartConfig } from "@/features/hardware/consts/chart";
 import {
   cpuUsageHistoryAtom,
-  gpuDedicatedMemoryKbAtom,
+  gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedAtom,
   gpuTempAtom,
-  gpuUsageSourceAtom,
-  graphicUsageHistoryAtom,
+  gpuUsageHistoriesAtom,
+  gpuUsageSourcesAtom,
   memoryUsageHistoryAtom,
   processorsUsageHistoryAtom,
+  selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import { events } from "@/rspc/bindings";
 
@@ -27,12 +28,13 @@ const padHistory = (arr: (number | null)[]): number[] => {
 export const useHardwareEventListener = () => {
   const setCpuHistory = useSetAtom(cpuUsageHistoryAtom);
   const setMemoryHistory = useSetAtom(memoryUsageHistoryAtom);
-  const setGpuHistory = useSetAtom(graphicUsageHistoryAtom);
+  const setGpuHistories = useSetAtom(gpuUsageHistoriesAtom);
   const setProcessorsHistory = useSetAtom(processorsUsageHistoryAtom);
   const setGpuTemp = useSetAtom(gpuTempAtom);
-  const setGpuUsageSource = useSetAtom(gpuUsageSourceAtom);
-  const setGpuDedicatedMemory = useSetAtom(gpuDedicatedMemoryKbAtom);
+  const setGpuSources = useSetAtom(gpuUsageSourcesAtom);
+  const setGpuMemoryMap = useSetAtom(gpuDedicatedMemoryKbMapAtom);
   const setGpuFanSpeed = useSetAtom(gpuFanSpeedAtom);
+  const setSelectedGpuId = useSetAtom(selectedGpuIdAtom);
 
   const handleHardwareUpdate = useCallback(
     (event: {
@@ -53,28 +55,61 @@ export const useHardwareEventListener = () => {
     }) => {
       const { cpuUsage, memoryUsage, gpus, processorsUsage } = event.payload;
 
-      // TODO: Multi-GPU support (#1299) — for now use the first GPU
-      const gpu = gpus[0] ?? null;
-
       setCpuHistory((prev) => padHistory([...prev, cpuUsage]));
       setMemoryHistory((prev) => padHistory([...prev, memoryUsage]));
 
-      if (gpu?.gpuUsage != null) {
-        setGpuHistory((prev) => padHistory([...prev, gpu.gpuUsage as number]));
-      }
+      // Per-GPU usage histories
+      setGpuHistories((prev) =>
+        gpus.reduce(
+          (acc, gpu) => {
+            if (gpu.gpuUsage != null) {
+              acc[gpu.gpuId] = padHistory([
+                ...(acc[gpu.gpuId] ?? []),
+                gpu.gpuUsage,
+              ]);
+            }
+            return acc;
+          },
+          { ...prev },
+        ),
+      );
 
-      if (gpu?.gpuName != null && gpu.gpuTemperature != null) {
-        setGpuTemp([{ name: gpu.gpuName, value: gpu.gpuTemperature }]);
-      }
-      setGpuUsageSource(gpu?.gpuSource ?? null);
+      // Temperature from all GPUs
+      setGpuTemp(
+        gpus
+          .filter((g) => g.gpuName != null && g.gpuTemperature != null)
+          .map((g) => ({ name: g.gpuName, value: g.gpuTemperature as number })),
+      );
 
-      if (gpu?.gpuDedicatedMemoryUsageKb != null) {
-        setGpuDedicatedMemory(gpu.gpuDedicatedMemoryUsageKb);
-      }
+      // Usage sources from all GPUs
+      setGpuSources(
+        Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuSource])),
+      );
 
-      if (gpu?.gpuName != null && gpu.gpuCoolerLevel != null) {
-        setGpuFanSpeed([{ name: gpu.gpuName, value: gpu.gpuCoolerLevel }]);
-      }
+      // Dedicated memory from all GPUs (only update when not null)
+      setGpuMemoryMap((prev) =>
+        gpus.reduce(
+          (acc, gpu) => {
+            if (gpu.gpuDedicatedMemoryUsageKb != null) {
+              acc[gpu.gpuId] = gpu.gpuDedicatedMemoryUsageKb;
+            }
+            return acc;
+          },
+          { ...prev },
+        ),
+      );
+
+      // Fan speed from all GPUs
+      setGpuFanSpeed(
+        gpus
+          .filter((g) => g.gpuName != null && g.gpuCoolerLevel != null)
+          .map((g) => ({ name: g.gpuName, value: g.gpuCoolerLevel as number })),
+      );
+
+      // Auto-select first GPU if none selected
+      setSelectedGpuId((prev) =>
+        prev != null ? prev : gpus.length > 0 ? gpus[0].gpuId : null,
+      );
 
       setProcessorsHistory((prev) => {
         const next = [...prev, processorsUsage];
@@ -84,12 +119,13 @@ export const useHardwareEventListener = () => {
     [
       setCpuHistory,
       setMemoryHistory,
-      setGpuHistory,
+      setGpuHistories,
       setGpuTemp,
       setProcessorsHistory,
-      setGpuUsageSource,
-      setGpuDedicatedMemory,
+      setGpuSources,
+      setGpuMemoryMap,
       setGpuFanSpeed,
+      setSelectedGpuId,
     ],
   );
   useEffect(() => {

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -4,8 +4,8 @@ import { chartConfig } from "@/features/hardware/consts/chart";
 import {
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
-  gpuFanSpeedAtom,
-  gpuTempAtom,
+  gpuFanSpeedMapAtom,
+  gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   gpuUsageSourcesAtom,
   memoryUsageHistoryAtom,
@@ -30,10 +30,10 @@ export const useHardwareEventListener = () => {
   const setMemoryHistory = useSetAtom(memoryUsageHistoryAtom);
   const setGpuHistories = useSetAtom(gpuUsageHistoriesAtom);
   const setProcessorsHistory = useSetAtom(processorsUsageHistoryAtom);
-  const setGpuTemp = useSetAtom(gpuTempAtom);
+  const setGpuTempMap = useSetAtom(gpuTempMapAtom);
   const setGpuSources = useSetAtom(gpuUsageSourcesAtom);
   const setGpuMemoryMap = useSetAtom(gpuDedicatedMemoryKbMapAtom);
-  const setGpuFanSpeed = useSetAtom(gpuFanSpeedAtom);
+  const setGpuFanSpeedMap = useSetAtom(gpuFanSpeedMapAtom);
   const setSelectedGpuId = useSetAtom(selectedGpuIdAtom);
 
   const handleHardwareUpdate = useCallback(
@@ -75,13 +75,18 @@ export const useHardwareEventListener = () => {
       );
 
       // Temperature from all GPUs
-      setGpuTemp(
-        gpus
-          .filter(
-            (g): g is typeof g & { gpuTemperature: number } =>
-              g.gpuTemperature != null,
-          )
-          .map((g) => ({ name: g.gpuName, value: g.gpuTemperature })),
+      setGpuTempMap(
+        Object.fromEntries(
+          gpus
+            .filter(
+              (g): g is typeof g & { gpuTemperature: number } =>
+                g.gpuTemperature != null,
+            )
+            .map((g) => [
+              g.gpuId,
+              { name: g.gpuName, value: g.gpuTemperature },
+            ]),
+        ),
       );
 
       // Usage sources from all GPUs
@@ -103,13 +108,18 @@ export const useHardwareEventListener = () => {
       );
 
       // Fan speed from all GPUs
-      setGpuFanSpeed(
-        gpus
-          .filter(
-            (g): g is typeof g & { gpuCoolerLevel: number } =>
-              g.gpuCoolerLevel != null,
-          )
-          .map((g) => ({ name: g.gpuName, value: g.gpuCoolerLevel })),
+      setGpuFanSpeedMap(
+        Object.fromEntries(
+          gpus
+            .filter(
+              (g): g is typeof g & { gpuCoolerLevel: number } =>
+                g.gpuCoolerLevel != null,
+            )
+            .map((g) => [
+              g.gpuId,
+              { name: g.gpuName, value: g.gpuCoolerLevel },
+            ]),
+        ),
       );
 
       // Auto-select first GPU if none selected
@@ -126,11 +136,11 @@ export const useHardwareEventListener = () => {
       setCpuHistory,
       setMemoryHistory,
       setGpuHistories,
-      setGpuTemp,
+      setGpuTempMap,
       setProcessorsHistory,
       setGpuSources,
       setGpuMemoryMap,
-      setGpuFanSpeed,
+      setGpuFanSpeedMap,
       setSelectedGpuId,
     ],
   );

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -21,10 +21,31 @@ export const gpuDedicatedMemoryKbMapAtom = atom<Record<string, number | null>>(
   {},
 );
 
+/** Per-GPU temperature keyed by gpuId */
+export const gpuTempMapAtom = atom<
+  Record<string, { name: string; value: number }>
+>({});
+
+/** Per-GPU fan speed keyed by gpuId */
+export const gpuFanSpeedMapAtom = atom<
+  Record<string, { name: string; value: number }>
+>({});
+
 export const cpuTempAtom = atom<NameValues>([]);
 export const cpuFanSpeedAtom = atom<NameValues>([]);
-export const gpuTempAtom = atom<NameValues>([]);
-export const gpuFanSpeedAtom = atom<NameValues>([]);
+
+/** All GPUs temperature as NameValues (read-write: write clears the map) */
+export const gpuTempAtom = atom<NameValues, [NameValues], void>(
+  (get) => Object.values(get(gpuTempMapAtom)),
+  (_get, set, _update) => {
+    set(gpuTempMapAtom, {});
+  },
+);
+
+/** All GPUs fan speed as NameValues */
+export const gpuFanSpeedAtom = atom<NameValues>((get) =>
+  Object.values(get(gpuFanSpeedMapAtom)),
+);
 
 // ── Derived atoms for backward compatibility ──
 

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -4,10 +4,53 @@ import type { NameValues } from "@/features/hardware/types/hardwareDataType";
 export const cpuUsageHistoryAtom = atom<number[]>([]);
 export const processorsUsageHistoryAtom = atom<number[][]>([]);
 export const memoryUsageHistoryAtom = atom<number[]>([]);
-export const graphicUsageHistoryAtom = atom<number[]>([]);
-export const gpuUsageSourceAtom = atom<string | null>(null);
+
+// ── Multi-GPU state ──
+
+/** Per-GPU usage histories keyed by gpuId */
+export const gpuUsageHistoriesAtom = atom<Record<string, number[]>>({});
+
+/** Currently selected GPU ID for dashboard/usage view */
+export const selectedGpuIdAtom = atom<string | null>(null);
+
+/** Per-GPU usage source keyed by gpuId */
+export const gpuUsageSourcesAtom = atom<Record<string, string | null>>({});
+
+/** Per-GPU dedicated memory (KB) keyed by gpuId */
+export const gpuDedicatedMemoryKbMapAtom = atom<Record<string, number | null>>(
+  {},
+);
+
 export const cpuTempAtom = atom<NameValues>([]);
 export const cpuFanSpeedAtom = atom<NameValues>([]);
 export const gpuTempAtom = atom<NameValues>([]);
 export const gpuFanSpeedAtom = atom<NameValues>([]);
-export const gpuDedicatedMemoryKbAtom = atom<number | null>(null);
+
+// ── Derived atoms for backward compatibility ──
+
+/** Resolves to the selected (or first) GPU's usage history */
+export const graphicUsageHistoryAtom = atom<number[]>((get) => {
+  const selected = get(selectedGpuIdAtom);
+  const histories = get(gpuUsageHistoriesAtom);
+  if (selected && histories[selected]) return histories[selected];
+  const keys = Object.keys(histories);
+  return keys.length > 0 ? histories[keys[0]] : [];
+});
+
+/** Resolves to the selected (or first) GPU's usage source */
+export const gpuUsageSourceAtom = atom<string | null>((get) => {
+  const selected = get(selectedGpuIdAtom);
+  const sources = get(gpuUsageSourcesAtom);
+  if (selected && selected in sources) return sources[selected];
+  const keys = Object.keys(sources);
+  return keys.length > 0 ? (sources[keys[0]] ?? null) : null;
+});
+
+/** Resolves to the selected (or first) GPU's dedicated memory (KB) */
+export const gpuDedicatedMemoryKbAtom = atom<number | null>((get) => {
+  const selected = get(selectedGpuIdAtom);
+  const map = get(gpuDedicatedMemoryKbMapAtom);
+  if (selected && selected in map) return map[selected];
+  const keys = Object.keys(map);
+  return keys.length > 0 ? (map[keys[0]] ?? null) : null;
+});


### PR DESCRIPTION
## Summary

Replace single-GPU atoms with per-GPU map atoms keyed by gpuId and add derived read-only atoms for backward compatibility so existing chart components continue working without changes.

## Related Issues

Close #1299


## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [x] Manual testing
- [x] Unit tests

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-GPU support: per‑GPU usage histories, memory, temperature, fan speed, and usage sources; aggregated temperature and fan-speed views.
  * Automatic GPU selection now defaults to the first available GPU when none is selected.

* **Tests**
  * Added multi‑GPU tests verifying per‑GPU histories, selection behavior, and correct aggregation and mapping of incoming GPU metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->