### PR TITLE
chore: add AI review triage skill

### DIFF
--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -28,7 +28,7 @@ Separate AI review noise from useful feedback. Inspect review threads, classify 
    - If `gh` auth or network access fails, report the blocker and ask for re-authentication or permission instead of guessing from incomplete data.
 
 4. Classify each comment.
-   - `Required`: correctness bug, build failure, clippy/lint warning that reproduces, test failure, security/soundness issue, or behavior that conflicts with the user request.
+   - `Required`: correctness bug, build failure, clippy/lint warning that reproduces, test failure, security/soundness issue, or behavior that conflicts with the user request. Note: a comment may only be classified `Required` after verification (see Step 5); if verification is not feasible, classify as `Should Fix` with a 'needs verification' tag instead.
    - `Should Fix`: non-blocking but clearly correct feedback that removes misleading code, unrealistic tests, stale comments, fragile behavior, or likely reviewer follow-up.
    - `Worth Fixing`: small low-risk change that improves clarity, test realism, performance in a hot path, user-visible behavior, or future maintainability.
    - `Optional`: nitpick, style preference, docstring/coverage suggestion outside project requirements, or UX improvement with fallback already implemented.
@@ -38,9 +38,10 @@ Separate AI review noise from useful feedback. Inspect review threads, classify 
    - Reproduce claimed CI-impacting issues locally when feasible.
    - Inspect the referenced code, not only the bot wording.
    - If a bot says "warnings-as-errors" or similar, run the relevant check before treating it as required.
+   - Only mark Required if the issue is verifiable with reproduction/test evidence or deterministically verifiable from available data; if verification isn't possible, downgrade to Should Fix with a 'needs verification' tag (or Ignore if clearly stale/duplicate).
 
 6. Decide action.
-   - Treat `Required`, `Should Fix`, and `Worth Fixing` as fix targets by default.
+   - Treat `Required`, `Should Fix`, and `Worth Fixing` as fix targets by default. Note: fix targets assume verification feasibility has been assessed per Step 5.
    - If the user explicitly says "必須だけ" or "only required", implement only `Required` items and report the skipped `Should Fix` / `Worth Fixing` items.
    - Do not address `Optional` or `Ignore` items unless the user explicitly asks.
    - Do not post replies, resolve threads, or submit reviews on GitHub unless the user explicitly requests that write action.

--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gh-ai-review-triage
+description: Triage and optionally address AI-generated GitHub PR review feedback from Copilot, CodeRabbit, or similar bots. Use when the user asks to check AI review comments, decide whether comments require action, ignore non-actionable suggestions, fix required/should-fix/worth-fixing feedback, or summarize bot review findings on a pull request.
+---
+
+# GitHub AI Review Triage
+
+## Goal
+
+Separate AI review noise from useful feedback. Inspect review threads, classify each comment, fix comments that are required, should be addressed, or are clearly worth addressing, and leave optional/nitpick comments alone unless the user asks to address them.
+
+## Workflow
+
+1. Resolve the target PR.
+   - Use a PR number or URL from the user when provided.
+   - Otherwise infer the PR from the current branch and repository.
+   - Prefer thread-aware data over flat comments when available, because resolution and outdated state matter.
+
+2. Collect review context.
+   - Fetch inline review threads with resolved/outdated state.
+   - Fetch top-level PR comments and review submissions to catch bot summaries, approvals, and nitpick-only reviews.
+   - Note the author for each item. Treat Copilot, CodeRabbit, and similar bot comments as advisory until verified.
+
+3. Use the best available retrieval method.
+   - If GitHub connector tools are available, prefer `_list_pull_request_review_threads` for inline threads and `_fetch_pr_comments` for the merged PR timeline.
+   - If the GitHub MCP server is available, use `get_pull_request_comments` and `get_pull_request_reviews` as a fallback; note that flat comments may not fully preserve thread resolution state.
+   - If only `gh` is available, use `gh pr view` to resolve the PR, then `gh api graphql` for `reviewThreads` and REST endpoints for `/pulls/{number}/comments`, `/pulls/{number}/reviews`, and `/issues/{number}/comments`.
+   - If `gh` auth or network access fails, report the blocker and ask for re-authentication or permission instead of guessing from incomplete data.
+
+4. Classify each comment.
+   - `Required`: correctness bug, build failure, clippy/lint warning that reproduces, test failure, security/soundness issue, or behavior that conflicts with the user request.
+   - `Should Fix`: non-blocking but clearly correct feedback that removes misleading code, unrealistic tests, stale comments, fragile behavior, or likely reviewer follow-up.
+   - `Worth Fixing`: small low-risk change that improves clarity, test realism, performance in a hot path, user-visible behavior, or future maintainability.
+   - `Optional`: nitpick, style preference, docstring/coverage suggestion outside project requirements, or UX improvement with fallback already implemented.
+   - `Ignore`: outdated, resolved, duplicate, incorrect after local verification, or unrelated to this PR.
+
+5. Verify before editing.
+   - Reproduce claimed CI-impacting issues locally when feasible.
+   - Inspect the referenced code, not only the bot wording.
+   - If a bot says "warnings-as-errors" or similar, run the relevant check before treating it as required.
+
+6. Decide action.
+   - Treat `Required`, `Should Fix`, and `Worth Fixing` as fix targets by default.
+   - If the user explicitly says "必須だけ" or "only required", implement only `Required` items and report the skipped `Should Fix` / `Worth Fixing` items.
+   - Do not address `Optional` or `Ignore` items unless the user explicitly asks.
+   - Do not post replies, resolve threads, or submit reviews on GitHub unless the user explicitly requests that write action.
+
+7. Implement and validate when changes are needed.
+   - Keep fixes narrowly scoped to the review comment.
+   - Run the smallest relevant tests/checks first, then broader checks if the fix touches shared behavior.
+   - Commit/push only when the user asks for that.
+
+## Output Format
+
+When only triaging, summarize in Japanese if the user is using Japanese:
+
+```text
+確認しました。修正対象は N 件です。
+
+- Required: ...
+- Should Fix: ...
+- Worth Fixing: ...
+- Optional/Ignore: ...
+
+対応する/しない理由:
+...
+```
+
+When changes are made, include:
+
+- which comments were addressed
+- which comments were intentionally ignored and why
+- validation commands and results
+- whether GitHub replies/resolution were left untouched
+
+## Heuristics
+
+- AI approvals and bot overview comments usually do not require code changes.
+- CodeRabbit "Nitpick" sections are optional by default, but promote them to `Worth Fixing` when the change is clearly safe and improves the PR directly.
+- "Consider ..." wording is usually optional unless it points to a real bug, misleading test/comment, measurable hot-path issue, or low-risk improvement with clear value.
+- A stale or incorrect bot claim should be called out briefly and left unchanged.
+- For Rust PRs, local `cargo clippy` success is stronger evidence than an AI claim about unused imports.

--- a/.agents/skills/gh-ai-review-triage/agents/openai.yaml
+++ b/.agents/skills/gh-ai-review-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Review Triage"
+  short_description: "Triage AI PR reviews and useful fixes."
+  default_prompt: "Use $gh-ai-review-triage to review AI-generated PR comments, separate useful fixes from optional suggestions, and address required, should-fix, and worth-fixing feedback."


### PR DESCRIPTION
## Summary

- Add a repository-local Codex skill for repeatedly triaging AI-generated PR review feedback.
- Document how to retrieve review threads and PR comment timelines through GitHub connector tools, GitHub MCP fallback, or `gh`.
- Define actionable classifications (`Required`, `Should Fix`, `Worth Fixing`, `Optional`, `Ignore`) so useful AI review comments can be addressed consistently while noise is left alone.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [ ] Manual testing
- [ ] Unit tests

Validation performed:

```bash
rg -n "TODO|\[TODO|Recommended|only what is necessary|必須対応" .agents/skills/gh-ai-review-triage
```

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Review Triage skill to categorize and prioritize AI-generated PR review comments, mark fixes as Required/Should/Worth/Optional/Ignore, and follow action-selection rules (including user constraints).
  * Outputs Japanese-first when triaging and reports addressed/ignored items, validation results, and reply/resolution status when changes are made.

* **Documentation**
  * Added detailed workflow, verification rules, and explicit handling for authentication/network failures during triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->