### PR TITLE
refactor(core): Phase 3.5 — split settings into core/app buckets (#1406)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,6 +2086,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sqlx",
  "sysinfo",
  "tempfile",
  "tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,12 @@ regex = "1.12.3"
 async-trait = "0.1"
 sysinfo = "0.38.4"
 tempfile = "3.27.0"
+sqlx = { version = "0.8.6", features = [
+    "sqlite",
+    "runtime-tokio-rustls",
+    "macros",
+    "chrono",
+] }
 
 [target.'cfg(windows)'.dependencies]
 wmi = "0.18.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,13 +6,13 @@
 
 pub mod collector;
 
-pub mod persistence {}
+pub mod persistence;
 
 pub mod monitoring {}
 
 pub mod event_bus;
 
-pub mod settings {}
+pub mod settings;
 
 pub mod platform;
 

--- a/core/src/models/hardware.rs
+++ b/core/src/models/hardware.rs
@@ -55,9 +55,9 @@ pub struct GpuUsageResult {
   pub source: String,
 }
 
-/// Generic `(name, integer)` pair. Used by the GPU temperature API.
-/// `value` is whatever unit the producer chose — currently temperature
-/// in the unit requested by the caller (°C or °F) — so don't assume °C.
+/// Generic `(name, integer)` pair. Used by the GPU temperature API,
+/// where `value` is always in raw degrees Celsius — presentation
+/// conversion (Celsius/Fahrenheit) lives at the App-side boundary.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NameValue {
   pub name: String,

--- a/core/src/persistence/mod.rs
+++ b/core/src/persistence/mod.rs
@@ -1,0 +1,9 @@
+//! Core-owned persistence primitives.
+//!
+//! Currently exposes [`preflight`] — the schema-version compatibility
+//! check that runs before the App brings up the SQLite plugin. The
+//! recovery dialog and process restart flow live in App
+//! (`src-tauri/src/app/startup.rs`); this module only owns the read-only,
+//! Tauri-independent compatibility decision.
+
+pub mod preflight;

--- a/core/src/persistence/preflight.rs
+++ b/core/src/persistence/preflight.rs
@@ -1,4 +1,3 @@
-use crate::utils;
 use sqlx::Row;
 use sqlx::sqlite::SqlitePool;
 use std::path::Path;
@@ -12,17 +11,16 @@ pub enum DbStartupError {
   Other(String),
 }
 
-/// Check if the database schema is compatible with this app version.
+/// Decide whether the on-disk SQLite database is compatible with the
+/// running app's migration set.
 ///
-/// Returns `None` if the database is compatible or doesn't exist yet.
-/// Returns `Some(DbStartupError)` if the database schema is incompatible.
-pub fn check_db_compatibility() -> Option<DbStartupError> {
-  let db_path = utils::file::get_app_data_dir("hv-database.db");
-  let app_max_version = super::migration::get_max_migration_version();
-  check_db_compatibility_at(&db_path, app_max_version)
-}
-
-fn check_db_compatibility_at(
+/// Returns `None` when the database is compatible (or doesn't exist /
+/// hasn't been migrated yet) and `Some(DbStartupError)` otherwise.
+///
+/// This function is intentionally Tauri-independent: callers in the App
+/// crate pass the resolved DB path and the highest migration version
+/// the binary is built with.
+pub fn check_db_compatibility(
   db_path: &Path,
   app_max_version: i64,
 ) -> Option<DbStartupError> {
@@ -32,9 +30,23 @@ fn check_db_compatibility_at(
 
   let database_url = format!("sqlite:{}", db_path.to_string_lossy());
 
-  let result = tauri::async_runtime::block_on(async {
-    query_max_migration_version(&database_url).await
-  });
+  // Core has no Tauri runtime, so spin up a single-threaded tokio
+  // runtime for this synchronous one-shot query. This function runs
+  // before the Tauri builder starts, so there is no enclosing runtime
+  // to clash with.
+  let runtime = match tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+  {
+    Ok(rt) => rt,
+    Err(e) => {
+      return Some(DbStartupError::Other(format!(
+        "Failed to build runtime for DB preflight: {e}"
+      )));
+    }
+  };
+
+  let result = runtime.block_on(query_max_migration_version(&database_url));
 
   match result {
     Ok(Some(db_max_version)) if db_max_version > app_max_version => {
@@ -46,7 +58,8 @@ fn check_db_compatibility_at(
     Ok(_) => None,
     Err(e) => {
       let err_msg = e.to_string();
-      // Table doesn't exist yet — first migration hasn't run
+      // The first migration hasn't run yet — the table simply doesn't exist
+      // in this database. That's compatible.
       if err_msg.contains("no such table") {
         None
       } else {
@@ -111,94 +124,108 @@ mod tests {
     .unwrap();
   }
 
-  #[tokio::test]
-  async fn query_returns_none_when_no_migration_table() {
+  fn run<F: std::future::Future<Output = T>, T>(f: F) -> T {
+    tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .unwrap()
+      .block_on(f)
+  }
+
+  #[test]
+  fn query_returns_err_when_no_migration_table() {
     let tmp = NamedTempFile::new().unwrap();
     let url = format!("sqlite:{}", tmp.path().to_string_lossy());
-    // Create an empty DB (no _sqlx_migrations table)
-    let _pool = SqlitePool::connect(&url).await.unwrap();
+    run(async {
+      let _pool = SqlitePool::connect(&url).await.unwrap();
+    });
 
-    let result = query_max_migration_version(&url).await;
+    let result = run(query_max_migration_version(&url));
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("no such table"));
   }
 
-  #[tokio::test]
-  async fn query_returns_none_when_table_empty() {
+  #[test]
+  fn query_returns_none_when_table_empty() {
     let tmp = NamedTempFile::new().unwrap();
-    let pool = create_test_db(tmp.path()).await;
-    pool.close().await;
+    run(async {
+      let pool = create_test_db(tmp.path()).await;
+      pool.close().await;
+    });
 
     let url = format!("sqlite:{}", tmp.path().to_string_lossy());
-    let result = query_max_migration_version(&url).await.unwrap();
-    // MAX() on empty table returns NULL → None
+    let result = run(query_max_migration_version(&url)).unwrap();
     assert_eq!(result, None);
   }
 
-  #[tokio::test]
-  async fn query_returns_max_successful_version() {
+  #[test]
+  fn query_returns_max_successful_version() {
     let tmp = NamedTempFile::new().unwrap();
-    let pool = create_test_db(tmp.path()).await;
-    insert_migration(&pool, 1, true).await;
-    insert_migration(&pool, 2, true).await;
-    insert_migration(&pool, 3, true).await;
-    pool.close().await;
+    run(async {
+      let pool = create_test_db(tmp.path()).await;
+      insert_migration(&pool, 1, true).await;
+      insert_migration(&pool, 2, true).await;
+      insert_migration(&pool, 3, true).await;
+      pool.close().await;
+    });
 
     let url = format!("sqlite:{}", tmp.path().to_string_lossy());
-    let result = query_max_migration_version(&url).await.unwrap();
+    let result = run(query_max_migration_version(&url)).unwrap();
     assert_eq!(result, Some(3));
   }
 
-  #[tokio::test]
-  async fn query_ignores_failed_migrations() {
+  #[test]
+  fn query_ignores_failed_migrations() {
     let tmp = NamedTempFile::new().unwrap();
-    let pool = create_test_db(tmp.path()).await;
-    insert_migration(&pool, 1, true).await;
-    insert_migration(&pool, 2, true).await;
-    insert_migration(&pool, 3, false).await; // failed
-    pool.close().await;
+    run(async {
+      let pool = create_test_db(tmp.path()).await;
+      insert_migration(&pool, 1, true).await;
+      insert_migration(&pool, 2, true).await;
+      insert_migration(&pool, 3, false).await;
+      pool.close().await;
+    });
 
     let url = format!("sqlite:{}", tmp.path().to_string_lossy());
-    let result = query_max_migration_version(&url).await.unwrap();
+    let result = run(query_max_migration_version(&url)).unwrap();
     assert_eq!(result, Some(2));
   }
 
   #[test]
   fn compatible_when_db_file_does_not_exist() {
     let path = Path::new("/nonexistent/path/to/db.sqlite");
-    assert_eq!(check_db_compatibility_at(path, 5), None);
+    assert_eq!(check_db_compatibility(path, 5), None);
   }
 
   #[test]
   fn compatible_when_db_version_equals_app_version() {
     let tmp = NamedTempFile::new().unwrap();
-    tauri::async_runtime::block_on(async {
+    run(async {
       let pool = create_test_db(tmp.path()).await;
       insert_migration(&pool, 1, true).await;
       insert_migration(&pool, 5, true).await;
       pool.close().await;
     });
 
-    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+    assert_eq!(check_db_compatibility(tmp.path(), 5), None);
   }
 
   #[test]
   fn compatible_when_db_version_lower_than_app() {
     let tmp = NamedTempFile::new().unwrap();
-    tauri::async_runtime::block_on(async {
+    run(async {
       let pool = create_test_db(tmp.path()).await;
       insert_migration(&pool, 1, true).await;
       insert_migration(&pool, 3, true).await;
       pool.close().await;
     });
 
-    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+    assert_eq!(check_db_compatibility(tmp.path(), 5), None);
   }
 
   #[test]
   fn incompatible_when_db_version_higher_than_app() {
     let tmp = NamedTempFile::new().unwrap();
-    tauri::async_runtime::block_on(async {
+    run(async {
       let pool = create_test_db(tmp.path()).await;
       insert_migration(&pool, 1, true).await;
       insert_migration(&pool, 6, true).await;
@@ -206,7 +233,7 @@ mod tests {
     });
 
     assert_eq!(
-      check_db_compatibility_at(tmp.path(), 5),
+      check_db_compatibility(tmp.path(), 5),
       Some(DbStartupError::IncompatibleVersion {
         db_max_version: 6,
         app_max_version: 5,
@@ -217,22 +244,22 @@ mod tests {
   #[test]
   fn compatible_when_no_migration_table() {
     let tmp = NamedTempFile::new().unwrap();
-    tauri::async_runtime::block_on(async {
+    run(async {
       let url = format!("sqlite:{}", tmp.path().to_string_lossy());
       let _pool = SqlitePool::connect(&url).await.unwrap();
     });
 
-    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+    assert_eq!(check_db_compatibility(tmp.path(), 5), None);
   }
 
   #[test]
   fn compatible_when_migration_table_empty() {
     let tmp = NamedTempFile::new().unwrap();
-    tauri::async_runtime::block_on(async {
+    run(async {
       let pool = create_test_db(tmp.path()).await;
       pool.close().await;
     });
 
-    assert_eq!(check_db_compatibility_at(tmp.path(), 5), None);
+    assert_eq!(check_db_compatibility(tmp.path(), 5), None);
   }
 }

--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -1,7 +1,5 @@
-use crate::enums;
 use crate::infrastructure;
 use crate::models;
-use crate::utils;
 
 pub async fn get_gpu_usage() -> Result<(f32, String), String> {
   let cards = infrastructure::providers::drm_sys::get_card_ids().await?;

--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -101,9 +101,9 @@ pub async fn get_intel_graphic_info(
   })
 }
 
-pub async fn get_gpu_temperature(
-  temperature_unit: enums::settings::TemperatureUnit,
-) -> Result<Vec<models::hardware::NameValue>, String> {
+/// Always returns raw degrees Celsius. Presentation conversion lives at
+/// the App-side boundary.
+pub async fn get_gpu_temperature() -> Result<Vec<models::hardware::NameValue>, String> {
   let cards = infrastructure::providers::drm_sys::get_all_card_ids();
   let mut all_temps: Vec<models::hardware::NameValue> = Vec::new();
 
@@ -118,14 +118,9 @@ pub async fn get_gpu_temperature(
     if let Ok(temps) = infrastructure::providers::hwmon::read_hwmon_temperatures(card_id)
     {
       for temp in temps {
-        let value = utils::formatter::format_temperature(
-          enums::settings::TemperatureUnit::Celsius,
-          temperature_unit.clone(),
-          temp.value,
-        );
         all_temps.push(models::hardware::NameValue {
           name: temp.name,
-          value,
+          value: temp.value,
         });
       }
     }

--- a/core/src/platform/linux/mod.rs
+++ b/core/src/platform/linux/mod.rs
@@ -1,4 +1,3 @@
-use crate::enums;
 use crate::enums::error::BackendError;
 use crate::models::hardware::{GpuMemoryUsage, GraphicInfo, NetworkInfo};
 use crate::platform::traits::{

--- a/core/src/platform/linux/mod.rs
+++ b/core/src/platform/linux/mod.rs
@@ -56,7 +56,6 @@ impl GpuPlatform for LinuxPlatform {
 
   fn get_gpu_temperature(
     &self,
-    temperature_unit: enums::settings::TemperatureUnit,
   ) -> Pin<
     Box<
       dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>
@@ -64,7 +63,7 @@ impl GpuPlatform for LinuxPlatform {
         + '_,
     >,
   > {
-    Box::pin(gpu::get_gpu_temperature(temperature_unit))
+    Box::pin(gpu::get_gpu_temperature())
   }
 
   fn get_gpu_info(

--- a/core/src/platform/macos/mod.rs
+++ b/core/src/platform/macos/mod.rs
@@ -1,5 +1,4 @@
 use crate::enums::error::BackendError;
-use crate::enums::settings::TemperatureUnit;
 use crate::models::hardware::{GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo};
 use crate::platform::traits::{
   GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
@@ -51,7 +50,6 @@ impl GpuPlatform for MacOSPlatform {
 
   fn get_gpu_temperature(
     &self,
-    _temperature_unit: TemperatureUnit,
   ) -> Pin<
     Box<
       dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>

--- a/core/src/platform/traits.rs
+++ b/core/src/platform/traits.rs
@@ -1,4 +1,3 @@
-use crate::enums;
 use crate::enums::error::BackendError;
 use crate::models;
 use std::future::Future;
@@ -32,10 +31,13 @@ pub trait GpuPlatform: Send + Sync {
     &self,
   ) -> Pin<Box<dyn Future<Output = Result<GpuUsageRaw, String>> + Send + '_>>;
 
-  /// Get GPU temperature
+  /// Get GPU temperatures, always in raw degrees Celsius.
+  ///
+  /// Presentation conversion (Celsius/Fahrenheit) is the App's
+  /// responsibility — Core never reads the user's preferred unit so the
+  /// trait stays decoupled from UI preferences.
   fn get_gpu_temperature(
     &self,
-    temperature_unit: enums::settings::TemperatureUnit,
   ) -> Pin<
     Box<
       dyn Future<Output = Result<Vec<models::hardware::NameValue>, String>> + Send + '_,

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -54,9 +54,10 @@ pub async fn get_gpu_usage() -> Result<(f32, String), String> {
   }
 }
 
-pub async fn get_gpu_temperature(
-  temperature_unit: enums::settings::TemperatureUnit,
-) -> Result<Vec<crate::models::hardware::NameValue>, String> {
+/// Always returns raw degrees Celsius. Presentation conversion lives at
+/// the App-side boundary.
+pub async fn get_gpu_temperature()
+-> Result<Vec<crate::models::hardware::NameValue>, String> {
   let mut all_temps: Vec<crate::models::hardware::NameValue> = Vec::new();
 
   // 1. NVAPI (NVIDIA)
@@ -66,11 +67,7 @@ pub async fn get_gpu_temperature(
     for temp in &nvidia_temps {
       all_temps.push(crate::models::hardware::NameValue {
         name: temp.name.clone(),
-        value: utils::formatter::format_temperature(
-          enums::settings::TemperatureUnit::Celsius,
-          temperature_unit.clone(),
-          temp.value,
-        ),
+        value: temp.value,
       });
     }
   }
@@ -82,11 +79,7 @@ pub async fn get_gpu_temperature(
     for temp in &amd_temps {
       all_temps.push(crate::models::hardware::NameValue {
         name: temp.name.clone(),
-        value: utils::formatter::format_temperature(
-          enums::settings::TemperatureUnit::Celsius,
-          temperature_unit.clone(),
-          temp.value,
-        ),
+        value: temp.value,
       });
     }
   }

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -1,6 +1,4 @@
-use crate::enums;
 use crate::infrastructure;
-use crate::utils;
 use crate::{log_error, log_warn};
 
 pub async fn get_gpu_usage() -> Result<(f32, String), String> {

--- a/core/src/platform/windows/mod.rs
+++ b/core/src/platform/windows/mod.rs
@@ -1,5 +1,4 @@
 use crate::enums::error::BackendError;
-use crate::enums::settings::TemperatureUnit;
 use crate::models::hardware::{
   GpuMemoryUsage, GraphicInfo, MotherboardInfo, NetworkInfo,
 };
@@ -59,7 +58,6 @@ impl GpuPlatform for WindowsPlatform {
 
   fn get_gpu_temperature(
     &self,
-    temperature_unit: TemperatureUnit,
   ) -> Pin<
     Box<
       dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>
@@ -67,7 +65,7 @@ impl GpuPlatform for WindowsPlatform {
         + '_,
     >,
   > {
-    Box::pin(gpu::get_gpu_temperature(temperature_unit))
+    Box::pin(gpu::get_gpu_temperature())
   }
 
   fn get_gpu_info(

--- a/core/src/settings/hardware_archive.rs
+++ b/core/src/settings/hardware_archive.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+/// Core-owned hardware archive settings.
+///
+/// Persisted as the `hardwareArchive` key in the shared `settings.json`.
+/// The struct intentionally lives in `hwviz_core` (not the App crate) so
+/// that the archive worker and any future Core consumer can read these
+/// values without depending on Tauri.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct HardwareArchiveSettings {
+  pub enabled: bool,
+  pub scheduled_data_deletion: bool,
+  pub refresh_interval_days: u32,
+}
+
+impl Default for HardwareArchiveSettings {
+  fn default() -> Self {
+    Self {
+      enabled: true,
+      refresh_interval_days: 30,
+      scheduled_data_deletion: true,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn defaults_match_documented_values() {
+    let s = HardwareArchiveSettings::default();
+    assert!(s.enabled);
+    assert!(s.scheduled_data_deletion);
+    assert_eq!(s.refresh_interval_days, 30);
+  }
+
+  #[test]
+  fn missing_fields_fall_back_to_defaults() {
+    let s: HardwareArchiveSettings =
+      serde_json::from_str(r#"{"enabled": false}"#).unwrap();
+    assert!(!s.enabled);
+    // Missing fields preserve defaults thanks to #[serde(default)]
+    assert!(s.scheduled_data_deletion);
+    assert_eq!(s.refresh_interval_days, 30);
+  }
+
+  #[test]
+  fn serializes_in_camel_case() {
+    let s = HardwareArchiveSettings::default();
+    let json = serde_json::to_string(&s).unwrap();
+    assert!(json.contains("\"refreshIntervalDays\""));
+    assert!(json.contains("\"scheduledDataDeletion\""));
+  }
+}

--- a/core/src/settings/mod.rs
+++ b/core/src/settings/mod.rs
@@ -84,12 +84,22 @@ impl CoreSettings {
         .map_err(|e| format!("Failed to create configuration directory: {e}"))?;
     }
 
+    // Refuse to silently overwrite a corrupted settings file — App-owned
+    // keys live under the same JSON object, so a "best-effort" reset
+    // would drop them. Bail out and let the caller surface the error.
     let mut document = match fs::read_to_string(path) {
-      Ok(input) => match serde_json::from_str::<serde_json::Value>(&input) {
-        Ok(serde_json::Value::Object(map)) => map,
-        _ => serde_json::Map::new(),
-      },
-      Err(_) => serde_json::Map::new(),
+      Ok(input) => {
+        let parsed: serde_json::Value = serde_json::from_str(&input)
+          .map_err(|e| format!("Existing settings file is invalid JSON: {e}"))?;
+        match parsed {
+          serde_json::Value::Object(map) => map,
+          _ => {
+            return Err("Existing settings file must be a JSON object".to_string());
+          }
+        }
+      }
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => serde_json::Map::new(),
+      Err(e) => return Err(format!("Failed to read existing settings file: {e}")),
     };
 
     document.insert(
@@ -211,6 +221,35 @@ mod tests {
       hw.get("refreshIntervalDays").and_then(|v| v.as_u64()),
       Some(90)
     );
+  }
+
+  #[test]
+  fn save_refuses_to_overwrite_corrupted_existing_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    fs::write(&path, "this is not json").unwrap();
+
+    let s = CoreSettings::default();
+    let err = s.save_to_path(&path).expect_err("must refuse to overwrite");
+    assert!(err.contains("invalid JSON"), "unexpected error: {err}");
+
+    // The on-disk content must be left untouched so a human can inspect /
+    // recover it instead of losing App-owned keys to a silent reset.
+    assert_eq!(fs::read_to_string(&path).unwrap(), "this is not json");
+  }
+
+  #[test]
+  fn save_refuses_when_existing_file_is_not_an_object() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    fs::write(&path, "[1, 2, 3]").unwrap();
+
+    let s = CoreSettings::default();
+    let err = s
+      .save_to_path(&path)
+      .expect_err("must refuse non-object root");
+    assert!(err.contains("JSON object"), "unexpected error: {err}");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "[1, 2, 3]");
   }
 
   #[test]

--- a/core/src/settings/mod.rs
+++ b/core/src/settings/mod.rs
@@ -1,0 +1,245 @@
+//! Core-owned settings.
+//!
+//! [`CoreSettings`] holds the fields whose values change Core behavior
+//! (currently the hardware archive worker's enabled/cadence/retention).
+//! It is intentionally a strict subset of the on-disk `settings.json` —
+//! UI-only fields (`theme`, `language`, `lineGraph*`, `burnInShift*`,
+//! `temperatureUnit`, etc.) are owned by the App crate and stay
+//! invisible to Core. Both crates can read and write the same JSON file:
+//! [`CoreSettings::save_to_path`] merges its own keys into any existing
+//! object so App-owned keys are preserved.
+
+pub mod hardware_archive;
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+pub use hardware_archive::HardwareArchiveSettings;
+
+/// JSON key under which [`HardwareArchiveSettings`] is persisted.
+const HARDWARE_ARCHIVE_KEY: &str = "hardwareArchive";
+
+/// Subset of the on-disk settings document that Core consumes.
+///
+/// Deserializing from a settings file that contains additional App-owned
+/// keys is supported: unknown keys are silently ignored, and missing
+/// Core keys fall back to their defaults.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CoreSettings {
+  pub hardware_archive: HardwareArchiveSettings,
+}
+
+impl CoreSettings {
+  /// Load `CoreSettings` from a JSON file, returning defaults if the
+  /// file does not exist. Field-level errors fall back to defaults so a
+  /// malformed App-only key does not block Core startup.
+  pub fn load_from_path(path: &Path) -> Result<Self, String> {
+    if !path.exists() {
+      return Ok(Self::default());
+    }
+
+    let input = fs::read_to_string(path)
+      .map_err(|e| format!("Failed to read settings file: {e}"))?;
+
+    Self::parse_with_recovery(&input)
+  }
+
+  /// Parse Core settings from a JSON string. Falls back to per-field
+  /// recovery when a strict deserialize fails so an unrelated invalid
+  /// App-owned key doesn't poison the Core view.
+  fn parse_with_recovery(input: &str) -> Result<Self, String> {
+    if let Ok(parsed) = serde_json::from_str::<Self>(input) {
+      return Ok(parsed);
+    }
+
+    let value: serde_json::Value = serde_json::from_str(input)
+      .map_err(|e| format!("Settings file is not valid JSON: {e}"))?;
+    let map = match value {
+      serde_json::Value::Object(map) => map,
+      _ => return Err("Settings file must be a JSON object".to_string()),
+    };
+
+    let mut settings = Self::default();
+    if let Some(v) = map.get(HARDWARE_ARCHIVE_KEY)
+      && let Ok(parsed) = serde_json::from_value::<HardwareArchiveSettings>(v.clone())
+    {
+      settings.hardware_archive = parsed;
+    }
+    Ok(settings)
+  }
+
+  /// Persist `CoreSettings` to disk, merging into any existing JSON
+  /// object so App-owned keys survive. Writes are atomic via a temp
+  /// file + rename.
+  pub fn save_to_path(&self, path: &Path) -> Result<(), String> {
+    let parent = path
+      .parent()
+      .ok_or_else(|| "Settings path has no parent directory".to_string())?;
+
+    if !parent.as_os_str().is_empty() && !parent.exists() {
+      fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create configuration directory: {e}"))?;
+    }
+
+    let mut document = match fs::read_to_string(path) {
+      Ok(input) => match serde_json::from_str::<serde_json::Value>(&input) {
+        Ok(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+      },
+      Err(_) => serde_json::Map::new(),
+    };
+
+    document.insert(
+      HARDWARE_ARCHIVE_KEY.to_string(),
+      serde_json::to_value(&self.hardware_archive)
+        .map_err(|e| format!("Failed to serialize hardware archive settings: {e}"))?,
+    );
+
+    let serialized = serde_json::to_string(&serde_json::Value::Object(document))
+      .map_err(|e| format!("Failed to serialize settings: {e}"))?;
+
+    let mut temp_file = tempfile::NamedTempFile::new_in(parent)
+      .map_err(|e| format!("Failed to create temporary settings file: {e}"))?;
+    temp_file
+      .write_all(serialized.as_bytes())
+      .map_err(|e| format!("Failed to write temporary settings file: {e}"))?;
+    temp_file
+      .persist(path)
+      .map_err(|e| format!("Failed to persist settings file: {e}"))?;
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+  use tempfile::TempDir;
+
+  #[test]
+  fn load_from_missing_path_yields_defaults() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("missing.json");
+    let s = CoreSettings::load_from_path(&path).unwrap();
+    assert_eq!(s, CoreSettings::default());
+  }
+
+  #[test]
+  fn load_ignores_app_only_keys() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    fs::write(
+      &path,
+      r#"{
+        "version": "0.1.0",
+        "language": "en",
+        "theme": "dark",
+        "burnInShift": true,
+        "temperatureUnit": "F",
+        "hardwareArchive": {
+          "enabled": false,
+          "refreshIntervalDays": 7,
+          "scheduledDataDeletion": false
+        }
+      }"#,
+    )
+    .unwrap();
+
+    let s = CoreSettings::load_from_path(&path).unwrap();
+    assert!(!s.hardware_archive.enabled);
+    assert_eq!(s.hardware_archive.refresh_interval_days, 7);
+    assert!(!s.hardware_archive.scheduled_data_deletion);
+  }
+
+  #[test]
+  fn load_recovers_when_unrelated_field_is_invalid() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    // `theme` is invalid for the (App-side) Settings struct, but Core
+    // doesn't care — it should still parse hardwareArchive correctly.
+    fs::write(
+      &path,
+      r#"{
+        "theme": "nonexistent_theme",
+        "hardwareArchive": {"enabled": false, "refreshIntervalDays": 14, "scheduledDataDeletion": true}
+      }"#,
+    )
+    .unwrap();
+
+    let s = CoreSettings::load_from_path(&path).unwrap();
+    assert!(!s.hardware_archive.enabled);
+    assert_eq!(s.hardware_archive.refresh_interval_days, 14);
+  }
+
+  #[test]
+  fn load_returns_err_on_invalid_json() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    fs::write(&path, "not json {{{").unwrap();
+    assert!(CoreSettings::load_from_path(&path).is_err());
+  }
+
+  #[test]
+  fn save_preserves_app_only_keys() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    fs::write(
+      &path,
+      r#"{
+        "language": "ja",
+        "theme": "light",
+        "hardwareArchive": {"enabled": true, "refreshIntervalDays": 30, "scheduledDataDeletion": true}
+      }"#,
+    )
+    .unwrap();
+
+    let mut s = CoreSettings::load_from_path(&path).unwrap();
+    s.hardware_archive.enabled = false;
+    s.hardware_archive.refresh_interval_days = 90;
+    s.save_to_path(&path).unwrap();
+
+    let written: serde_json::Value =
+      serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(written.get("language").and_then(|v| v.as_str()), Some("ja"));
+    assert_eq!(written.get("theme").and_then(|v| v.as_str()), Some("light"));
+    let hw = written.get("hardwareArchive").unwrap();
+    assert_eq!(hw.get("enabled").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(
+      hw.get("refreshIntervalDays").and_then(|v| v.as_u64()),
+      Some(90)
+    );
+  }
+
+  #[test]
+  fn save_creates_file_and_parent_when_missing() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("nested").join("settings.json");
+    let s = CoreSettings::default();
+    s.save_to_path(&path).unwrap();
+
+    assert!(path.exists());
+    let written: serde_json::Value =
+      serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(written.get("hardwareArchive").is_some());
+  }
+
+  #[test]
+  fn round_trip_preserves_values() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+
+    let s = CoreSettings {
+      hardware_archive: HardwareArchiveSettings {
+        enabled: false,
+        scheduled_data_deletion: false,
+        refresh_interval_days: 365,
+      },
+    };
+    s.save_to_path(&path).unwrap();
+    let loaded = CoreSettings::load_from_path(&path).unwrap();
+    assert_eq!(s, loaded);
+  }
+}

--- a/src-tauri/src/_tests/commands/settings_test.rs
+++ b/src-tauri/src/_tests/commands/settings_test.rs
@@ -35,11 +35,6 @@ mod tests {
       background_img_opacity: 50,
       selected_background_img: None,
       temperature_unit: enums::settings::TemperatureUnit::Celsius,
-      hardware_archive: models::hardware_archive::HardwareArchiveSettings {
-        enabled: true,
-        refresh_interval_days: 30,
-        scheduled_data_deletion: true,
-      },
       burn_in_shift: false,
       burn_in_shift_mode: enums::settings::BurnInShiftMode::Jump,
       burn_in_shift_preset: enums::settings::BurnInShiftPreset::Aggressive,

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -1,0 +1,1 @@
+pub mod startup;

--- a/src-tauri/src/app/startup.rs
+++ b/src-tauri/src/app/startup.rs
@@ -1,5 +1,5 @@
-use crate::infrastructure::database::preflight::DbStartupError;
 use crate::utils;
+use hwviz_core::persistence::preflight::DbStartupError;
 use std::path::Path;
 use tauri_plugin_dialog::{
   DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,17 +3,35 @@ use crate::log_error;
 use crate::models;
 use crate::services;
 use crate::utils;
+use hwviz_core::settings::CoreSettings;
 use tauri_plugin_opener::OpenerExt;
 
 #[derive(Debug)]
 pub struct AppState {
   pub settings: std::sync::Mutex<models::settings::Settings>,
+  /// Core-owned settings (currently `hardwareArchive`). Loaded from the
+  /// same `settings.json` as the App-side `Settings`, but each side only
+  /// (de)serializes its own keys so writes don't clobber each other.
+  pub core_settings: std::sync::Mutex<CoreSettings>,
 }
 
 impl AppState {
   pub fn new() -> Self {
+    let settings_path =
+      utils::file::get_app_data_dir(services::settings_service::SETTINGS_FILENAME);
+    let core_settings =
+      CoreSettings::load_from_path(&settings_path).unwrap_or_else(|e| {
+        log_error!(
+          "Failed to load core settings",
+          "AppState::new",
+          Some(e.to_string())
+        );
+        CoreSettings::default()
+      });
+
     Self {
       settings: std::sync::Mutex::from(models::settings::Settings::new()),
+      core_settings: std::sync::Mutex::from(core_settings),
     }
   }
 }
@@ -59,6 +77,7 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
   ) -> Result<models::settings::ClientSettings, String> {
     let settings = state.settings.lock().unwrap().clone();
+    let core_settings = state.core_settings.lock().unwrap().clone();
 
     // Convert to comma-separated string for easier handling in frontend
     let color_strings = models::settings::LineGraphColorStringSettings {
@@ -102,7 +121,7 @@ pub mod commands {
       background_img_opacity: settings.background_img_opacity,
       selected_background_img: settings.selected_background_img,
       temperature_unit: settings.temperature_unit,
-      hardware_archive: settings.hardware_archive,
+      hardware_archive: core_settings.hardware_archive.into(),
       burn_in_shift: settings.burn_in_shift,
       burn_in_shift_mode: settings.burn_in_shift_mode,
       burn_in_shift_preset: settings.burn_in_shift_preset,
@@ -359,6 +378,23 @@ pub mod commands {
     Ok(())
   }
 
+  /// Apply a mutation to `CoreSettings` and persist via the Core
+  /// storage helper (which merges into the shared `settings.json` so
+  /// App-owned keys are preserved).
+  fn update_core_settings<F>(
+    state: &tauri::State<'_, AppState>,
+    mutate: F,
+  ) -> Result<(), String>
+  where
+    F: FnOnce(&mut CoreSettings),
+  {
+    let mut core_settings = state.core_settings.lock().unwrap();
+    mutate(&mut core_settings);
+    let path =
+      utils::file::get_app_data_dir(services::settings_service::SETTINGS_FILENAME);
+    core_settings.save_to_path(&path)
+  }
+
   #[tauri::command]
   #[specta::specta]
   pub async fn set_hardware_archive_enabled(
@@ -366,9 +402,9 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
     new_value: bool,
   ) -> Result<(), String> {
-    let mut settings = state.settings.lock().unwrap();
-
-    if let Err(e) = settings.set_hardware_archive_enabled(new_value) {
+    if let Err(e) =
+      update_core_settings(&state, |s| s.hardware_archive.enabled = new_value)
+    {
       emit_error(&window)?;
       return Err(e);
     }
@@ -382,9 +418,9 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
     new_interval: u32,
   ) -> Result<(), String> {
-    let mut settings = state.settings.lock().unwrap();
-
-    if let Err(e) = settings.set_hardware_archive_interval(new_interval) {
+    if let Err(e) = update_core_settings(&state, |s| {
+      s.hardware_archive.refresh_interval_days = new_interval
+    }) {
       emit_error(&window)?;
       return Err(e);
     }
@@ -398,9 +434,9 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
     new_value: bool,
   ) -> Result<(), String> {
-    let mut settings = state.settings.lock().unwrap();
-
-    if let Err(e) = settings.set_hardware_archive_scheduled_data_deletion(new_value) {
+    if let Err(e) = update_core_settings(&state, |s| {
+      s.hardware_archive.scheduled_data_deletion = new_value
+    }) {
       emit_error(&window)?;
       return Err(e);
     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -381,6 +381,12 @@ pub mod commands {
   /// Apply a mutation to `CoreSettings` and persist via the Core
   /// storage helper (which merges into the shared `settings.json` so
   /// App-owned keys are preserved).
+  ///
+  /// The mutation is applied to a clone first; the in-memory state is
+  /// only swapped in after the on-disk write succeeds. This keeps the
+  /// process from advertising a value the disk hasn't accepted (e.g.
+  /// when the existing file is corrupted and `save_to_path` refuses to
+  /// overwrite it).
   fn update_core_settings<F>(
     state: &tauri::State<'_, AppState>,
     mutate: F,
@@ -389,10 +395,13 @@ pub mod commands {
     F: FnOnce(&mut CoreSettings),
   {
     let mut core_settings = state.core_settings.lock().unwrap();
-    mutate(&mut core_settings);
+    let mut next = core_settings.clone();
+    mutate(&mut next);
     let path =
       utils::file::get_app_data_dir(services::settings_service::SETTINGS_FILENAME);
-    core_settings.save_to_path(&path)
+    next.save_to_path(&path)?;
+    *core_settings = next;
+    Ok(())
   }
 
   #[tauri::command]
@@ -418,6 +427,12 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
     new_interval: u32,
   ) -> Result<(), String> {
+    // Reject 0: zero retention would mean "delete every record
+    // immediately" via the scheduled cleanup path, which is never what
+    // a user means by entering a refresh interval.
+    if new_interval == 0 {
+      return Err("refresh_interval_days must be greater than 0".to_string());
+    }
     if let Err(e) = update_core_settings(&state, |s| {
       s.hardware_archive.refresh_interval_days = new_interval
     }) {

--- a/src-tauri/src/infrastructure/database/mod.rs
+++ b/src-tauri/src/infrastructure/database/mod.rs
@@ -2,5 +2,4 @@ pub mod db;
 pub mod gpu_archive;
 pub mod hardware_archive;
 pub mod migration;
-pub mod preflight;
 pub mod process_stats;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 pub use hwviz_core::{log_debug, log_error, log_info, log_internal, log_warn};
 
 mod adapters;
+mod app;
 mod commands;
 mod constants;
 mod enums;
@@ -45,9 +46,12 @@ pub fn run() {
   // until Phase 4 replaces `MonitorResources` with an EventBus subscription.
   let history_store = Arc::new(HistoryStore::new());
 
-  let settings = app_state.settings.lock().unwrap().clone();
+  let core_settings = app_state.core_settings.lock().unwrap().clone();
 
-  let db_error = infrastructure::database::preflight::check_db_compatibility();
+  let db_path = utils::file::get_app_data_dir("hv-database.db");
+  let app_max_version = infrastructure::database::migration::get_max_migration_version();
+  let db_error =
+    hwviz_core::persistence::preflight::check_db_compatibility(&db_path, app_max_version);
   let is_db_ok = db_error.is_none();
 
   let migrations = infrastructure::database::migration::get_migrations();
@@ -152,7 +156,7 @@ pub fn run() {
 
       if is_db_ok {
         // Start DB-dependent archive services
-        if settings.hardware_archive.enabled {
+        if core_settings.hardware_archive.enabled {
           let handles = store_for_setup.arc_handles();
           let hw_archive = workers::hardware_archive::HardwareArchiveController::setup(
             models::hardware_archive::MonitorResources {
@@ -172,9 +176,9 @@ pub fn run() {
           }
         }
 
-        if settings.hardware_archive.scheduled_data_deletion {
+        if core_settings.hardware_archive.scheduled_data_deletion {
           tauri::async_runtime::spawn(workers::hardware_archive::batch_delete_old_data(
-            settings.hardware_archive.refresh_interval_days,
+            core_settings.hardware_archive.refresh_interval_days,
           ));
         }
       } else {
@@ -187,10 +191,10 @@ pub fn run() {
         let handle = app.handle().clone();
         let db_err = db_error.expect("db_error must be Some when is_db_ok is false");
         std::thread::spawn(move || {
-          use services::db_startup_service::{self, StartupErrorAction};
-          match db_startup_service::prompt_startup_error(&handle, db_err) {
+          use app::startup::{self, StartupErrorAction};
+          match startup::prompt_startup_error(&handle, db_err) {
             StartupErrorAction::ResetAndRestart => {
-              db_startup_service::reset_database_and_restart(&handle);
+              startup::reset_database_and_restart(&handle);
             }
             StartupErrorAction::ContinueAnyway => {
               // Show the main window — app runs without DB-backed features

--- a/src-tauri/src/models/hardware_archive.rs
+++ b/src-tauri/src/models/hardware_archive.rs
@@ -1,3 +1,4 @@
+use hwviz_core::settings::HardwareArchiveSettings as CoreHardwareArchiveSettings;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::{
@@ -17,6 +18,12 @@ pub struct MonitorResources {
   pub gpu_name_map: Arc<Mutex<HashMap<String, String>>>,
 }
 
+/// Wire-format mirror of [`hwviz_core::settings::HardwareArchiveSettings`].
+///
+/// The canonical definition lives in `hwviz_core::settings` so the
+/// archive worker (and any future Core consumer) doesn't need to know
+/// about Tauri or specta. This App-side struct exists only because the
+/// frontend wire format requires `specta::Type`.
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 #[serde(default, rename_all = "camelCase")]
 pub struct HardwareArchiveSettings {
@@ -27,10 +34,26 @@ pub struct HardwareArchiveSettings {
 
 impl Default for HardwareArchiveSettings {
   fn default() -> Self {
+    CoreHardwareArchiveSettings::default().into()
+  }
+}
+
+impl From<CoreHardwareArchiveSettings> for HardwareArchiveSettings {
+  fn from(value: CoreHardwareArchiveSettings) -> Self {
     Self {
-      enabled: true,
-      refresh_interval_days: 30,
-      scheduled_data_deletion: true,
+      enabled: value.enabled,
+      scheduled_data_deletion: value.scheduled_data_deletion,
+      refresh_interval_days: value.refresh_interval_days,
+    }
+  }
+}
+
+impl From<HardwareArchiveSettings> for CoreHardwareArchiveSettings {
+  fn from(value: HardwareArchiveSettings) -> Self {
+    Self {
+      enabled: value.enabled,
+      scheduled_data_deletion: value.scheduled_data_deletion,
+      refresh_interval_days: value.refresh_interval_days,
     }
   }
 }

--- a/src-tauri/src/models/hardware_archive.rs
+++ b/src-tauri/src/models/hardware_archive.rs
@@ -48,15 +48,11 @@ impl From<CoreHardwareArchiveSettings> for HardwareArchiveSettings {
   }
 }
 
-impl From<HardwareArchiveSettings> for CoreHardwareArchiveSettings {
-  fn from(value: HardwareArchiveSettings) -> Self {
-    Self {
-      enabled: value.enabled,
-      scheduled_data_deletion: value.scheduled_data_deletion,
-      refresh_interval_days: value.refresh_interval_days,
-    }
-  }
-}
+// Only the Core → App direction has a real consumer (the
+// `ClientSettings` response). The reverse direction is unnecessary
+// because mutation goes through `commands::settings::update_core_settings`
+// which operates on `CoreSettings` directly, never converting from the
+// wire mirror back into the Core type.
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct HardwareData {

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -24,7 +24,12 @@ impl Default for LineGraphColorSettings {
 }
 
 ///
-/// ## JSON structure stored in settings.json
+/// ## App-owned settings persisted in `settings.json`.
+///
+/// Core-owned fields (currently `hardwareArchive`) live in
+/// [`hwviz_core::settings::CoreSettings`] and are persisted to the same
+/// file under their own keys — they are intentionally absent here so
+/// App-side setters never touch Core fields.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default, rename_all = "camelCase")]
@@ -45,7 +50,6 @@ pub struct Settings {
   pub background_img_opacity: u8,
   pub selected_background_img: Option<String>,
   pub temperature_unit: enums::settings::TemperatureUnit,
-  pub hardware_archive: models::hardware_archive::HardwareArchiveSettings,
   pub burn_in_shift: bool,
   pub burn_in_shift_mode: enums::settings::BurnInShiftMode,
   pub burn_in_shift_preset: enums::settings::BurnInShiftPreset,
@@ -120,11 +124,6 @@ impl Default for Settings {
       background_img_opacity: 50,
       selected_background_img: None,
       temperature_unit: enums::settings::TemperatureUnit::Celsius,
-      hardware_archive: models::hardware_archive::HardwareArchiveSettings {
-        enabled: true,
-        refresh_interval_days: 30,
-        scheduled_data_deletion: true,
-      },
       burn_in_shift: false,
       burn_in_shift_mode: enums::settings::BurnInShiftMode::Jump,
       burn_in_shift_preset: enums::settings::BurnInShiftPreset::Aggressive,
@@ -261,11 +260,8 @@ mod tests {
       background_img_opacity: 75,
       selected_background_img: Some("test.png".to_string()),
       temperature_unit: enums::settings::TemperatureUnit::Celsius,
-      hardware_archive: crate::models::hardware_archive::HardwareArchiveSettings {
-        enabled: true,
-        refresh_interval_days: 30,
-        scheduled_data_deletion: true,
-      },
+      hardware_archive: crate::models::hardware_archive::HardwareArchiveSettings::default(
+      ),
       burn_in_shift: false,
       burn_in_shift_mode: enums::settings::BurnInShiftMode::Jump,
       burn_in_shift_preset: enums::settings::BurnInShiftPreset::Aggressive,
@@ -328,6 +324,9 @@ mod tests {
     // Simulate an old settings.json that lacks fields added in newer versions
     // (e.g., burnInShift*, textSelectable). With #[serde(default)], missing
     // fields should fall back to their defaults instead of failing entirely.
+    // The `hardwareArchive` key here is a Core-owned key; the App-side
+    // Settings struct ignores it via `#[serde(deny_unknown_fields)]`-free
+    // defaults — this asserts we don't break when both buckets share a file.
     let old_json = r#"{
       "version": "0.1.0",
       "language": "en",
@@ -364,8 +363,6 @@ mod tests {
       settings.temperature_unit,
       enums::settings::TemperatureUnit::Fahrenheit
     );
-    assert!(!settings.hardware_archive.enabled);
-    assert_eq!(settings.hardware_archive.refresh_interval_days, 7);
 
     // Missing fields should have default values
     let defaults = Settings::default();
@@ -392,19 +389,6 @@ mod tests {
     assert_eq!(settings.line_graph_border, defaults.line_graph_border);
     assert_eq!(settings.burn_in_shift, defaults.burn_in_shift);
     assert_eq!(settings.text_selectable, defaults.text_selectable);
-  }
-
-  #[test]
-  fn test_hardware_archive_settings_missing_fields() {
-    // HardwareArchiveSettings with missing fields should use defaults
-    let json = r#"{"enabled": false}"#;
-    let settings: crate::models::hardware_archive::HardwareArchiveSettings =
-      serde_json::from_str(json).unwrap();
-
-    assert!(!settings.enabled);
-    // Missing fields should use defaults
-    assert!(settings.scheduled_data_deletion);
-    assert_eq!(settings.refresh_interval_days, 30);
   }
 
   #[test]

--- a/src-tauri/src/services/gpu_service.rs
+++ b/src-tauri/src/services/gpu_service.rs
@@ -17,8 +17,10 @@ pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, String> {
 }
 
 ///
-/// Get list of GPU temperatures
-/// `temperature_unit` assumes user setting (Celsius/Fahrenheit etc.)
+/// Get list of GPU temperatures.
+///
+/// Core always returns raw °C; this layer formats into the user's
+/// preferred unit so Core's API stays decoupled from UI preferences.
 ///
 pub async fn fetch_gpu_temperature(
   temperature_unit: enums::settings::TemperatureUnit,
@@ -27,11 +29,24 @@ pub async fn fetch_gpu_temperature(
     PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
 
   let core_temps = platform
-    .get_gpu_temperature(temperature_unit.into())
+    .get_gpu_temperature()
     .await
     .map_err(|e| format!("Failed to get GPU temperature: {e:?}"))?;
 
-  Ok(core_temps.into_iter().map(NameValue::from).collect())
+  let unit: hwviz_core::enums::settings::TemperatureUnit = temperature_unit.into();
+  Ok(
+    core_temps
+      .into_iter()
+      .map(|t| NameValue {
+        name: t.name,
+        value: hwviz_core::utils::formatter::format_temperature(
+          hwviz_core::enums::settings::TemperatureUnit::Celsius,
+          unit.clone(),
+          t.value,
+        ),
+      })
+      .collect(),
+  )
 }
 
 ///

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,6 +1,5 @@
 pub mod archive_service;
 pub mod background_image_service;
-pub mod db_startup_service;
 pub mod gpu_service;
 pub mod hardware_service;
 pub mod language_service;

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -180,7 +180,6 @@ impl models::settings::Settings {
     try_field!(background_img_opacity, "backgroundImgOpacity");
     try_field!(selected_background_img, "selectedBackgroundImg");
     try_field!(temperature_unit, "temperatureUnit");
-    try_field!(hardware_archive, "hardwareArchive");
     try_field!(burn_in_shift, "burnInShift");
     try_field!(burn_in_shift_mode, "burnInShiftMode");
     try_field!(burn_in_shift_preset, "burnInShiftPreset");
@@ -367,27 +366,6 @@ impl models::settings::Settings {
     new_unit: enums::settings::TemperatureUnit,
   ) -> Result<(), String> {
     self.temperature_unit = new_unit;
-    self.write_file()
-  }
-
-  pub fn set_hardware_archive_enabled(&mut self, new_value: bool) -> Result<(), String> {
-    self.hardware_archive.enabled = new_value;
-    self.write_file()
-  }
-
-  pub fn set_hardware_archive_interval(
-    &mut self,
-    new_interval: u32,
-  ) -> Result<(), String> {
-    self.hardware_archive.refresh_interval_days = new_interval;
-    self.write_file()
-  }
-
-  pub fn set_hardware_archive_scheduled_data_deletion(
-    &mut self,
-    new_value: bool,
-  ) -> Result<(), String> {
-    self.hardware_archive.scheduled_data_deletion = new_value;
     self.write_file()
   }
 

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -529,6 +529,14 @@ export type GpuMonitorData = { gpuId: string; gpuName: string; gpuUsage: number 
 export type GpuUsageResult = { usage: number; source: string }
 export type GraphSize = "sm" | "md" | "lg" | "xl" | "2xl"
 export type GraphicInfo = { id: string; name: string; vendorName: string; clock: number; memorySize: string; memorySizeDedicated: string; coreCount: string | null }
+/**
+ * Wire-format mirror of [`hwviz_core::settings::HardwareArchiveSettings`].
+ * 
+ * The canonical definition lives in `hwviz_core::settings` so the
+ * archive worker (and any future Core consumer) doesn't need to know
+ * about Tauri or specta. This App-side struct exists only because the
+ * frontend wire format requires `specta::Type`.
+ */
 export type HardwareArchiveSettings = { enabled: boolean; scheduledDataDeletion: boolean; refreshIntervalDays: number }
 export type HardwareMonitorUpdate = { cpuUsage: number; memoryUsage: number; gpus: GpuMonitorData[]; processorsUsage: number[] }
 export type HardwareType = "cpu" | "memory" | "gpu"


### PR DESCRIPTION
## Summary
Closes #1406. Part of #1402 (depends on Phase 3).

- **`core::settings`** — new `CoreSettings` struct owning `HardwareArchiveSettings`. Loads from the shared `settings.json` ignoring App-only keys, saves by merging into the existing JSON object so neither bucket clobbers the other.
- **`core::persistence::preflight`** — `DbStartupError` + `check_db_compatibility(path, app_max_version)` ported from `infrastructure::database::preflight`. Uses a self-contained tokio runtime instead of `tauri::async_runtime` so Core stays Tauri-free.
- **`app::startup`** (was `services::db_startup_service`) — the dialog/recovery flow stays App-side and now imports `DbStartupError` from Core.
- App's `Settings` struct drops `hardware_archive`; the three `set_hardware_archive_*` commands route through a shared `update_core_settings` helper on a new `AppState.core_settings` mutex. `get_settings` builds `ClientSettings` from both buckets.
- `models::hardware_archive::HardwareArchiveSettings` becomes a thin wire mirror with bidirectional `From` conversions to/from the Core type (specta `Type` derive stays App-side).
- **Temperature unit direction (DoD bullet 3)** — `GpuPlatform::get_gpu_temperature` no longer takes a `TemperatureUnit`; Core always returns raw °C and `services::gpu_service::fetch_gpu_temperature` formats on the App boundary, mirroring what the EventBus path (`adapters::window`) already did.

## DoD checklist
- [x] `core::settings` deserializes only Core-relevant fields and is unit-tested via `cargo test -p hwviz-core` without a Tauri runtime
- [x] `commands/settings.rs` setters touching UI-only fields no longer round-trip through state structs Core can see
- [x] `temperature_unit` only affects formatting in App; raw temperature values in Core are always °C
- [ ] No user-visible regression in the Settings page (manual smoke test pending — backend wiring verified, UI not yet exercised)

## Open question (from parent #1402)
Confirmed direction: **Core stores °C, App formats**. Implemented for both the EventBus snapshot path (already in Phase 3) and the on-demand command path (this PR).

## Test plan
- [x] \`cargo tauri-fmt\` / \`cargo tauri-lint\` clean
- [x] \`cargo test --workspace --lib --bins --tests -- --test-threads=1\` — 113 core + 177 app, all green
- [x] New core unit tests cover: load missing path → defaults; load ignores App-only keys; load recovers when sibling field is invalid; save preserves App-only keys; save creates parent dir; round-trip persistence
- [ ] Manual smoke: open Settings page, toggle hardware-archive enabled/interval/scheduled-deletion, restart app, confirm values persist and archive worker honours them
- [ ] Manual smoke: switch temperature unit between Celsius/Fahrenheit and confirm both the realtime monitor (EventBus) and the on-demand GPU temperature command reflect the change

## Notes
- `sqlx` is now a direct dependency of `hwviz-core` (needed by preflight). Persistence relocation proper is still scope of Phase 4.
- Pre-existing `src-tauri/examples/adl_diagnostic.rs` doesn't compile on macOS due to a missing \`cfg(windows)\` guard on its \`libloading\` import — unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core-managed hardware-archive settings with persistent storage and defaults

* **Improvements**
  * GPU temperatures standardized as raw Celsius in core; the app now performs unit presentation/formatting
  * Settings load/save and recovery hardened; app reads/writes shared Core settings to preserve app keys

* **Bug Fixes**
  * Stronger database compatibility checks during startup and clearer DB-incompatibility handling
  * Legacy app-level hardware-archive setters removed; management now via Core settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->