### PR TITLE
feat: close-to-tray setting + first-run dialog

### DIFF
--- a/src-tauri/src/adapters/tray.rs
+++ b/src-tauri/src/adapters/tray.rs
@@ -7,10 +7,9 @@
 //! the Pause / Resume entries belong to #1424.
 //!
 //! ## Visibility policy
-//! The tray is registered unconditionally on app startup. Whether it
-//! should appear conditionally — only in close-to-tray mode, or driven
-//! by a persisted user setting — is a UX call owned by #1423; the
-//! adapter itself stays policy-free.
+//! The tray is registered unconditionally on app startup. The persisted
+//! close-to-tray preference is handled by `crate::lifecycle`; this
+//! adapter stays policy-free.
 //!
 //! ## Platform notes
 //! - **Windows / macOS**: left-clicking the icon restores the window;
@@ -23,9 +22,8 @@
 //!   `Quit` through the menu always works. Environments without an
 //!   indicator implementation may fail to register the tray entirely;
 //!   when that happens [`TrayAdapter::setup`] returns the error to the
-//!   caller, which logs and continues without a tray. The close-to-
-//!   tray fallback that handles "no tray, no way back to the window"
-//!   for affected users lands with #1423.
+//!   caller, which logs, disables close-to-tray for the current
+//!   session, and continues without a tray.
 
 use tauri::{
   AppHandle, Manager,

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -21,6 +21,6 @@ pub async fn quit_app(app_handle: tauri::AppHandle) {
 /// Returns whether close-to-tray can safely be enabled in this session.
 #[tauri::command]
 #[specta::specta]
-pub fn is_close_to_tray_available(app_handle: tauri::AppHandle) -> bool {
-  crate::lifecycle::is_close_to_tray_available(&app_handle)
+pub fn is_close_to_tray_available(app_handle: tauri::AppHandle) -> Result<bool, String> {
+  Ok(crate::lifecycle::is_close_to_tray_available(&app_handle))
 }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -24,3 +24,12 @@ pub async fn quit_app(app_handle: tauri::AppHandle) {
 pub fn is_close_to_tray_available(app_handle: tauri::AppHandle) -> Result<bool, String> {
   Ok(crate::lifecycle::is_close_to_tray_available(&app_handle))
 }
+
+/// Mark the frontend close-to-tray dialog listener as ready.
+#[tauri::command]
+#[specta::specta]
+pub async fn mark_close_to_tray_listener_ready(
+  app_handle: tauri::AppHandle,
+) -> Result<(), String> {
+  crate::lifecycle::mark_close_to_tray_listener_ready(app_handle).await
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -17,3 +17,10 @@ pub async fn restart_app(app_handle: tauri::AppHandle) {
 pub async fn quit_app(app_handle: tauri::AppHandle) {
   crate::lifecycle::request_quit(app_handle).await;
 }
+
+/// Returns whether close-to-tray can safely be enabled in this session.
+#[tauri::command]
+#[specta::specta]
+pub fn is_close_to_tray_available(app_handle: tauri::AppHandle) -> bool {
+  crate::lifecycle::is_close_to_tray_available(&app_handle)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,7 @@ pub fn run() {
       system::restart_app,
       system::quit_app,
       system::is_close_to_tray_available,
+      system::mark_close_to_tray_listener_ready,
     ]);
 
   // TS bindings

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,6 +116,7 @@ pub fn run() {
       ui::set_decoration,
       system::restart_app,
       system::quit_app,
+      system::is_close_to_tray_available,
     ]);
 
   // TS bindings
@@ -172,11 +173,12 @@ pub fn run() {
           ws.tray.lock().unwrap().replace(tray);
         }
         Err(e) => {
+          app
+            .state::<lifecycle::CloseToTrayRuntimeState>()
+            .disable_for_session();
           // Linux desktops without an indicator implementation, or any
-          // other tray failure: log and continue. `Quit` from the
-          // in-process command path still works, so the user is not
-          // stranded once the close-to-tray setting (#1423) lands and
-          // can fall back to "quit on close" when the tray is missing.
+          // other tray failure: log and continue. Close-to-tray is
+          // disabled for this session so the close button still quits.
           log_warn!(
             &format!("tray icon setup failed; continuing without tray: {e}"),
             "lib::setup",
@@ -261,6 +263,7 @@ pub fn run() {
     .plugin(tauri_plugin_opener::init())
     .manage(history_store)
     .manage(app_state)
+    .manage(lifecycle::CloseToTrayRuntimeState::default())
     .manage(workers::WorkersState::default())
     .manage(app_updates::PendingUpdate(Mutex::new(None)));
 

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -166,16 +166,16 @@ pub async fn mark_close_to_tray_listener_ready(app: AppHandle) -> Result<(), Str
   let state = app.state::<CloseToTrayRuntimeState>();
   state.mark_listener_ready();
 
-  if state.take_choice_request_pending() {
-    if let Err(e) = emit_close_to_tray_choice_request(&app) {
-      log_warn!(
-        &format!("failed to emit pending close-to-tray choice request: {e}"),
-        "lifecycle::mark_close_to_tray_listener_ready",
-        None::<&str>
-      );
-      request_quit(app).await;
-      return Err(e);
-    }
+  if state.take_choice_request_pending()
+    && let Err(e) = emit_close_to_tray_choice_request(&app)
+  {
+    log_warn!(
+      &format!("failed to emit pending close-to-tray choice request: {e}"),
+      "lifecycle::mark_close_to_tray_listener_ready",
+      None::<&str>
+    );
+    request_quit(app).await;
+    return Err(e);
   }
 
   Ok(())

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -31,12 +31,16 @@ const EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED: &str = "close-to-tray-choice-request
 /// hide the only window on platforms without a working tray.
 pub struct CloseToTrayRuntimeState {
   tray_available: AtomicBool,
+  listener_ready: AtomicBool,
+  choice_request_pending: AtomicBool,
 }
 
 impl Default for CloseToTrayRuntimeState {
   fn default() -> Self {
     Self {
       tray_available: AtomicBool::new(true),
+      listener_ready: AtomicBool::new(false),
+      choice_request_pending: AtomicBool::new(false),
     }
   }
 }
@@ -48,6 +52,22 @@ impl CloseToTrayRuntimeState {
 
   pub fn is_available(&self) -> bool {
     self.tray_available.load(Ordering::SeqCst)
+  }
+
+  fn mark_listener_ready(&self) {
+    self.listener_ready.store(true, Ordering::SeqCst);
+  }
+
+  fn is_listener_ready(&self) -> bool {
+    self.listener_ready.load(Ordering::SeqCst)
+  }
+
+  fn set_choice_request_pending(&self) {
+    self.choice_request_pending.store(true, Ordering::SeqCst);
+  }
+
+  fn take_choice_request_pending(&self) -> bool {
+    self.choice_request_pending.swap(false, Ordering::SeqCst)
   }
 }
 
@@ -80,7 +100,16 @@ pub fn on_close_requested(window: &Window) {
 /// Decide what closing the main window means.
 async fn handle_close_request(app: AppHandle, window: Window) {
   if should_close_to_background() {
-    hide_window_on_close(&window);
+    if let Err(e) = hide_window_on_close(&window) {
+      log_warn!(
+        &format!(
+          "failed to hide main window on env override close; quitting instead: {e}"
+        ),
+        "lifecycle::handle_close_request",
+        None::<&str>
+      );
+      request_quit(app).await;
+    }
     return;
   }
 
@@ -91,16 +120,36 @@ async fn handle_close_request(app: AppHandle, window: Window) {
 
   match read_close_to_tray_settings(&app) {
     Ok(settings) if !settings.choice_made => {
-      if let Err(e) = app.emit(EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED, ()) {
+      let state = app.state::<CloseToTrayRuntimeState>();
+      state.set_choice_request_pending();
+
+      if state.is_listener_ready() {
+        match emit_close_to_tray_choice_request(&app) {
+          Ok(()) => {
+            state.take_choice_request_pending();
+          }
+          Err(e) => {
+            state.take_choice_request_pending();
+            log_warn!(
+              &format!("failed to emit close-to-tray choice request: {e}"),
+              "lifecycle::handle_close_request",
+              None::<&str>
+            );
+            request_quit(app).await;
+          }
+        }
+      }
+    }
+    Ok(settings) if settings.close_to_tray => {
+      if let Err(e) = hide_window_on_close(&window) {
         log_warn!(
-          &format!("failed to emit close-to-tray choice request: {e}"),
+          &format!("failed to hide main window on close; quitting instead: {e}"),
           "lifecycle::handle_close_request",
           None::<&str>
         );
         request_quit(app).await;
       }
     }
-    Ok(settings) if settings.close_to_tray => hide_window_on_close(&window),
     Ok(_) => request_quit(app).await,
     Err(e) => {
       log_warn!(
@@ -113,6 +162,31 @@ async fn handle_close_request(app: AppHandle, window: Window) {
   }
 }
 
+pub async fn mark_close_to_tray_listener_ready(app: AppHandle) -> Result<(), String> {
+  let state = app.state::<CloseToTrayRuntimeState>();
+  state.mark_listener_ready();
+
+  if state.take_choice_request_pending() {
+    if let Err(e) = emit_close_to_tray_choice_request(&app) {
+      log_warn!(
+        &format!("failed to emit pending close-to-tray choice request: {e}"),
+        "lifecycle::mark_close_to_tray_listener_ready",
+        None::<&str>
+      );
+      request_quit(app).await;
+      return Err(e);
+    }
+  }
+
+  Ok(())
+}
+
+fn emit_close_to_tray_choice_request(app: &AppHandle) -> Result<(), String> {
+  app
+    .emit(EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED, ())
+    .map_err(|e| e.to_string())
+}
+
 pub fn is_close_to_tray_available(app: &AppHandle) -> bool {
   app
     .try_state::<CloseToTrayRuntimeState>()
@@ -120,14 +194,8 @@ pub fn is_close_to_tray_available(app: &AppHandle) -> bool {
     .unwrap_or(true)
 }
 
-fn hide_window_on_close(window: &Window) {
-  if let Err(e) = window.hide() {
-    log_warn!(
-      &format!("failed to hide main window on close: {e}"),
-      "lifecycle::handle_close_request",
-      None::<&str>
-    );
-  }
+fn hide_window_on_close(window: &Window) -> Result<(), tauri::Error> {
+  window.hide()
 }
 
 struct CloseToTraySettings {

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -1,15 +1,17 @@
 //! App-side lifecycle wiring for Core start/stop.
 //!
-//! Phase 5 (#1408) decouples the process lifetime from the main
-//! window. Closing the window no longer terminates the collector and
-//! exits the process; that path is now reached only by an explicit
-//! Quit action. The user-visible "close to tray" UX (tray menu, first-
-//! run dialog, persisted setting) lands with #1275, so for now the
-//! new background-mode path is gated by an env var.
+//! Closing the main window is user-configurable: the app can either
+//! hide to the tray and keep monitoring, or stop workers and exit. The
+//! transitional env-var override from #1408 remains available for tests
+//! and debug sessions.
 
-use std::env;
+use std::{
+  env,
+  sync::atomic::{AtomicBool, Ordering},
+};
 
-use tauri::{AppHandle, Manager, Window};
+use tauri::{AppHandle, Emitter, Manager, Window};
+use tauri_plugin_store::StoreExt;
 
 use crate::log_warn;
 use crate::workers::WorkersState;
@@ -19,6 +21,35 @@ use crate::workers::WorkersState;
 /// preserve the historical quit-on-close behavior until the
 /// user-facing UX in #1275 ships.
 pub const CLOSE_TO_BACKGROUND_ENV: &str = "HARDVIZ_CLOSE_TO_BACKGROUND";
+const STORE_FILENAME: &str = "store.json";
+const KEY_CLOSE_TO_TRAY: &str = "closeToTray";
+const KEY_CLOSE_TO_TRAY_CHOICE_MADE: &str = "closeToTrayChoiceMade";
+const EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED: &str = "close-to-tray-choice-requested";
+
+/// Session-only lifecycle capability. `tray_available` starts true and
+/// is flipped off when tray setup fails, so persisted preferences never
+/// hide the only window on platforms without a working tray.
+pub struct CloseToTrayRuntimeState {
+  tray_available: AtomicBool,
+}
+
+impl Default for CloseToTrayRuntimeState {
+  fn default() -> Self {
+    Self {
+      tray_available: AtomicBool::new(true),
+    }
+  }
+}
+
+impl CloseToTrayRuntimeState {
+  pub fn disable_for_session(&self) {
+    self.tray_available.store(false, Ordering::SeqCst);
+  }
+
+  pub fn is_available(&self) -> bool {
+    self.tray_available.load(Ordering::SeqCst)
+  }
+}
 
 /// `true` when the env var holds a truthy value (`1`, `true`, `yes`,
 /// case-insensitive). Anything else — unset, empty, or any other
@@ -46,25 +77,78 @@ pub fn on_close_requested(window: &Window) {
   });
 }
 
-/// Decide what closing the main window means in this build.
-///
-/// - With [`should_close_to_background`] on: hide the window. The
-///   collector, archive worker, and event bus stay alive.
-/// - Otherwise: fall back to the historical behavior — terminate
-///   workers and exit the process. The user-facing tray + setting
-///   that flips this default ships with #1275.
+/// Decide what closing the main window means.
 async fn handle_close_request(app: AppHandle, window: Window) {
   if should_close_to_background() {
-    if let Err(e) = window.hide() {
+    hide_window_on_close(&window);
+    return;
+  }
+
+  if !is_close_to_tray_available(&app) {
+    request_quit(app).await;
+    return;
+  }
+
+  match read_close_to_tray_settings(&app) {
+    Ok(settings) if !settings.choice_made => {
+      if let Err(e) = app.emit(EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED, ()) {
+        log_warn!(
+          &format!("failed to emit close-to-tray choice request: {e}"),
+          "lifecycle::handle_close_request",
+          None::<&str>
+        );
+      }
+    }
+    Ok(settings) if settings.close_to_tray => hide_window_on_close(&window),
+    Ok(_) => request_quit(app).await,
+    Err(e) => {
       log_warn!(
-        &format!("failed to hide main window on close: {e}"),
+        &format!("failed to read close-to-tray setting; quitting on close: {e}"),
         "lifecycle::handle_close_request",
         None::<&str>
       );
+      request_quit(app).await;
     }
-    return;
   }
-  request_quit(app).await;
+}
+
+pub fn is_close_to_tray_available(app: &AppHandle) -> bool {
+  app
+    .try_state::<CloseToTrayRuntimeState>()
+    .map(|state| state.is_available())
+    .unwrap_or(true)
+}
+
+fn hide_window_on_close(window: &Window) {
+  if let Err(e) = window.hide() {
+    log_warn!(
+      &format!("failed to hide main window on close: {e}"),
+      "lifecycle::handle_close_request",
+      None::<&str>
+    );
+  }
+}
+
+struct CloseToTraySettings {
+  close_to_tray: bool,
+  choice_made: bool,
+}
+
+fn read_close_to_tray_settings(app: &AppHandle) -> Result<CloseToTraySettings, String> {
+  let store = app
+    .store(STORE_FILENAME)
+    .map_err(|e| format!("failed to open store: {e}"))?;
+
+  Ok(CloseToTraySettings {
+    close_to_tray: store
+      .get(KEY_CLOSE_TO_TRAY)
+      .and_then(|value| value.as_bool())
+      .unwrap_or(false),
+    choice_made: store
+      .get(KEY_CLOSE_TO_TRAY_CHOICE_MADE)
+      .and_then(|value| value.as_bool())
+      .unwrap_or(false),
+  })
 }
 
 /// Stop Core cleanly and exit the process.

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -163,16 +163,16 @@ pub async fn mark_close_to_tray_listener_ready(app: AppHandle) -> Result<(), Str
   let state = app.state::<CloseToTrayRuntimeState>();
   state.mark_listener_ready();
 
-  if state.take_choice_request_pending() {
-    if let Err(e) = emit_close_to_tray_choice_request(&app) {
-      log_warn!(
-        &format!("failed to emit pending close-to-tray choice request: {e}"),
-        "lifecycle::mark_close_to_tray_listener_ready",
-        None::<&str>
-      );
-      request_quit(app).await;
-      return Err(e);
-    }
+  if state.take_choice_request_pending()
+    && let Err(e) = emit_close_to_tray_choice_request(&app)
+  {
+    log_warn!(
+      &format!("failed to emit pending close-to-tray choice request: {e}"),
+      "lifecycle::mark_close_to_tray_listener_ready",
+      None::<&str>
+    );
+    request_quit(app).await;
+    return Err(e);
   }
 
   Ok(())

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -123,13 +123,10 @@ async fn handle_close_request(app: AppHandle, window: Window) {
       let state = app.state::<CloseToTrayRuntimeState>();
       state.set_choice_request_pending();
 
-      if state.is_listener_ready() {
+      if state.is_listener_ready() && state.take_choice_request_pending() {
         match emit_close_to_tray_choice_request(&app) {
-          Ok(()) => {
-            state.take_choice_request_pending();
-          }
+          Ok(()) => {}
           Err(e) => {
-            state.take_choice_request_pending();
             log_warn!(
               &format!("failed to emit close-to-tray choice request: {e}"),
               "lifecycle::handle_close_request",
@@ -166,16 +163,16 @@ pub async fn mark_close_to_tray_listener_ready(app: AppHandle) -> Result<(), Str
   let state = app.state::<CloseToTrayRuntimeState>();
   state.mark_listener_ready();
 
-  if state.take_choice_request_pending()
-    && let Err(e) = emit_close_to_tray_choice_request(&app)
-  {
-    log_warn!(
-      &format!("failed to emit pending close-to-tray choice request: {e}"),
-      "lifecycle::mark_close_to_tray_listener_ready",
-      None::<&str>
-    );
-    request_quit(app).await;
-    return Err(e);
+  if state.take_choice_request_pending() {
+    if let Err(e) = emit_close_to_tray_choice_request(&app) {
+      log_warn!(
+        &format!("failed to emit pending close-to-tray choice request: {e}"),
+        "lifecycle::mark_close_to_tray_listener_ready",
+        None::<&str>
+      );
+      request_quit(app).await;
+      return Err(e);
+    }
   }
 
   Ok(())

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -97,6 +97,7 @@ async fn handle_close_request(app: AppHandle, window: Window) {
           "lifecycle::handle_close_request",
           None::<&str>
         );
+        request_quit(app).await;
       }
     }
     Ok(settings) if settings.close_to_tray => hide_window_on_close(&window),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import type { ErrorInfo, JSX } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/ErrorFallback";
 import { RootErrorFallback } from "@/components/RootErrorFallback";
+import { CloseToTrayFirstRunDialog } from "@/components/shared/CloseToTrayFirstRunDialog";
 import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
 import { useSelectedGpuPersistence } from "@/features/hardware/hooks/useSelectedGpuPersistence";
 import { useErrorModalListener } from "@/hooks/useTauriEventListener";
@@ -233,6 +234,7 @@ const AppContent = () => {
             )}
           </Suspense>
           <AppUpdate />
+          <CloseToTrayFirstRunDialog />
         </div>
       </div>
       <FullscreenExitButton

--- a/src/components/shared/CloseToTrayFirstRunDialog.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.tsx
@@ -14,34 +14,67 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { setCloseToTrayPreference } from "@/hooks/useCloseToTrayPreference";
+import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { commands } from "@/rspc/bindings";
 
 const EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED = "close-to-tray-choice-requested";
 
 export const CloseToTrayFirstRunDialog = () => {
   const { t } = useTranslation();
+  const { error } = useTauriDialog();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const unlisten = listen(EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED, () => {
-      setOpen(true);
-    });
+    let off: (() => void) | undefined;
+    let isCancelled = false;
+
+    const setupListener = async () => {
+      try {
+        const unlisten = await listen(
+          EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED,
+          () => {
+            setOpen(true);
+          },
+        );
+
+        if (isCancelled) {
+          unlisten();
+        } else {
+          off = unlisten;
+        }
+      } catch (err) {
+        console.error("Failed to register close-to-tray dialog listener:", err);
+      }
+    };
+
+    setupListener();
 
     return () => {
-      unlisten.then((off) => off());
+      isCancelled = true;
+      off?.();
     };
   }, []);
 
   const continueInBackground = async () => {
-    await setCloseToTrayPreference(true);
-    setOpen(false);
-    await getCurrentWindow().hide();
+    try {
+      await setCloseToTrayPreference(true);
+      await getCurrentWindow().hide();
+      setOpen(false);
+    } catch (err) {
+      console.error("Failed to continue in background:", err);
+      await error(t("closeToTray.errors.continueInBackground"));
+    }
   };
 
   const quitApp = async () => {
-    await setCloseToTrayPreference(false);
-    setOpen(false);
-    await commands.quitApp();
+    try {
+      await setCloseToTrayPreference(false);
+      setOpen(false);
+      await commands.quitApp();
+    } catch (err) {
+      console.error("Failed to quit from close-to-tray dialog:", err);
+      await error(t("closeToTray.errors.quitApp"));
+    }
   };
 
   return (

--- a/src/components/shared/CloseToTrayFirstRunDialog.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.tsx
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -46,6 +47,16 @@ export const CloseToTrayFirstRunDialog = () => {
   return (
     <AlertDialog open={open}>
       <AlertDialogContent className="text-foreground">
+        <AlertDialogCancel
+          aria-label={t("closeToTray.firstRunDialog.close")}
+          className="absolute top-4 right-4 h-8 w-8 border-0 bg-transparent p-0 opacity-70 hover:bg-muted hover:opacity-100"
+          onClick={() => setOpen(false)}
+        >
+          <XIcon className="size-4" />
+          <span className="sr-only">
+            {t("closeToTray.firstRunDialog.close")}
+          </span>
+        </AlertDialogCancel>
         <AlertDialogHeader>
           <AlertDialogTitle>
             {t("closeToTray.firstRunDialog.title")}

--- a/src/components/shared/CloseToTrayFirstRunDialog.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.tsx
@@ -13,9 +13,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { setCloseToTrayPreference } from "@/hooks/useCloseToTrayPreference";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { commands } from "@/rspc/bindings";
+import { isError } from "@/types/result";
 
 const EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED = "close-to-tray-choice-requested";
 
@@ -24,6 +26,7 @@ export const CloseToTrayFirstRunDialog = () => {
   const { error } = useTauriDialog();
   const [open, setOpen] = useState(false);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: The listener is registered once for the app lifetime.
   useEffect(() => {
     let off: (() => void) | undefined;
     let isCancelled = false;
@@ -42,8 +45,19 @@ export const CloseToTrayFirstRunDialog = () => {
         } else {
           off = unlisten;
         }
+
+        const result = await commands.markCloseToTrayListenerReady();
+
+        if (isError(result)) {
+          console.error(
+            "Failed to mark close-to-tray listener ready:",
+            result.error,
+          );
+          await error(t("closeToTray.errors.listenerReady"));
+        }
       } catch (err) {
         console.error("Failed to register close-to-tray dialog listener:", err);
+        await error(t("closeToTray.errors.listenerReady"));
       }
     };
 
@@ -57,7 +71,13 @@ export const CloseToTrayFirstRunDialog = () => {
 
   const continueInBackground = async () => {
     try {
-      await setCloseToTrayPreference(true);
+      const saved = await setCloseToTrayPreference(true);
+
+      if (!saved) {
+        await error(t("closeToTray.errors.continueInBackground"));
+        return;
+      }
+
       await getCurrentWindow().hide();
       setOpen(false);
     } catch (err) {
@@ -68,7 +88,13 @@ export const CloseToTrayFirstRunDialog = () => {
 
   const quitApp = async () => {
     try {
-      await setCloseToTrayPreference(false);
+      const saved = await setCloseToTrayPreference(false);
+
+      if (!saved) {
+        await error(t("closeToTray.errors.quitApp"));
+        return;
+      }
+
       setOpen(false);
       await commands.quitApp();
     } catch (err) {
@@ -80,16 +106,18 @@ export const CloseToTrayFirstRunDialog = () => {
   return (
     <AlertDialog open={open}>
       <AlertDialogContent className="text-foreground">
-        <AlertDialogCancel
-          aria-label={t("closeToTray.firstRunDialog.close")}
+        <Button
+          aria-label={t("closeToTray.firstRunDialog.quitApp")}
           className="absolute top-4 right-4 h-8 w-8 border-0 bg-transparent p-0 opacity-70 hover:bg-muted hover:opacity-100"
-          onClick={() => setOpen(false)}
+          onClick={quitApp}
+          type="button"
+          variant="outline"
         >
           <XIcon className="size-4" />
           <span className="sr-only">
-            {t("closeToTray.firstRunDialog.close")}
+            {t("closeToTray.firstRunDialog.quitApp")}
           </span>
-        </AlertDialogCancel>
+        </Button>
         <AlertDialogHeader>
           <AlertDialogTitle>
             {t("closeToTray.firstRunDialog.title")}

--- a/src/components/shared/CloseToTrayFirstRunDialog.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.tsx
@@ -1,0 +1,68 @@
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { setCloseToTrayPreference } from "@/hooks/useCloseToTrayPreference";
+import { commands } from "@/rspc/bindings";
+
+const EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED = "close-to-tray-choice-requested";
+
+export const CloseToTrayFirstRunDialog = () => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen(EVENT_CLOSE_TO_TRAY_CHOICE_REQUESTED, () => {
+      setOpen(true);
+    });
+
+    return () => {
+      unlisten.then((off) => off());
+    };
+  }, []);
+
+  const continueInBackground = async () => {
+    await setCloseToTrayPreference(true);
+    setOpen(false);
+    await getCurrentWindow().hide();
+  };
+
+  const quitApp = async () => {
+    await setCloseToTrayPreference(false);
+    setOpen(false);
+    await commands.quitApp();
+  };
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent className="text-foreground">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("closeToTray.firstRunDialog.title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("closeToTray.firstRunDialog.description")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={quitApp}>
+            {t("closeToTray.firstRunDialog.quitApp")}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={continueInBackground}>
+            {t("closeToTray.firstRunDialog.continueInBackground")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/features/settings/components/general/CloseToTrayToggle.tsx
+++ b/src/features/settings/components/general/CloseToTrayToggle.tsx
@@ -4,19 +4,50 @@ import { useTranslation } from "react-i18next";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useCloseToTrayPreference } from "@/hooks/useCloseToTrayPreference";
+import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { commands } from "@/rspc/bindings";
+import { isError } from "@/types/result";
 
 export const CloseToTrayToggle = () => {
   const { t } = useTranslation();
+  const { error } = useTauriDialog();
   const { closeToTray, isPending, setCloseToTray } = useCloseToTrayPreference();
   const [isAvailable, setIsAvailable] = useState(true);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Availability is checked once when the settings row mounts.
   useEffect(() => {
-    commands
-      .isCloseToTrayAvailable()
-      .then(setIsAvailable)
-      .catch(() => setIsAvailable(true));
+    const checkAvailability = async () => {
+      try {
+        const result = await commands.isCloseToTrayAvailable();
+
+        if (isError(result)) {
+          setIsAvailable(false);
+          console.error(
+            "Failed to check close-to-tray availability:",
+            result.error,
+          );
+          await error(t("closeToTray.errors.availability"));
+          return;
+        }
+
+        setIsAvailable(result.data);
+      } catch (err) {
+        setIsAvailable(false);
+        console.error("Failed to check close-to-tray availability:", err);
+        await error(t("closeToTray.errors.availability"));
+      }
+    };
+
+    checkAvailability();
   }, []);
+
+  const updateCloseToTray = async (value: boolean) => {
+    const saved = await setCloseToTray(value);
+
+    if (!saved) {
+      await error(t("closeToTray.errors.savePreference"));
+    }
+  };
 
   return (
     <div className="space-y-3 py-6 xl:w-1/2">
@@ -34,7 +65,7 @@ export const CloseToTrayToggle = () => {
           id="closeToTray"
           checked={isAvailable && closeToTray}
           disabled={isPending || !isAvailable}
-          onCheckedChange={setCloseToTray}
+          onCheckedChange={updateCloseToTray}
         />
       </div>
 

--- a/src/features/settings/components/general/CloseToTrayToggle.tsx
+++ b/src/features/settings/components/general/CloseToTrayToggle.tsx
@@ -1,0 +1,49 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useCloseToTrayPreference } from "@/hooks/useCloseToTrayPreference";
+import { commands } from "@/rspc/bindings";
+
+export const CloseToTrayToggle = () => {
+  const { t } = useTranslation();
+  const { closeToTray, isPending, setCloseToTray } = useCloseToTrayPreference();
+  const [isAvailable, setIsAvailable] = useState(true);
+
+  useEffect(() => {
+    commands
+      .isCloseToTrayAvailable()
+      .then(setIsAvailable)
+      .catch(() => setIsAvailable(true));
+  }, []);
+
+  return (
+    <div className="space-y-3 py-6 xl:w-1/2">
+      <div className="flex w-full items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="closeToTray" className="text-lg">
+            {t("pages.settings.general.closeToTray.name")}
+          </Label>
+          <p className="text-muted-foreground text-sm">
+            {t("pages.settings.general.closeToTray.description")}
+          </p>
+        </div>
+
+        <Switch
+          id="closeToTray"
+          checked={isAvailable && closeToTray}
+          disabled={isPending || !isAvailable}
+          onCheckedChange={setCloseToTray}
+        />
+      </div>
+
+      {!isAvailable && (
+        <div className="flex items-start gap-2 rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm">
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-yellow-600" />
+          <p>{t("pages.settings.general.closeToTray.unavailable")}</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/settings/components/general/GeneralSettings.tsx
+++ b/src/features/settings/components/general/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { AutoStartToggle } from "./AutoStartToggle";
 import { BurnInShiftSettings } from "./BurnInShiftSettings";
+import { CloseToTrayToggle } from "./CloseToTrayToggle";
 import { LanguageSelect } from "./LanguageSelect";
 import { TemperatureUnitSelect } from "./TemperatureUnitSelect";
 import { TextSelectionToggle } from "./TextSelectionToggle";
@@ -19,6 +20,7 @@ export const GeneralSettings = () => {
         <ThemeSelect />
         <TemperatureUnitSelect />
         <TextSelectionToggle />
+        <CloseToTrayToggle />
         <AutoStartToggle />
         <BurnInShiftSettings />
       </div>

--- a/src/hooks/useCloseToTrayPreference.test.ts
+++ b/src/hooks/useCloseToTrayPreference.test.ts
@@ -1,0 +1,136 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeStore {
+  data: Record<string, unknown>;
+  has: (key: string) => Promise<boolean>;
+  get: <T = unknown>(key: string) => Promise<T | undefined>;
+  set: <T>(key: string, value: T) => Promise<void>;
+  save: () => Promise<void>;
+}
+
+let fakeStore: FakeStore;
+let useCloseToTrayPreference: typeof import("./useCloseToTrayPreference").useCloseToTrayPreference;
+let setCloseToTrayPreference: typeof import("./useCloseToTrayPreference").setCloseToTrayPreference;
+
+const setupModule = async () => {
+  const module = await import("./useCloseToTrayPreference");
+  useCloseToTrayPreference = module.useCloseToTrayPreference;
+  setCloseToTrayPreference = module.setCloseToTrayPreference;
+};
+
+describe("useCloseToTrayPreference", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    fakeStore = {
+      data: {},
+      has: vi.fn((key: string) => Promise.resolve(key in fakeStore.data)),
+      get: vi
+        .fn()
+        .mockImplementation(<T>(key: string) =>
+          Promise.resolve(fakeStore.data[key] as T | undefined),
+        ) as <T = unknown>(key: string) => Promise<T | undefined>,
+      set: vi.fn(<T>(key: string, value: T) => {
+        fakeStore.data[key] = value;
+        return Promise.resolve();
+      }),
+      save: vi.fn(() => Promise.resolve()),
+    };
+
+    vi.doMock("@tauri-apps/plugin-store", () => ({
+      load: vi.fn(() => Promise.resolve(fakeStore)),
+    }));
+
+    await setupModule();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("loads unset preference as disabled with no choice made", async () => {
+    const { result } = renderHook(() => useCloseToTrayPreference());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.closeToTray).toBe(false);
+    expect(result.current.choiceMade).toBe(false);
+    expect(fakeStore.set).not.toHaveBeenCalled();
+  });
+
+  it("loads persisted close-to-tray preference", async () => {
+    fakeStore.data.closeToTray = true;
+    fakeStore.data.closeToTrayChoiceMade = true;
+
+    const { result } = renderHook(() => useCloseToTrayPreference());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.closeToTray).toBe(true);
+    expect(result.current.choiceMade).toBe(true);
+    expect(fakeStore.get).toHaveBeenCalledWith("closeToTray");
+    expect(fakeStore.get).toHaveBeenCalledWith("closeToTrayChoiceMade");
+  });
+
+  it("persists both preference keys from the direct setter", async () => {
+    await setCloseToTrayPreference(true);
+
+    expect(fakeStore.set).toHaveBeenCalledWith("closeToTray", true);
+    expect(fakeStore.set).toHaveBeenCalledWith("closeToTrayChoiceMade", true);
+    expect(fakeStore.save).toHaveBeenCalledOnce();
+  });
+
+  it("updates hook state only after persistence succeeds", async () => {
+    const { result } = renderHook(() => useCloseToTrayPreference());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    await act(async () => {
+      const saved = await result.current.setCloseToTray(true);
+      expect(saved).toBe(true);
+    });
+
+    expect(result.current.closeToTray).toBe(true);
+    expect(result.current.choiceMade).toBe(true);
+    expect(fakeStore.set).toHaveBeenCalledWith("closeToTray", true);
+    expect(fakeStore.set).toHaveBeenCalledWith("closeToTrayChoiceMade", true);
+  });
+
+  it("clears pending state when preference loading fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(fakeStore.has).mockRejectedValueOnce(new Error("store failed"));
+
+    const { result } = renderHook(() => useCloseToTrayPreference());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.closeToTray).toBe(false);
+    expect(result.current.choiceMade).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to load close-to-tray preference:",
+      expect.any(Error),
+    );
+  });
+
+  it("returns false and keeps state unchanged when saving fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useCloseToTrayPreference());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    vi.mocked(fakeStore.set).mockRejectedValueOnce(new Error("save failed"));
+
+    await act(async () => {
+      const saved = await result.current.setCloseToTray(true);
+      expect(saved).toBe(false);
+    });
+
+    expect(result.current.closeToTray).toBe(false);
+    expect(result.current.choiceMade).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to save close-to-tray preference:",
+      expect.any(Error),
+    );
+  });
+});

--- a/src/hooks/useCloseToTrayPreference.test.ts
+++ b/src/hooks/useCloseToTrayPreference.test.ts
@@ -75,8 +75,9 @@ describe("useCloseToTrayPreference", () => {
   });
 
   it("persists both preference keys from the direct setter", async () => {
-    await setCloseToTrayPreference(true);
+    const saved = await setCloseToTrayPreference(true);
 
+    expect(saved).toBe(true);
     expect(fakeStore.set).toHaveBeenCalledWith("closeToTray", true);
     expect(fakeStore.set).toHaveBeenCalledWith("closeToTrayChoiceMade", true);
     expect(fakeStore.save).toHaveBeenCalledOnce();

--- a/src/hooks/useCloseToTrayPreference.ts
+++ b/src/hooks/useCloseToTrayPreference.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getStoreInstance } from "@/lib/tauriStore";
+
+const KEY_CLOSE_TO_TRAY = "closeToTray";
+const KEY_CLOSE_TO_TRAY_CHOICE_MADE = "closeToTrayChoiceMade";
+
+export const setCloseToTrayPreference = async (value: boolean) => {
+  const store = await getStoreInstance();
+  await store.set(KEY_CLOSE_TO_TRAY, value);
+  await store.set(KEY_CLOSE_TO_TRAY_CHOICE_MADE, true);
+  await store.save();
+};
+
+export const useCloseToTrayPreference = () => {
+  const [closeToTray, setCloseToTrayState] = useState(false);
+  const [choiceMade, setChoiceMade] = useState(false);
+  const [isPending, setIsPending] = useState(true);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    const loadPreference = async () => {
+      const store = await getStoreInstance();
+      const storedCloseToTray = (await store.has(KEY_CLOSE_TO_TRAY))
+        ? await store.get<boolean>(KEY_CLOSE_TO_TRAY)
+        : undefined;
+      const storedChoiceMade = (await store.has(KEY_CLOSE_TO_TRAY_CHOICE_MADE))
+        ? await store.get<boolean>(KEY_CLOSE_TO_TRAY_CHOICE_MADE)
+        : undefined;
+
+      if (isMountedRef.current) {
+        setCloseToTrayState(storedCloseToTray ?? false);
+        setChoiceMade(storedChoiceMade ?? false);
+        setIsPending(false);
+      }
+    };
+
+    loadPreference();
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const setCloseToTray = useCallback(async (value: boolean) => {
+    await setCloseToTrayPreference(value);
+    setCloseToTrayState(value);
+    setChoiceMade(true);
+  }, []);
+
+  return {
+    closeToTray,
+    choiceMade,
+    isPending,
+    setCloseToTray,
+  };
+};

--- a/src/hooks/useCloseToTrayPreference.ts
+++ b/src/hooks/useCloseToTrayPreference.ts
@@ -21,18 +21,27 @@ export const useCloseToTrayPreference = () => {
     isMountedRef.current = true;
 
     const loadPreference = async () => {
-      const store = await getStoreInstance();
-      const storedCloseToTray = (await store.has(KEY_CLOSE_TO_TRAY))
-        ? await store.get<boolean>(KEY_CLOSE_TO_TRAY)
-        : undefined;
-      const storedChoiceMade = (await store.has(KEY_CLOSE_TO_TRAY_CHOICE_MADE))
-        ? await store.get<boolean>(KEY_CLOSE_TO_TRAY_CHOICE_MADE)
-        : undefined;
+      try {
+        const store = await getStoreInstance();
+        const storedCloseToTray = (await store.has(KEY_CLOSE_TO_TRAY))
+          ? await store.get<boolean>(KEY_CLOSE_TO_TRAY)
+          : undefined;
+        const storedChoiceMade = (await store.has(
+          KEY_CLOSE_TO_TRAY_CHOICE_MADE,
+        ))
+          ? await store.get<boolean>(KEY_CLOSE_TO_TRAY_CHOICE_MADE)
+          : undefined;
 
-      if (isMountedRef.current) {
-        setCloseToTrayState(storedCloseToTray ?? false);
-        setChoiceMade(storedChoiceMade ?? false);
-        setIsPending(false);
+        if (isMountedRef.current) {
+          setCloseToTrayState(storedCloseToTray ?? false);
+          setChoiceMade(storedChoiceMade ?? false);
+        }
+      } catch (error) {
+        console.error("Failed to load close-to-tray preference:", error);
+      } finally {
+        if (isMountedRef.current) {
+          setIsPending(false);
+        }
       }
     };
 
@@ -43,11 +52,20 @@ export const useCloseToTrayPreference = () => {
     };
   }, []);
 
-  const setCloseToTray = useCallback(async (value: boolean) => {
-    await setCloseToTrayPreference(value);
-    setCloseToTrayState(value);
-    setChoiceMade(true);
-  }, []);
+  const setCloseToTray = useCallback(
+    async (value: boolean): Promise<boolean> => {
+      try {
+        await setCloseToTrayPreference(value);
+        setCloseToTrayState(value);
+        setChoiceMade(true);
+        return true;
+      } catch (error) {
+        console.error("Failed to save close-to-tray preference:", error);
+        return false;
+      }
+    },
+    [],
+  );
 
   return {
     closeToTray,

--- a/src/hooks/useCloseToTrayPreference.ts
+++ b/src/hooks/useCloseToTrayPreference.ts
@@ -4,11 +4,19 @@ import { getStoreInstance } from "@/lib/tauriStore";
 const KEY_CLOSE_TO_TRAY = "closeToTray";
 const KEY_CLOSE_TO_TRAY_CHOICE_MADE = "closeToTrayChoiceMade";
 
-export const setCloseToTrayPreference = async (value: boolean) => {
-  const store = await getStoreInstance();
-  await store.set(KEY_CLOSE_TO_TRAY, value);
-  await store.set(KEY_CLOSE_TO_TRAY_CHOICE_MADE, true);
-  await store.save();
+export const setCloseToTrayPreference = async (
+  value: boolean,
+): Promise<boolean> => {
+  try {
+    const store = await getStoreInstance();
+    await store.set(KEY_CLOSE_TO_TRAY, value);
+    await store.set(KEY_CLOSE_TO_TRAY_CHOICE_MADE, true);
+    await store.save();
+    return true;
+  } catch (error) {
+    console.error("Failed to save close-to-tray preference:", error);
+    return false;
+  }
 };
 
 export const useCloseToTrayPreference = () => {
@@ -54,15 +62,15 @@ export const useCloseToTrayPreference = () => {
 
   const setCloseToTray = useCallback(
     async (value: boolean): Promise<boolean> => {
-      try {
-        await setCloseToTrayPreference(value);
-        setCloseToTrayState(value);
-        setChoiceMade(true);
-        return true;
-      } catch (error) {
-        console.error("Failed to save close-to-tray preference:", error);
+      const saved = await setCloseToTrayPreference(value);
+
+      if (!saved) {
         return false;
       }
+
+      setCloseToTrayState(value);
+      setChoiceMade(true);
+      return true;
     },
     [],
   );

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -136,6 +136,12 @@
       "continueInBackground": "Continue in background",
       "quitApp": "Quit app",
       "close": "Close dialog"
+    },
+    "errors": {
+      "continueInBackground": "Failed to keep the app running in the background.",
+      "quitApp": "Failed to quit the app.",
+      "availability": "Failed to check whether the system tray is available.",
+      "savePreference": "Failed to save the close-to-tray setting."
     }
   },
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -129,6 +129,15 @@
     }
   },
 
+  "closeToTray": {
+    "firstRunDialog": {
+      "title": "Keep HardwareVisualizer running?",
+      "description": "HardwareVisualizer can keep monitoring in the background after you close the main window. You can change this later in Settings.",
+      "continueInBackground": "Continue in background",
+      "quitApp": "Quit app"
+    }
+  },
+
   "pages": {
     "dashboard": {
       "name": "Dashboard",
@@ -184,6 +193,11 @@
         },
         "textSelection": {
           "name": "Enable text selection"
+        },
+        "closeToTray": {
+          "name": "Close to tray instead of quitting",
+          "description": "Keep monitoring running when the main window is closed.",
+          "unavailable": "The system tray is not available in this desktop environment, so closing the window will quit the app for this session."
         },
         "autostart": {
           "name": "Automatic startup at OS startup"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -134,7 +134,8 @@
       "title": "Keep HardwareVisualizer running?",
       "description": "HardwareVisualizer can keep monitoring in the background after you close the main window. You can change this later in Settings.",
       "continueInBackground": "Continue in background",
-      "quitApp": "Quit app"
+      "quitApp": "Quit app",
+      "close": "Close dialog"
     }
   },
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -141,7 +141,8 @@
       "continueInBackground": "Failed to keep the app running in the background.",
       "quitApp": "Failed to quit the app.",
       "availability": "Failed to check whether the system tray is available.",
-      "savePreference": "Failed to save the close-to-tray setting."
+      "savePreference": "Failed to save the close-to-tray setting.",
+      "listenerReady": "Failed to initialize the close-to-tray dialog."
     }
   },
 

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -136,6 +136,12 @@
       "continueInBackground": "バックグラウンドで継続",
       "quitApp": "アプリを終了",
       "close": "ダイアログを閉じる"
+    },
+    "errors": {
+      "continueInBackground": "アプリをバックグラウンドで継続できませんでした。",
+      "quitApp": "アプリを終了できませんでした。",
+      "availability": "システムトレイを利用できるか確認できませんでした。",
+      "savePreference": "トレイ格納設定を保存できませんでした。"
     }
   },
 

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -134,7 +134,8 @@
       "title": "HardwareVisualizer を起動したままにしますか？",
       "description": "メインウィンドウを閉じたあとも、HardwareVisualizer はバックグラウンドで監視を続けられます。この設定はあとから設定画面で変更できます。",
       "continueInBackground": "バックグラウンドで継続",
-      "quitApp": "アプリを終了"
+      "quitApp": "アプリを終了",
+      "close": "ダイアログを閉じる"
     }
   },
 

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -129,6 +129,15 @@
     }
   },
 
+  "closeToTray": {
+    "firstRunDialog": {
+      "title": "HardwareVisualizer を起動したままにしますか？",
+      "description": "メインウィンドウを閉じたあとも、HardwareVisualizer はバックグラウンドで監視を続けられます。この設定はあとから設定画面で変更できます。",
+      "continueInBackground": "バックグラウンドで継続",
+      "quitApp": "アプリを終了"
+    }
+  },
+
   "pages": {
     "dashboard": {
       "name": "ダッシュボード",
@@ -184,6 +193,11 @@
         },
         "textSelection": {
           "name": "テキスト選択を有効にする"
+        },
+        "closeToTray": {
+          "name": "閉じるボタンで終了せずトレイに格納する",
+          "description": "メインウィンドウを閉じても、監視をバックグラウンドで継続します。",
+          "unavailable": "このデスクトップ環境ではシステムトレイを利用できないため、このセッションではウィンドウを閉じるとアプリを終了します。"
         },
         "autostart": {
           "name": "OS起動時に自動起動"

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -141,7 +141,8 @@
       "continueInBackground": "アプリをバックグラウンドで継続できませんでした。",
       "quitApp": "アプリを終了できませんでした。",
       "availability": "システムトレイを利用できるか確認できませんでした。",
-      "savePreference": "トレイ格納設定を保存できませんでした。"
+      "savePreference": "トレイ格納設定を保存できませんでした。",
+      "listenerReady": "トレイ格納ダイアログを初期化できませんでした。"
     }
   },
 

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -488,8 +488,13 @@ async quitApp() : Promise<void> {
 /**
  * Returns whether close-to-tray can safely be enabled in this session.
  */
-async isCloseToTrayAvailable() : Promise<boolean> {
-    return await TAURI_INVOKE("is_close_to_tray_available");
+async isCloseToTrayAvailable() : Promise<Result<boolean, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("is_close_to_tray_available") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -495,6 +495,17 @@ async isCloseToTrayAvailable() : Promise<Result<boolean, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Mark the frontend close-to-tray dialog listener as ready.
+ */
+async markCloseToTrayListenerReady() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("mark_close_to_tray_listener_ready") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -484,6 +484,12 @@ async restartApp() : Promise<void> {
  */
 async quitApp() : Promise<void> {
     await TAURI_INVOKE("quit_app");
+},
+/**
+ * Returns whether close-to-tray can safely be enabled in this session.
+ */
+async isCloseToTrayAvailable() : Promise<boolean> {
+    return await TAURI_INVOKE("is_close_to_tray_available");
 }
 }
 


### PR DESCRIPTION
## Summary
- Add persisted close-to-tray preference and first-run close dialog
- Wire Rust lifecycle close handling to store-backed settings while keeping HARDVIZ_CLOSE_TO_BACKGROUND override
- Add Settings toggle and tray-unavailable session fallback/banner

Closes #1423

## Verification
- npm run lint
- npm test
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml lifecycle::tests

## Notes
- Full cargo test still fails on this macOS environment because src-tauri/examples/adl_diagnostic.rs references the Windows-only libloading dependency.
- cargo test --lib still has pre-existing settings test failures around shared settings state; lifecycle targeted tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Close to Tray" flow: availability-aware settings toggle, a first-run dialog to choose background or quit, persisted preference, and runtime readiness/availability checks.

* **Bug Fixes / Behavior**
  * If system tray setup fails, close-to-tray is disabled for that session and closing the window will quit the app.

* **Localization**
  * Added English and Japanese strings for dialogs, settings, and errors.

* **Tests**
  * Added tests covering preference persistence, loading, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->