### PR TITLE
feat: add native macOS tray renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,9 @@ dependencies = [
  "libloading 0.9.0",
  "mockall",
  "nvapi",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "regex",
  "serde",
  "serde_json",
@@ -3077,10 +3080,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3100,6 +3110,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3158,6 +3169,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]

--- a/assets/hv-icon-outline.svg
+++ b/assets/hv-icon-outline.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 658.21 658.21">
+  <g>
+    <rect x="36.55" y="164.05" width="585.81" height="330.1" rx="25" ry="25" style="fill:none; stroke:#fff; stroke-miterlimit:10; stroke-width:25px;"/>
+  </g>
+  <g>
+    <path d="M622.26,385.68c-97.75-.19-97.53-112.19-195.28-112.38-97.76-.19-97.97,111.81-195.73,111.62s-97.54-112.19-195.29-112.38" style="fill:none; stroke:#fff; stroke-miterlimit:10; stroke-width:30px;"/>
+  </g>
+</svg>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -91,6 +91,33 @@ dirs = "6.0.0"
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 core-foundation = "0.10.1"
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", features = [
+    "NSAttributedString",
+    "NSButton",
+    "NSColor",
+    "NSControl",
+    "NSEvent",
+    "NSFont",
+    "NSImage",
+    "NSMenu",
+    "NSMenuItem",
+    "NSStatusBar",
+    "NSStatusBarButton",
+    "NSStatusItem",
+    "NSTextAttachment",
+    "NSView",
+    "objc2-core-foundation",
+] }
+objc2-foundation = { version = "0.3.2", features = [
+    "NSAttributedString",
+    "NSData",
+    "NSDictionary",
+    "NSGeometry",
+    "NSObject",
+    "NSRange",
+    "NSString",
+] }
 
 [lib]
 name = "hardware_monitor_lib"

--- a/src-tauri/src/adapters/tray.rs
+++ b/src-tauri/src/adapters/tray.rs
@@ -27,16 +27,13 @@
 //!   caller, which logs, disables close-to-tray for the current
 //!   session, and continues without a tray.
 
-use tauri::{
-  AppHandle, Manager,
-  menu::{Menu, MenuEvent, MenuItem},
-  tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
-};
+use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt as _;
 use tokio::sync::broadcast::{Receiver, error::RecvError};
 use tokio::sync::watch;
 
 use crate::log_warn;
+use crate::tray::surface::{self, TraySurface};
 use crate::tray::widget::{
   STORE_KEY_TRAY_WIDGET, TrayFrame, TrayWidgetSettings, build_frame, should_skip_frame,
 };
@@ -46,14 +43,10 @@ use hardviz_core::models::MetricsSnapshot;
 use crate::commands::settings;
 use crate::enums::settings::TemperatureUnit;
 
-const MENU_OPEN_ID: &str = "tray::open";
-const MENU_QUIT_ID: &str = "tray::quit";
-
-/// Owns the [`TrayIcon`] handle. Dropping the adapter removes the
-/// icon, so it must live for as long as the tray should be visible —
-/// `lib.rs` stashes it in `WorkersState`.
+/// Owns the tray surface task. The surface itself lives inside the
+/// updater task so platform-specific handles stay alive until
+/// termination.
 pub struct TrayAdapter {
-  _tray: TrayIcon,
   handle: tauri::async_runtime::JoinHandle<()>,
   stop_tx: watch::Sender<bool>,
 }
@@ -65,34 +58,10 @@ impl TrayAdapter {
   /// keeps the visual minimal. A dedicated tray-tuned asset can land
   /// alongside #1401's live widget.
   pub fn setup(app: &tauri::App, rx: Receiver<MetricsSnapshot>) -> tauri::Result<Self> {
-    let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
-    let quit_item = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
-    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+    let surface = surface::create(app)?;
+    let (handle, stop_tx) = spawn_widget_updater(app.handle().clone(), surface, rx);
 
-    let icon = app
-      .default_window_icon()
-      .cloned()
-      .ok_or_else(|| tauri::Error::AssetNotFound("default_window_icon".into()))?;
-
-    let tray = TrayIconBuilder::new()
-      .icon(icon)
-      .menu(&menu)
-      // Without this, macOS pops the menu on left-click instead of
-      // forwarding the click event we use to restore the window.
-      // Windows defaults to false; setting it explicitly keeps the
-      // behavior consistent across platforms.
-      .show_menu_on_left_click(false)
-      .on_menu_event(handle_menu_event)
-      .on_tray_icon_event(handle_tray_event)
-      .build(app)?;
-
-    let (handle, stop_tx) = spawn_widget_updater(app.handle().clone(), tray.clone(), rx);
-
-    Ok(Self {
-      _tray: tray,
-      handle,
-      stop_tx,
-    })
+    Ok(Self { handle, stop_tx })
   }
 
   pub async fn terminate(self) {
@@ -103,7 +72,7 @@ impl TrayAdapter {
 
 fn spawn_widget_updater(
   app_handle: AppHandle,
-  tray: TrayIcon,
+  surface: Box<dyn TraySurface>,
   mut rx: Receiver<MetricsSnapshot>,
 ) -> (tauri::async_runtime::JoinHandle<()>, watch::Sender<bool>) {
   let (stop_tx, mut stop_rx) = watch::channel(false);
@@ -131,7 +100,7 @@ fn spawn_widget_updater(
               continue;
             }
 
-            apply_frame(&tray, &next_frame);
+            surface.apply_frame(&next_frame);
             previous_frame = Some(next_frame);
             previous_update_at = Some(now);
           }
@@ -151,29 +120,11 @@ fn spawn_widget_updater(
         }
       }
     }
+
+    surface.close();
   });
 
   (handle, stop_tx)
-}
-
-fn apply_frame(tray: &TrayIcon, frame: &TrayFrame) {
-  // `None` is not a reliable clear operation on macOS in tray-icon
-  // 0.21, so use an empty title for disabled / unavailable frames.
-  if let Err(e) = tray.set_title(Some(frame.title.as_deref().unwrap_or(""))) {
-    log_warn!(
-      &format!("failed to update tray widget title: {e}"),
-      "adapters::tray::apply_frame",
-      None::<&str>
-    );
-  }
-
-  if let Err(e) = tray.set_tooltip(Some(frame.tooltip.as_str())) {
-    log_warn!(
-      &format!("failed to update tray widget tooltip: {e}"),
-      "adapters::tray::apply_frame",
-      None::<&str>
-    );
-  }
 }
 
 fn current_widget_settings(app_handle: &AppHandle) -> TrayWidgetSettings {
@@ -199,35 +150,7 @@ fn current_temperature_unit(app_handle: &AppHandle) -> TemperatureUnit {
     .unwrap_or(TemperatureUnit::Celsius)
 }
 
-fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
-  match event.id.as_ref() {
-    MENU_OPEN_ID => restore_main_window(app),
-    MENU_QUIT_ID => spawn_quit(app.clone()),
-    other => {
-      log_warn!(
-        &format!("unhandled tray menu event: {other}"),
-        "adapters::tray::handle_menu_event",
-        None::<&str>
-      );
-    }
-  }
-}
-
-fn handle_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
-  // Restore on a *released* left click. Filtering on `Up` matches the
-  // intuitive "click to focus" gesture and avoids firing twice on
-  // platforms that emit both press and release events.
-  if let TrayIconEvent::Click {
-    button: MouseButton::Left,
-    button_state: MouseButtonState::Up,
-    ..
-  } = event
-  {
-    restore_main_window(tray.app_handle());
-  }
-}
-
-fn restore_main_window(app: &AppHandle) {
+pub(crate) fn restore_main_window(app: &AppHandle) {
   let Some(window) = app.get_webview_window("main") else {
     log_warn!(
       "main window not found while handling tray Open",
@@ -263,7 +186,7 @@ fn restore_main_window(app: &AppHandle) {
   }
 }
 
-fn spawn_quit(app: AppHandle) {
+pub(crate) fn spawn_quit(app: AppHandle) {
   // `request_quit` is async (it awaits worker termination); the menu
   // callback runs on the main thread and must return promptly, so we
   // hand the work off to the tokio runtime.

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,1 +1,2 @@
+pub mod surface;
 pub mod widget;

--- a/src-tauri/src/tray/surface/macos.rs
+++ b/src-tauri/src/tray/surface/macos.rs
@@ -1,0 +1,569 @@
+use std::sync::{Arc, Mutex};
+
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{
+  AnyThread, ClassType, DeclaredClass, MainThreadOnly, define_class, msg_send, sel,
+};
+use objc2_app_kit::{
+  NSAttributedStringAttachmentConveniences, NSColor, NSFont, NSFontAttributeName,
+  NSForegroundColorAttributeName, NSImage, NSMenu, NSMenuItem, NSStatusBar, NSStatusItem,
+  NSTextAttachment, NSVariableStatusItemLength, NSView,
+};
+use objc2_foundation::{
+  MainThreadMarker, NSAttributedString, NSData, NSMutableAttributedString, NSPoint,
+  NSRange, NSRect, NSSize, NSString,
+};
+use tauri::AppHandle;
+
+use crate::log_warn;
+use crate::tray::widget::{MetricState, TrayFrame, TrayMetricIcon};
+
+use super::TraySurface;
+
+const APP_LOGO_SVG: &[u8] = include_bytes!("../../../../assets/hv-icon-outline.svg");
+const APP_LOGO_SIZE: f64 = 18.0;
+const METRIC_ICON_SIZE: f64 = 13.0;
+
+pub struct MacosTraySurface {
+  app_handle: AppHandle,
+  state: Arc<MainThreadState>,
+}
+
+impl MacosTraySurface {
+  pub fn new(app_handle: AppHandle) -> tauri::Result<Self> {
+    let mtm = MainThreadMarker::new().ok_or_else(|| {
+      tauri::Error::Io(std::io::Error::other(
+        "native macOS tray surface must be created on the main thread",
+      ))
+    })?;
+    let native = NativeMacosStatusItem::new(app_handle.clone(), mtm)?;
+
+    Ok(Self {
+      app_handle,
+      state: Arc::new(MainThreadState {
+        item: Mutex::new(Some(native)),
+      }),
+    })
+  }
+
+  fn run_on_main_thread<F>(&self, label: &'static str, task: F)
+  where
+    F: FnOnce(&mut NativeMacosStatusItem) + Send + 'static,
+  {
+    let state = Arc::clone(&self.state);
+    if let Err(e) = self.app_handle.run_on_main_thread(move || {
+      if let Some(item) = state.item.lock().unwrap().as_mut() {
+        task(item);
+      }
+    }) {
+      log_warn!(
+        &format!("failed to schedule macOS tray {label}: {e}"),
+        "tray::surface::macos",
+        None::<&str>
+      );
+    }
+  }
+}
+
+impl TraySurface for MacosTraySurface {
+  fn apply_frame(&self, frame: &TrayFrame) {
+    let frame = frame.clone();
+    self.run_on_main_thread("frame update", move |item| item.apply_frame(&frame));
+  }
+
+  fn close(&self) {
+    let state = Arc::clone(&self.state);
+    if let Err(e) = self.app_handle.run_on_main_thread(move || {
+      state.item.lock().unwrap().take();
+    }) {
+      log_warn!(
+        &format!("failed to schedule macOS tray removal: {e}"),
+        "tray::surface::macos",
+        None::<&str>
+      );
+    }
+  }
+}
+
+impl Drop for MacosTraySurface {
+  fn drop(&mut self) {
+    self.close();
+  }
+}
+
+struct MainThreadState {
+  item: Mutex<Option<NativeMacosStatusItem>>,
+}
+
+impl Drop for MainThreadState {
+  fn drop(&mut self) {
+    let Ok(item) = self.item.get_mut() else {
+      return;
+    };
+
+    if item.is_some() && MainThreadMarker::new().is_none() {
+      // SAFETY: Dropping AppKit objects off the main thread can call into
+      // Objective-C dealloc paths on the wrong thread. If Tauri can no
+      // longer schedule the normal close path, leaking the status item is
+      // safer; the process is already shutting down in that case.
+      std::mem::forget(item.take());
+    }
+  }
+}
+
+// SAFETY: `NativeMacosStatusItem` contains AppKit objects, which are only
+// touched inside closures scheduled via `AppHandle::run_on_main_thread`.
+// The mutex only guards ownership transfer into those closures; it is not
+// permission to use the AppKit objects off the main thread.
+unsafe impl Send for MainThreadState {}
+
+// SAFETY: Shared access follows the same rule as `Send`: every read/write
+// of the contained AppKit object is routed back to the main thread first.
+unsafe impl Sync for MainThreadState {}
+
+struct NativeMacosStatusItem {
+  status_item: Retained<NSStatusItem>,
+  target: Retained<MacosTrayTarget>,
+  _menu: Retained<NSMenu>,
+}
+
+impl NativeMacosStatusItem {
+  fn new(app_handle: AppHandle, mtm: MainThreadMarker) -> tauri::Result<Self> {
+    let status_item =
+      NSStatusBar::systemStatusBar().statusItemWithLength(NSVariableStatusItemLength);
+    let menu = build_menu(&app_handle, mtm);
+
+    status_item.setMenu(Some(&menu));
+
+    let button = status_item.button(mtm).ok_or_else(|| {
+      tauri::Error::Io(std::io::Error::other(
+        "failed to resolve macOS status item button",
+      ))
+    })?;
+    button.setAttributedTitle(&empty_attributed_title());
+    button.setToolTip(Some(&NSString::from_str("HardwareVisualizer")));
+
+    let target = mtm.alloc().set_ivars(MacosTrayTargetIvars {
+      app_handle,
+      menu: menu.clone(),
+      status_item: status_item.clone(),
+    });
+    let frame = button.frame();
+    let target: Retained<MacosTrayTarget> =
+      unsafe { msg_send![super(target), initWithFrame: frame] };
+    target.setWantsLayer(true);
+    button.addSubview(&target);
+
+    Ok(Self {
+      status_item,
+      target,
+      _menu: menu,
+    })
+  }
+
+  fn apply_frame(&mut self, frame: &TrayFrame) {
+    let Some(button) = self
+      .status_item
+      .button(MainThreadMarker::from(&*self.target))
+    else {
+      return;
+    };
+
+    let title = attributed_title(frame);
+    button.setAttributedTitle(&title);
+    button.setToolTip(Some(&NSString::from_str(&frame.tooltip)));
+    self.target.update_dimensions();
+  }
+}
+
+impl Drop for NativeMacosStatusItem {
+  fn drop(&mut self) {
+    self.target.removeFromSuperview();
+    NSStatusBar::systemStatusBar().removeStatusItem(&self.status_item);
+  }
+}
+
+fn build_menu(app_handle: &AppHandle, mtm: MainThreadMarker) -> Retained<NSMenu> {
+  let menu_title = NSString::from_str("HardwareVisualizer");
+  let menu = NSMenu::initWithTitle(NSMenu::alloc(mtm), &menu_title);
+  let open_item = MacosTrayMenuItem::create(
+    mtm,
+    app_handle.clone(),
+    "Open",
+    MacosTrayMenuCommand::Open,
+  );
+  let separator = NSMenuItem::separatorItem(mtm);
+  let quit_item = MacosTrayMenuItem::create(
+    mtm,
+    app_handle.clone(),
+    "Quit",
+    MacosTrayMenuCommand::Quit,
+  );
+
+  menu.addItem(&open_item);
+  menu.addItem(&separator);
+  menu.addItem(&quit_item);
+
+  menu
+}
+
+fn attributed_title(frame: &TrayFrame) -> Retained<objc2_foundation::NSAttributedString> {
+  let (attributed, value_ranges) = build_attributed_title(frame);
+  let full_range = NSRange::new(0, attributed.length());
+  let label_color: Retained<AnyObject> = NSColor::labelColor().into();
+  let font: Retained<AnyObject> =
+    NSFont::systemFontOfSize(NSFont::systemFontSize()).into();
+
+  // SAFETY: These AppKit attribute keys expect NSColor / NSFont objects,
+  // and `full_range` covers the attributed string that was just built.
+  unsafe {
+    attributed.addAttribute_value_range(
+      NSForegroundColorAttributeName,
+      &label_color,
+      full_range,
+    );
+    attributed.addAttribute_value_range(NSFontAttributeName, &font, full_range);
+  }
+
+  for (range, state) in value_ranges {
+    let color: Retained<AnyObject> = match state {
+      MetricState::Normal => NSColor::labelColor().into(),
+      MetricState::Warning => NSColor::systemYellowColor().into(),
+      MetricState::Critical => NSColor::systemRedColor().into(),
+    };
+
+    // SAFETY: The attribute value is an NSColor and the range was
+    // produced while building the same NSString content.
+    unsafe {
+      attributed.addAttribute_value_range(NSForegroundColorAttributeName, &color, range);
+    }
+  }
+
+  Retained::into_super(attributed)
+}
+
+fn build_attributed_title(
+  frame: &TrayFrame,
+) -> (
+  Retained<NSMutableAttributedString>,
+  Vec<(NSRange, MetricState)>,
+) {
+  let attributed = NSMutableAttributedString::from_nsstring(&NSString::from_str(""));
+  append_app_logo(&attributed);
+
+  if frame.items.is_empty() {
+    return (attributed, vec![]);
+  }
+
+  let mut value_ranges = Vec::with_capacity(frame.items.len());
+
+  for item in &frame.items {
+    append_text(&attributed, "  ");
+    append_metric_icon(&attributed, item.icon);
+    append_text(&attributed, " ");
+
+    let value_start = attributed.length();
+    append_text(&attributed, &item.value);
+    let value_len = attributed.length() - value_start;
+    value_ranges.push((NSRange::new(value_start, value_len), item.state));
+  }
+
+  (attributed, value_ranges)
+}
+
+fn append_metric_icon(attributed: &NSMutableAttributedString, icon: TrayMetricIcon) {
+  let Some(image) = system_symbol_image(icon) else {
+    append_text(attributed, icon.fallback_label);
+    return;
+  };
+
+  image.setTemplate(true);
+
+  let attachment = NSTextAttachment::new();
+  attachment.setImage(Some(&image));
+  attachment.setBounds(NSRect::new(
+    NSPoint::new(0.0, -2.0),
+    NSSize::new(METRIC_ICON_SIZE, METRIC_ICON_SIZE),
+  ));
+
+  let symbol = NSAttributedString::attributedStringWithAttachment(&attachment);
+  attributed.appendAttributedString(&symbol);
+}
+
+fn append_app_logo(attributed: &NSMutableAttributedString) {
+  let Some(image) = app_logo_image() else {
+    append_text(attributed, "HV");
+    return;
+  };
+
+  let attachment = NSTextAttachment::new();
+  attachment.setImage(Some(&image));
+  attachment.setBounds(NSRect::new(
+    NSPoint::new(0.0, -4.0),
+    NSSize::new(APP_LOGO_SIZE, APP_LOGO_SIZE),
+  ));
+
+  let logo = NSAttributedString::attributedStringWithAttachment(&attachment);
+  attributed.appendAttributedString(&logo);
+}
+
+fn app_logo_image() -> Option<Retained<NSImage>> {
+  let data = NSData::from_vec(APP_LOGO_SVG.to_vec());
+  let image = NSImage::initWithData(NSImage::alloc(), &data)?;
+  image.setTemplate(true);
+  image.setSize(NSSize::new(APP_LOGO_SIZE, APP_LOGO_SIZE));
+  Some(image)
+}
+
+fn empty_attributed_title() -> Retained<objc2_foundation::NSAttributedString> {
+  let attributed = NSMutableAttributedString::from_nsstring(&NSString::from_str(""));
+  append_app_logo(&attributed);
+  Retained::into_super(attributed)
+}
+
+fn system_symbol_image(icon: TrayMetricIcon) -> Option<Retained<NSImage>> {
+  if !NSImage::class()
+    .metaclass()
+    .responds_to(sel!(imageWithSystemSymbolName:accessibilityDescription:))
+  {
+    return None;
+  }
+
+  NSImage::imageWithSystemSymbolName_accessibilityDescription(
+    &NSString::from_str(icon.macos_symbol_name),
+    Some(&NSString::from_str(icon.accessibility_label)),
+  )
+}
+
+fn append_text(attributed: &NSMutableAttributedString, text: &str) {
+  let text = NSAttributedString::from_nsstring(&NSString::from_str(text));
+  attributed.appendAttributedString(&text);
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::tray::widget::{TrayFrameItem, TrayMetric, TrayMetricIcon};
+
+  use super::*;
+
+  #[test]
+  fn title_parts_keep_status_item_visible_without_metrics() {
+    let frame = TrayFrame {
+      title: None,
+      items: vec![],
+      tooltip: "HardwareVisualizer".to_string(),
+    };
+    let (attributed, ranges) = build_attributed_title(&frame);
+
+    assert_eq!(attributed.length(), 1);
+    assert_ne!(&attributed.string().to_string(), "HV");
+    assert_eq!(ranges, vec![]);
+  }
+
+  #[test]
+  fn title_parts_keep_app_logo_when_metrics_are_visible() {
+    let frame = TrayFrame {
+      title: Some("CPU 42%".to_string()),
+      items: vec![TrayFrameItem {
+        metric: TrayMetric::Cpu,
+        icon: TrayMetricIcon {
+          fallback_label: "CPU",
+          macos_symbol_name: "missing.hardwarevisualizer.cpu",
+          accessibility_label: "CPU usage",
+        },
+        value: "42%".to_string(),
+        state: MetricState::Normal,
+      }],
+      tooltip: "CPU usage: 42% (normal)".to_string(),
+    };
+    let (attributed, ranges) = build_attributed_title(&frame);
+    let title = attributed.string().to_string();
+
+    assert_eq!(title, "\u{fffc}  CPU 42%");
+    assert_eq!(title.matches('\u{fffc}').count(), 1);
+    assert_eq!(ranges, vec![(NSRange::new(7, 3), MetricState::Normal)]);
+  }
+
+  #[test]
+  fn app_logo_image_is_template_for_label_color_tinting() {
+    let image = app_logo_image().expect("app logo image should load from bundled SVG");
+
+    assert!(image.isTemplate());
+  }
+
+  #[test]
+  fn title_parts_color_only_metric_values() {
+    let cpu_icon = TrayMetricIcon {
+      fallback_label: "CPU",
+      macos_symbol_name: "missing.hardwarevisualizer.cpu",
+      accessibility_label: "CPU usage",
+    };
+    let gpu_icon = TrayMetricIcon {
+      fallback_label: "GPU",
+      macos_symbol_name: "missing.hardwarevisualizer.gpu",
+      accessibility_label: "GPU usage",
+    };
+    let frame = TrayFrame {
+      title: Some("CPU 72%!  GPU 91%!!".to_string()),
+      items: vec![
+        TrayFrameItem {
+          metric: TrayMetric::Cpu,
+          icon: cpu_icon,
+          value: "72%".to_string(),
+          state: MetricState::Warning,
+        },
+        TrayFrameItem {
+          metric: TrayMetric::Gpu,
+          icon: gpu_icon,
+          value: "91%".to_string(),
+          state: MetricState::Critical,
+        },
+      ],
+      tooltip: "CPU usage: 72% (warning)\nGPU usage: 91% (critical)".to_string(),
+    };
+    let (attributed, ranges) = build_attributed_title(&frame);
+
+    assert_eq!(
+      &attributed.string().to_string(),
+      "\u{fffc}  CPU 72%  GPU 91%"
+    );
+    assert_eq!(
+      ranges,
+      vec![
+        (NSRange::new(7, 3), MetricState::Warning),
+        (NSRange::new(16, 3), MetricState::Critical),
+      ]
+    );
+  }
+}
+
+#[derive(Clone, Copy)]
+enum MacosTrayMenuCommand {
+  Open,
+  Quit,
+}
+
+struct MacosTrayMenuItemIvars {
+  app_handle: AppHandle,
+  command: MacosTrayMenuCommand,
+}
+
+define_class!(
+  #[unsafe(super(NSMenuItem))]
+  #[name = "HardwareVisualizerTrayMenuItem"]
+  #[thread_kind = MainThreadOnly]
+  #[ivars = MacosTrayMenuItemIvars]
+  struct MacosTrayMenuItem;
+
+  impl MacosTrayMenuItem {
+    #[unsafe(method(perform:))]
+    fn perform(&self, _sender: Option<&AnyObject>) {
+      match self.ivars().command {
+        MacosTrayMenuCommand::Open => {
+          crate::adapters::tray::restore_main_window(&self.ivars().app_handle);
+        }
+        MacosTrayMenuCommand::Quit => {
+          crate::adapters::tray::spawn_quit(self.ivars().app_handle.clone());
+        }
+      }
+    }
+  }
+);
+
+impl MacosTrayMenuItem {
+  fn create(
+    mtm: MainThreadMarker,
+    app_handle: AppHandle,
+    title: &str,
+    command: MacosTrayMenuCommand,
+  ) -> Retained<NSMenuItem> {
+    let item = mtm.alloc().set_ivars(MacosTrayMenuItemIvars {
+      app_handle,
+      command,
+    });
+    let title = NSString::from_str(title);
+    let key_equivalent = NSString::from_str("");
+    let item: Retained<MacosTrayMenuItem> = unsafe {
+      msg_send![super(item), initWithTitle: &*title, action: Some(sel!(perform:)), keyEquivalent: &*key_equivalent]
+    };
+
+    // SAFETY: The selector is implemented by `MacosTrayMenuItem`, and
+    // NSMenuItem keeps a weak target reference while we retain the item
+    // through its parent menu for the status item's lifetime.
+    unsafe {
+      item.setTarget(Some(&item));
+      item.setEnabled(true);
+    }
+
+    Retained::into_super(item)
+  }
+}
+
+struct MacosTrayTargetIvars {
+  app_handle: AppHandle,
+  menu: Retained<NSMenu>,
+  status_item: Retained<NSStatusItem>,
+}
+
+define_class!(
+  #[unsafe(super(NSView))]
+  #[name = "HardwareVisualizerTrayTarget"]
+  #[thread_kind = MainThreadOnly]
+  #[ivars = MacosTrayTargetIvars]
+  struct MacosTrayTarget;
+
+  impl MacosTrayTarget {
+    #[unsafe(method(mouseDown:))]
+    fn mouse_down(&self, _event: &objc2_app_kit::NSEvent) {
+      self.highlight(true);
+    }
+
+    #[unsafe(method(mouseUp:))]
+    fn mouse_up(&self, _event: &objc2_app_kit::NSEvent) {
+      self.highlight(false);
+      crate::adapters::tray::restore_main_window(&self.ivars().app_handle);
+    }
+
+    #[unsafe(method(rightMouseDown:))]
+    fn right_mouse_down(&self, _event: &objc2_app_kit::NSEvent) {
+      self.open_menu();
+    }
+
+    #[unsafe(method(rightMouseUp:))]
+    fn right_mouse_up(&self, _event: &objc2_app_kit::NSEvent) {
+      self.highlight(false);
+    }
+  }
+);
+
+impl MacosTrayTarget {
+  fn update_dimensions(&self) {
+    let mtm = MainThreadMarker::from(self);
+    if let Some(button) = self.ivars().status_item.button(mtm) {
+      self.setFrame(button.frame());
+    }
+  }
+
+  fn highlight(&self, highlighted: bool) {
+    let mtm = MainThreadMarker::from(self);
+    if let Some(button) = self.ivars().status_item.button(mtm) {
+      button.highlight(highlighted);
+    }
+  }
+
+  fn open_menu(&self) {
+    if self.ivars().menu.numberOfItems() == 0 {
+      return;
+    }
+
+    let mtm = MainThreadMarker::from(self);
+    if let Some(button) = self.ivars().status_item.button(mtm) {
+      // SAFETY: The button and menu belong to this live NSStatusItem and
+      // this method always runs on the AppKit main thread.
+      unsafe {
+        button.performClick(None);
+      }
+    }
+  }
+}

--- a/src-tauri/src/tray/surface/mod.rs
+++ b/src-tauri/src/tray/surface/mod.rs
@@ -1,0 +1,25 @@
+use crate::tray::widget::TrayFrame;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(target_os = "macos"))]
+mod tauri_surface;
+
+pub trait TraySurface: Send {
+  fn apply_frame(&self, frame: &TrayFrame);
+  fn close(&self);
+}
+
+pub fn create(app: &tauri::App) -> tauri::Result<Box<dyn TraySurface>> {
+  #[cfg(target_os = "macos")]
+  {
+    macos::MacosTraySurface::new(app.handle().clone())
+      .map(|surface| Box::new(surface) as Box<dyn TraySurface>)
+  }
+
+  #[cfg(not(target_os = "macos"))]
+  {
+    tauri_surface::TauriTraySurface::new(app)
+      .map(|surface| Box::new(surface) as Box<dyn TraySurface>)
+  }
+}

--- a/src-tauri/src/tray/surface/tauri_surface.rs
+++ b/src-tauri/src/tray/surface/tauri_surface.rs
@@ -1,0 +1,97 @@
+use tauri::{
+  AppHandle,
+  menu::{Menu, MenuEvent, MenuItem},
+  tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+};
+
+use crate::log_warn;
+use crate::tray::widget::TrayFrame;
+
+use super::TraySurface;
+
+const MENU_OPEN_ID: &str = "tray::open";
+const MENU_QUIT_ID: &str = "tray::quit";
+
+pub struct TauriTraySurface {
+  _tray: TrayIcon,
+}
+
+impl TauriTraySurface {
+  pub fn new(app: &tauri::App) -> tauri::Result<Self> {
+    let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+    let icon = app
+      .default_window_icon()
+      .cloned()
+      .ok_or_else(|| tauri::Error::AssetNotFound("default_window_icon".into()))?;
+
+    let tray = TrayIconBuilder::new()
+      .icon(icon)
+      .menu(&menu)
+      // Keep the "left click restores, right click opens the menu"
+      // contract on backends that forward raw tray click events.
+      .show_menu_on_left_click(false)
+      .on_menu_event(handle_menu_event)
+      .on_tray_icon_event(handle_tray_event)
+      .build(app)?;
+
+    Ok(Self { _tray: tray })
+  }
+}
+
+impl TraySurface for TauriTraySurface {
+  fn apply_frame(&self, frame: &TrayFrame) {
+    // `None` is not a reliable clear operation on macOS in tray-icon
+    // 0.21, so use an empty title for disabled / unavailable frames.
+    if let Err(e) = self
+      ._tray
+      .set_title(Some(frame.title.as_deref().unwrap_or("")))
+    {
+      log_warn!(
+        &format!("failed to update tray widget title: {e}"),
+        "tray::surface::tauri::apply_frame",
+        None::<&str>
+      );
+    }
+
+    if let Err(e) = self._tray.set_tooltip(Some(frame.tooltip.as_str())) {
+      log_warn!(
+        &format!("failed to update tray widget tooltip: {e}"),
+        "tray::surface::tauri::apply_frame",
+        None::<&str>
+      );
+    }
+  }
+
+  fn close(&self) {}
+}
+
+fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+  match event.id.as_ref() {
+    MENU_OPEN_ID => crate::adapters::tray::restore_main_window(app),
+    MENU_QUIT_ID => crate::adapters::tray::spawn_quit(app.clone()),
+    other => {
+      log_warn!(
+        &format!("unhandled tray menu event: {other}"),
+        "tray::surface::tauri::handle_menu_event",
+        None::<&str>
+      );
+    }
+  }
+}
+
+fn handle_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
+  // Restore on a *released* left click. Filtering on `Up` matches the
+  // intuitive "click to focus" gesture and avoids firing twice on
+  // platforms that emit both press and release events.
+  if let TrayIconEvent::Click {
+    button: MouseButton::Left,
+    button_state: MouseButtonState::Up,
+    ..
+  } = event
+  {
+    crate::adapters::tray::restore_main_window(tray.app_handle());
+  }
+}

--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -87,9 +87,25 @@ pub struct TrayMetricSample {
   pub state: MetricState,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrayMetricIcon {
+  pub fallback_label: &'static str,
+  pub macos_symbol_name: &'static str,
+  pub accessibility_label: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrayFrameItem {
+  pub metric: TrayMetric,
+  pub icon: TrayMetricIcon,
+  pub value: String,
+  pub state: MetricState,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrayFrame {
   pub title: Option<String>,
+  pub items: Vec<TrayFrameItem>,
   pub tooltip: String,
 }
 
@@ -101,6 +117,7 @@ pub fn build_frame(
   if !settings.enabled {
     return TrayFrame {
       title: None,
+      items: vec![],
       tooltip: "HardwareVisualizer".to_string(),
     };
   }
@@ -110,10 +127,15 @@ pub fn build_frame(
   if samples.is_empty() {
     return TrayFrame {
       title: None,
+      items: vec![],
       tooltip: "HardwareVisualizer: no tray metrics available".to_string(),
     };
   }
 
+  let items = samples
+    .iter()
+    .map(|sample| format_frame_item(sample, temperature_unit))
+    .collect::<Vec<_>>();
   let title = samples
     .iter()
     .map(|sample| format_title_sample(sample, temperature_unit))
@@ -128,6 +150,7 @@ pub fn build_frame(
 
   TrayFrame {
     title: Some(title),
+    items,
     tooltip,
   }
 }
@@ -256,17 +279,48 @@ fn format_title_sample(
   sample: &TrayMetricSample,
   temperature_unit: &TemperatureUnit,
 ) -> String {
-  let label = match sample.metric {
-    TrayMetric::Cpu => "C",
-    TrayMetric::Gpu => "G",
-    TrayMetric::Temp => "T",
-  };
-
   format!(
-    "{label} {}{}",
+    "{} {}{}",
+    metric_icon(sample.metric),
     format_value(sample.metric, sample.value, temperature_unit),
     state_suffix(sample.state)
   )
+}
+
+fn format_frame_item(
+  sample: &TrayMetricSample,
+  temperature_unit: &TemperatureUnit,
+) -> TrayFrameItem {
+  TrayFrameItem {
+    metric: sample.metric,
+    icon: metric_icon_config(sample.metric),
+    value: format_value(sample.metric, sample.value, temperature_unit),
+    state: sample.state,
+  }
+}
+
+fn metric_icon(metric: TrayMetric) -> &'static str {
+  metric_icon_config(metric).fallback_label
+}
+
+fn metric_icon_config(metric: TrayMetric) -> TrayMetricIcon {
+  match metric {
+    TrayMetric::Cpu => TrayMetricIcon {
+      fallback_label: "CPU",
+      macos_symbol_name: "cpu",
+      accessibility_label: "CPU usage",
+    },
+    TrayMetric::Gpu => TrayMetricIcon {
+      fallback_label: "GPU",
+      macos_symbol_name: "display",
+      accessibility_label: "GPU usage",
+    },
+    TrayMetric::Temp => TrayMetricIcon {
+      fallback_label: "TEMP",
+      macos_symbol_name: "thermometer",
+      accessibility_label: "Temperature",
+    },
+  }
 }
 
 fn format_tooltip_sample(
@@ -392,8 +446,62 @@ mod tests {
       &TemperatureUnit::Celsius,
     );
 
-    assert_eq!(frame.title, Some("C 42%  G 56%".to_string()));
+    assert_eq!(frame.title, Some("CPU 42%  GPU 56%".to_string()));
+    assert_eq!(
+      frame.items,
+      vec![
+        TrayFrameItem {
+          metric: TrayMetric::Cpu,
+          icon: metric_icon_config(TrayMetric::Cpu),
+          value: "42%".to_string(),
+          state: MetricState::Normal,
+        },
+        TrayFrameItem {
+          metric: TrayMetric::Gpu,
+          icon: metric_icon_config(TrayMetric::Gpu),
+          value: "56%".to_string(),
+          state: MetricState::Normal,
+        },
+      ]
+    );
     assert!(frame.tooltip.contains("CPU usage: 42% (normal)"));
+  }
+
+  #[test]
+  fn build_frame_includes_platform_icon_metadata_for_visible_metrics() {
+    let settings = TrayWidgetSettings {
+      enabled: true,
+      metric_order: vec![TrayMetric::Cpu, TrayMetric::Gpu],
+      visible_metrics: vec![TrayMetric::Cpu, TrayMetric::Gpu],
+      update_interval_secs: 1,
+      legacy_metrics: vec![],
+    };
+    let frame = build_frame(
+      &snapshot(42.4, vec![gpu(Some(55.8), Some(70.0))]),
+      &settings,
+      &TemperatureUnit::Celsius,
+    );
+
+    let icons = frame
+      .items
+      .iter()
+      .map(|item| {
+        (
+          item.metric,
+          item.icon.fallback_label,
+          item.icon.macos_symbol_name,
+          item.icon.accessibility_label,
+        )
+      })
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      icons,
+      vec![
+        (TrayMetric::Cpu, "CPU", "cpu", "CPU usage"),
+        (TrayMetric::Gpu, "GPU", "display", "GPU usage"),
+      ]
+    );
   }
 
   #[test]
@@ -409,9 +517,33 @@ mod tests {
   }
 
   #[test]
+  fn enabled_widget_without_available_metrics_keeps_empty_frame() {
+    let settings = TrayWidgetSettings {
+      enabled: true,
+      metric_order: vec![TrayMetric::Gpu],
+      visible_metrics: vec![TrayMetric::Gpu],
+      update_interval_secs: 1,
+      legacy_metrics: vec![],
+    };
+    let frame = build_frame(
+      &snapshot(42.4, vec![]),
+      &settings,
+      &TemperatureUnit::Celsius,
+    );
+
+    assert_eq!(frame.title, None);
+    assert_eq!(frame.items, vec![]);
+    assert_eq!(
+      frame.tooltip,
+      "HardwareVisualizer: no tray metrics available"
+    );
+  }
+
+  #[test]
   fn skips_identical_frame_before_throttle_check() {
     let frame = TrayFrame {
       title: Some("C 42%".to_string()),
+      items: vec![],
       tooltip: "CPU usage: 42% (normal)".to_string(),
     };
 
@@ -427,10 +559,12 @@ mod tests {
   fn skips_changed_frame_until_interval_elapses() {
     let previous = TrayFrame {
       title: Some("C 42%".to_string()),
+      items: vec![],
       tooltip: "CPU usage: 42% (normal)".to_string(),
     };
     let next = TrayFrame {
       title: Some("C 43%".to_string()),
+      items: vec![],
       tooltip: "CPU usage: 43% (normal)".to_string(),
     };
 
@@ -514,7 +648,7 @@ mod tests {
       &TemperatureUnit::Celsius,
     );
 
-    assert_eq!(frame.title, Some("C 42%  G 18%".to_string()));
+    assert_eq!(frame.title, Some("CPU 42%  GPU 18%".to_string()));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Add a `TraySurface` abstraction so platform-specific tray renderers can be swapped independently.
- Implement a native AppKit-backed macOS tray renderer for #1401 while keeping the existing Tauri tray path for other OSes.
- Render CPU/GPU values with native icons, keep the app logo visible in the tray, and tint the SVG logo through AppKit template rendering so it follows `NSColor::labelColor()`.
- Add focused tests for tray frame icon metadata, empty metric frames, macOS attributed title layout, and logo template behavior.

## Related Issues

Refs #1401

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [x] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [x] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Commands run:

```bash
cargo test -p hardware_visualizer tray::
cargo clippy -p hardware_visualizer --all-targets
```

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tray interface now displays metric icons and values alongside status information
  * Enhanced macOS tray integration with native system appearance and interactions
  * Visual state indicators for metrics with color-based differentiation (normal, warning, critical)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->