### PR TITLE
feat(frontend): add GPU selector to dashboard for multi-GPU systems (#1300)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/ErrorFallback";
 import { RootErrorFallback } from "@/components/RootErrorFallback";
 import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
+import { useSelectedGpuPersistence } from "@/features/hardware/hooks/useSelectedGpuPersistence";
 import { useErrorModalListener } from "@/hooks/useTauriEventListener";
 import { ScreenTemplate } from "./components/shared/ScreenTemplate";
 import { SideMenu } from "./features/menu/SideMenu";
@@ -84,6 +85,7 @@ const AppContent = () => {
 
   useErrorModalListener();
   useHardwareEventListener();
+  useSelectedGpuPersistence();
   const { hardwareInfo } = useHardwareInfoAtom();
 
   useEffect(() => {

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -16,14 +16,13 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { minOpacity } from "@/consts/style";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
@@ -117,27 +116,39 @@ export const GPUInfo = () => {
   return (
     <>
       {hasMultipleGpus && targetGpu && (
-        <div className="mb-3 flex justify-end">
-          <Select
-            value={targetGpu.id}
-            onValueChange={(value) => setSelectedGpuId(value)}
+        <TooltipProvider>
+          <div
+            role="tablist"
+            aria-label={t("pages.dashboard.gpuSelector.label")}
+            className="mb-3 flex justify-end gap-1"
           >
-            <SelectTrigger
-              size="sm"
-              className="max-w-full text-xs"
-              aria-label={t("pages.dashboard.gpuSelector.label")}
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {gpus.map((gpu) => (
-                <SelectItem key={gpu.id} value={gpu.id} className="text-xs">
-                  {gpu.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+            {gpus.map((gpu, i) => {
+              const isSelected = gpu.id === targetGpu.id;
+              return (
+                <Tooltip key={gpu.id}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={isSelected}
+                      aria-label={gpu.name}
+                      onClick={() => setSelectedGpuId(gpu.id)}
+                      className={cn(
+                        "min-w-7 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                        isSelected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border bg-transparent text-muted-foreground hover:bg-muted",
+                      )}
+                    >
+                      #{i + 1}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{gpu.name}</TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        </TooltipProvider>
       )}
       <div className="relative">
         <div
@@ -173,6 +184,20 @@ export const GPUInfo = () => {
             className={index !== 0 ? "py-3" : arr.length > 1 ? "pb-3" : ""}
             key={gpu.id}
           >
+            {hasMultipleGpus && (
+              <div className="mb-1 flex items-center px-4">
+                <span
+                  className={cn(
+                    "rounded-md px-2 py-0.5 font-mono text-xs",
+                    gpu.id === targetGpu?.id
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  #{index + 1}
+                </span>
+              </div>
+            )}
             {(() => {
               const dedicatedMemoryKb = gpuDedicatedMemoryKbMap[gpu.id] ?? null;
               const hasMemorySize = gpu.memorySize !== "N/A";

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -16,17 +16,25 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { minOpacity } from "@/consts/style";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuUsageHistoryAtom,
-  gpuDedicatedMemoryKbAtom,
+  gpuDedicatedMemoryKbMapAtom,
   gpuTempAtom,
   gpuUsageSourceAtom,
   graphicUsageHistoryAtom,
   memoryUsageHistoryAtom,
   processorsUsageHistoryAtom,
+  selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import type { NameValues } from "@/features/hardware/types/hardwareDataType";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
@@ -80,24 +88,24 @@ export const GPUInfo = () => {
   const [graphicUsageHistory] = useAtom(graphicUsageHistoryAtom);
   const [gpuTemp] = useAtom(gpuTempAtom);
   const [gpuUsageSource] = useAtom(gpuUsageSourceAtom);
+  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
   const { hardwareInfo } = useHardwareInfoAtom();
   const { isBreak } = useWindowSize();
   const [showGpuUsageSource] = useTauriStore("showGpuUsageSource", false);
-  const [gpuDedicatedMemoryKb] = useAtom(gpuDedicatedMemoryKbAtom);
+  const [gpuDedicatedMemoryKbMap] = useAtom(gpuDedicatedMemoryKbMapAtom);
   const os = useMemo(() => platform(), []);
 
+  const gpus = hardwareInfo.gpus ?? [];
+  const targetGpu = gpus.find((g) => g.id === selectedGpuId) ?? gpus[0] ?? null;
+  const hasMultipleGpus = gpus.length > 1;
+
   const getTargetInfo = (data: NameValues) => {
-    if (
-      !hardwareInfo.gpus ||
-      hardwareInfo.gpus.length === 0 ||
-      data.length === 0
-    )
-      return undefined;
-    // Prefer an exact name match for the primary GPU.
-    const matched = data.find((x) => x.name === hardwareInfo.gpus?.[0]?.name);
+    if (!targetGpu || data.length === 0) return undefined;
+    // Prefer an exact name match for the currently selected GPU.
+    const matched = data.find((x) => x.name === targetGpu.name);
     if (matched) return matched.value;
     // If there is exactly one GPU and one metric entry, allow a safe fallback.
-    if (hardwareInfo.gpus.length === 1 && data.length === 1) {
+    if (gpus.length === 1 && data.length === 1) {
       return data[0]?.value;
     }
     // Otherwise, avoid showing potentially incorrect metrics.
@@ -108,6 +116,29 @@ export const GPUInfo = () => {
 
   return (
     <>
+      {hasMultipleGpus && targetGpu && (
+        <div className="mb-3 flex justify-end">
+          <Select
+            value={targetGpu.id}
+            onValueChange={(value) => setSelectedGpuId(value)}
+          >
+            <SelectTrigger
+              size="sm"
+              className="max-w-full text-xs"
+              aria-label={t("pages.dashboard.gpuSelector.label")}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {gpus.map((gpu) => (
+                <SelectItem key={gpu.id} value={gpu.id} className="text-xs">
+                  {gpu.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
       <div className="relative">
         <div
           className={cn(
@@ -143,13 +174,12 @@ export const GPUInfo = () => {
             key={gpu.id}
           >
             {(() => {
+              const dedicatedMemoryKb = gpuDedicatedMemoryKbMap[gpu.id] ?? null;
               const hasMemorySize = gpu.memorySize !== "N/A";
-              const hasMemoryUsage = gpuDedicatedMemoryKb != null;
+              const hasMemoryUsage = dedicatedMemoryKb != null;
               const formattedMemoryUsage = hasMemoryUsage
                 ? (() => {
-                    const [value, unit] = formatBytes(
-                      gpuDedicatedMemoryKb * 1024,
-                    );
+                    const [value, unit] = formatBytes(dedicatedMemoryKb * 1024);
                     return `${value} ${unit}`;
                   })()
                 : null;

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,0 +1,38 @@
+import { useAtom } from "jotai";
+import { useEffect, useRef } from "react";
+import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
+import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
+import { useTauriStore } from "@/hooks/useTauriStore";
+
+const STORE_KEY = "selectedGpuId";
+
+/**
+ * Persist the currently selected GPU id via Tauri Store so it survives
+ * app restarts. Stored values referencing GPUs that no longer exist are
+ * ignored so the event listener's auto-selection of the first GPU wins.
+ */
+export const useSelectedGpuPersistence = () => {
+  const [storedId, setStoredId, isPending] = useTauriStore<string | null>(
+    STORE_KEY,
+    null,
+  );
+  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
+  const { hardwareInfo } = useHardwareInfoAtom();
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    if (isPending || hydratedRef.current) return;
+    const gpus = hardwareInfo.gpus ?? [];
+    if (gpus.length === 0) return;
+    if (storedId && gpus.some((g) => g.id === storedId)) {
+      setSelectedGpuId(storedId);
+    }
+    hydratedRef.current = true;
+  }, [isPending, storedId, hardwareInfo.gpus, setSelectedGpuId]);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    if (selectedGpuId === storedId) return;
+    setStoredId(selectedGpuId);
+  }, [selectedGpuId, storedId, setStoredId]);
+};

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -133,7 +133,10 @@
     "dashboard": {
       "name": "Dashboard",
       "visibleItems": "Visible Items",
-      "selectItems": "Select items to display on the dashboard"
+      "selectItems": "Select items to display on the dashboard",
+      "gpuSelector": {
+        "label": "Select GPU"
+      }
     },
     "usage": {
       "name": "Usage"

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -133,7 +133,10 @@
     "dashboard": {
       "name": "ダッシュボード",
       "visibleItems": "表示項目",
-      "selectItems": "表示する項目を選択してください"
+      "selectItems": "表示する項目を選択してください",
+      "gpuSelector": {
+        "label": "GPU を選択"
+      }
     },
     "usage": {
       "name": "ハードウェア使用率"


### PR DESCRIPTION
## Summary

When hardwareInfo.gpus has more than one entry, show a compact select in the dashboard GPU card that writes to selectedGpuIdAtom. Single-GPU systems are unchanged.

- GPUInfo now resolves a target GPU from selectedGpuIdAtom (falling back to gpus[0]) and uses it in getTargetInfo for temperature lookup.
- Doughnut (usage) continues to read graphicUsageHistoryAtom, which is derived from selectedGpuIdAtom.
- Per-GPU info table rows now read dedicated memory per gpuId from gpuDedicatedMemoryKbMapAtom instead of the selected-GPU-only value.

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU selector to the dashboard that appears when multiple GPUs are detected, enabling users to switch between available GPUs
  * Dashboard metrics now dynamically update to display data for the currently selected GPU
  * Added GPU selector localization in English and Japanese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->