### PR TITLE
refactor(core): Phase 2 — introduce in-process EventBus for metric snapshots (#1404)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "hwviz-core"
 version = "0.1.0"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "hyper"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,3 +14,7 @@ name = "hwviz_core"
 path = "src/lib.rs"
 
 [dependencies]
+tokio = { version = "1.52.1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1.52.1", features = ["macros", "rt"] }

--- a/core/src/event_bus.rs
+++ b/core/src/event_bus.rs
@@ -24,7 +24,18 @@ impl EventBus {
         Self::with_capacity(DEFAULT_CAPACITY)
     }
 
+    /// Create an event bus with the given broadcast channel capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero. (`tokio::sync::broadcast::channel`
+    /// itself panics in that case; this assertion just gives a clearer
+    /// message at the source-of-truth boundary.)
     pub fn with_capacity(capacity: usize) -> Self {
+        assert!(
+            capacity > 0,
+            "EventBus::with_capacity requires a non-zero capacity"
+        );
         let (tx, _rx) = broadcast::channel(capacity);
         Self { tx }
     }
@@ -111,6 +122,12 @@ mod tests {
         let bus = EventBus::new();
         bus.publish(snapshot(42.0));
         assert_eq!(bus.subscriber_count(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-zero capacity")]
+    fn with_capacity_zero_panics() {
+        let _ = EventBus::with_capacity(0);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/core/src/event_bus.rs
+++ b/core/src/event_bus.rs
@@ -1,0 +1,151 @@
+//! In-process broadcast channel for [`MetricsSnapshot`].
+//!
+//! `EventBus` lets the collector publish a single snapshot per tick that
+//! is fanned out to multiple subscribers (window adapter, persistence,
+//! future tray/overlay/alert consumers) without any of them depending on
+//! Tauri or on each other.
+
+use tokio::sync::broadcast;
+
+use crate::models::MetricsSnapshot;
+
+/// Default channel capacity. Snapshots are produced at ~1 Hz, so 16 slots
+/// give every subscriber ample headroom before they observe a `Lagged`
+/// error from `broadcast::Receiver::recv`.
+pub const DEFAULT_CAPACITY: usize = 16;
+
+#[derive(Clone)]
+pub struct EventBus {
+    tx: broadcast::Sender<MetricsSnapshot>,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Publish a snapshot to all current subscribers. With no subscribers
+    /// the snapshot is silently dropped.
+    pub fn publish(&self, snapshot: MetricsSnapshot) {
+        let _ = self.tx.send(snapshot);
+    }
+
+    /// Create a new subscriber. Subscribers only see snapshots published
+    /// after this call returns.
+    pub fn subscribe(&self) -> broadcast::Receiver<MetricsSnapshot> {
+        self.tx.subscribe()
+    }
+
+    /// Number of currently active subscribers. Primarily for tests and
+    /// observability.
+    pub fn subscriber_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::GpuMetric;
+
+    fn snapshot(cpu_usage: f32) -> MetricsSnapshot {
+        MetricsSnapshot {
+            cpu_usage,
+            memory_usage: 0.0,
+            processors_usage: vec![],
+            gpus: vec![],
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn single_subscriber_receives_published_snapshot() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        bus.publish(snapshot(50.0));
+
+        let received = rx.recv().await.expect("receive snapshot");
+        assert_eq!(received.cpu_usage, 50.0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fan_out_reaches_every_subscriber() {
+        let bus = EventBus::new();
+        let mut a = bus.subscribe();
+        let mut b = bus.subscribe();
+        let mut c = bus.subscribe();
+        assert_eq!(bus.subscriber_count(), 3);
+
+        bus.publish(snapshot(75.0));
+
+        for rx in [&mut a, &mut b, &mut c] {
+            let received = rx.recv().await.expect("receive snapshot");
+            assert_eq!(received.cpu_usage, 75.0);
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn late_subscriber_does_not_observe_prior_messages() {
+        let bus = EventBus::new();
+        bus.publish(snapshot(10.0));
+
+        let mut rx = bus.subscribe();
+        bus.publish(snapshot(20.0));
+
+        let received = rx.recv().await.expect("receive snapshot");
+        assert_eq!(received.cpu_usage, 20.0);
+    }
+
+    #[test]
+    fn publish_with_no_subscribers_does_not_panic() {
+        let bus = EventBus::new();
+        bus.publish(snapshot(42.0));
+        assert_eq!(bus.subscriber_count(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn snapshot_carries_gpu_payload() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        bus.publish(MetricsSnapshot {
+            cpu_usage: 0.0,
+            memory_usage: 0.0,
+            processors_usage: vec![],
+            gpus: vec![GpuMetric {
+                gpu_id: "test:0".into(),
+                gpu_name: "Test GPU".into(),
+                gpu_usage: Some(80.0),
+                gpu_temperature: Some(70.0),
+                gpu_source: "Test".into(),
+                gpu_dedicated_memory_usage_kb: Some(2048.0),
+                gpu_cooler_level: Some(50),
+            }],
+        });
+
+        let received = rx.recv().await.expect("receive snapshot");
+        assert_eq!(received.gpus.len(), 1);
+        assert_eq!(received.gpus[0].gpu_id, "test:0");
+        assert_eq!(received.gpus[0].gpu_usage, Some(80.0));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_a_subscriber_decrements_count() {
+        let bus = EventBus::new();
+        let rx_a = bus.subscribe();
+        let _rx_b = bus.subscribe();
+        assert_eq!(bus.subscriber_count(), 2);
+
+        drop(rx_a);
+        assert_eq!(bus.subscriber_count(), 1);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,8 +1,8 @@
 //! Tauri-independent core for HardwareVisualizer.
 //!
-//! Phase 1 establishes the workspace boundary only — module bodies are
-//! populated in subsequent phases (see issue #1402). The Cargo dependency
-//! graph enforces "no `tauri::*` under `core/src/`" at compile time.
+//! Module bodies are populated incrementally across the phases of #1402.
+//! The Cargo dependency graph enforces "no `tauri::*` under `core/src/`"
+//! at compile time.
 
 pub mod collector {}
 
@@ -10,7 +10,7 @@ pub mod persistence {}
 
 pub mod monitoring {}
 
-pub mod event_bus {}
+pub mod event_bus;
 
 pub mod settings {}
 
@@ -18,4 +18,4 @@ pub mod platform {}
 
 pub mod infrastructure {}
 
-pub mod models {}
+pub mod models;

--- a/core/src/models/metrics.rs
+++ b/core/src/models/metrics.rs
@@ -1,0 +1,24 @@
+/// One sample of per-GPU metrics, normalized across vendors and platforms.
+///
+/// `None` indicates the metric is unavailable for this vendor/platform.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GpuMetric {
+    pub gpu_id: String,
+    pub gpu_name: String,
+    pub gpu_usage: Option<f32>,
+    pub gpu_temperature: Option<f32>,
+    pub gpu_source: String,
+    pub gpu_dedicated_memory_usage_kb: Option<f32>,
+    pub gpu_cooler_level: Option<u32>,
+}
+
+/// One real-time snapshot of system + GPU metrics, fanned out via
+/// [`crate::event_bus::EventBus`] to all in-process subscribers
+/// (window adapter, persistence, future tray/overlay/alert consumers).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricsSnapshot {
+    pub cpu_usage: f32,
+    pub memory_usage: f32,
+    pub processors_usage: Vec<f32>,
+    pub gpus: Vec<GpuMetric>,
+}

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -1,0 +1,5 @@
+//! Tauri-independent data models shared across the core crate.
+
+mod metrics;
+
+pub use metrics::{GpuMetric, MetricsSnapshot};

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,0 +1,1 @@
+pub mod window;

--- a/src-tauri/src/adapters/window.rs
+++ b/src-tauri/src/adapters/window.rs
@@ -27,10 +27,9 @@ impl WindowAdapter {
             Err(RecvError::Lagged(skipped)) => {
               log_warn!(
                 &format!("WindowAdapter lagged, dropped {skipped} snapshot(s)"),
-                "app::adapters::window",
+                "adapters::window",
                 None::<&str>
               );
-              continue;
             }
             Err(RecvError::Closed) => break,
           },
@@ -57,7 +56,7 @@ fn emit_snapshot(app_handle: &tauri::AppHandle, snapshot: MetricsSnapshot) {
   if let Err(e) = payload.emit(app_handle) {
     log_warn!(
       &format!("failed to emit HardwareMonitorUpdate event: {e}"),
-      "app::adapters::window",
+      "adapters::window",
       None::<&str>
     );
   }

--- a/src-tauri/src/adapters/window.rs
+++ b/src-tauri/src/adapters/window.rs
@@ -1,0 +1,163 @@
+use hwviz_core::models::{GpuMetric, MetricsSnapshot};
+use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tokio::sync::watch;
+
+use crate::models::hardware::{GpuMonitorData, HardwareMonitorUpdate};
+use crate::{log_internal, log_warn};
+use tauri_specta::Event as _;
+
+/// Subscribes to the in-process [`hwviz_core::event_bus::EventBus`] and
+/// forwards each [`MetricsSnapshot`] to the main window as the existing
+/// [`HardwareMonitorUpdate`] Tauri event. This is the only place that
+/// translates Core events into a Tauri emit.
+pub struct WindowAdapter {
+  handle: tauri::async_runtime::JoinHandle<()>,
+  stop_tx: watch::Sender<bool>,
+}
+
+impl WindowAdapter {
+  pub fn setup(app_handle: tauri::AppHandle, mut rx: Receiver<MetricsSnapshot>) -> Self {
+    let (stop_tx, mut stop_rx) = watch::channel(false);
+
+    let handle = tauri::async_runtime::spawn(async move {
+      loop {
+        tokio::select! {
+          result = rx.recv() => match result {
+            Ok(snapshot) => emit_snapshot(&app_handle, snapshot),
+            Err(RecvError::Lagged(skipped)) => {
+              log_warn!(
+                &format!("WindowAdapter lagged, dropped {skipped} snapshot(s)"),
+                "app::adapters::window",
+                None::<&str>
+              );
+              continue;
+            }
+            Err(RecvError::Closed) => break,
+          },
+          changed = stop_rx.changed() => {
+            if changed.is_err() || *stop_rx.borrow() {
+              break;
+            }
+          }
+        }
+      }
+    });
+
+    Self { handle, stop_tx }
+  }
+
+  pub async fn terminate(self) {
+    let _ = self.stop_tx.send(true);
+    let _ = self.handle.await;
+  }
+}
+
+fn emit_snapshot(app_handle: &tauri::AppHandle, snapshot: MetricsSnapshot) {
+  let payload = to_hardware_monitor_update(snapshot);
+  if let Err(e) = payload.emit(app_handle) {
+    log_warn!(
+      &format!("failed to emit HardwareMonitorUpdate event: {e}"),
+      "app::adapters::window",
+      None::<&str>
+    );
+  }
+}
+
+fn to_hardware_monitor_update(snapshot: MetricsSnapshot) -> HardwareMonitorUpdate {
+  HardwareMonitorUpdate {
+    cpu_usage: snapshot.cpu_usage,
+    memory_usage: snapshot.memory_usage,
+    processors_usage: snapshot.processors_usage,
+    gpus: snapshot.gpus.into_iter().map(to_gpu_monitor_data).collect(),
+  }
+}
+
+fn to_gpu_monitor_data(g: GpuMetric) -> GpuMonitorData {
+  GpuMonitorData {
+    gpu_id: g.gpu_id,
+    gpu_name: g.gpu_name,
+    gpu_usage: g.gpu_usage,
+    gpu_temperature: g.gpu_temperature,
+    gpu_source: g.gpu_source,
+    gpu_dedicated_memory_usage_kb: g.gpu_dedicated_memory_usage_kb,
+    gpu_cooler_level: g.gpu_cooler_level,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn make_metric(gpu_id: &str, name: &str) -> GpuMetric {
+    GpuMetric {
+      gpu_id: gpu_id.to_string(),
+      gpu_name: name.to_string(),
+      gpu_usage: Some(60.0),
+      gpu_temperature: Some(55.0),
+      gpu_source: "Test".to_string(),
+      gpu_dedicated_memory_usage_kb: Some(1024.0),
+      gpu_cooler_level: Some(40),
+    }
+  }
+
+  #[test]
+  fn translation_preserves_top_level_fields() {
+    let snap = MetricsSnapshot {
+      cpu_usage: 12.5,
+      memory_usage: 67.0,
+      processors_usage: vec![10.0, 20.0, 30.0, 40.0],
+      gpus: vec![],
+    };
+    let update = to_hardware_monitor_update(snap);
+    assert_eq!(update.cpu_usage, 12.5);
+    assert_eq!(update.memory_usage, 67.0);
+    assert_eq!(update.processors_usage, vec![10.0, 20.0, 30.0, 40.0]);
+    assert!(update.gpus.is_empty());
+  }
+
+  #[test]
+  fn translation_preserves_per_gpu_fields() {
+    let snap = MetricsSnapshot {
+      cpu_usage: 0.0,
+      memory_usage: 0.0,
+      processors_usage: vec![],
+      gpus: vec![
+        make_metric("pci:0:2.0", "RTX 4090"),
+        make_metric("pci:0:3.0", "RX 7900 XTX"),
+      ],
+    };
+    let update = to_hardware_monitor_update(snap);
+    assert_eq!(update.gpus.len(), 2);
+    assert_eq!(update.gpus[0].gpu_id, "pci:0:2.0");
+    assert_eq!(update.gpus[0].gpu_name, "RTX 4090");
+    assert_eq!(update.gpus[0].gpu_usage, Some(60.0));
+    assert_eq!(update.gpus[0].gpu_temperature, Some(55.0));
+    assert_eq!(update.gpus[0].gpu_source, "Test");
+    assert_eq!(update.gpus[0].gpu_dedicated_memory_usage_kb, Some(1024.0));
+    assert_eq!(update.gpus[0].gpu_cooler_level, Some(40));
+    assert_eq!(update.gpus[1].gpu_id, "pci:0:3.0");
+  }
+
+  #[test]
+  fn translation_passes_through_none_optionals() {
+    let snap = MetricsSnapshot {
+      cpu_usage: 0.0,
+      memory_usage: 0.0,
+      processors_usage: vec![],
+      gpus: vec![GpuMetric {
+        gpu_id: "x".into(),
+        gpu_name: "x".into(),
+        gpu_usage: None,
+        gpu_temperature: None,
+        gpu_source: "x".into(),
+        gpu_dedicated_memory_usage_kb: None,
+        gpu_cooler_level: None,
+      }],
+    };
+    let update = to_hardware_monitor_update(snap);
+    assert!(update.gpus[0].gpu_usage.is_none());
+    assert!(update.gpus[0].gpu_temperature.is_none());
+    assert!(update.gpus[0].gpu_dedicated_memory_usage_kb.is_none());
+    assert!(update.gpus[0].gpu_cooler_level.is_none());
+  }
+}

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,5 +1,0 @@
-//! Tauri-aware application layer.
-//!
-//! Phase 1 placeholder. Subsequent phases relocate adapters, lifecycle and
-//! UI-only settings here from the existing `commands` / `services` /
-//! `workers` modules. See issue #1402.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![macro_use]
 
-mod app;
+mod adapters;
 mod commands;
 mod constants;
 mod enums;
@@ -140,6 +140,12 @@ pub fn run() {
       commands::ui::init(app);
       builder.mount_events(app);
 
+      // Real-time pipeline: collector publishes MetricsSnapshot to the
+      // EventBus, WindowAdapter subscribes and emits HardwareMonitorUpdate.
+      let bus = hwviz_core::event_bus::EventBus::new();
+      let window_adapter =
+        adapters::window::WindowAdapter::setup(app.handle().clone(), bus.subscribe());
+
       let monitor = workers::system_monitor::SystemMonitorController::setup(
         models::hardware_archive::MonitorResources {
           system: Arc::clone(&system),
@@ -153,10 +159,12 @@ pub fn run() {
           gpu_name_map: Arc::clone(&gpu_name_map),
         },
         app.handle().clone(),
+        bus,
       );
       {
         let ws = app.state::<workers::WorkersState>();
         ws.monitor.lock().unwrap().replace(monitor);
+        ws.window_adapter.lock().unwrap().replace(window_adapter);
       }
 
       if is_db_ok {

--- a/src-tauri/src/workers/mod.rs
+++ b/src-tauri/src/workers/mod.rs
@@ -3,9 +3,12 @@ pub mod system_monitor;
 
 use std::sync::{Mutex, atomic::AtomicBool};
 
+use crate::adapters::window::WindowAdapter;
+
 #[derive(Default)]
 pub struct WorkersState {
   pub monitor: Mutex<Option<system_monitor::SystemMonitorController>>,
+  pub window_adapter: Mutex<Option<WindowAdapter>>,
   pub hw_archive: Mutex<Option<hardware_archive::HardwareArchiveController>>,
   pub shutting_down: AtomicBool,
 }
@@ -19,10 +22,17 @@ impl WorkersState {
       return;
     }
     let monitor = self.monitor.lock().unwrap().take();
+    let window_adapter = self.window_adapter.lock().unwrap().take();
     let hw_archive = self.hw_archive.lock().unwrap().take();
 
+    // Stop the source first so no further snapshots are produced, then
+    // drain the adapter, then shut down the archive worker.
     if let Some(monitor) = monitor {
       monitor.terminate().await;
+    }
+
+    if let Some(adapter) = window_adapter {
+      adapter.terminate().await;
     }
 
     if let Some(hw_archive) = hw_archive {

--- a/src-tauri/src/workers/system_monitor.rs
+++ b/src-tauri/src/workers/system_monitor.rs
@@ -73,7 +73,7 @@ impl SystemMonitorController {
   ///   `temperature_unit` from `settings::AppState`. The collector no
   ///   longer emits Tauri events directly — snapshots are published to
   ///   `bus` and translated to `HardwareMonitorUpdate` by
-  ///   `app::adapters::window::WindowAdapter`. Phase 3 removes the
+  ///   `crate::adapters::window::WindowAdapter`. Phase 3 removes the
   ///   `app_handle` parameter when the collector relocates into Core.
   /// - param bus: in-process [`EventBus`] for `MetricsSnapshot` fan-out.
   ///

--- a/src-tauri/src/workers/system_monitor.rs
+++ b/src-tauri/src/workers/system_monitor.rs
@@ -1,11 +1,10 @@
 use crate::commands::settings;
 use crate::enums::settings::TemperatureUnit;
-use crate::models::hardware::{GpuMonitorData, HardwareMonitorUpdate};
 use crate::services::monitoring_service;
-use crate::{log_error, models};
 use crate::{log_internal, log_warn};
+use hwviz_core::event_bus::EventBus;
+use hwviz_core::models::{GpuMetric, MetricsSnapshot};
 use tauri::Manager as _;
-use tauri_specta::Event as _;
 
 pub struct SystemMonitorController {
   handle: tauri::async_runtime::JoinHandle<()>,
@@ -17,12 +16,12 @@ pub struct SystemMonitorController {
 ///
 const SYSTEM_INFO_INIT_INTERVAL: u64 = 1; // TODO move to constants.rs
 
-/// Build `Vec<GpuMonitorData>` from raw GPU samples, applying temperature
+/// Build `Vec<GpuMetric>` from raw GPU samples, applying temperature
 /// unit conversion per GPU.
-fn build_gpu_payloads(
+fn build_gpu_metrics(
   gpu_samples: &[monitoring_service::GpuSample],
   temp_unit: &TemperatureUnit,
-) -> Vec<GpuMonitorData> {
+) -> Vec<GpuMetric> {
   gpu_samples
     .iter()
     .map(|s| {
@@ -30,7 +29,7 @@ fn build_gpu_payloads(
         TemperatureUnit::Celsius => t.round(),
         TemperatureUnit::Fahrenheit => (t * 9.0 / 5.0 + 32.0).round(),
       });
-      GpuMonitorData {
+      GpuMetric {
         gpu_id: s.gpu_id.clone(),
         gpu_name: s.name.clone(),
         gpu_usage: s.usage.map(|u| u.round()),
@@ -43,7 +42,8 @@ fn build_gpu_payloads(
     .collect()
 }
 
-fn emit_hardware_update(
+fn publish_metrics(
+  bus: &EventBus,
   app_handle: &tauri::AppHandle,
   system_sample: Option<&monitoring_service::SystemSample>,
   gpu_samples: &[monitoring_service::GpuSample],
@@ -54,21 +54,13 @@ fn emit_hardware_update(
       .map(|state| state.settings.lock().unwrap().temperature_unit.clone())
       .unwrap_or(TemperatureUnit::Celsius);
 
-    let gpus = build_gpu_payloads(gpu_samples, &temp_unit);
-
-    let payload = HardwareMonitorUpdate {
+    let snapshot = MetricsSnapshot {
       cpu_usage: sys.cpu_usage,
       memory_usage: sys.memory_usage,
-      gpus,
       processors_usage: sys.processors_usage.clone(),
+      gpus: build_gpu_metrics(gpu_samples, &temp_unit),
     };
-    if let Err(e) = payload.emit(app_handle) {
-      log_error!(
-        &format!("failed to emit HardwareMonitorUpdate event: {}", e),
-        "system_monitor",
-        None::<&str>
-      );
-    }
+    bus.publish(snapshot);
   }
 }
 
@@ -76,13 +68,22 @@ impl SystemMonitorController {
   ///
   /// ## Initialize system information
   ///
-  /// - param system: `Arc<Mutex<System>>` System information
+  /// - param resources: shared sample/history bag.
+  /// - param app_handle: still required this phase to read the user's
+  ///   `temperature_unit` from `settings::AppState`. The collector no
+  ///   longer emits Tauri events directly — snapshots are published to
+  ///   `bus` and translated to `HardwareMonitorUpdate` by
+  ///   `app::adapters::window::WindowAdapter`. Phase 3 removes the
+  ///   `app_handle` parameter when the collector relocates into Core.
+  /// - param bus: in-process [`EventBus`] for `MetricsSnapshot` fan-out.
   ///
-  /// - Updates CPU usage and memory usage every `SYSTEM_INFO_INIT_INTERVAL` seconds
+  /// Updates CPU usage and memory usage every
+  /// `SYSTEM_INFO_INIT_INTERVAL` seconds.
   ///
   pub fn setup(
-    resources: models::hardware_archive::MonitorResources,
+    resources: crate::models::hardware_archive::MonitorResources,
     app_handle: tauri::AppHandle,
+    bus: EventBus,
   ) -> Self {
     let (tx, mut rx) = tokio::sync::watch::channel(false);
 
@@ -96,7 +97,7 @@ impl SystemMonitorController {
         let system_sample = monitoring_service::sample_system(&resources);
         let gpu_samples = monitoring_service::sample_gpu(&resources).await;
 
-        emit_hardware_update(&app_handle, system_sample.as_ref(), &gpu_samples);
+        publish_metrics(&bus, &app_handle, system_sample.as_ref(), &gpu_samples);
 
         loop {
           tokio::select! {
@@ -105,7 +106,7 @@ impl SystemMonitorController {
 
               let system_sample = monitoring_service::sample_system(&resources);
               let gpu_samples = monitoring_service::sample_gpu(&resources).await;
-              emit_hardware_update(&app_handle, system_sample.as_ref(), &gpu_samples);
+              publish_metrics(&bus, &app_handle, system_sample.as_ref(), &gpu_samples);
 
               let elapsed = start.elapsed();
               if elapsed > tokio::time::Duration::from_secs(SYSTEM_INFO_INIT_INTERVAL) {
@@ -161,14 +162,14 @@ mod tests {
 
   #[test]
   fn build_gpus_from_empty_samples() {
-    let result = build_gpu_payloads(&[], &TemperatureUnit::Celsius);
+    let result = build_gpu_metrics(&[], &TemperatureUnit::Celsius);
     assert!(result.is_empty());
   }
 
   #[test]
   fn build_gpus_from_single_sample() {
     let samples = vec![make_sample("gpu:0", "RTX 4090", Some(75.3), Some(65.0))];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Celsius);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Celsius);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].gpu_id, "gpu:0");
     assert_eq!(result[0].gpu_name, "RTX 4090");
@@ -184,7 +185,7 @@ mod tests {
       make_sample("pci:0:2.0", "RTX 4090", Some(80.0), Some(70.0)),
       make_sample("pci:0:3.0", "RX 7900 XTX", Some(50.0), Some(60.0)),
     ];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Celsius);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Celsius);
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].gpu_id, "pci:0:2.0");
     assert_eq!(result[1].gpu_id, "pci:0:3.0");
@@ -193,28 +194,28 @@ mod tests {
   #[test]
   fn temperature_conversion_celsius() {
     let samples = vec![make_sample("gpu:0", "GPU", None, Some(100.0))];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Celsius);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Celsius);
     assert_eq!(result[0].gpu_temperature, Some(100.0));
   }
 
   #[test]
   fn temperature_conversion_fahrenheit() {
     let samples = vec![make_sample("gpu:0", "GPU", None, Some(100.0))];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Fahrenheit);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Fahrenheit);
     assert_eq!(result[0].gpu_temperature, Some(212.0)); // 100*9/5+32 = 212
   }
 
   #[test]
   fn temperature_none_preserved() {
     let samples = vec![make_sample("gpu:0", "GPU", Some(50.0), None)];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Fahrenheit);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Fahrenheit);
     assert!(result[0].gpu_temperature.is_none());
   }
 
   #[test]
   fn usage_rounded() {
     let samples = vec![make_sample("gpu:0", "GPU", Some(33.7), None)];
-    let result = build_gpu_payloads(&samples, &TemperatureUnit::Celsius);
+    let result = build_gpu_metrics(&samples, &TemperatureUnit::Celsius);
     assert_eq!(result[0].gpu_usage, Some(34.0));
   }
 }


### PR DESCRIPTION
## Summary

Phase 2 of #1402. Introduce `hwviz_core::event_bus::EventBus`, a Tauri-independent in-process broadcast channel for `MetricsSnapshot`. The collector no longer emits Tauri events directly; the new `adapters::window::WindowAdapter` is the sole place that translates a Core snapshot into the existing `HardwareMonitorUpdate` Tauri event. The wire format is unchanged.

This PR also drops the `src-tauri/src/app/` namespace introduced as a placeholder in #1411 — with Core promoted to a workspace crate, the entire `src-tauri/` crate is Tauri-aware by construction, so `adapters/` lives directly under `src-tauri/src/`. See the discussion on #1402.

Closes #1404. Refs #1402.

## Changes

### `core/`
- **`core::event_bus::EventBus`** — wraps `tokio::sync::broadcast::Sender<MetricsSnapshot>`. `publish` / `subscribe` / `subscriber_count`, default capacity 16. `Clone` so it can be cheaply handed to multiple producers.
- **`core::models::{MetricsSnapshot, GpuMetric}`** — Tauri-independent data shape mirroring the existing wire payload. No `serde` / `specta` derives; that ceremony stays App-side.
- **`tokio` dep** — added to `core/Cargo.toml` with only the `sync` feature in `[dependencies]`; `["macros", "rt"]` in `[dev-dependencies]` for `#[tokio::test]`. Verified `cargo tree -p hwviz-core | grep -ic tauri == 0`.

### `src-tauri/`
- **`workers::system_monitor`** — `payload.emit(app_handle)` becomes `bus.publish(snapshot)`. `SystemMonitorController::setup` now takes an `EventBus`. The GPU payload builder is renamed `build_gpu_metrics` and returns `Vec<GpuMetric>`. The `app_handle` parameter is retained this phase only for the `temperature_unit` lookup; Phase 3.5 moves that to the adapter.
- **`adapters::window::WindowAdapter`** — long-running tokio task that subscribes to the bus and emits `HardwareMonitorUpdate`. Handles `Lagged` (warn + skip) and `Closed` (exit). `terminate()` uses the same `watch::Sender<bool>` pattern as the collector.
- **`WorkersState`** — gains a `window_adapter` slot. `terminate_all` order: collector first (stop sources) → adapter (drain consumer) → archive worker.
- **`run()` wiring** — creates the bus, starts `WindowAdapter` with `bus.subscribe()`, then starts the collector with `bus`.
- **Drop `src-tauri/src/app/` placeholder** — empty Phase 1 module deleted; `mod app;` replaced by `mod adapters;` in `lib.rs`.

## Notable choices

- **`MetricsSnapshot` is a fresh Core type** rather than re-exporting `HardwareMonitorUpdate`. Sharing the type would force `core` to depend on `serde` / `specta` (and through specta, on Tauri-adjacent crates). The 1:1 field translation lives in `WindowAdapter` and is unit-tested.
- **`app_handle` stays on the collector** to read `temperature_unit`. Removing it (and pushing °C-only snapshots through the bus, with adapter-side conversion) is explicitly Phase 3.5 — keeping it here avoids changing wire-format-relevant behavior in this PR.
- **`WorkersState` ownership of the adapter** keeps the existing shutdown path unchanged for callers; `on_window_event(CloseRequested)` still calls `terminate_all` and the adapter is now part of that.
- **No bus exposed via `app.manage(...)` yet.** Phase 4 (persistence) is the natural place to make the bus shared state; until then, scoping it to `setup()` keeps the surface minimal.
- **No `app/` namespace** — see #1402 (Change Log entry).

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo tauri-lint` succeeds
- [x] `cargo tauri-fmt -- --check` succeeds
- [x] `cargo llvm-cov --workspace --no-report -- --test-threads=1 --nocapture`: 279 src-tauri tests + 6 hwviz-core tests pass (was 276 + 0 before this PR)
- [x] `cargo test -p hwviz-core` runs without a Tauri runtime
- [x] `cargo tree -p hwviz-core | grep -ic tauri` returns `0`
- [x] No `.emit(` / `Emitter::emit` / `AppHandle::emit` remains in `workers/system_monitor.rs`
- [ ] `tauri dev`: dashboard updates indistinguishably from `develop` (please verify on Windows during review — host platform dictates which sensors are exercised)
- [ ] CI green across `lint-backend` / `test-backend` / `test-build`

## Out of scope (later phases)

- Removing `app_handle` from the collector / pushing temperature-unit conversion to the adapter — Phase 3.5 (#1406).
- Moving the collector under `core/` — Phase 3 (#1405).
- Persistence subscribing to the bus — Phase 4 (#1407).
- Renaming `HardwareMonitorUpdate` to a Core-aligned wire format — deferred per the issue's "Out of Scope".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time metrics broadcasting enabling live delivery of CPU, memory, and GPU snapshots to the UI.

* **Refactor**
  * Reworked monitoring pipeline to publish snapshots internally and subscribe from the window adapter for smoother, more reliable updates.
  * Added GPU metrics support (per-GPU usage, temperature, memory, cooler level) in reported snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->