### PR TITLE
feat(app): system tray adapter with Open / Quit menu (#1422)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2.5.6", features = [] }
 hwviz-core = { path = "../core" }
 serde_json = "1.0.149"
 serde = { version = "1.0.228", features = ["derive"] }
-tauri = { version = "2.10.3", features = [] }
+tauri = { version = "2.10.3", features = ["tray-icon"] }
 sysinfo = "0.38.4"
 tauri-plugin-window-state = { version = "2.4.1" }
 tokio = { version = "1.52.1", features = [

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -1,1 +1,2 @@
+pub mod tray;
 pub mod window;

--- a/src-tauri/src/adapters/tray.rs
+++ b/src-tauri/src/adapters/tray.rs
@@ -1,0 +1,151 @@
+//! System-tray menu adapter — #1422.
+//!
+//! Provides a minimal `Open` / `Quit` menu plus a left-click that
+//! restores the main window. Calls [`crate::lifecycle::request_quit`]
+//! (shipped by Phase 5 of #1402) to drive the lifecycle state machine
+//! to `Stopped` on quit. Live metric rendering belongs to #1401, and
+//! the Pause / Resume entries belong to #1424.
+//!
+//! ## Visibility policy
+//! The tray is registered unconditionally on app startup. Whether it
+//! should appear conditionally — only in close-to-tray mode, or driven
+//! by a persisted user setting — is a UX call owned by #1423; the
+//! adapter itself stays policy-free.
+//!
+//! ## Platform notes
+//! - **Windows / macOS**: left-clicking the icon restores the window;
+//!   right-click opens the menu.
+//! - **Linux**: tray support depends on the desktop environment.
+//!   AppIndicator-based environments (GNOME with the AppIndicator
+//!   extension, KDE) usually show the menu on any click and never
+//!   forward a raw click event, so the left-click-restores path may be
+//!   silently inactive. Users still reach `Open` through the menu, and
+//!   `Quit` through the menu always works. Environments without an
+//!   indicator implementation may fail to register the tray entirely;
+//!   when that happens [`TrayAdapter::setup`] returns the error to the
+//!   caller, which logs and continues without a tray. The close-to-
+//!   tray fallback that handles "no tray, no way back to the window"
+//!   for affected users lands with #1423.
+
+use tauri::{
+  AppHandle, Manager,
+  menu::{Menu, MenuEvent, MenuItem},
+  tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+};
+
+use crate::log_warn;
+
+const MENU_OPEN_ID: &str = "tray::open";
+const MENU_QUIT_ID: &str = "tray::quit";
+
+/// Owns the [`TrayIcon`] handle. Dropping the adapter removes the
+/// icon, so it must live for as long as the tray should be visible —
+/// `lib.rs` stashes it in `WorkersState`.
+pub struct TrayAdapter {
+  _tray: TrayIcon,
+}
+
+impl TrayAdapter {
+  /// Build the tray icon, menu, and event handlers.
+  ///
+  /// The default window icon is reused as the tray icon — Phase 6
+  /// keeps the visual minimal. A dedicated tray-tuned asset can land
+  /// alongside #1401's live widget.
+  pub fn setup(app: &tauri::App) -> tauri::Result<Self> {
+    let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+    let icon = app
+      .default_window_icon()
+      .cloned()
+      .ok_or_else(|| tauri::Error::AssetNotFound("default_window_icon".into()))?;
+
+    let tray = TrayIconBuilder::new()
+      .icon(icon)
+      .menu(&menu)
+      // Without this, macOS pops the menu on left-click instead of
+      // forwarding the click event we use to restore the window.
+      // Windows defaults to false; setting it explicitly keeps the
+      // behavior consistent across platforms.
+      .show_menu_on_left_click(false)
+      .on_menu_event(handle_menu_event)
+      .on_tray_icon_event(handle_tray_event)
+      .build(app)?;
+
+    Ok(Self { _tray: tray })
+  }
+}
+
+fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+  match event.id.as_ref() {
+    MENU_OPEN_ID => restore_main_window(app),
+    MENU_QUIT_ID => spawn_quit(app.clone()),
+    other => {
+      log_warn!(
+        &format!("unhandled tray menu event: {other}"),
+        "adapters::tray::handle_menu_event",
+        None::<&str>
+      );
+    }
+  }
+}
+
+fn handle_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
+  // Restore on a *released* left click. Filtering on `Up` matches the
+  // intuitive "click to focus" gesture and avoids firing twice on
+  // platforms that emit both press and release events.
+  if let TrayIconEvent::Click {
+    button: MouseButton::Left,
+    button_state: MouseButtonState::Up,
+    ..
+  } = event
+  {
+    restore_main_window(tray.app_handle());
+  }
+}
+
+fn restore_main_window(app: &AppHandle) {
+  let Some(window) = app.get_webview_window("main") else {
+    log_warn!(
+      "main window not found while handling tray Open",
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+    return;
+  };
+
+  // Best-effort: each call may legitimately fail (window already
+  // visible, already in the foreground, OS denying focus) without
+  // affecting the others. Logging keeps the trail without aborting.
+  if let Err(e) = window.show() {
+    log_warn!(
+      &format!("failed to show main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.unminimize() {
+    log_warn!(
+      &format!("failed to unminimize main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.set_focus() {
+    log_warn!(
+      &format!("failed to focus main window from tray: {e}"),
+      "adapters::tray::restore_main_window",
+      None::<&str>
+    );
+  }
+}
+
+fn spawn_quit(app: AppHandle) {
+  // `request_quit` is async (it awaits worker termination); the menu
+  // callback runs on the main thread and must return promptly, so we
+  // hand the work off to the tokio runtime.
+  tauri::async_runtime::spawn(async move {
+    crate::lifecycle::request_quit(app).await;
+  });
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,28 @@ pub fn run() {
         ws.window_adapter.lock().unwrap().replace(window_adapter);
       }
 
+      // #1422: register the tray unconditionally. The visibility
+      // policy (always-on vs persisted user setting) is a UX call owned
+      // by #1423 and lives outside the adapter.
+      match adapters::tray::TrayAdapter::setup(app) {
+        Ok(tray) => {
+          let ws = app.state::<workers::WorkersState>();
+          ws.tray.lock().unwrap().replace(tray);
+        }
+        Err(e) => {
+          // Linux desktops without an indicator implementation, or any
+          // other tray failure: log and continue. `Quit` from the
+          // in-process command path still works, so the user is not
+          // stranded once the close-to-tray setting (#1423) lands and
+          // can fall back to "quit on close" when the tray is missing.
+          log_warn!(
+            &format!("tray icon setup failed; continuing without tray: {e}"),
+            "lib::setup",
+            None::<&str>
+          );
+        }
+      }
+
       if is_db_ok {
         // Start DB-dependent archive services. Persistence subscribes to
         // the EventBus so a slow DB write can't back-pressure the

--- a/src-tauri/src/workers/mod.rs
+++ b/src-tauri/src/workers/mod.rs
@@ -2,6 +2,7 @@ use std::sync::{Mutex, atomic::AtomicBool};
 
 use hwviz_core::monitoring::MonitoringState;
 
+use crate::adapters::tray::TrayAdapter;
 use crate::adapters::window::WindowAdapter;
 
 #[derive(Default)]
@@ -9,6 +10,11 @@ pub struct WorkersState {
   pub monitor: Mutex<Option<hwviz_core::collector::SystemMonitorController>>,
   pub window_adapter: Mutex<Option<WindowAdapter>>,
   pub hw_archive: Mutex<Option<hwviz_core::persistence::ArchiveController>>,
+  /// Holds the tray icon for as long as the process should display it.
+  /// Dropping this releases the OS handle and removes the icon, so it
+  /// stays here until shutdown rather than living in the setup
+  /// closure's scope.
+  pub tray: Mutex<Option<TrayAdapter>>,
   pub shutting_down: AtomicBool,
   /// Lifecycle state of sensor collection. Owned here because the
   /// lifecycle module already locks workers on quit; colocating the


### PR DESCRIPTION
Closes #1422. Part of #1275 (umbrella).

## Summary
Add a minimal `adapters::tray::TrayAdapter` with `Open` / `Quit` menu items and a left-click that restores the main window. Calls `lifecycle::request_quit` (shipped in #1420 as Phase 5 of #1402) to drive the lifecycle state machine to `Stopped` on quit.

The tray is registered unconditionally on app startup. The visibility policy — always-on vs gated by a persisted setting — is owned by sibling issue #1423 and lives outside this adapter.

## Background
This implementation reuses the work originally drafted as Phase 6 (#1409) of the Core/App split Epic (#1402). The Epic's acceptance criteria require no user-visible regression, so the tray (a user-visible UX surface) was rescoped out of #1402 into the standalone feature issue #1422 under the #1275 umbrella. The implementation kept here drops the `HARDVIZ_CLOSE_TO_BACKGROUND` env-var gate that the Phase 6 draft used to stay invisible — visibility is no longer this issue's concern.

The original Phase 6 PR #1421 was closed without merging; this PR replaces it.

## Scope
- `src-tauri/src/adapters/tray.rs` — `TrayAdapter::setup(app)` builds a two-item menu, attaches it to `TrayIconBuilder`, wires `on_menu_event` and `on_tray_icon_event`. The handle is held in the adapter so dropping the value removes the icon.
- `src-tauri/src/workers/mod.rs` — `WorkersState` gains a `tray: Mutex<Option<TrayAdapter>>` slot keeping the icon alive for the process lifetime.
- `src-tauri/src/lib.rs` — registers the tray inside `setup`. On failure (typically a Linux desktop without an indicator implementation) we log and continue without a tray; the close-to-tray fallback that prevents users from being stranded ships with #1423.
- `src-tauri/Cargo.toml` — enable the `tray-icon` feature on `tauri = "2.10.3"`.

## Platform notes
- **Windows / macOS**: left-click restores; right-click opens the menu. `show_menu_on_left_click(false)` overrides the macOS default of popping the menu on left-click so the click event reaches our handler.
- **Linux**: tray support depends on the desktop environment. AppIndicator-based environments (GNOME with the AppIndicator extension, KDE) typically forward all clicks to the menu and never raise a raw click event, so the left-click-restores path may be silently inactive — `Open` through the menu still works. Environments without an indicator implementation may fail to register the tray at all; the setup error is logged and the app continues without a tray rather than aborting.

## Out of scope (per #1422)
- Live metric values in the tray — #1401.
- Pause / Resume entries — #1424.
- Visibility policy / persisted close-to-tray setting — #1423.
- Custom icons / theming.

## Test plan
- [x] `cargo tauri-fmt -- --check`
- [x] `cargo tauri-lint`
- [x] `cargo test --workspace --lib --bins -- --test-threads=1` (`hwviz-core` 153 + `hardware_visualizer` 140)
- [x] `npm run lint`
- [x] `npm run test`
- [ ] Manual macOS: tray appears on launch; right-click shows Open / Quit; left-click restores the window after `window.hide()`; Quit flushes the archive (final summary written) and exits.
- [ ] Manual Windows: same as macOS plus left-click + right-click distinction works.
- [ ] Manual Linux (KDE / GNOME w/ AppIndicator): tray appears; menu items work; left-click-restore behavior documented as "may be inactive depending on indicator backend".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added system tray support with a menu containing Open and Quit options.
  * Left-clicking the tray icon restores and focuses the main application window.
  * System tray provides an alternative interface for app interaction and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->