### PR TITLE
refactor(core): Phase 5 — MonitoringState machine and lifecycle decoupling (#1408)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod collector;
 
 pub mod persistence;
 
-pub mod monitoring {}
+pub mod monitoring;
 
 pub mod event_bus;
 

--- a/core/src/monitoring/mod.rs
+++ b/core/src/monitoring/mod.rs
@@ -1,0 +1,14 @@
+//! Monitoring lifecycle state machine.
+//!
+//! [`MonitoringState`] tracks whether sensor collection is running,
+//! paused, or stopped. Transitions are explicit; same-state transitions
+//! and any transition out of `Stopped` are rejected with
+//! [`InvalidTransition`]. App-side callers (`src-tauri/src/lifecycle.rs`)
+//! own the state instance and combine it with worker termination, while
+//! `Stopped` is terminal — once reached, the process is on its way out.
+//!
+//! Unit-tested without a Tauri runtime: this module has no I/O.
+
+pub mod state;
+
+pub use state::{InvalidTransition, MonitoringState};

--- a/core/src/monitoring/state.rs
+++ b/core/src/monitoring/state.rs
@@ -1,0 +1,276 @@
+use std::fmt;
+
+/// Lifecycle state of sensor collection.
+///
+/// `Running` is the default. `Paused` halts new sample emission while
+/// keeping the collector resident (Phase 5 doesn't wire pause to the
+/// runtime yet — that's #1275). `Stopped` is terminal: the worker tasks
+/// are draining and the process is on its way to `exit(0)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MonitoringState {
+  Running,
+  Paused,
+  Stopped,
+}
+
+/// Returned when a caller asks for a transition the state machine
+/// rejects: any transition that doesn't change state, or any transition
+/// out of [`MonitoringState::Stopped`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidTransition {
+  pub from: MonitoringState,
+  pub to: MonitoringState,
+}
+
+impl fmt::Display for InvalidTransition {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(
+      f,
+      "invalid monitoring transition: {:?} -> {:?}",
+      self.from, self.to
+    )
+  }
+}
+
+impl std::error::Error for InvalidTransition {}
+
+impl MonitoringState {
+  /// Initial state for a freshly-started monitor.
+  pub fn new() -> Self {
+    Self::Running
+  }
+
+  pub fn is_running(&self) -> bool {
+    matches!(self, Self::Running)
+  }
+
+  pub fn is_paused(&self) -> bool {
+    matches!(self, Self::Paused)
+  }
+
+  pub fn is_stopped(&self) -> bool {
+    matches!(self, Self::Stopped)
+  }
+
+  /// Pause collection. Valid only from [`MonitoringState::Running`].
+  pub fn pause(&mut self) -> Result<(), InvalidTransition> {
+    self.try_transition(Self::Paused)
+  }
+
+  /// Resume collection. Valid only from [`MonitoringState::Paused`].
+  pub fn resume(&mut self) -> Result<(), InvalidTransition> {
+    self.try_transition(Self::Running)
+  }
+
+  /// Move to [`MonitoringState::Stopped`]. Valid from `Running` or
+  /// `Paused`. Terminal — no transitions out of `Stopped` are accepted.
+  pub fn stop(&mut self) -> Result<(), InvalidTransition> {
+    self.try_transition(Self::Stopped)
+  }
+
+  /// Generic transition entry point. Prefer [`Self::pause`],
+  /// [`Self::resume`], [`Self::stop`] at call sites; this is exposed for
+  /// callers that hold a target state value (e.g. test parameterization).
+  pub fn try_transition(
+    &mut self,
+    target: MonitoringState,
+  ) -> Result<(), InvalidTransition> {
+    if Self::is_valid_transition(*self, target) {
+      *self = target;
+      Ok(())
+    } else {
+      Err(InvalidTransition {
+        from: *self,
+        to: target,
+      })
+    }
+  }
+
+  fn is_valid_transition(from: MonitoringState, to: MonitoringState) -> bool {
+    use MonitoringState::*;
+    matches!(
+      (from, to),
+      (Running, Paused) | (Paused, Running) | (Running, Stopped) | (Paused, Stopped)
+    )
+  }
+}
+
+impl Default for MonitoringState {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn default_state_is_running() {
+    assert_eq!(MonitoringState::new(), MonitoringState::Running);
+    assert_eq!(MonitoringState::default(), MonitoringState::Running);
+  }
+
+  #[test]
+  fn predicates_match_state() {
+    assert!(MonitoringState::Running.is_running());
+    assert!(!MonitoringState::Running.is_paused());
+    assert!(!MonitoringState::Running.is_stopped());
+
+    assert!(MonitoringState::Paused.is_paused());
+    assert!(!MonitoringState::Paused.is_running());
+    assert!(!MonitoringState::Paused.is_stopped());
+
+    assert!(MonitoringState::Stopped.is_stopped());
+    assert!(!MonitoringState::Stopped.is_running());
+    assert!(!MonitoringState::Stopped.is_paused());
+  }
+
+  // ── Valid transitions ──
+
+  #[test]
+  fn running_to_paused_is_valid() {
+    let mut s = MonitoringState::Running;
+    s.pause().unwrap();
+    assert_eq!(s, MonitoringState::Paused);
+  }
+
+  #[test]
+  fn paused_to_running_is_valid() {
+    let mut s = MonitoringState::Paused;
+    s.resume().unwrap();
+    assert_eq!(s, MonitoringState::Running);
+  }
+
+  #[test]
+  fn running_to_stopped_is_valid() {
+    let mut s = MonitoringState::Running;
+    s.stop().unwrap();
+    assert_eq!(s, MonitoringState::Stopped);
+  }
+
+  #[test]
+  fn paused_to_stopped_is_valid() {
+    let mut s = MonitoringState::Paused;
+    s.stop().unwrap();
+    assert_eq!(s, MonitoringState::Stopped);
+  }
+
+  // ── Invalid: no-op same-state transitions ──
+
+  #[test]
+  fn running_to_running_is_rejected() {
+    let mut s = MonitoringState::Running;
+    let err = s.try_transition(MonitoringState::Running).unwrap_err();
+    assert_eq!(err.from, MonitoringState::Running);
+    assert_eq!(err.to, MonitoringState::Running);
+    // State unchanged on failure.
+    assert_eq!(s, MonitoringState::Running);
+  }
+
+  #[test]
+  fn paused_to_paused_is_rejected() {
+    let mut s = MonitoringState::Paused;
+    assert!(s.pause().is_err());
+    assert_eq!(s, MonitoringState::Paused);
+  }
+
+  #[test]
+  fn resume_from_running_is_rejected() {
+    let mut s = MonitoringState::Running;
+    assert!(s.resume().is_err());
+    assert_eq!(s, MonitoringState::Running);
+  }
+
+  // ── Invalid: Stopped is terminal ──
+
+  #[test]
+  fn stopped_to_running_is_rejected() {
+    let mut s = MonitoringState::Stopped;
+    let err = s.try_transition(MonitoringState::Running).unwrap_err();
+    assert_eq!(err.from, MonitoringState::Stopped);
+    assert_eq!(err.to, MonitoringState::Running);
+    assert_eq!(s, MonitoringState::Stopped);
+  }
+
+  #[test]
+  fn stopped_to_paused_is_rejected() {
+    let mut s = MonitoringState::Stopped;
+    assert!(s.try_transition(MonitoringState::Paused).is_err());
+    assert_eq!(s, MonitoringState::Stopped);
+  }
+
+  #[test]
+  fn stopped_to_stopped_is_rejected() {
+    let mut s = MonitoringState::Stopped;
+    assert!(s.stop().is_err());
+    assert_eq!(s, MonitoringState::Stopped);
+  }
+
+  // ── Invalid: cannot pause from Stopped ──
+
+  #[test]
+  fn pause_from_paused_is_rejected() {
+    let mut s = MonitoringState::Paused;
+    assert!(s.pause().is_err());
+  }
+
+  #[test]
+  fn pause_from_stopped_is_rejected() {
+    let mut s = MonitoringState::Stopped;
+    assert!(s.pause().is_err());
+  }
+
+  #[test]
+  fn resume_from_stopped_is_rejected() {
+    let mut s = MonitoringState::Stopped;
+    assert!(s.resume().is_err());
+  }
+
+  // ── Exhaustive coverage of the (from, to) grid ──
+
+  #[test]
+  fn transition_grid_matches_specification() {
+    use MonitoringState::*;
+    let cases = [
+      // (from, to, expected_valid)
+      (Running, Running, false),
+      (Running, Paused, true),
+      (Running, Stopped, true),
+      (Paused, Running, true),
+      (Paused, Paused, false),
+      (Paused, Stopped, true),
+      (Stopped, Running, false),
+      (Stopped, Paused, false),
+      (Stopped, Stopped, false),
+    ];
+
+    for (from, to, expected_valid) in cases {
+      let mut s = from;
+      let result = s.try_transition(to);
+      assert_eq!(
+        result.is_ok(),
+        expected_valid,
+        "transition {:?} -> {:?} expected valid={}, got result={:?}",
+        from,
+        to,
+        expected_valid,
+        result
+      );
+      // On success, state advances; on failure, state is unchanged.
+      let expected_after = if expected_valid { to } else { from };
+      assert_eq!(s, expected_after);
+    }
+  }
+
+  #[test]
+  fn invalid_transition_display_includes_states() {
+    let err = InvalidTransition {
+      from: MonitoringState::Stopped,
+      to: MonitoringState::Running,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("Stopped"));
+    assert!(msg.contains("Running"));
+  }
+}

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -114,6 +114,15 @@ impl ArchiveController {
           },
         }
       }
+
+      // Phase 5 (#1408): write a final summary on shutdown so samples
+      // accumulated since the last 60s tick are not lost when the user
+      // explicitly quits. `is_dirty()` skips the flush when nothing has
+      // been ingested since the previous write — common when shutdown
+      // lands within a fraction of a second after a scheduled tick.
+      if tracker.is_dirty() {
+        tracker.write_archive().await;
+      }
     });
 
     Self { handle, stop_tx }
@@ -204,6 +213,11 @@ struct ArchiveTracker {
   /// Number of CPU cores observed in the most recent snapshot. Used to
   /// normalize sysinfo's per-core CPU values to a 0-100 percentage.
   cores: f32,
+  /// Set on every `ingest`; cleared by `write_archive`. Drives the
+  /// shutdown-time final flush so we skip the write when nothing has
+  /// been ingested since the previous tick (e.g. shutdown lands within
+  /// a fraction of a second after a scheduled write).
+  dirty: bool,
 }
 
 impl ArchiveTracker {
@@ -211,7 +225,12 @@ impl ArchiveTracker {
     Self::default()
   }
 
+  fn is_dirty(&self) -> bool {
+    self.dirty
+  }
+
   fn ingest(&mut self, snapshot: MetricsSnapshot) {
+    self.dirty = true;
     self.tick_counter = self.tick_counter.saturating_add(1);
     push_capped(&mut self.cpu_history, snapshot.cpu_usage);
     push_capped(&mut self.memory_history, snapshot.memory_usage);
@@ -296,9 +315,11 @@ impl ArchiveTracker {
     }
   }
 
-  async fn write_archive(&self) {
+  async fn write_archive(&mut self) {
     use crate::infrastructure::database;
     use crate::log_error;
+
+    self.dirty = false;
 
     let cpu = StatsCalculator::compute_stats(self.cpu_history.iter().copied());
     let memory = StatsCalculator::compute_stats(self.memory_history.iter().copied());
@@ -618,6 +639,25 @@ mod tests {
       vec![50.0, 60.0]
     );
     assert_eq!(t.cores, 4.0);
+  }
+
+  #[test]
+  fn fresh_tracker_is_not_dirty() {
+    let t = ArchiveTracker::new();
+    assert!(
+      !t.is_dirty(),
+      "an unused tracker must not trigger a shutdown flush"
+    );
+  }
+
+  #[test]
+  fn ingest_marks_tracker_dirty() {
+    let mut t = ArchiveTracker::new();
+    t.ingest(make_snapshot(10.0, 50.0, 1));
+    assert!(
+      t.is_dirty(),
+      "ingest must set the dirty flag so shutdown writes a final summary"
+    );
   }
 
   #[test]

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -4,3 +4,16 @@
 pub async fn restart_app(app_handle: tauri::AppHandle) {
   crate::services::system_service::restart_app(&app_handle).await;
 }
+
+/// Stop monitoring and exit the process.
+///
+/// Phase 5 (#1408): the explicit Quit path. Keep it gated to the
+/// internal callers that the lifecycle module owns — Phase 6's tray
+/// menu and the future "Quit" UX from #1275. Until those land, this
+/// command is reachable only from devtools / tauri-specta-generated
+/// bindings, which is enough to validate the cleanup ordering.
+#[tauri::command]
+#[specta::specta]
+pub async fn quit_app(app_handle: tauri::AppHandle) {
+  crate::lifecycle::request_quit(app_handle).await;
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod app;
 mod commands;
 mod enums;
 mod infrastructure;
+mod lifecycle;
 mod models;
 mod services;
 mod utils;
@@ -114,6 +115,7 @@ pub fn run() {
       background_image::delete_background_image,
       ui::set_decoration,
       system::restart_app,
+      system::quit_app,
     ]);
 
   // TS bindings
@@ -216,16 +218,11 @@ pub fn run() {
     })
     .on_window_event(|win, ev| {
       if let tauri::WindowEvent::CloseRequested { api, .. } = ev {
+        // Always prevent the default close so lifecycle picks the
+        // outcome (hide vs. quit) deterministically — see
+        // `lifecycle::handle_close_request` for the policy.
         api.prevent_close();
-        let app = win.app_handle().clone();
-
-        tauri::async_runtime::spawn(async move {
-          // Stop all background processing
-          let ws = app.state::<workers::WorkersState>();
-          ws.terminate_all().await;
-
-          app.exit(0);
-        });
+        lifecycle::on_close_requested(win);
       }
     })
     .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -1,0 +1,123 @@
+//! App-side lifecycle wiring for Core start/stop.
+//!
+//! Phase 5 (#1408) decouples the process lifetime from the main
+//! window. Closing the window no longer terminates the collector and
+//! exits the process; that path is now reached only by an explicit
+//! Quit action. The user-visible "close to tray" UX (tray menu, first-
+//! run dialog, persisted setting) lands with #1275, so for now the
+//! new background-mode path is gated by an env var.
+
+use std::env;
+
+use tauri::{AppHandle, Manager, Window};
+
+use crate::log_warn;
+use crate::workers::WorkersState;
+
+/// Env var that switches the close-button behavior from "quit" to
+/// "hide window, keep monitoring". Off by default — release builds
+/// preserve the historical quit-on-close behavior until the
+/// user-facing UX in #1275 ships.
+pub const CLOSE_TO_BACKGROUND_ENV: &str = "HARDVIZ_CLOSE_TO_BACKGROUND";
+
+/// `true` when the env var holds a truthy value (`1`, `true`, `yes`,
+/// case-insensitive). Anything else — unset, empty, or any other
+/// value — reads as off.
+pub fn should_close_to_background() -> bool {
+  env::var(CLOSE_TO_BACKGROUND_ENV)
+    .ok()
+    .as_deref()
+    .map(is_truthy)
+    .unwrap_or(false)
+}
+
+fn is_truthy(s: &str) -> bool {
+  matches!(s.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+}
+
+/// Hook into `on_window_event(CloseRequested)`. The Tauri callback
+/// runs on the UI thread, so we always spawn the work onto the async
+/// runtime — `terminate_all` awaits inside.
+pub fn on_close_requested(window: &Window) {
+  let app = window.app_handle().clone();
+  let win = window.clone();
+  tauri::async_runtime::spawn(async move {
+    handle_close_request(app, win).await;
+  });
+}
+
+/// Decide what closing the main window means in this build.
+///
+/// - With [`should_close_to_background`] on: hide the window. The
+///   collector, archive worker, and event bus stay alive.
+/// - Otherwise: fall back to the historical behavior — terminate
+///   workers and exit the process. The user-facing tray + setting
+///   that flips this default ships with #1275.
+async fn handle_close_request(app: AppHandle, window: Window) {
+  if should_close_to_background() {
+    if let Err(e) = window.hide() {
+      log_warn!(
+        &format!("failed to hide main window on close: {e}"),
+        "lifecycle::handle_close_request",
+        None::<&str>
+      );
+    }
+    return;
+  }
+  request_quit(app).await;
+}
+
+/// Stop Core cleanly and exit the process.
+///
+/// Order matters:
+/// 1. Move the monitoring state to `Stopped`. Best-effort: a second
+///    call returns `InvalidTransition`, which we drop — terminal
+///    states are idempotent for callers.
+/// 2. `WorkersState::terminate_all` shuts the collector first, then
+///    the window adapter, then the archive worker. The archive worker
+///    writes a final summary on the way out so DB writes are flushed.
+/// 3. `app.exit(0)`.
+pub async fn request_quit(app: AppHandle) {
+  let ws = app.state::<WorkersState>();
+  // The state-machine error here means another caller already moved
+  // us to Stopped; the workers terminate guard handles double-call
+  // safety, so we don't need to short-circuit on it.
+  let _ = ws.monitoring_state.lock().unwrap().stop();
+  ws.terminate_all().await;
+  app.exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // The env-var check uses process-global state; running multiple
+  // tests against it in parallel would race. We can still test the
+  // pure parser without touching the environment.
+
+  #[test]
+  fn truthy_values_match_case_insensitively() {
+    assert!(is_truthy("1"));
+    assert!(is_truthy("true"));
+    assert!(is_truthy("TRUE"));
+    assert!(is_truthy("True"));
+    assert!(is_truthy("yes"));
+    assert!(is_truthy("YES"));
+  }
+
+  #[test]
+  fn truthy_tolerates_whitespace() {
+    assert!(is_truthy(" 1 "));
+    assert!(is_truthy("\ttrue\n"));
+  }
+
+  #[test]
+  fn other_values_read_as_off() {
+    assert!(!is_truthy(""));
+    assert!(!is_truthy("0"));
+    assert!(!is_truthy("false"));
+    assert!(!is_truthy("no"));
+    assert!(!is_truthy("on")); // intentionally not accepted — keep the set tight
+    assert!(!is_truthy("anything"));
+  }
+}

--- a/src-tauri/src/workers/mod.rs
+++ b/src-tauri/src/workers/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::{Mutex, atomic::AtomicBool};
 
+use hwviz_core::monitoring::MonitoringState;
+
 use crate::adapters::window::WindowAdapter;
 
 #[derive(Default)]
@@ -8,6 +10,13 @@ pub struct WorkersState {
   pub window_adapter: Mutex<Option<WindowAdapter>>,
   pub hw_archive: Mutex<Option<hwviz_core::persistence::ArchiveController>>,
   pub shutting_down: AtomicBool,
+  /// Lifecycle state of sensor collection. Owned here because the
+  /// lifecycle module already locks workers on quit; colocating the
+  /// state avoids a second `Mutex` around the same critical section.
+  /// Phase 5 only writes `Stopped` from `lifecycle::request_quit`;
+  /// the `Paused` / `Running` transitions become user-visible with
+  /// #1275 and #1401.
+  pub monitoring_state: Mutex<MonitoringState>,
 }
 
 impl WorkersState {

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -472,6 +472,18 @@ async setDecoration(isDecorated: boolean) : Promise<Result<null, string>> {
  */
 async restartApp() : Promise<void> {
     await TAURI_INVOKE("restart_app");
+},
+/**
+ * Stop monitoring and exit the process.
+ * 
+ * Phase 5 (#1408): the explicit Quit path. Keep it gated to the
+ * internal callers that the lifecycle module owns — Phase 6's tray
+ * menu and the future "Quit" UX from #1275. Until those land, this
+ * command is reachable only from devtools / tauri-specta-generated
+ * bindings, which is enough to validate the cleanup ordering.
+ */
+async quitApp() : Promise<void> {
+    await TAURI_INVOKE("quit_app");
 }
 }
 


### PR DESCRIPTION
Closes #1408. Part of #1402 (Epic).

## Summary
- Add `core::monitoring::MonitoringState` (Running / Paused / Stopped) with explicit transitions and exhaustive unit tests.
- Move start/stop wiring out of the inline `on_window_event` handler into `src-tauri/src/lifecycle.rs`. The process lifetime is no longer tied to the main window's `CloseRequested` event.
- Add a `quit_app` Tauri command. `lifecycle::request_quit` transitions the state machine to `Stopped`, drains workers, then `app.exit(0)`.
- `ArchiveController` writes a final summary on shutdown so samples accumulated since the last 60-second tick are not lost on Quit (DoD "DB writes flushed").

## User-visible behavior
**Unchanged in this phase.** Closing the window still quits the app by default. The new "hide window, keep monitoring" path is gated by the env var ` HARDVIZ_CLOSE_TO_BACKGROUND=1`. The persisted setting + tray UX that flip the default ship with #1275 / Phase 6.

## Path note
The #1408 issue body says \`src-tauri/src/app/lifecycle.rs\`, but #1402's 2026-04-30 changelog supersedes it (\"\`app::lifecycle\` → \`lifecycle\`\"). Following the parent epic — \`src-tauri/src/lifecycle.rs\` directly. \`src-tauri/src/app/startup.rs\` (DB startup error dialog) is unrelated and stays as-is.

## Layout
- `core/src/monitoring/state.rs` — `MonitoringState` with `pause` / `resume` / `stop`. Same-state transitions and any transition out of `Stopped` are rejected with `InvalidTransition`. Pure Rust, no Tauri runtime needed.
- `src-tauri/src/lifecycle.rs` — `on_close_requested`, `handle_close_request`, `request_quit`, `should_close_to_background`.
- `src-tauri/src/workers/mod.rs` — `WorkersState` gains a `monitoring_state: Mutex<MonitoringState>` field, colocated with the worker handles so the lifecycle module locks once on quit.
- `src-tauri/src/commands/system.rs` — `quit_app` command delegates to `lifecycle::request_quit`. Reachable via the generated bindings; Phase 6's tray will be the first user-facing caller.
- `core/src/persistence/archive.rs` — `ArchiveTracker` gains a `dirty` flag; the spawn loop runs a final `write_archive` on shutdown signal when dirty.

## Tests
- 17 new state-machine tests cover the full (from, to) grid plus the `InvalidTransition` `Display` and per-method coverage. Runnable via `cargo test -p hwviz-core` without a Tauri runtime.
- `lifecycle::is_truthy` parser tests (no env-var mutation, parallel-safe).
- 2 new `ArchiveTracker` tests (`fresh_tracker_is_not_dirty`, `ingest_marks_tracker_dirty`).
- All workspace tests pass: 153 in \`hwviz-core\`, 140 in \`hardware_visualizer\`.

## Out of scope (per #1408)
- Tray UI — Phase 6.
- \"Close to tray\" persisted setting + first-run dialog — #1275.
- Wiring `Paused` to actually halt sensor emission, and stopping frontend render work when the window is hidden — also #1275.

## Test plan
- [x] `cargo tauri-fmt -- --check`
- [x] `cargo tauri-lint`
- [x] `cargo test --workspace --lib --bins -- --test-threads=1` (the `adl_diagnostic` example fails to build on macOS; this is pre-existing on `develop` and unrelated)
- [x] `npm run lint`
- [x] `npm run test`
- [x] Bindings regenerated by running the binary (only `quitApp` added).
- [ ] Manual: launch with `HARDVIZ_CLOSE_TO_BACKGROUND=1`, close the window, verify the process keeps running and the collector keeps polling. Calling `commands.quitApp()` from devtools must terminate cleanly with a final archive row written.
- [ ] Manual: launch without the env var, close the window, confirm the historical quit-on-close behavior is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring state management with pause, resume, and stop capabilities for sensor collection
  * Window close behavior is now configurable—minimize to background or fully quit the app
  * New explicit quit command for app termination

* **Chores**
  * Refactored module structure to support lifecycle management and monitoring state tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->