### PR TITLE
feat: add Windows tray widget flyout

### DIFF
--- a/src-tauri/capabilities/tray-widget-flyout.json
+++ b/src-tauri/capabilities/tray-widget-flyout.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "tray-widget-flyout",
   "description": "Capability for the Windows tray widget flyout",
   "platforms": ["windows"],

--- a/src-tauri/capabilities/tray-widget-flyout.json
+++ b/src-tauri/capabilities/tray-widget-flyout.json
@@ -1,0 +1,7 @@
+{
+  "identifier": "tray-widget-flyout",
+  "description": "Capability for the Windows tray widget flyout",
+  "platforms": ["windows"],
+  "windows": ["tray-widget-flyout"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -245,7 +245,23 @@ pub fn run() {
       Ok(())
     })
     .on_window_event(|win, ev| {
-      if let tauri::WindowEvent::CloseRequested { api, .. } = ev {
+      if win.label() == tray::TRAY_WIDGET_FLYOUT_LABEL {
+        match ev {
+          tauri::WindowEvent::CloseRequested { api, .. } => {
+            api.prevent_close();
+            let _ = win.hide();
+          }
+          tauri::WindowEvent::Focused(false) => {
+            let _ = win.hide();
+          }
+          _ => {}
+        }
+        return;
+      }
+
+      if win.label() == "main"
+        && let tauri::WindowEvent::CloseRequested { api, .. } = ev
+      {
         // Always prevent the default close so lifecycle picks the
         // outcome (hide vs. quit) deterministically — see
         // `lifecycle::handle_close_request` for the policy.

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,2 +1,4 @@
 pub mod surface;
 pub mod widget;
+
+pub const TRAY_WIDGET_FLYOUT_LABEL: &str = "tray-widget-flyout";

--- a/src-tauri/src/tray/surface/mod.rs
+++ b/src-tauri/src/tray/surface/mod.rs
@@ -2,8 +2,10 @@ use crate::tray::widget::TrayFrame;
 
 #[cfg(target_os = "macos")]
 mod macos;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 mod tauri_surface;
+#[cfg(target_os = "windows")]
+mod windows;
 
 pub trait TraySurface: Send {
   fn apply_frame(&self, frame: &TrayFrame);
@@ -17,7 +19,13 @@ pub fn create(app: &tauri::App) -> tauri::Result<Box<dyn TraySurface>> {
       .map(|surface| Box::new(surface) as Box<dyn TraySurface>)
   }
 
-  #[cfg(not(target_os = "macos"))]
+  #[cfg(target_os = "windows")]
+  {
+    windows::WindowsTraySurface::new(app)
+      .map(|surface| Box::new(surface) as Box<dyn TraySurface>)
+  }
+
+  #[cfg(not(any(target_os = "macos", target_os = "windows")))]
   {
     tauri_surface::TauriTraySurface::new(app)
       .map(|surface| Box::new(surface) as Box<dyn TraySurface>)

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -1,0 +1,863 @@
+use std::{
+  collections::{HashMap, VecDeque},
+  sync::{Arc, Mutex},
+};
+
+use serde::Serialize;
+use tauri::{
+  AppHandle, Emitter, Listener, Manager, PhysicalPosition, WebviewUrl, WebviewWindow,
+  WebviewWindowBuilder,
+  image::Image,
+  menu::{Menu, MenuEvent, MenuItem},
+  tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+};
+
+use crate::log_warn;
+use crate::tray::TRAY_WIDGET_FLYOUT_LABEL;
+use crate::tray::widget::{MetricState, TrayFrame, TrayFrameItem, TrayMetric};
+
+use super::TraySurface;
+
+const MENU_OPEN_ID: &str = "tray::open";
+const MENU_QUIT_ID: &str = "tray::quit";
+
+const ICON_SIZE: u32 = 64;
+const ICON_CACHE_LIMIT: usize = 3;
+const FLYOUT_WIDTH: f64 = 300.0;
+const FLYOUT_HEIGHT: f64 = 148.0;
+
+const ICON_COLOR: Rgba = Rgba([245, 247, 250, 255]);
+const WARNING_COLOR: Rgba = Rgba([255, 185, 0, 255]);
+const CRITICAL_COLOR: Rgba = Rgba([255, 69, 58, 255]);
+const FLYOUT_OFFSET: f64 = 12.0;
+const EVENT_TRAY_WIDGET_FRAME: &str = "tray-widget-frame";
+const EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED: &str = "tray-widget-open-main-requested";
+const EVENT_TRAY_WIDGET_HIDE_REQUESTED: &str = "tray-widget-hide-requested";
+
+pub struct WindowsTraySurface {
+  app_handle: AppHandle,
+  tray: TrayIcon,
+  state: Arc<WindowsTrayState>,
+}
+
+#[derive(Default)]
+struct WindowsTrayState {
+  cache: Mutex<WindowsIconCache>,
+  latest_frame: Mutex<Option<WindowsFlyoutFrame>>,
+}
+
+impl WindowsTraySurface {
+  pub fn new(app: &tauri::App) -> tauri::Result<Self> {
+    let app_handle = app.handle().clone();
+    ensure_flyout_window(&app_handle)?;
+    register_flyout_event_handlers(&app_handle);
+
+    let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, MENU_QUIT_ID, "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+    let icon = render_hv_outline_image(MetricState::Normal);
+
+    let state = Arc::new(WindowsTrayState::default());
+    let event_app_handle = app_handle.clone();
+    let event_state = Arc::clone(&state);
+
+    let tray = TrayIconBuilder::new()
+      .icon(icon.clone())
+      .menu(&menu)
+      .show_menu_on_left_click(false)
+      .on_menu_event(handle_menu_event)
+      .on_tray_icon_event(move |_tray, event| {
+        handle_tray_event(&event_app_handle, &event_state, event);
+      })
+      .build(app)?;
+
+    Ok(Self {
+      app_handle,
+      tray,
+      state,
+    })
+  }
+}
+
+impl TraySurface for WindowsTraySurface {
+  fn apply_frame(&self, frame: &TrayFrame) {
+    let flyout_frame = WindowsFlyoutFrame::from_frame(frame);
+    self
+      .state
+      .latest_frame
+      .lock()
+      .unwrap()
+      .replace(flyout_frame.clone());
+    emit_flyout_frame(&self.app_handle, &flyout_frame);
+
+    if let Err(e) = self.tray.set_tooltip(Some(frame.tooltip.as_str())) {
+      log_warn!(
+        &format!("failed to update Windows tray widget tooltip: {e}"),
+        "tray::surface::windows::apply_frame",
+        None::<&str>
+      );
+    }
+
+    let icon = self.state.cache.lock().unwrap().image_for_frame(frame);
+
+    if let Err(e) = self.tray.set_icon(Some(icon)) {
+      log_warn!(
+        &format!("failed to update Windows tray widget icon: {e}"),
+        "tray::surface::windows::apply_frame",
+        None::<&str>
+      );
+    }
+  }
+
+  fn close(&self) {}
+}
+
+fn ensure_flyout_window(app_handle: &AppHandle) -> tauri::Result<WebviewWindow> {
+  if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) {
+    return Ok(window);
+  }
+
+  WebviewWindowBuilder::new(
+    app_handle,
+    TRAY_WIDGET_FLYOUT_LABEL,
+    WebviewUrl::App("index.html".into()),
+  )
+  .title("HardwareVisualizer")
+  .inner_size(FLYOUT_WIDTH, FLYOUT_HEIGHT)
+  .resizable(false)
+  .decorations(false)
+  .skip_taskbar(true)
+  .always_on_top(true)
+  .focused(false)
+  .visible(false)
+  .shadow(true)
+  .build()
+}
+
+fn register_flyout_event_handlers(app_handle: &AppHandle) {
+  let open_app = app_handle.clone();
+  app_handle.listen_any(EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED, move |_| {
+    crate::adapters::tray::restore_main_window(&open_app);
+    hide_flyout_window(&open_app);
+  });
+
+  let hide_app = app_handle.clone();
+  app_handle.listen_any(EVENT_TRAY_WIDGET_HIDE_REQUESTED, move |_| {
+    hide_flyout_window(&hide_app);
+  });
+}
+
+fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
+  match event.id.as_ref() {
+    MENU_OPEN_ID => crate::adapters::tray::restore_main_window(app),
+    MENU_QUIT_ID => crate::adapters::tray::spawn_quit(app.clone()),
+    other => {
+      log_warn!(
+        &format!("unhandled tray menu event: {other}"),
+        "tray::surface::windows::handle_menu_event",
+        None::<&str>
+      );
+    }
+  }
+}
+
+fn handle_tray_event(
+  app_handle: &AppHandle,
+  state: &WindowsTrayState,
+  event: TrayIconEvent,
+) {
+  if let TrayIconEvent::Click {
+    position,
+    button: MouseButton::Left,
+    button_state: MouseButtonState::Up,
+    ..
+  } = event
+  {
+    toggle_flyout_window(app_handle, state, position)
+  }
+}
+
+fn toggle_flyout_window(
+  app_handle: &AppHandle,
+  state: &WindowsTrayState,
+  click_position: PhysicalPosition<f64>,
+) {
+  let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) else {
+    log_warn!(
+      "Windows tray flyout window was not available",
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+    return;
+  };
+
+  if window.is_visible().unwrap_or(false) {
+    if let Err(e) = window.hide() {
+      log_warn!(
+        &format!("failed to hide Windows tray flyout: {e}"),
+        "tray::surface::windows::toggle_flyout_window",
+        None::<&str>
+      );
+    }
+    return;
+  }
+
+  if let Err(e) = window.set_position(flyout_position(click_position)) {
+    log_warn!(
+      &format!("failed to position Windows tray flyout: {e}"),
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+  }
+
+  if let Some(frame) = state.latest_frame.lock().unwrap().clone() {
+    emit_flyout_frame_to_window(&window, &frame);
+  }
+
+  if let Err(e) = window.show() {
+    log_warn!(
+      &format!("failed to show Windows tray flyout: {e}"),
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+  }
+
+  if let Err(e) = window.set_focus() {
+    log_warn!(
+      &format!("failed to focus Windows tray flyout: {e}"),
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+  }
+}
+
+fn hide_flyout_window(app_handle: &AppHandle) {
+  if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL)
+    && let Err(e) = window.hide()
+  {
+    log_warn!(
+      &format!("failed to hide Windows tray flyout: {e}"),
+      "tray::surface::windows::hide_flyout_window",
+      None::<&str>
+    );
+  }
+}
+
+fn flyout_position(click_position: PhysicalPosition<f64>) -> PhysicalPosition<f64> {
+  PhysicalPosition::new(
+    (click_position.x - FLYOUT_WIDTH + 28.0).max(0.0),
+    (click_position.y - FLYOUT_HEIGHT - FLYOUT_OFFSET).max(0.0),
+  )
+}
+
+fn emit_flyout_frame(app_handle: &AppHandle, frame: &WindowsFlyoutFrame) {
+  if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) {
+    emit_flyout_frame_to_window(&window, frame);
+  }
+}
+
+fn emit_flyout_frame_to_window(window: &WebviewWindow, frame: &WindowsFlyoutFrame) {
+  if let Err(e) = window.emit(EVENT_TRAY_WIDGET_FRAME, frame) {
+    log_warn!(
+      &format!("failed to emit Windows tray flyout frame: {e}"),
+      "tray::surface::windows::emit_flyout_frame_to_window",
+      None::<&str>
+    );
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowsFlyoutFrame {
+  items: Vec<WindowsFlyoutItem>,
+  tooltip: String,
+}
+
+impl WindowsFlyoutFrame {
+  fn from_frame(frame: &TrayFrame) -> Self {
+    Self {
+      items: frame
+        .items
+        .iter()
+        .map(WindowsFlyoutItem::from_item)
+        .collect(),
+      tooltip: frame.tooltip.clone(),
+    }
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowsFlyoutItem {
+  metric: TrayMetric,
+  value: String,
+  state: &'static str,
+}
+
+impl WindowsFlyoutItem {
+  fn from_item(item: &TrayFrameItem) -> Self {
+    Self {
+      metric: item.metric,
+      value: item.value.clone(),
+      state: state_name(item.state),
+    }
+  }
+}
+
+#[derive(Default)]
+struct WindowsIconCache {
+  images: HashMap<WindowsFrameKey, Image<'static>>,
+  order: VecDeque<WindowsFrameKey>,
+}
+
+impl WindowsIconCache {
+  fn image_for_frame(&mut self, frame: &TrayFrame) -> Image<'static> {
+    let key = WindowsFrameKey::from_frame(frame);
+
+    if let Some(image) = self.images.get(&key) {
+      return image.clone();
+    }
+
+    let image = render_frame_icon(frame);
+
+    if self.images.len() >= ICON_CACHE_LIMIT
+      && let Some(oldest) = self.order.pop_front()
+    {
+      self.images.remove(&oldest);
+    }
+
+    self.order.push_back(key.clone());
+    self.images.insert(key, image.clone());
+
+    image
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct WindowsFrameKey {
+  state: MetricState,
+}
+
+impl WindowsFrameKey {
+  fn from_frame(frame: &TrayFrame) -> Self {
+    Self {
+      state: worst_metric_state(&frame.items),
+    }
+  }
+}
+
+fn render_frame_icon(frame: &TrayFrame) -> Image<'static> {
+  render_hv_outline_image(worst_metric_state(&frame.items))
+}
+
+fn render_hv_outline_image(state: MetricState) -> Image<'static> {
+  let mut canvas = IconCanvas::new(ICON_SIZE, ICON_SIZE);
+  draw_hv_outline_icon(&mut canvas, state_color(state));
+
+  Image::new_owned(canvas.into_rgba(), ICON_SIZE, ICON_SIZE)
+}
+
+fn worst_metric_state(items: &[TrayFrameItem]) -> MetricState {
+  items
+    .iter()
+    .map(|item| item.state)
+    .max_by_key(|state| metric_state_rank(*state))
+    .unwrap_or(MetricState::Normal)
+}
+
+fn state_color(state: MetricState) -> Rgba {
+  match state {
+    MetricState::Normal => ICON_COLOR,
+    MetricState::Warning => WARNING_COLOR,
+    MetricState::Critical => CRITICAL_COLOR,
+  }
+}
+
+fn metric_state_rank(state: MetricState) -> u8 {
+  match state {
+    MetricState::Normal => 0,
+    MetricState::Warning => 1,
+    MetricState::Critical => 2,
+  }
+}
+
+fn state_name(state: MetricState) -> &'static str {
+  match state {
+    MetricState::Normal => "normal",
+    MetricState::Warning => "warning",
+    MetricState::Critical => "critical",
+  }
+}
+
+// This is the `assets/hv-icon-outline.svg` geometry in its 658.21 viewBox.
+// Windows tray APIs require an HICON, so the SVG outline is rasterized here
+// and tinted from the current worst metric state.
+const SVG_VIEWBOX: f32 = 658.21;
+const SVG_ICON_PADDING: f32 = 4.0;
+const SVG_RECT: RectF = RectF {
+  x: 36.55,
+  y: 164.05,
+  width: 585.81,
+  height: 330.1,
+};
+const SVG_RECT_RADIUS: f32 = 25.0;
+const SVG_RECT_STROKE_WIDTH: f32 = 25.0;
+const SVG_WAVE_STROKE_WIDTH: f32 = 30.0;
+const SVG_WAVE: [CubicBezier; 3] = [
+  CubicBezier {
+    p0: PointF {
+      x: 622.26,
+      y: 385.68,
+    },
+    p1: PointF {
+      x: 524.51,
+      y: 385.49,
+    },
+    p2: PointF {
+      x: 524.73,
+      y: 273.49,
+    },
+    p3: PointF {
+      x: 426.98,
+      y: 273.30,
+    },
+  },
+  CubicBezier {
+    p0: PointF {
+      x: 426.98,
+      y: 273.30,
+    },
+    p1: PointF {
+      x: 329.22,
+      y: 273.11,
+    },
+    p2: PointF {
+      x: 329.01,
+      y: 385.11,
+    },
+    p3: PointF {
+      x: 231.25,
+      y: 384.92,
+    },
+  },
+  CubicBezier {
+    p0: PointF {
+      x: 231.25,
+      y: 384.92,
+    },
+    p1: PointF {
+      x: 133.49,
+      y: 384.73,
+    },
+    p2: PointF {
+      x: 133.71,
+      y: 272.73,
+    },
+    p3: PointF {
+      x: 35.96,
+      y: 272.54,
+    },
+  },
+];
+
+fn draw_hv_outline_icon(canvas: &mut IconCanvas, color: Rgba) {
+  let transform = SvgTransform::new();
+  let rect = transform.rect(SVG_RECT);
+  let rect_radius = transform.length(SVG_RECT_RADIUS);
+  let rect_stroke = transform.length(SVG_RECT_STROKE_WIDTH).max(4.0);
+  let wave_stroke = transform.length(SVG_WAVE_STROKE_WIDTH).max(5.0);
+
+  canvas.draw_rounded_rect_stroke(rect, rect_radius, rect_stroke, color);
+
+  for curve in SVG_WAVE {
+    draw_cubic_stroke(canvas, transform.cubic(curve), wave_stroke, color);
+  }
+}
+
+fn draw_cubic_stroke(
+  canvas: &mut IconCanvas,
+  curve: CubicBezier,
+  stroke_width: f32,
+  color: Rgba,
+) {
+  let mut previous = curve.p0;
+
+  for step in 1..=72 {
+    let t = step as f32 / 72.0;
+    let next = curve.sample(t);
+    canvas.draw_stroked_segment(previous, next, stroke_width, color);
+    previous = next;
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SvgTransform {
+  scale: f32,
+}
+
+impl SvgTransform {
+  fn new() -> Self {
+    Self {
+      scale: (ICON_SIZE as f32 - SVG_ICON_PADDING * 2.0) / SVG_VIEWBOX,
+    }
+  }
+
+  fn point(&self, point: PointF) -> PointF {
+    PointF {
+      x: point.x * self.scale + SVG_ICON_PADDING,
+      y: point.y * self.scale + SVG_ICON_PADDING,
+    }
+  }
+
+  fn length(&self, value: f32) -> f32 {
+    value * self.scale
+  }
+
+  fn rect(&self, rect: RectF) -> RectF {
+    RectF {
+      x: rect.x * self.scale + SVG_ICON_PADDING,
+      y: rect.y * self.scale + SVG_ICON_PADDING,
+      width: rect.width * self.scale,
+      height: rect.height * self.scale,
+    }
+  }
+
+  fn cubic(&self, cubic: CubicBezier) -> CubicBezier {
+    CubicBezier {
+      p0: self.point(cubic.p0),
+      p1: self.point(cubic.p1),
+      p2: self.point(cubic.p2),
+      p3: self.point(cubic.p3),
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PointF {
+  x: f32,
+  y: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RectF {
+  x: f32,
+  y: f32,
+  width: f32,
+  height: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CubicBezier {
+  p0: PointF,
+  p1: PointF,
+  p2: PointF,
+  p3: PointF,
+}
+
+impl CubicBezier {
+  fn sample(&self, t: f32) -> PointF {
+    let one_minus_t = 1.0 - t;
+    let a = one_minus_t * one_minus_t * one_minus_t;
+    let b = 3.0 * one_minus_t * one_minus_t * t;
+    let c = 3.0 * one_minus_t * t * t;
+    let d = t * t * t;
+
+    PointF {
+      x: self.p0.x * a + self.p1.x * b + self.p2.x * c + self.p3.x * d,
+      y: self.p0.y * a + self.p1.y * b + self.p2.y * c + self.p3.y * d,
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Rgba([u8; 4]);
+
+impl Rgba {
+  fn with_alpha_factor(self, factor: f32) -> Self {
+    let mut color = self;
+    color.0[3] = (color.0[3] as f32 * factor.clamp(0.0, 1.0)).round() as u8;
+    color
+  }
+}
+
+struct IconCanvas {
+  width: u32,
+  height: u32,
+  pixels: Vec<u8>,
+}
+
+impl IconCanvas {
+  fn new(width: u32, height: u32) -> Self {
+    Self {
+      width,
+      height,
+      pixels: vec![0; (width * height * 4) as usize],
+    }
+  }
+
+  fn into_rgba(self) -> Vec<u8> {
+    self.pixels
+  }
+
+  fn draw_rounded_rect_stroke(
+    &mut self,
+    rect: RectF,
+    radius: f32,
+    stroke_width: f32,
+    color: Rgba,
+  ) {
+    let padding = stroke_width / 2.0 + 2.0;
+    let left = (rect.x - padding).floor() as i32;
+    let top = (rect.y - padding).floor() as i32;
+    let right = (rect.x + rect.width + padding).ceil() as i32;
+    let bottom = (rect.y + rect.height + padding).ceil() as i32;
+
+    for y in top..=bottom {
+      for x in left..=right {
+        let px = x as f32 + 0.5;
+        let py = y as f32 + 0.5;
+        let distance = rounded_rect_signed_distance(px, py, rect, radius).abs();
+        let coverage = stroke_coverage(distance, stroke_width);
+
+        if coverage > 0.0 {
+          self.blend_pixel(x, y, color.with_alpha_factor(coverage));
+        }
+      }
+    }
+  }
+
+  fn draw_stroked_segment(
+    &mut self,
+    start: PointF,
+    end: PointF,
+    stroke_width: f32,
+    color: Rgba,
+  ) {
+    let padding = stroke_width / 2.0 + 2.0;
+    let left = (start.x.min(end.x) - padding).floor() as i32;
+    let top = (start.y.min(end.y) - padding).floor() as i32;
+    let right = (start.x.max(end.x) + padding).ceil() as i32;
+    let bottom = (start.y.max(end.y) + padding).ceil() as i32;
+
+    for y in top..=bottom {
+      for x in left..=right {
+        let point = PointF {
+          x: x as f32 + 0.5,
+          y: y as f32 + 0.5,
+        };
+        let distance = distance_to_segment(point, start, end);
+        let coverage = stroke_coverage(distance, stroke_width);
+
+        if coverage > 0.0 {
+          self.blend_pixel(x, y, color.with_alpha_factor(coverage));
+        }
+      }
+    }
+  }
+
+  fn blend_pixel(&mut self, x: i32, y: i32, color: Rgba) {
+    if x < 0 || y < 0 || x >= self.width as i32 || y >= self.height as i32 {
+      return;
+    }
+
+    let index = ((y as u32 * self.width + x as u32) * 4) as usize;
+    let src = color.0;
+    let src_alpha = src[3] as u32;
+    let dst_alpha = self.pixels[index + 3] as u32;
+    let out_alpha = src_alpha + (dst_alpha * (255 - src_alpha)) / 255;
+
+    if out_alpha == 0 {
+      return;
+    }
+
+    for (channel, src_channel) in src.iter().take(3).enumerate() {
+      let dst_channel = self.pixels[index + channel] as u32;
+      let out_channel = (*src_channel as u32 * src_alpha
+        + dst_channel * dst_alpha * (255 - src_alpha) / 255)
+        / out_alpha;
+      self.pixels[index + channel] = out_channel as u8;
+    }
+    self.pixels[index + 3] = out_alpha as u8;
+  }
+}
+
+fn stroke_coverage(distance: f32, stroke_width: f32) -> f32 {
+  let half_width = stroke_width / 2.0;
+  (half_width + 0.75 - distance).clamp(0.0, 1.0)
+}
+
+fn distance_to_segment(point: PointF, start: PointF, end: PointF) -> f32 {
+  let vx = end.x - start.x;
+  let vy = end.y - start.y;
+  let wx = point.x - start.x;
+  let wy = point.y - start.y;
+  let len_sq = vx * vx + vy * vy;
+
+  if len_sq <= f32::EPSILON {
+    return ((point.x - start.x).powi(2) + (point.y - start.y).powi(2)).sqrt();
+  }
+
+  let t = ((wx * vx + wy * vy) / len_sq).clamp(0.0, 1.0);
+  let projection = PointF {
+    x: start.x + vx * t,
+    y: start.y + vy * t,
+  };
+
+  ((point.x - projection.x).powi(2) + (point.y - projection.y).powi(2)).sqrt()
+}
+
+fn rounded_rect_signed_distance(px: f32, py: f32, rect: RectF, radius: f32) -> f32 {
+  let half_width = rect.width / 2.0;
+  let half_height = rect.height / 2.0;
+  let center_x = rect.x + half_width;
+  let center_y = rect.y + half_height;
+  let qx = (px - center_x).abs() - (half_width - radius);
+  let qy = (py - center_y).abs() - (half_height - radius);
+  let outside_x = qx.max(0.0);
+  let outside_y = qy.max(0.0);
+  let outside = (outside_x * outside_x + outside_y * outside_y).sqrt();
+  let inside = qx.max(qy).min(0.0);
+
+  outside + inside - radius
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::tray::widget::TrayMetricIcon;
+
+  fn item(metric: TrayMetric, value: &str, state: MetricState) -> TrayFrameItem {
+    TrayFrameItem {
+      metric,
+      icon: TrayMetricIcon {
+        fallback_label: "CPU",
+        macos_symbol_name: "cpu",
+        accessibility_label: "CPU usage",
+      },
+      value: value.to_string(),
+      state,
+    }
+  }
+
+  #[test]
+  fn renders_non_empty_rgba_icon_for_metric_frame() {
+    let frame = TrayFrame {
+      title: Some("CPU 42%  GPU 91%".to_string()),
+      items: vec![
+        item(TrayMetric::Cpu, "42%", MetricState::Normal),
+        item(TrayMetric::Gpu, "91%", MetricState::Critical),
+      ],
+      tooltip: "CPU usage: 42% (normal)\nGPU usage: 91% (critical)".to_string(),
+    };
+
+    let image = render_frame_icon(&frame);
+
+    assert_eq!(image.width(), ICON_SIZE);
+    assert_eq!(image.height(), ICON_SIZE);
+    assert_eq!(image.rgba().len(), (ICON_SIZE * ICON_SIZE * 4) as usize);
+    assert!(image.rgba().chunks_exact(4).any(|pixel| pixel[3] > 0));
+  }
+
+  #[test]
+  fn cache_key_tracks_rendered_metric_and_state() {
+    let first = TrayFrame {
+      title: Some("CPU 69%".to_string()),
+      items: vec![item(TrayMetric::Cpu, "69%", MetricState::Normal)],
+      tooltip: "first".to_string(),
+    };
+    let same_rendered_icon = TrayFrame {
+      title: Some("CPU changed title".to_string()),
+      items: vec![item(TrayMetric::Cpu, "70%", MetricState::Normal)],
+      tooltip: "second".to_string(),
+    };
+    let warning = TrayFrame {
+      title: Some("CPU 70%".to_string()),
+      items: vec![item(TrayMetric::Cpu, "70%", MetricState::Warning)],
+      tooltip: "third".to_string(),
+    };
+
+    assert_eq!(
+      WindowsFrameKey::from_frame(&first),
+      WindowsFrameKey::from_frame(&same_rendered_icon)
+    );
+    assert_ne!(
+      WindowsFrameKey::from_frame(&first),
+      WindowsFrameKey::from_frame(&warning)
+    );
+  }
+
+  #[test]
+  fn warning_and_critical_states_use_state_colors() {
+    assert_eq!(state_color(MetricState::Normal), ICON_COLOR);
+    assert_eq!(state_color(MetricState::Warning), WARNING_COLOR);
+    assert_eq!(state_color(MetricState::Critical), CRITICAL_COLOR);
+  }
+
+  #[test]
+  fn icon_tint_follows_worst_metric_state() {
+    let frame = TrayFrame {
+      title: Some("CPU 42%  GPU 91%".to_string()),
+      items: vec![
+        item(TrayMetric::Cpu, "42%", MetricState::Normal),
+        item(TrayMetric::Gpu, "91%", MetricState::Critical),
+      ],
+      tooltip: "CPU usage: 42% (normal)\nGPU usage: 91% (critical)".to_string(),
+    };
+
+    let image = render_frame_icon(&frame);
+
+    assert!(
+      image
+        .rgba()
+        .chunks_exact(4)
+        .any(|pixel| &pixel[0..3] == &CRITICAL_COLOR.0[0..3] && pixel[3] > 0)
+    );
+  }
+
+  #[test]
+  fn empty_frame_uses_normal_hv_outline_tint() {
+    let frame = TrayFrame {
+      title: None,
+      items: vec![],
+      tooltip: "HardwareVisualizer".to_string(),
+    };
+
+    let image = render_frame_icon(&frame);
+
+    assert!(
+      image
+        .rgba()
+        .chunks_exact(4)
+        .any(|pixel| &pixel[0..3] == &ICON_COLOR.0[0..3] && pixel[3] > 0)
+    );
+  }
+
+  #[test]
+  fn flyout_frame_preserves_metric_values_for_readable_ui() {
+    let frame = TrayFrame {
+      title: Some("CPU 42%  GPU 91%".to_string()),
+      items: vec![
+        item(TrayMetric::Cpu, "42%", MetricState::Normal),
+        item(TrayMetric::Gpu, "91%", MetricState::Critical),
+      ],
+      tooltip: "CPU usage: 42% (normal)\nGPU usage: 91% (critical)".to_string(),
+    };
+
+    let flyout_frame = WindowsFlyoutFrame::from_frame(&frame);
+
+    assert_eq!(flyout_frame.tooltip, frame.tooltip);
+    assert_eq!(flyout_frame.items[0].value, "42%");
+    assert_eq!(flyout_frame.items[0].state, "normal");
+    assert_eq!(flyout_frame.items[1].value, "91%");
+    assert_eq!(flyout_frame.items[1].state, "critical");
+  }
+
+  #[test]
+  fn flyout_position_opens_above_the_tray_click() {
+    let position = flyout_position(PhysicalPosition::new(1920.0, 1080.0));
+
+    assert_eq!(position.x, 1648.0);
+    assert_eq!(position.y, 920.0);
+  }
+}

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -5,8 +5,8 @@ use std::{
 
 use serde::Serialize;
 use tauri::{
-  AppHandle, Emitter, Listener, Manager, PhysicalPosition, WebviewUrl, WebviewWindow,
-  WebviewWindowBuilder,
+  AppHandle, Emitter, Listener, Manager, Monitor, PhysicalPosition, PhysicalSize, Rect,
+  WebviewUrl, WebviewWindow, WebviewWindowBuilder,
   image::Image,
   menu::{Menu, MenuEvent, MenuItem},
   tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
@@ -169,19 +169,35 @@ fn handle_tray_event(
 ) {
   if let TrayIconEvent::Click {
     position,
+    rect,
     button: MouseButton::Left,
     button_state: MouseButtonState::Up,
     ..
   } = event
   {
-    toggle_flyout_window(app_handle, state, position)
+    if has_visible_flyout_frame(state) {
+      toggle_flyout_window(app_handle, state, position, rect);
+    } else {
+      hide_flyout_window(app_handle);
+      crate::adapters::tray::restore_main_window(app_handle);
+    }
   }
+}
+
+fn has_visible_flyout_frame(state: &WindowsTrayState) -> bool {
+  state
+    .latest_frame
+    .lock()
+    .unwrap()
+    .as_ref()
+    .is_some_and(|frame| !frame.items.is_empty())
 }
 
 fn toggle_flyout_window(
   app_handle: &AppHandle,
   state: &WindowsTrayState,
   click_position: PhysicalPosition<f64>,
+  tray_rect: Rect,
 ) {
   let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) else {
     log_warn!(
@@ -203,7 +219,31 @@ fn toggle_flyout_window(
     return;
   }
 
-  if let Err(e) = window.set_position(flyout_position(click_position)) {
+  let monitor = match app_handle.monitor_from_point(click_position.x, click_position.y) {
+    Ok(monitor) => monitor,
+    Err(e) => {
+      log_warn!(
+        &format!("failed to resolve monitor for Windows tray flyout: {e}"),
+        "tray::surface::windows::toggle_flyout_window",
+        None::<&str>
+      );
+      None
+    }
+  };
+  let scale_factor = monitor
+    .as_ref()
+    .map(Monitor::scale_factor)
+    .unwrap_or_else(|| window.scale_factor().unwrap_or(1.0));
+  let flyout_size =
+    PhysicalSize::new(FLYOUT_WIDTH * scale_factor, FLYOUT_HEIGHT * scale_factor);
+  let position = flyout_position(
+    physical_rect_from_tauri_rect(tray_rect, scale_factor),
+    monitor.as_ref().map(monitor_work_area),
+    flyout_size,
+    FLYOUT_OFFSET * scale_factor,
+  );
+
+  if let Err(e) = window.set_position(position) {
     log_warn!(
       &format!("failed to position Windows tray flyout: {e}"),
       "tray::surface::windows::toggle_flyout_window",
@@ -244,11 +284,65 @@ fn hide_flyout_window(app_handle: &AppHandle) {
   }
 }
 
-fn flyout_position(click_position: PhysicalPosition<f64>) -> PhysicalPosition<f64> {
-  PhysicalPosition::new(
-    (click_position.x - FLYOUT_WIDTH + 28.0).max(0.0),
-    (click_position.y - FLYOUT_HEIGHT - FLYOUT_OFFSET).max(0.0),
-  )
+fn physical_rect_from_tauri_rect(rect: Rect, scale_factor: f64) -> PhysicalRectF {
+  let position = rect.position.to_physical::<f64>(scale_factor);
+  let size = rect.size.to_physical::<f64>(scale_factor);
+
+  PhysicalRectF {
+    x: position.x,
+    y: position.y,
+    width: size.width,
+    height: size.height,
+  }
+}
+
+fn monitor_work_area(monitor: &Monitor) -> PhysicalRectF {
+  let work_area = monitor.work_area();
+
+  PhysicalRectF {
+    x: work_area.position.x as f64,
+    y: work_area.position.y as f64,
+    width: work_area.size.width as f64,
+    height: work_area.size.height as f64,
+  }
+}
+
+fn flyout_position(
+  tray_rect: PhysicalRectF,
+  work_area: Option<PhysicalRectF>,
+  flyout_size: PhysicalSize<f64>,
+  offset: f64,
+) -> PhysicalPosition<f64> {
+  let mut x = tray_rect.right() - flyout_size.width;
+  let mut y = tray_rect.y - flyout_size.height - offset;
+
+  if let Some(work_area) = work_area {
+    if tray_rect.bottom() <= work_area.y {
+      x = tray_rect.center_x() - flyout_size.width / 2.0;
+      y = tray_rect.bottom() + offset;
+    } else if tray_rect.right() <= work_area.x {
+      x = tray_rect.right() + offset;
+      y = tray_rect.center_y() - flyout_size.height / 2.0;
+    } else if tray_rect.x >= work_area.right() {
+      x = tray_rect.x - flyout_size.width - offset;
+      y = tray_rect.center_y() - flyout_size.height / 2.0;
+    }
+
+    x = clamp_to_bounds(x, flyout_size.width, work_area.x, work_area.right());
+    y = clamp_to_bounds(y, flyout_size.height, work_area.y, work_area.bottom());
+  }
+
+  PhysicalPosition::new(x.round(), y.round())
+}
+
+fn clamp_to_bounds(value: f64, size: f64, min: f64, max: f64) -> f64 {
+  let max_start = max - size;
+
+  if max_start < min {
+    min
+  } else {
+    value.clamp(min, max_start)
+  }
 }
 
 fn emit_flyout_frame(app_handle: &AppHandle, frame: &WindowsFlyoutFrame) {
@@ -387,6 +481,32 @@ fn state_name(state: MetricState) -> &'static str {
     MetricState::Normal => "normal",
     MetricState::Warning => "warning",
     MetricState::Critical => "critical",
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct PhysicalRectF {
+  x: f64,
+  y: f64,
+  width: f64,
+  height: f64,
+}
+
+impl PhysicalRectF {
+  fn right(self) -> f64 {
+    self.x + self.width
+  }
+
+  fn bottom(self) -> f64 {
+    self.y + self.height
+  }
+
+  fn center_x(self) -> f64 {
+    self.x + self.width / 2.0
+  }
+
+  fn center_y(self) -> f64 {
+    self.y + self.height / 2.0
   }
 }
 
@@ -854,10 +974,66 @@ mod tests {
   }
 
   #[test]
-  fn flyout_position_opens_above_the_tray_click() {
-    let position = flyout_position(PhysicalPosition::new(1920.0, 1080.0));
+  fn flyout_position_opens_above_a_bottom_taskbar_tray_rect() {
+    let position = flyout_position(
+      PhysicalRectF {
+        x: 1880.0,
+        y: 1048.0,
+        width: 32.0,
+        height: 32.0,
+      },
+      Some(PhysicalRectF {
+        x: 0.0,
+        y: 0.0,
+        width: 1920.0,
+        height: 1040.0,
+      }),
+      PhysicalSize::new(300.0, 148.0),
+      12.0,
+    );
 
-    assert_eq!(position.x, 1648.0);
-    assert_eq!(position.y, 920.0);
+    assert_eq!(position.x, 1612.0);
+    assert_eq!(position.y, 888.0);
+  }
+
+  #[test]
+  fn flyout_position_does_not_clamp_unknown_monitor_to_zero() {
+    let position = flyout_position(
+      PhysicalRectF {
+        x: -80.0,
+        y: 1048.0,
+        width: 32.0,
+        height: 32.0,
+      },
+      None,
+      PhysicalSize::new(300.0, 148.0),
+      12.0,
+    );
+
+    assert_eq!(position.x, -348.0);
+    assert_eq!(position.y, 888.0);
+  }
+
+  #[test]
+  fn flyout_position_opens_below_a_top_taskbar_tray_rect() {
+    let position = flyout_position(
+      PhysicalRectF {
+        x: 944.0,
+        y: 0.0,
+        width: 32.0,
+        height: 32.0,
+      },
+      Some(PhysicalRectF {
+        x: 0.0,
+        y: 40.0,
+        width: 1920.0,
+        height: 1040.0,
+      }),
+      PhysicalSize::new(300.0, 148.0),
+      12.0,
+    );
+
+    assert_eq!(position.x, 810.0);
+    assert_eq!(position.y, 44.0);
   }
 }

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -811,7 +811,7 @@ mod tests {
       image
         .rgba()
         .chunks_exact(4)
-        .any(|pixel| &pixel[0..3] == &CRITICAL_COLOR.0[0..3] && pixel[3] > 0)
+        .any(|pixel| pixel[0..3] == CRITICAL_COLOR.0[0..3] && pixel[3] > 0)
     );
   }
 
@@ -829,7 +829,7 @@ mod tests {
       image
         .rgba()
         .chunks_exact(4)
-        .any(|pixel| &pixel[0..3] == &ICON_COLOR.0[0..3] && pixel[3] > 0)
+        .any(|pixel| pixel[0..3] == ICON_COLOR.0[0..3] && pixel[3] > 0)
     );
   }
 

--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -73,7 +73,7 @@ impl TrayWidgetSettings {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MetricState {
   Normal,
   Warning,

--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -9,7 +9,8 @@ pub const STORE_KEY_TRAY_WIDGET: &str = "trayWidget";
 
 const DEFAULT_UPDATE_INTERVAL_SECS: u64 = 1;
 const UPDATE_INTERVALS_SECS: [u64; 3] = [1, 2, 5];
-const CONFIGURABLE_METRICS: [TrayMetric; 2] = [TrayMetric::Cpu, TrayMetric::Gpu];
+const CONFIGURABLE_METRICS: [TrayMetric; 3] =
+  [TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -595,11 +596,11 @@ mod tests {
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu]
+      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu]
+      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp]
     );
     assert_eq!(settings.update_interval_secs, 1);
   }
@@ -664,9 +665,12 @@ mod tests {
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu]
+      vec![TrayMetric::Temp, TrayMetric::Cpu, TrayMetric::Gpu]
     );
-    assert_eq!(settings.visible_metrics, vec![TrayMetric::Cpu]);
+    assert_eq!(
+      settings.visible_metrics,
+      vec![TrayMetric::Temp, TrayMetric::Cpu]
+    );
   }
 
   #[test]
@@ -681,16 +685,16 @@ mod tests {
     assert_eq!(settings.update_interval_secs, 1);
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      vec![TrayMetric::Gpu, TrayMetric::Temp, TrayMetric::Cpu]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      vec![TrayMetric::Gpu, TrayMetric::Temp, TrayMetric::Cpu]
     );
   }
 
   #[test]
-  fn normalizes_temperature_out_of_current_store_shape() {
+  fn keeps_temperature_in_current_store_shape() {
     let settings = TrayWidgetSettings {
       enabled: true,
       metric_order: vec![TrayMetric::Temp, TrayMetric::Gpu],
@@ -702,8 +706,11 @@ mod tests {
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      vec![TrayMetric::Temp, TrayMetric::Gpu, TrayMetric::Cpu]
     );
-    assert_eq!(settings.visible_metrics, vec![TrayMetric::Gpu]);
+    assert_eq!(
+      settings.visible_metrics,
+      vec![TrayMetric::Temp, TrayMetric::Gpu]
+    );
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
   GearIcon,
   SquaresFourIcon,
 } from "@phosphor-icons/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";
 import { clearTauriStore } from "@/lib/tauriStore";
@@ -35,6 +36,7 @@ import { FullScreenButton } from "./components/ui/FullScreenButton";
 import { FullscreenExitButton } from "./components/ui/FullScreenExit";
 import { useHardwareInfoAtom } from "./features/hardware/hooks/useHardwareInfoAtom";
 import { displayTargetAtom } from "./features/menu/hooks/useMenu";
+import { TrayWidgetFlyout } from "./features/tray/TrayWidgetFlyout";
 import { AppUpdate } from "./features/updater/AppUpdate";
 import { useFullScreenMode } from "./hooks/useFullScreenMode";
 import { useKeydown } from "./hooks/useInputListener";
@@ -65,11 +67,23 @@ const onError = (error: unknown, info: ErrorInfo) => {
 
 /** Outer wrapper to catch initialization errors */
 export const App = () => {
+  if (getCurrentWindowLabel() === "tray-widget-flyout") {
+    return <TrayWidgetFlyout />;
+  }
+
   return (
     <ErrorBoundary FallbackComponent={RootErrorFallback} onError={onRootError}>
       <AppContent />
     </ErrorBoundary>
   );
+};
+
+const getCurrentWindowLabel = () => {
+  try {
+    return getCurrentWindow().label;
+  } catch {
+    return "main";
+  }
 };
 
 /** Main app content with reset-capable error boundary */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,14 @@ const onError = (error: unknown, info: ErrorInfo) => {
 /** Outer wrapper to catch initialization errors */
 export const App = () => {
   if (getCurrentWindowLabel() === "tray-widget-flyout") {
-    return <TrayWidgetFlyout />;
+    return (
+      <ErrorBoundary
+        FallbackComponent={RootErrorFallback}
+        onError={onRootError}
+      >
+        <TrayWidgetFlyout />
+      </ErrorBoundary>
+    );
   }
 
   return (

--- a/src/features/settings/components/general/TrayWidgetSettings.test.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.test.tsx
@@ -34,6 +34,7 @@ vi.mock("react-i18next", () => ({
         "pages.settings.general.trayWidget.updateInterval": "Update interval",
         "pages.settings.general.trayWidget.metric.cpu": "CPU",
         "pages.settings.general.trayWidget.metric.gpu": "GPU",
+        "pages.settings.general.trayWidget.metric.temp": "Temperature",
         "pages.settings.general.trayWidget.dragMetric": `Drag ${params?.metric}`,
         "pages.settings.general.trayWidget.seconds": `${params?.count}s`,
       };
@@ -232,8 +233,8 @@ describe("TrayWidgetSettings normalization", () => {
 
     expect(settings).toEqual({
       enabled: false,
-      metricOrder: ["gpu", "cpu"],
-      visibleMetrics: ["gpu", "cpu"],
+      metricOrder: ["gpu", "temp", "cpu"],
+      visibleMetrics: ["gpu", "temp", "cpu"],
       updateIntervalSecs: 2,
     });
   });
@@ -248,15 +249,16 @@ describe("TrayWidgetSettings normalization", () => {
 
     expect(settings).toEqual({
       enabled: true,
-      metricOrder: ["gpu", "cpu"],
-      visibleMetrics: ["cpu"],
+      metricOrder: ["gpu", "cpu", "temp"],
+      visibleMetrics: ["cpu", "temp"],
       updateIntervalSecs: 1,
     });
   });
 
-  it("removes duplicate and non-configurable metrics from metric order", () => {
+  it("removes duplicate metrics from metric order", () => {
     expect(normalizeMetricOrder(["gpu", "temp", "gpu", "cpu"])).toEqual([
       "gpu",
+      "temp",
       "cpu",
     ]);
   });
@@ -292,8 +294,8 @@ describe("TrayWidgetSettings normalization", () => {
 
     expect(settings).toEqual({
       enabled: false,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -306,8 +308,8 @@ describe("TrayWidgetSettings", () => {
     mockAvailability(true);
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -319,8 +321,8 @@ describe("TrayWidgetSettings", () => {
   it("hides metric controls while the tray widget is disabled", () => {
     mockStore({
       enabled: false,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
 
@@ -347,6 +349,7 @@ describe("TrayWidgetSettings", () => {
     expect(screen.getByText("Metrics")).toBeInTheDocument();
     expect(screen.getByLabelText("GPU")).toBeChecked();
     expect(screen.getByLabelText("CPU")).not.toBeChecked();
+    expect(screen.getByLabelText("Temperature")).not.toBeChecked();
     expect(screen.getByLabelText("GPU")).toBeDisabled();
     expect(screen.getByLabelText("Update interval")).toHaveValue("2");
     expect(screen.getByRole("button", { name: "Drag GPU" })).toBeEnabled();
@@ -356,8 +359,8 @@ describe("TrayWidgetSettings", () => {
     const user = userEvent.setup();
     mockStore({
       enabled: false,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
 
@@ -367,8 +370,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -382,8 +385,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "temp"],
       updateIntervalSecs: 1,
     });
 
@@ -391,7 +394,7 @@ describe("TrayWidgetSettings", () => {
     setSettings.mockClear();
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
       visibleMetrics: ["cpu"],
       updateIntervalSecs: 1,
     });
@@ -406,7 +409,7 @@ describe("TrayWidgetSettings", () => {
     const user = userEvent.setup();
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
       visibleMetrics: ["cpu"],
       updateIntervalSecs: 1,
     });
@@ -417,7 +420,7 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
       visibleMetrics: ["cpu", "gpu"],
       updateIntervalSecs: 1,
     });
@@ -432,8 +435,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["cpu", "gpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 5,
     });
   });
@@ -449,8 +452,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["gpu", "cpu"],
-      visibleMetrics: ["cpu", "gpu"],
+      metricOrder: ["gpu", "cpu", "temp"],
+      visibleMetrics: ["cpu", "gpu", "temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -468,7 +471,7 @@ describe("TrayWidgetSettings", () => {
       over: null,
     });
     await mocks.latestDragEnd?.({
-      active: { id: "temp" },
+      active: { id: "memory" },
       over: { id: "cpu" },
     });
 

--- a/src/features/settings/components/general/TrayWidgetSettings.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.tsx
@@ -46,12 +46,12 @@ type PersistedTrayWidgetStore = Partial<TrayWidgetStore>;
 
 const DEFAULT_TRAY_WIDGET_SETTINGS: TrayWidgetStore = {
   enabled: false,
-  metricOrder: ["cpu", "gpu"],
-  visibleMetrics: ["cpu", "gpu"],
+  metricOrder: ["cpu", "gpu", "temp"],
+  visibleMetrics: ["cpu", "gpu", "temp"],
   updateIntervalSecs: 1,
 };
 
-const CONFIGURABLE_METRICS: TrayMetric[] = ["cpu", "gpu"];
+const CONFIGURABLE_METRICS: TrayMetric[] = ["cpu", "gpu", "temp"];
 const UPDATE_INTERVALS = [1, 2, 5] as const;
 
 export const TrayWidgetSettings = () => {

--- a/src/features/tray/TrayWidgetFlyout.test.tsx
+++ b/src/features/tray/TrayWidgetFlyout.test.tsx
@@ -1,0 +1,102 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrayWidgetFlyout } from "@/features/tray/TrayWidgetFlyout";
+
+type TrayWidgetFrameEvent = {
+  payload: {
+    items: Array<{
+      metric: "cpu" | "gpu" | "temp";
+      value: string;
+      state: "normal" | "warning" | "critical";
+    }>;
+    tooltip: string;
+  };
+};
+
+const mocks = vi.hoisted(() => ({
+  emit: vi.fn(),
+  listen: vi.fn(),
+  listeners: new Map<string, (event: TrayWidgetFrameEvent) => void>(),
+  translations: {
+    "trayWidgetFlyout.openMainWindow": "Open main window",
+    "trayWidgetFlyout.close": "Close tray widget",
+    "trayWidgetFlyout.noMetrics": "No tray metrics available",
+    "trayWidgetFlyout.metric.cpu": "CPU usage",
+    "trayWidgetFlyout.metric.gpu": "GPU usage",
+    "trayWidgetFlyout.metric.temp": "Temperature",
+  } as Record<string, string>,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
+  listen: mocks.listen,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => mocks.translations[key] ?? key,
+  }),
+}));
+
+const emitFrame = (event: TrayWidgetFrameEvent) => {
+  act(() => {
+    mocks.listeners.get("tray-widget-frame")?.(event);
+  });
+};
+
+describe("TrayWidgetFlyout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+    mocks.emit.mockResolvedValue(undefined);
+    mocks.listen.mockImplementation((eventName, handler) => {
+      mocks.listeners.set(eventName, handler);
+
+      return Promise.resolve(() => {
+        mocks.listeners.delete(eventName);
+      });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a localized empty state before the first tray frame", () => {
+    render(<TrayWidgetFlyout />);
+
+    expect(screen.getByText("No tray metrics available")).toBeInTheDocument();
+  });
+
+  it("listens for tray frames and renders localized metric rows", async () => {
+    render(<TrayWidgetFlyout />);
+
+    await waitFor(() => expect(mocks.listen).toHaveBeenCalled());
+    emitFrame({
+      payload: {
+        items: [
+          { metric: "cpu", value: "42%", state: "normal" },
+          { metric: "temp", value: "84C", state: "warning" },
+        ],
+        tooltip: "CPU usage: 42%",
+      },
+    });
+
+    expect(screen.getByText("CPU usage")).toBeInTheDocument();
+    expect(screen.getByText("42%")).toBeInTheDocument();
+    expect(screen.getByText("Temperature")).toBeInTheDocument();
+    expect(screen.getByText("84C")).toBeInTheDocument();
+  });
+
+  it("emits window action events from the header buttons", async () => {
+    const user = userEvent.setup();
+    render(<TrayWidgetFlyout />);
+
+    await user.click(screen.getByRole("button", { name: "Open main window" }));
+    await user.click(screen.getByRole("button", { name: "Close tray widget" }));
+
+    expect(mocks.emit).toHaveBeenCalledWith("tray-widget-open-main-requested");
+    expect(mocks.emit).toHaveBeenCalledWith("tray-widget-hide-requested");
+  });
+});

--- a/src/features/tray/TrayWidgetFlyout.tsx
+++ b/src/features/tray/TrayWidgetFlyout.tsx
@@ -1,0 +1,156 @@
+import { emit, listen } from "@tauri-apps/api/event";
+import { Cpu, ExternalLink, Gpu, Thermometer, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+const EVENT_TRAY_WIDGET_FRAME = "tray-widget-frame";
+const EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED = "tray-widget-open-main-requested";
+const EVENT_TRAY_WIDGET_HIDE_REQUESTED = "tray-widget-hide-requested";
+
+type TrayMetric = "cpu" | "gpu" | "temp";
+type TrayMetricState = "normal" | "warning" | "critical";
+
+type TrayWidgetFlyoutItem = {
+  metric: TrayMetric;
+  value: string;
+  state: TrayMetricState;
+};
+
+type TrayWidgetFlyoutFrame = {
+  items: TrayWidgetFlyoutItem[];
+  tooltip: string;
+};
+
+const INITIAL_FRAME: TrayWidgetFlyoutFrame = {
+  items: [],
+  tooltip: "HardwareVisualizer",
+};
+
+export const TrayWidgetFlyout = () => {
+  const [frame, setFrame] = useState<TrayWidgetFlyoutFrame>(INITIAL_FRAME);
+  const worstState = useMemo(() => getWorstState(frame.items), [frame.items]);
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    let disposed = false;
+
+    listen<TrayWidgetFlyoutFrame>(EVENT_TRAY_WIDGET_FRAME, (event) => {
+      setFrame(event.payload);
+    })
+      .then((unlisten) => {
+        if (disposed) {
+          unlisten();
+          return;
+        }
+        cleanup = unlisten;
+      })
+      .catch((error) => {
+        console.error("Failed to listen for tray widget frame:", error);
+      });
+
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, []);
+
+  return (
+    <main className="flex h-screen w-screen flex-col overflow-hidden border border-zinc-700/80 bg-zinc-950 px-3 py-2 text-zinc-100 shadow-2xl">
+      <header className="flex h-8 shrink-0 items-center justify-between gap-2 border-zinc-800 border-b">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={`size-2 rounded-full ${stateDotClass[worstState]}`}
+          />
+          <h1 className="truncate font-medium text-[13px] leading-none">
+            HardwareVisualizer
+          </h1>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            aria-label="Open main window"
+            className="flex size-7 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-50"
+            onClick={() => emit(EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED)}
+            type="button"
+          >
+            <ExternalLink className="size-4" />
+          </button>
+          <button
+            aria-label="Close tray widget"
+            className="flex size-7 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-50"
+            onClick={() => emit(EVENT_TRAY_WIDGET_HIDE_REQUESTED)}
+            type="button"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </header>
+
+      <section className="grid flex-1 content-center gap-1 py-2">
+        {frame.items.length > 0 ? (
+          frame.items.map((item) => <MetricRow item={item} key={item.metric} />)
+        ) : (
+          <p className="px-1 text-center text-sm text-zinc-400">
+            No tray metrics available
+          </p>
+        )}
+      </section>
+    </main>
+  );
+};
+
+const MetricRow = ({ item }: { item: TrayWidgetFlyoutItem }) => {
+  const Icon = metricIcon[item.metric];
+
+  return (
+    <div className="grid min-h-8 grid-cols-[28px_1fr_auto] items-center gap-2 rounded px-1.5">
+      <div className="flex size-7 items-center justify-center rounded bg-zinc-900 text-zinc-300">
+        <Icon className="size-4" />
+      </div>
+      <span className="truncate text-[13px] text-zinc-400">
+        {metricLabel[item.metric]}
+      </span>
+      <strong
+        className={`font-semibold text-base tabular-nums leading-none ${stateTextClass[item.state]}`}
+      >
+        {item.value}
+      </strong>
+    </div>
+  );
+};
+
+const metricLabel: Record<TrayMetric, string> = {
+  cpu: "CPU",
+  gpu: "GPU",
+  temp: "Temp",
+};
+
+const metricIcon = {
+  cpu: Cpu,
+  gpu: Gpu,
+  temp: Thermometer,
+};
+
+const stateTextClass: Record<TrayMetricState, string> = {
+  normal: "text-zinc-50",
+  warning: "text-amber-400",
+  critical: "text-red-400",
+};
+
+const stateDotClass: Record<TrayMetricState, string> = {
+  normal: "bg-zinc-400",
+  warning: "bg-amber-400",
+  critical: "bg-red-500",
+};
+
+const stateRank: Record<TrayMetricState, number> = {
+  normal: 0,
+  warning: 1,
+  critical: 2,
+};
+
+const getWorstState = (items: TrayWidgetFlyoutItem[]): TrayMetricState => {
+  return items.reduce<TrayMetricState>(
+    (worst, item) =>
+      stateRank[item.state] > stateRank[worst] ? item.state : worst,
+    "normal",
+  );
+};

--- a/src/features/tray/TrayWidgetFlyout.tsx
+++ b/src/features/tray/TrayWidgetFlyout.tsx
@@ -1,6 +1,7 @@
 import { emit, listen } from "@tauri-apps/api/event";
 import { Cpu, ExternalLink, Gpu, Thermometer, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 const EVENT_TRAY_WIDGET_FRAME = "tray-widget-frame";
 const EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED = "tray-widget-open-main-requested";
@@ -26,6 +27,7 @@ const INITIAL_FRAME: TrayWidgetFlyoutFrame = {
 };
 
 export const TrayWidgetFlyout = () => {
+  const { t } = useTranslation();
   const [frame, setFrame] = useState<TrayWidgetFlyoutFrame>(INITIAL_FRAME);
   const worstState = useMemo(() => getWorstState(frame.items), [frame.items]);
 
@@ -66,7 +68,7 @@ export const TrayWidgetFlyout = () => {
         </div>
         <div className="flex items-center gap-1">
           <button
-            aria-label="Open main window"
+            aria-label={t("trayWidgetFlyout.openMainWindow")}
             className="flex size-7 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-50"
             onClick={() => emit(EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED)}
             type="button"
@@ -74,7 +76,7 @@ export const TrayWidgetFlyout = () => {
             <ExternalLink className="size-4" />
           </button>
           <button
-            aria-label="Close tray widget"
+            aria-label={t("trayWidgetFlyout.close")}
             className="flex size-7 items-center justify-center rounded text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-50"
             onClick={() => emit(EVENT_TRAY_WIDGET_HIDE_REQUESTED)}
             type="button"
@@ -89,7 +91,7 @@ export const TrayWidgetFlyout = () => {
           frame.items.map((item) => <MetricRow item={item} key={item.metric} />)
         ) : (
           <p className="px-1 text-center text-sm text-zinc-400">
-            No tray metrics available
+            {t("trayWidgetFlyout.noMetrics")}
           </p>
         )}
       </section>
@@ -98,6 +100,7 @@ export const TrayWidgetFlyout = () => {
 };
 
 const MetricRow = ({ item }: { item: TrayWidgetFlyoutItem }) => {
+  const { t } = useTranslation();
   const Icon = metricIcon[item.metric];
 
   return (
@@ -106,7 +109,7 @@ const MetricRow = ({ item }: { item: TrayWidgetFlyoutItem }) => {
         <Icon className="size-4" />
       </div>
       <span className="truncate text-[13px] text-zinc-400">
-        {metricLabel[item.metric]}
+        {t(`trayWidgetFlyout.metric.${item.metric}`)}
       </span>
       <strong
         className={`font-semibold text-base tabular-nums leading-none ${stateTextClass[item.state]}`}
@@ -115,12 +118,6 @@ const MetricRow = ({ item }: { item: TrayWidgetFlyoutItem }) => {
       </strong>
     </div>
   );
-};
-
-const metricLabel: Record<TrayMetric, string> = {
-  cpu: "CPU",
-  gpu: "GPU",
-  temp: "Temp",
 };
 
 const metricIcon = {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -114,6 +114,17 @@
     "title": "Title"
   },
 
+  "trayWidgetFlyout": {
+    "openMainWindow": "Open main window",
+    "close": "Close tray widget",
+    "noMetrics": "No tray metrics available",
+    "metric": {
+      "cpu": "CPU usage",
+      "gpu": "GPU usage",
+      "temp": "Temperature"
+    }
+  },
+
   "errorBoundary": {
     "title": "An unexpected error has occurred",
     "description": "Reset the UI and settings, or report this issue if it persists.",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -114,6 +114,17 @@
     "title": "タイトル"
   },
 
+  "trayWidgetFlyout": {
+    "openMainWindow": "メインウィンドウを開く",
+    "close": "トレイウィジェットを閉じる",
+    "noMetrics": "表示できるトレイメトリクスがありません",
+    "metric": {
+      "cpu": "CPU使用率",
+      "gpu": "GPU使用率",
+      "temp": "温度"
+    }
+  },
+
   "errorBoundary": {
     "title": "予期しないエラーが発生しました",
     "description": "UI と設定をリセットするか、問題が続く場合は報告してください。",


### PR DESCRIPTION
## Summary
- add a Windows-specific tray surface that shows the HardwareVisualizer outline icon tinted by metric state
- move readable CPU/GPU/temperature values into a small tray flyout window
- keep right-click Open/Quit behavior and add a minimal flyout capability

Closes #1401

## Validation
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml tray::
- tsc --noEmit
- biome check src/App.tsx src/features/tray/TrayWidgetFlyout.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows tray widget flyout: displays CPU, GPU, and Temperature metrics with severity indicators, quick actions to open the app or dismiss, auto-hides on blur, and updates icon/tooltip based on worst metric.
  * App renders a dedicated flyout window label so the flyout UI shows independently of the main window.

* **Chores**
  * Enabled a Windows-only capability to support the tray widget.

* **Tests**
  * Added UI and unit tests covering flyout behavior, icon rendering, and settings normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->