### PR TITLE
fix: correct history atom types to reflect null padding (#1344)

### DIFF
--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -24,13 +24,13 @@ import { cn } from "@/lib/utils";
 
 type DoughnutChartProps =
   | {
-      chartValue: number;
+      chartValue: number | null;
       usagePercentage: number;
       dataType: "memoryUsageValue";
       unit: string;
     }
   | {
-      chartValue: number;
+      chartValue: number | null;
       dataType: Exclude<HardwareDataType, "memoryUsageValue">;
       unit?: never;
       usagePercentage?: never;

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -104,7 +104,7 @@ export const DoughnutChart = ({
       config={chartConfig}
       className={cn("aspect-square max-h-[100px] xl:max-h-[200px]", className)}
     >
-      {chartData[0].value != null ? (
+      {chartValue != null ? (
         <RadialBarChart
           data={chartData}
           startAngle={0}

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -36,9 +36,9 @@ type SingleChartProps = {
 } & ChartProps;
 
 type MultiChartProps = {
-  cpuData: number[];
-  memoryData: number[];
-  gpuData: number[];
+  cpuData: (number | null)[];
+  memoryData: (number | null)[];
+  gpuData: (number | null)[];
   lineGraphMix: true;
 } & ChartProps;
 

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -214,7 +214,7 @@ export const MemoryInfo = () => {
     const current = memoryUsageHistory[memoryUsageHistory.length - 1];
     const [total, unit] = hardwareInfo.memory?.size.split(" ") || [null, null];
 
-    if (total === null || unit === null) {
+    if (total === null || unit === null || current == null) {
       return {
         memoryCurrentUsage: null,
         memoryCurrentUsageUnit: null,
@@ -235,7 +235,9 @@ export const MemoryInfo = () => {
         {memoryCurrentUsage ? (
           <DoughnutChart
             chartValue={memoryCurrentUsage}
-            usagePercentage={memoryUsageHistory[memoryUsageHistory.length - 1]}
+            usagePercentage={
+              memoryUsageHistory[memoryUsageHistory.length - 1] ?? 0
+            }
             dataType={"memoryUsageValue"}
             unit={memoryCurrentUsageUnit}
           />

--- a/src/features/hardware/dashboard/components/MiniLineChart.tsx
+++ b/src/features/hardware/dashboard/components/MiniLineChart.tsx
@@ -24,7 +24,7 @@ export const MiniLineChart = memo(
     usage,
   }: {
     hardwareType: ChartDataType;
-    usage: number[];
+    usage: (number | null)[];
   }) => {
     const { settings } = useSettingsAtom();
     const { t } = useTranslation();

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -14,7 +14,7 @@ import {
 } from "@/features/hardware/store/chart";
 import { events } from "@/rspc/bindings";
 
-const padHistory = (arr: (number | null)[]): number[] => {
+const padHistory = (arr: (number | null)[]): (number | null)[] => {
   const padded = Array(Math.max(chartConfig.historyLengthSec - arr.length, 0))
     .fill(null)
     .concat(arr);

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -1,14 +1,16 @@
 import { atom } from "jotai";
 import type { NameValues } from "@/features/hardware/types/hardwareDataType";
 
-export const cpuUsageHistoryAtom = atom<number[]>([]);
+export const cpuUsageHistoryAtom = atom<(number | null)[]>([]);
 export const processorsUsageHistoryAtom = atom<number[][]>([]);
-export const memoryUsageHistoryAtom = atom<number[]>([]);
+export const memoryUsageHistoryAtom = atom<(number | null)[]>([]);
 
 // ── Multi-GPU state ──
 
 /** Per-GPU usage histories keyed by gpuId */
-export const gpuUsageHistoriesAtom = atom<Record<string, number[]>>({});
+export const gpuUsageHistoriesAtom = atom<Record<string, (number | null)[]>>(
+  {},
+);
 
 /** Currently selected GPU ID for dashboard/usage view */
 export const selectedGpuIdAtom = atom<string | null>(null);
@@ -50,7 +52,7 @@ export const gpuFanSpeedAtom = atom<NameValues>((get) =>
 // ── Derived atoms for backward compatibility ──
 
 /** Resolves to the selected (or first) GPU's usage history */
-export const graphicUsageHistoryAtom = atom<number[]>((get) => {
+export const graphicUsageHistoryAtom = atom<(number | null)[]>((get) => {
   const selected = get(selectedGpuIdAtom);
   const histories = get(gpuUsageHistoriesAtom);
   if (selected && histories[selected]) return histories[selected];


### PR DESCRIPTION
## Summary

padHistory fills arrays with null, but all history atoms and chart component props were typed as number[]. Update types to (number | null)[] across atoms, padHistory, LineChart MultiChartProps, MiniLineChart, and DoughnutChart. Add null guard in MemoryInfo useMemo.

## Related Issues

Close #1344

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Charts and internal data flows now accept and propagate missing/nullable data points so visualizations render reliably when samples are unavailable.
  * Line and mini charts updated to handle nullable datapoints without breaking the display.
* **Bug Fixes**
  * Dashboard memory display and donut chart rendering now avoid showing undefined values and fall back to appropriate placeholders (e.g., loading/skeleton) when data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->