### PR TITLE
fix(ci): update workflow target artifact paths

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           xvfb-run --auto-servernum \
             ./perf-monitor/target/release/perf-monitor \
-              --binary src-tauri/target/ci/hardware-visualizer \
+              --binary target/ci/hardware-visualizer \
               --config perf-thresholds.toml \
               --output json \
             > perf-results.json
@@ -76,7 +76,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           ./perf-monitor/target/release/perf-monitor \
-            --binary "src-tauri/target/ci/bundle/macos/HardwareVisualizer.app/Contents/MacOS/hardware-visualizer" \
+            --binary "target/ci/bundle/macos/HardwareVisualizer.app/Contents/MacOS/hardware-visualizer" \
             --config perf-thresholds.toml \
             --output json \
           > perf-results.json
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           ./perf-monitor/target/release/perf-monitor.exe \
-            --binary src-tauri/target/ci/hardware-visualizer.exe \
+            --binary target/ci/hardware-visualizer.exe \
             --config perf-thresholds.toml \
             --output json \
           > perf-results.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,7 +154,7 @@ jobs:
         name: Rename Offline Installer
         run: |
           mkdir -p dist/offline
-          cp src-tauri/target/release/bundle/msi/*.msi "dist/offline/HardwareVisualizer_${VERSION}_x64_en-US_offline.msi"
+          cp target/release/bundle/msi/*.msi "dist/offline/HardwareVisualizer_${VERSION}_x64_en-US_offline.msi"
 
       - if: ${{ matrix.platform == 'windows-latest' }}
         name: Upload MSI via gh CLI


### PR DESCRIPTION
## Summary

Update GitHub Actions artifact paths to match the root Cargo workspace target directory.

- Point the performance monitor at `target/ci/...` instead of `src-tauri/target/ci/...`.
- Copy the offline Windows MSI from `target/release/bundle/msi/...` during publish.

Root cause: after the Cargo workspace was moved to the repository root, Tauri/Cargo build outputs are created under the root `target/` directory. The performance workflow was still looking under `src-tauri/target/`, so `perf-monitor` failed with `binary not found` before threshold evaluation.

## Related Issues

Fixes #1428

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Reviewed the failing GitHub Actions logs for run `25227290938` and confirmed the build output path was `target/ci/hardware-visualizer.exe` while the workflow referenced `src-tauri/target/ci/hardware-visualizer.exe`. Also searched `.github` workflow references for related stale artifact paths.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configurations to reflect revised directory structure for performance testing and Windows installer generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->