### PR TITLE
refactor(core): Phase 1 — empty core/ and app/ modules with no-tauri-import lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,33 @@ jobs:
         shell: bash
 
   #
+  # Enforce Core/App split: no `tauri::*` imports under src-tauri/src/core/
+  # See #1402.
+  #
+  check-core-no-tauri:
+    needs: change-detection
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.backend-changed == 'true'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure no `tauri::*` references under src-tauri/src/core/
+        run: |
+          if [ ! -d src-tauri/src/core ]; then
+            echo "::error::Expected directory src-tauri/src/core/ to exist"
+            exit 1
+          fi
+          # Match `tauri::` (e.g. `use tauri::Manager`, `tauri::Wry`).
+          # `tauri_plugin_*` and `tauri_specta::` use `_` and are not matched.
+          if grep -rn --include='*.rs' 'tauri::' src-tauri/src/core/; then
+            echo "::error::Files under src-tauri/src/core/ must not reference tauri::* (Core stays Tauri-independent — see #1402)"
+            exit 1
+          fi
+          echo "OK: no tauri::* references under src-tauri/src/core/"
+        shell: bash
+
+  #
   # Backend lint and clippy
   #
   lint-backend:
@@ -391,6 +418,7 @@ jobs:
     needs:
       - change-detection
       - lint-actions
+      - check-core-no-tauri
       - lint-backend
       - test-backend
       - test-build

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,0 +1,4 @@
+//! Tauri-aware adapters around `core::*`.
+//!
+//! Tauri-specific concerns (commands, window emitter, tray, error dialogs)
+//! belong here. Population of submodules is tracked under issue #1402.

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,0 +1,4 @@
+//! Tauri-independent backend core.
+//!
+//! Code under this module must not depend on the Tauri runtime
+//! (enforced in CI). Population of submodules is tracked under issue #1402.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![macro_use]
 
+mod app;
 mod commands;
 mod constants;
+mod core;
 mod enums;
 mod infrastructure;
 mod models;


### PR DESCRIPTION
## Summary
- Adds empty `core/` and `app/` module skeletons under `src-tauri/src/` (`mod core;` and `mod app;` declared in `lib.rs`).
- Adds a `check-core-no-tauri` CI job that fails if any `*.rs` file under `src-tauri/src/core/` contains a `tauri::` reference, and wires it into the `merge-gate`.
- No code is moved in this phase. Existing modules remain in place.

Phase 1 of the Core/App split (#1402). Closes #1403.

## Implementation notes
- Lint pattern: `grep -rn --include='*.rs' 'tauri::' src-tauri/src/core/`. This matches `use tauri::Manager`, `tauri::Wry`, etc., but does **not** match `tauri_plugin_*` or `tauri_specta::*` (different crates, separated by `_`).
- The doc comments in `core/mod.rs` and `app/mod.rs` were phrased to avoid the literal `tauri::` substring so they don't trip the new lint.
- The crate-split alternative (workspace + `[lints] tauri = { level = "deny" }`) is deferred — see the parent's Open Questions.

## Verification
- [x] `cargo tauri-fmt -- --check` passes.
- [x] `cargo tauri-lint` passes.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` passes (276 tests).
- [x] Local dry-run of the new CI step: passes on a clean tree, and fails when a `use tauri::Manager;` file is dropped under `src-tauri/src/core/`.
- [ ] CI run on this PR confirms `check-core-no-tauri` fires on the matrix.

## Test plan
- [ ] CI green on this PR.
- [ ] Optional: open a throwaway draft commit that adds `use tauri::Manager;` under `src-tauri/src/core/` and confirm CI fails (per the issue's DoD). Will run separately if needed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend code organization and strengthened continuous integration checks to enhance code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->