### PR TITLE
refactor(app): Phase 6 — tray adapter skeleton (Open / Quit) (#1409)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2.5.6", features = [] }
 hwviz-core = { path = "../core" }
 serde_json = "1.0.149"
 serde = { version = "1.0.228", features = ["derive"] }
-tauri = { version = "2.10.3", features = [] }
+tauri = { version = "2.10.3", features = ["tray-icon"] }
 sysinfo = "0.38.4"
 tauri-plugin-window-state = { version = "2.4.1" }
 tokio = { version = "1.52.1", features = [

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,1 +1,2 @@
+pub mod tray;
 pub mod window;

--- a/src-tauri/src/adapters/tray.rs
+++ b/src-tauri/src/adapters/tray.rs
@@ -1,0 +1,149 @@
+//! System-tray menu adapter — Phase 6 skeleton (#1409).
+//!
+//! The tray gives users a way back to the main window once Phase 5
+//! stops auto-quitting on close. This phase ships the bare minimum:
+//! `Open` and `Quit` menu items plus a left-click that restores the
+//! window. Live metric rendering belongs to #1401, and the Pause /
+//! Resume entry belongs to #1275.
+//!
+//! Setup is gated by [`crate::lifecycle::should_close_to_background`]
+//! so the user-visible behavior stays unchanged from Phase 5: in
+//! release builds without `HARDVIZ_CLOSE_TO_BACKGROUND=1`, no tray is
+//! registered. The flag flip — and the persisted setting that owns it
+//! — ships with #1275.
+//!
+//! ## Platform notes
+//! - **Windows / macOS**: left-clicking the icon restores the window;
+//!   right-click opens the menu.
+//! - **Linux**: tray support depends on the desktop environment.
+//!   AppIndicator-based environments (GNOME with the AppIndicator
+//!   extension, KDE) usually show the menu on any click and never
+//!   forward a raw click event, so the left-click-restores path may be
+//!   silently inactive. Users still reach `Open` through the menu, and
+//!   `Quit` through the menu always works. Environments without an
+//!   indicator implementation may fail to register the tray entirely;
+//!   when that happens [`TrayAdapter::setup`] logs and returns the
+//!   error to the caller, who falls back to running without a tray.
+
+use tauri::{
+  AppHandle, Manager,
+  menu::{Menu, MenuEvent, MenuItem},
+  tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+};
+
+use crate::log_warn;
+
+const MENU_OPEN_ID: &str = "tray::open";
+const MENU_QUIT_ID: &str = "tray::quit";
+
+/// Owns the [`TrayIcon`] handle. Dropping the adapter removes the
+/// icon, so it must live for as long as the tray should be visible —
+/// `lib.rs` stashes it in `WorkersState`.
+pub struct TrayAdapter {
+  _tray: TrayIcon,
+}
+
+impl TrayAdapter {
+  /// Build the tray icon, menu, and event handlers.
+  ///
+  /// The default window icon is reused as the tray icon — Phase 6
+  /// keeps the visual minimal. A dedicated tray-tuned asset can land
+  /// alongside #1401's live widget.
+  pub fn setup(app: &tauri::App) -> tauri::Result<Self> {
+    let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+    let icon = app
+      .default_window_icon()
+      .cloned()
+      .ok_or_else(|| tauri::Error::AssetNotFound("default_window_icon".into()))?;
+
+    let tray = TrayIconBuilder::new()
+      .icon(icon)
+      .menu(&menu)
+      // Without this, macOS pops the menu on left-click instead of
+      // forwarding the click event we use to restore the window.
+      // Windows defaults to false; setting it explicitly keeps the
+      // behavior consistent across platforms.
+      .show_menu_on_left_click(false)
+      .on_menu_event(handle_menu_event)
+      .on_tray_icon_event(handle_tray_event)
+      .build(app)?;
+
+    Ok(Self { _tray: tray })
+  }
+}
+
+fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+  match event.id.as_ref() {
+    MENU_OPEN_ID => restore_main_window(app),
+    MENU_QUIT_ID => spawn_quit(app.clone()),
+    other => {
+      log_warn!(
+        &format!("unhandled tray menu event: {other}"),
+        "adapters::tray::handle_menu_event",
+        None::<&str>
+      );
+    }
+  }
+}
+
+fn handle_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
+  // Restore on a *released* left click. Filtering on `Up` matches the
+  // intuitive "click to focus" gesture and avoids firing twice on
+  // platforms that emit both press and release events.
+  if let TrayIconEvent::Click {
+    button: MouseButton::Left,
+    button_state: MouseButtonState::Up,
+    ..
+  } = event
+  {
+    restore_main_window(tray.app_handle());
+  }
+}
+
+fn restore_main_window(app: &AppHandle) {
+  let Some(window) = app.get_webview_window("main") else {
+    log_warn!(
+      "main window not found while handling tray Open",
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+    return;
+  };
+
+  // Best-effort: each call may legitimately fail (window already
+  // visible, already in the foreground, OS denying focus) without
+  // affecting the others. Logging keeps the trail without aborting.
+  if let Err(e) = window.show() {
+    log_warn!(
+      &format!("failed to show main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.unminimize() {
+    log_warn!(
+      &format!("failed to unminimize main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.set_focus() {
+    log_warn!(
+      &format!("failed to focus main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+}
+
+fn spawn_quit(app: AppHandle) {
+  // `request_quit` is async (it awaits worker termination); the menu
+  // callback runs on the main thread and must return promptly, so we
+  // hand the work off to the tokio runtime.
+  tauri::async_runtime::spawn(async move {
+    crate::lifecycle::request_quit(app).await;
+  });
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,32 @@ pub fn run() {
         ws.window_adapter.lock().unwrap().replace(window_adapter);
       }
 
+      // Phase 6 (#1409): register the tray icon only when the close-to-
+      // background path is active. Without that, closing the window
+      // still quits the process, and a tray icon would point at a
+      // running app that the user has no way of reaching otherwise. The
+      // user-facing toggle (and an always-on tray once #1275 ships)
+      // arrives with the persisted setting in #1275.
+      if lifecycle::should_close_to_background() {
+        match adapters::tray::TrayAdapter::setup(app) {
+          Ok(tray) => {
+            let ws = app.state::<workers::WorkersState>();
+            ws.tray.lock().unwrap().replace(tray);
+          }
+          Err(e) => {
+            // Linux desktops without an indicator implementation, or
+            // any other tray failure: log and continue. `Quit` from
+            // the in-process command path still works, so the user is
+            // not stranded — just without a visible tray entry point.
+            log_warn!(
+              &format!("tray icon setup failed; continuing without tray: {e}"),
+              "lib::setup",
+              None::<&str>
+            );
+          }
+        }
+      }
+
       if is_db_ok {
         // Start DB-dependent archive services. Persistence subscribes to
         // the EventBus so a slow DB write can't back-pressure the

--- a/src-tauri/src/workers/mod.rs
+++ b/src-tauri/src/workers/mod.rs
@@ -2,6 +2,7 @@ use std::sync::{Mutex, atomic::AtomicBool};
 
 use hwviz_core::monitoring::MonitoringState;
 
+use crate::adapters::tray::TrayAdapter;
 use crate::adapters::window::WindowAdapter;
 
 #[derive(Default)]
@@ -9,6 +10,11 @@ pub struct WorkersState {
   pub monitor: Mutex<Option<hwviz_core::collector::SystemMonitorController>>,
   pub window_adapter: Mutex<Option<WindowAdapter>>,
   pub hw_archive: Mutex<Option<hwviz_core::persistence::ArchiveController>>,
+  /// Holds the tray icon for as long as the process should display it.
+  /// Dropping this releases the OS handle and removes the icon, so it
+  /// stays here until shutdown rather than living in the setup
+  /// closure's scope.
+  pub tray: Mutex<Option<TrayAdapter>>,
   pub shutting_down: AtomicBool,
   /// Lifecycle state of sensor collection. Owned here because the
   /// lifecycle module already locks workers on quit; colocating the


### PR DESCRIPTION
Closes #1409. Part of #1402 (Epic).

## Summary
- Add `src-tauri/src/adapters/tray.rs` with a minimal `TrayAdapter` (Open / Quit menu, left-click-restore).
- Setup is gated behind `lifecycle::should_close_to_background` (`HARDVIZ_CLOSE_TO_BACKGROUND=1`), so user-visible behavior stays the same as Phase 5.
- Tray icon failure (e.g. some Linux desktops) is logged; the app continues without a tray and `Quit` via the in-process command path keeps working.
- Enable the `tray-icon` feature on `tauri = "2.10.3"`.

## User-visible behavior
**Unchanged in default release builds.** With `HARDVIZ_CLOSE_TO_BACKGROUND=1`:
- Closing the window leaves the tray icon visible.
- Tray menu `Open` (or left-click on Windows / macOS) restores the main window with state intact.
- Tray menu `Quit` exits cleanly via Phase 5's `lifecycle::request_quit` (state machine → `Stopped`, archive flushed, `app.exit(0)`).

## Path note
The #1409 issue body says `src-tauri/src/app/adapters/tray.rs`, but #1402's 2026-04-30 changelog supersedes it (\"`app::adapters` → `adapters`\"). Following the parent epic — `src-tauri/src/adapters/tray.rs`, next to the existing `window.rs`. Same path-resolution as Phase 5.

## Visibility gate
Per discussion, the tray is gated by `HARDVIZ_CLOSE_TO_BACKGROUND` rather than always-on:
- The tray's purpose (a way back to the window once close-to-background hides it instead of quitting) only makes sense when that path is active.
- Keeps Phase 6 user-invisible until #1275 lands the persisted setting that owns this UX. #1275 will switch the gate to the setting and remove the env-var read.

## Layout
- `src-tauri/src/adapters/tray.rs` — `TrayAdapter::setup(app)` builds the menu, wires `on_menu_event` and `on_tray_icon_event`, and returns a struct that owns the `TrayIcon` handle.
- `src-tauri/src/workers/mod.rs` — `WorkersState` gains `tray: Mutex<Option<TrayAdapter>>` so the icon survives setup-closure scope.
- `src-tauri/src/lib.rs` — registers the tray in `setup` when `should_close_to_background()` is true; logs and continues on failure.
- `src-tauri/Cargo.toml` — adds `tray-icon` to the `tauri` features list.

## Platform notes (in code comments)
- **Windows / macOS**: left-click restores, right-click opens the menu. `show_menu_on_left_click(false)` keeps the click event reaching our handler.
- **Linux**: AppIndicator-based environments forward all clicks to the menu and don't fire raw click events — left-click-restore may be silently inactive there; the menu still works. Environments without any indicator implementation fail tray registration; we log and continue.

## Tests
- Existing `cargo test --workspace --lib --bins` passes (140 + 153). No new tests — the tray adapter is mostly Tauri-runtime glue and the menu / tray event handlers are exercised through the `tauri::App` setup, which lives outside the unit-test boundary. The pure-Rust dispatch (`handle_menu_event` matches on `MENU_OPEN_ID` / `MENU_QUIT_ID`) is small enough to verify by inspection.
- No new Tauri commands → `src/rspc/bindings.ts` unchanged.

## Out of scope (per #1409)
- Live metric values in the tray — #1401.
- Pause / Resume entries in the tray menu — #1275.
- Custom icons / theming — uses the default window icon.

## Test plan
- [x] `cargo tauri-fmt -- --check`
- [x] `cargo tauri-lint`
- [x] `cargo test --workspace --lib --bins -- --test-threads=1` (the `adl_diagnostic` example failure is pre-existing on `develop`)
- [x] `npm run lint`
- [x] `npm run test`
- [ ] Manual (Windows): launch with `HARDVIZ_CLOSE_TO_BACKGROUND=1`, close the window, confirm the tray icon stays visible. Click `Open` and left-click the icon — both restore the window. Click `Quit` — the app exits with a final archive row written.
- [ ] Manual (macOS): same as Windows, plus verify `show_menu_on_left_click(false)` actually reaches the click handler.
- [ ] Manual (Linux): document which DE was tested. Note any AppIndicator quirks observed.
- [ ] Manual: launch without the env var — confirm no tray is registered and close-to-quit still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System tray icon integration enabling the app to minimize to system tray (when configured)
  * Left-click tray icon to restore and bring the application window to focus
  * Context menu with "Open" and "Quit" options for easy app management from the tray

<!-- end of auto-generated comment: release notes by coderabbit.ai -->