### PR TITLE
fix: resolve clippy::unnecessary_sort_by errors on Rust 1.95

### DIFF
--- a/src-tauri/src/services/archive_service.rs
+++ b/src-tauri/src/services/archive_service.rs
@@ -434,10 +434,10 @@ impl<'a> ProcessStatsCollector<'a> {
         stats.sort_by(|a, b| b.cpu_usage.total_cmp(&a.cpu_usage));
       }
       ProcessRankingMetric::Memory => {
-        stats.sort_by(|a, b| b.memory_usage.cmp(&a.memory_usage));
+        stats.sort_by_key(|s| std::cmp::Reverse(s.memory_usage));
       }
       ProcessRankingMetric::ExecutionTime => {
-        stats.sort_by(|a, b| b.execution_sec.cmp(&a.execution_sec));
+        stats.sort_by_key(|s| std::cmp::Reverse(s.execution_sec));
       }
     }
     stats


### PR DESCRIPTION
## Summary

Rust 1.95 introduced the `unnecessary_sort_by` clippy lint, which fired on two sort_by calls in ProcessStatsCollector and failed tauri-lint under `-D warnings`. Switch to `sort_by_key` with `std::cmp::Reverse`.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized process sorting performance for memory and execution time metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->