### PR TITLE
fix: refine tray widget GPU temperature metric

### DIFF
--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -9,6 +9,10 @@ pub const STORE_KEY_TRAY_WIDGET: &str = "trayWidget";
 
 const DEFAULT_UPDATE_INTERVAL_SECS: u64 = 1;
 const UPDATE_INTERVALS_SECS: [u64; 3] = [1, 2, 5];
+
+#[cfg(target_os = "macos")]
+const CONFIGURABLE_METRICS: [TrayMetric; 2] = [TrayMetric::Cpu, TrayMetric::Gpu];
+#[cfg(not(target_os = "macos"))]
 const CONFIGURABLE_METRICS: [TrayMetric; 3] =
   [TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp];
 
@@ -17,6 +21,7 @@ const CONFIGURABLE_METRICS: [TrayMetric; 3] =
 pub enum TrayMetric {
   Cpu,
   Gpu,
+  #[serde(alias = "temp")]
   GpuTemp,
 }
 
@@ -594,14 +599,8 @@ mod tests {
     }
     .normalized();
 
-    assert_eq!(
-      settings.metric_order,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp]
-    );
-    assert_eq!(
-      settings.visible_metrics,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp]
-    );
+    assert_eq!(settings.metric_order, CONFIGURABLE_METRICS.to_vec());
+    assert_eq!(settings.visible_metrics, CONFIGURABLE_METRICS.to_vec());
     assert_eq!(settings.update_interval_secs, 1);
   }
 
@@ -663,14 +662,55 @@ mod tests {
     }
     .normalized();
 
-    assert_eq!(
-      settings.metric_order,
-      vec![TrayMetric::GpuTemp, TrayMetric::Cpu, TrayMetric::Gpu]
-    );
-    assert_eq!(
-      settings.visible_metrics,
-      vec![TrayMetric::GpuTemp, TrayMetric::Cpu]
-    );
+    #[cfg(target_os = "macos")]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Cpu, TrayMetric::Gpu]
+      );
+      assert_eq!(settings.visible_metrics, vec![TrayMetric::Cpu]);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::GpuTemp, TrayMetric::Cpu, TrayMetric::Gpu]
+      );
+      assert_eq!(
+        settings.visible_metrics,
+        vec![TrayMetric::GpuTemp, TrayMetric::Cpu]
+      );
+    }
+  }
+
+  #[test]
+  fn deserializes_old_temperature_metric_key() {
+    let settings = serde_json::from_value::<TrayWidgetSettings>(serde_json::json!({
+      "metricOrder": ["gpu", "temp", "cpu"],
+      "visibleMetrics": ["temp", "gpu"]
+    }))
+    .expect("old tray widget temperature metric key should deserialize")
+    .normalized();
+
+    #[cfg(target_os = "macos")]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      );
+      assert_eq!(settings.visible_metrics, vec![TrayMetric::Gpu]);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
+      );
+      assert_eq!(
+        settings.visible_metrics,
+        vec![TrayMetric::GpuTemp, TrayMetric::Gpu]
+      );
+    }
   }
 
   #[test]
@@ -683,14 +723,28 @@ mod tests {
 
     assert!(!settings.enabled);
     assert_eq!(settings.update_interval_secs, 1);
-    assert_eq!(
-      settings.metric_order,
-      vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
-    );
-    assert_eq!(
-      settings.visible_metrics,
-      vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
-    );
+    #[cfg(target_os = "macos")]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      );
+      assert_eq!(
+        settings.visible_metrics,
+        vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      );
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
+      );
+      assert_eq!(
+        settings.visible_metrics,
+        vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
+      );
+    }
   }
 
   #[test]
@@ -704,13 +758,24 @@ mod tests {
     }
     .normalized();
 
-    assert_eq!(
-      settings.metric_order,
-      vec![TrayMetric::GpuTemp, TrayMetric::Gpu, TrayMetric::Cpu]
-    );
-    assert_eq!(
-      settings.visible_metrics,
-      vec![TrayMetric::GpuTemp, TrayMetric::Gpu]
-    );
+    #[cfg(target_os = "macos")]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::Gpu, TrayMetric::Cpu]
+      );
+      assert_eq!(settings.visible_metrics, vec![TrayMetric::Gpu]);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+      assert_eq!(
+        settings.metric_order,
+        vec![TrayMetric::GpuTemp, TrayMetric::Gpu, TrayMetric::Cpu]
+      );
+      assert_eq!(
+        settings.visible_metrics,
+        vec![TrayMetric::GpuTemp, TrayMetric::Gpu]
+      );
+    }
   }
 }

--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -10,14 +10,14 @@ pub const STORE_KEY_TRAY_WIDGET: &str = "trayWidget";
 const DEFAULT_UPDATE_INTERVAL_SECS: u64 = 1;
 const UPDATE_INTERVALS_SECS: [u64; 3] = [1, 2, 5];
 const CONFIGURABLE_METRICS: [TrayMetric; 3] =
-  [TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp];
+  [TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub enum TrayMetric {
   Cpu,
   Gpu,
-  Temp,
+  GpuTemp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -173,7 +173,7 @@ pub fn collect_samples(
     .filter_map(|metric| match metric {
       TrayMetric::Cpu => Some((*metric, snapshot.cpu_usage)),
       TrayMetric::Gpu => max_gpu_usage(snapshot).map(|value| (*metric, value)),
-      TrayMetric::Temp => {
+      TrayMetric::GpuTemp => {
         hottest_temperature_celsius(snapshot).map(|value| (*metric, value))
       }
     })
@@ -233,7 +233,7 @@ pub fn classify_metric_state(metric: TrayMetric, value: f32) -> MetricState {
   match metric {
     TrayMetric::Cpu => classify(value, 70.0, 85.0),
     TrayMetric::Gpu => classify(value, 70.0, 90.0),
-    TrayMetric::Temp => classify(value, 70.0, 85.0),
+    TrayMetric::GpuTemp => classify(value, 70.0, 85.0),
   }
 }
 
@@ -316,10 +316,10 @@ fn metric_icon_config(metric: TrayMetric) -> TrayMetricIcon {
       macos_symbol_name: "display",
       accessibility_label: "GPU usage",
     },
-    TrayMetric::Temp => TrayMetricIcon {
+    TrayMetric::GpuTemp => TrayMetricIcon {
       fallback_label: "TEMP",
       macos_symbol_name: "thermometer",
-      accessibility_label: "Temperature",
+      accessibility_label: "GPU temperature",
     },
   }
 }
@@ -331,7 +331,7 @@ fn format_tooltip_sample(
   let label = match sample.metric {
     TrayMetric::Cpu => "CPU usage",
     TrayMetric::Gpu => "GPU usage",
-    TrayMetric::Temp => "Temperature",
+    TrayMetric::GpuTemp => "GPU temperature",
   };
 
   format!(
@@ -348,7 +348,7 @@ fn format_value(
 ) -> String {
   match metric {
     TrayMetric::Cpu | TrayMetric::Gpu => format!("{}%", value.round() as i32),
-    TrayMetric::Temp => {
+    TrayMetric::GpuTemp => {
       let (value, suffix) = match temperature_unit {
         TemperatureUnit::Celsius => (value, "C"),
         TemperatureUnit::Fahrenheit => (value * 9.0 / 5.0 + 32.0, "F"),
@@ -424,7 +424,7 @@ mod tests {
       MetricState::Critical
     );
     assert_eq!(
-      classify_metric_state(TrayMetric::Temp, 85.0),
+      classify_metric_state(TrayMetric::GpuTemp, 85.0),
       MetricState::Critical
     );
   }
@@ -596,11 +596,11 @@ mod tests {
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp]
+      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::Temp]
+      vec![TrayMetric::Cpu, TrayMetric::Gpu, TrayMetric::GpuTemp]
     );
     assert_eq!(settings.update_interval_secs, 1);
   }
@@ -638,7 +638,7 @@ mod tests {
   fn filters_visible_metrics_by_metric_order() {
     let settings = TrayWidgetSettings {
       enabled: true,
-      metric_order: vec![TrayMetric::Temp, TrayMetric::Cpu, TrayMetric::Gpu],
+      metric_order: vec![TrayMetric::GpuTemp, TrayMetric::Cpu, TrayMetric::Gpu],
       visible_metrics: vec![TrayMetric::Gpu, TrayMetric::Cpu],
       update_interval_secs: 1,
       legacy_metrics: vec![],
@@ -659,24 +659,24 @@ mod tests {
       metric_order: vec![],
       visible_metrics: vec![],
       update_interval_secs: 2,
-      legacy_metrics: vec![TrayMetric::Temp, TrayMetric::Cpu],
+      legacy_metrics: vec![TrayMetric::GpuTemp, TrayMetric::Cpu],
     }
     .normalized();
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Temp, TrayMetric::Cpu, TrayMetric::Gpu]
+      vec![TrayMetric::GpuTemp, TrayMetric::Cpu, TrayMetric::Gpu]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Temp, TrayMetric::Cpu]
+      vec![TrayMetric::GpuTemp, TrayMetric::Cpu]
     );
   }
 
   #[test]
   fn deserializes_partial_legacy_store_shape() {
     let settings = serde_json::from_value::<TrayWidgetSettings>(serde_json::json!({
-      "metrics": ["gpu", "temp", "cpu"]
+      "metrics": ["gpu", "gpu-temp", "cpu"]
     }))
     .expect("partial legacy tray widget settings should deserialize")
     .normalized();
@@ -685,11 +685,11 @@ mod tests {
     assert_eq!(settings.update_interval_secs, 1);
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Gpu, TrayMetric::Temp, TrayMetric::Cpu]
+      vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Gpu, TrayMetric::Temp, TrayMetric::Cpu]
+      vec![TrayMetric::Gpu, TrayMetric::GpuTemp, TrayMetric::Cpu]
     );
   }
 
@@ -697,8 +697,8 @@ mod tests {
   fn keeps_temperature_in_current_store_shape() {
     let settings = TrayWidgetSettings {
       enabled: true,
-      metric_order: vec![TrayMetric::Temp, TrayMetric::Gpu],
-      visible_metrics: vec![TrayMetric::Temp, TrayMetric::Gpu],
+      metric_order: vec![TrayMetric::GpuTemp, TrayMetric::Gpu],
+      visible_metrics: vec![TrayMetric::GpuTemp, TrayMetric::Gpu],
       update_interval_secs: 1,
       legacy_metrics: vec![],
     }
@@ -706,11 +706,11 @@ mod tests {
 
     assert_eq!(
       settings.metric_order,
-      vec![TrayMetric::Temp, TrayMetric::Gpu, TrayMetric::Cpu]
+      vec![TrayMetric::GpuTemp, TrayMetric::Gpu, TrayMetric::Cpu]
     );
     assert_eq!(
       settings.visible_metrics,
-      vec![TrayMetric::Temp, TrayMetric::Gpu]
+      vec![TrayMetric::GpuTemp, TrayMetric::Gpu]
     );
   }
 }

--- a/src/features/settings/components/general/TrayWidgetSettings.test.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
         over: { id: string } | null;
       }) => Promise<void>)
     | undefined,
+  platform: vi.fn(() => "windows"),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -34,7 +35,7 @@ vi.mock("react-i18next", () => ({
         "pages.settings.general.trayWidget.updateInterval": "Update interval",
         "pages.settings.general.trayWidget.metric.cpu": "CPU",
         "pages.settings.general.trayWidget.metric.gpu": "GPU",
-        "pages.settings.general.trayWidget.metric.temp": "Temperature",
+        "pages.settings.general.trayWidget.metric.gpu-temp": "GPU temperature",
         "pages.settings.general.trayWidget.dragMetric": `Drag ${params?.metric}`,
         "pages.settings.general.trayWidget.seconds": `${params?.count}s`,
       };
@@ -46,6 +47,10 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/hooks/useTauriStore", () => ({
   useTauriStore: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: mocks.platform,
 }));
 
 vi.mock("@/rspc/bindings", () => ({
@@ -227,14 +232,14 @@ describe("TrayWidgetSettings normalization", () => {
 
   it("normalizes legacy metrics into order and visibility", () => {
     const settings = normalizeSettings({
-      metrics: ["gpu", "temp", "cpu"],
+      metrics: ["gpu", "gpu-temp", "cpu"],
       updateIntervalSecs: 2,
     });
 
     expect(settings).toEqual({
       enabled: false,
-      metricOrder: ["gpu", "temp", "cpu"],
-      visibleMetrics: ["gpu", "temp", "cpu"],
+      metricOrder: ["gpu", "gpu-temp", "cpu"],
+      visibleMetrics: ["gpu", "gpu-temp", "cpu"],
       updateIntervalSecs: 2,
     });
   });
@@ -243,29 +248,57 @@ describe("TrayWidgetSettings normalization", () => {
     const settings = normalizeSettings({
       enabled: true,
       metricOrder: ["gpu", "cpu"],
-      visibleMetrics: ["cpu", "temp"],
+      visibleMetrics: ["cpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
 
     expect(settings).toEqual({
       enabled: true,
-      metricOrder: ["gpu", "cpu", "temp"],
-      visibleMetrics: ["cpu", "temp"],
+      metricOrder: ["gpu", "cpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu-temp"],
+      updateIntervalSecs: 1,
+    });
+  });
+
+  it("removes unavailable metrics from order and visibility", () => {
+    const settings = normalizeSettings(
+      {
+        enabled: true,
+        metricOrder: ["gpu-temp", "gpu", "cpu"],
+        visibleMetrics: ["gpu-temp", "gpu"],
+        updateIntervalSecs: 1,
+      },
+      ["gpu-temp"],
+    );
+
+    expect(settings).toEqual({
+      enabled: true,
+      metricOrder: ["gpu", "cpu"],
+      visibleMetrics: ["gpu"],
       updateIntervalSecs: 1,
     });
   });
 
   it("removes duplicate metrics from metric order", () => {
-    expect(normalizeMetricOrder(["gpu", "temp", "gpu", "cpu"])).toEqual([
+    expect(normalizeMetricOrder(["gpu", "gpu-temp", "gpu", "cpu"])).toEqual([
       "gpu",
-      "temp",
+      "gpu-temp",
       "cpu",
     ]);
   });
 
+  it("removes unavailable metrics from metric order", () => {
+    expect(
+      normalizeMetricOrder(["gpu", "gpu-temp", "cpu"], ["gpu-temp"]),
+    ).toEqual(["gpu", "cpu"]);
+  });
+
   it("removes duplicate and non-configurable visible metrics", () => {
     expect(
-      normalizeVisibleMetrics(["temp", "gpu", "gpu", "cpu"], ["cpu", "gpu"]),
+      normalizeVisibleMetrics(
+        ["gpu-temp", "gpu", "gpu", "cpu"],
+        ["cpu", "gpu"],
+      ),
     ).toEqual(["gpu", "cpu"]);
   });
 
@@ -283,7 +316,7 @@ describe("TrayWidgetSettings normalization", () => {
   });
 
   it("falls back to metric order when visible metrics normalize to empty", () => {
-    expect(normalizeVisibleMetrics(["temp"], ["gpu", "cpu"])).toEqual([
+    expect(normalizeVisibleMetrics(["gpu-temp"], ["gpu", "cpu"])).toEqual([
       "gpu",
       "cpu",
     ]);
@@ -294,8 +327,8 @@ describe("TrayWidgetSettings normalization", () => {
 
     expect(settings).toEqual({
       enabled: false,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -305,11 +338,12 @@ describe("TrayWidgetSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.latestDragEnd = undefined;
+    mocks.platform.mockReturnValue("windows");
     mockAvailability(true);
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -321,8 +355,8 @@ describe("TrayWidgetSettings", () => {
   it("hides metric controls while the tray widget is disabled", () => {
     mockStore({
       enabled: false,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
 
@@ -349,18 +383,31 @@ describe("TrayWidgetSettings", () => {
     expect(screen.getByText("Metrics")).toBeInTheDocument();
     expect(screen.getByLabelText("GPU")).toBeChecked();
     expect(screen.getByLabelText("CPU")).not.toBeChecked();
-    expect(screen.getByLabelText("Temperature")).not.toBeChecked();
+    expect(screen.getByLabelText("GPU temperature")).not.toBeChecked();
     expect(screen.getByLabelText("GPU")).toBeDisabled();
     expect(screen.getByLabelText("Update interval")).toHaveValue("2");
     expect(screen.getByRole("button", { name: "Drag GPU" })).toBeEnabled();
+  });
+
+  it("hides GPU temperature metric on macOS", () => {
+    mocks.platform.mockReturnValue("macos");
+
+    render(<TrayWidgetSettings />);
+
+    expect(screen.getByLabelText("CPU")).toBeChecked();
+    expect(screen.getByLabelText("GPU")).toBeChecked();
+    expect(screen.queryByLabelText("GPU temperature")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Drag GPU temperature" }),
+    ).not.toBeInTheDocument();
   });
 
   it("persists enabled changes", async () => {
     const user = userEvent.setup();
     mockStore({
       enabled: false,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
 
@@ -370,8 +417,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
   });
@@ -385,8 +432,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
 
@@ -394,7 +441,7 @@ describe("TrayWidgetSettings", () => {
     setSettings.mockClear();
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
       visibleMetrics: ["cpu"],
       updateIntervalSecs: 1,
     });
@@ -409,7 +456,7 @@ describe("TrayWidgetSettings", () => {
     const user = userEvent.setup();
     mockStore({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
       visibleMetrics: ["cpu"],
       updateIntervalSecs: 1,
     });
@@ -420,7 +467,7 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
       visibleMetrics: ["cpu", "gpu"],
       updateIntervalSecs: 1,
     });
@@ -435,8 +482,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["cpu", "gpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["cpu", "gpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 5,
     });
   });
@@ -452,8 +499,8 @@ describe("TrayWidgetSettings", () => {
 
     expect(setSettings).toHaveBeenCalledWith({
       enabled: true,
-      metricOrder: ["gpu", "cpu", "temp"],
-      visibleMetrics: ["cpu", "gpu", "temp"],
+      metricOrder: ["gpu", "cpu", "gpu-temp"],
+      visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
   });

--- a/src/features/settings/components/general/TrayWidgetSettings.test.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.test.tsx
@@ -244,6 +244,21 @@ describe("TrayWidgetSettings normalization", () => {
     });
   });
 
+  it("normalizes old temperature metric keys", () => {
+    const settings = normalizeSettings({
+      metricOrder: ["gpu", "temp", "cpu"],
+      visibleMetrics: ["temp", "gpu"],
+      updateIntervalSecs: 2,
+    });
+
+    expect(settings).toEqual({
+      enabled: false,
+      metricOrder: ["gpu", "gpu-temp", "cpu"],
+      visibleMetrics: ["gpu-temp", "gpu"],
+      updateIntervalSecs: 2,
+    });
+  });
+
   it("keeps metric order and filters visible metrics by that order", () => {
     const settings = normalizeSettings({
       enabled: true,

--- a/src/features/settings/components/general/TrayWidgetSettings.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.tsx
@@ -15,6 +15,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { platform } from "@tauri-apps/plugin-os";
 import { AlertTriangleIcon, GripVerticalIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,7 +33,7 @@ import { useTauriStore } from "@/hooks/useTauriStore";
 import { commands } from "@/rspc/bindings";
 import { isError } from "@/types/result";
 
-export type TrayMetric = "cpu" | "gpu" | "temp";
+export type TrayMetric = "cpu" | "gpu" | "gpu-temp";
 
 export type TrayWidgetStore = {
   enabled: boolean;
@@ -46,16 +47,19 @@ type PersistedTrayWidgetStore = Partial<TrayWidgetStore>;
 
 const DEFAULT_TRAY_WIDGET_SETTINGS: TrayWidgetStore = {
   enabled: false,
-  metricOrder: ["cpu", "gpu", "temp"],
-  visibleMetrics: ["cpu", "gpu", "temp"],
+  metricOrder: ["cpu", "gpu", "gpu-temp"],
+  visibleMetrics: ["cpu", "gpu", "gpu-temp"],
   updateIntervalSecs: 1,
 };
 
-const CONFIGURABLE_METRICS: TrayMetric[] = ["cpu", "gpu", "temp"];
+const CONFIGURABLE_METRICS: TrayMetric[] = ["cpu", "gpu", "gpu-temp"];
+const MACOS_UNAVAILABLE_METRICS: TrayMetric[] = ["gpu-temp"];
 const UPDATE_INTERVALS = [1, 2, 5] as const;
 
 export const TrayWidgetSettings = () => {
   const { t } = useTranslation();
+  const unavailableMetrics =
+    platform() === "macos" ? MACOS_UNAVAILABLE_METRICS : [];
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -68,7 +72,7 @@ export const TrayWidgetSettings = () => {
       DEFAULT_TRAY_WIDGET_SETTINGS,
     );
   const [isAvailable, setIsAvailable] = useState(true);
-  const normalizedSettings = normalizeSettings(settings);
+  const normalizedSettings = normalizeSettings(settings, unavailableMetrics);
 
   useEffect(() => {
     const checkAvailability = async () => {
@@ -315,6 +319,7 @@ const SortableMetricRow = ({
 
 export const normalizeSettings = (
   settings: PersistedTrayWidgetStore | null,
+  unavailableMetrics: TrayMetric[] = [],
 ): TrayWidgetStore | null => {
   if (!settings) {
     return null;
@@ -323,10 +328,12 @@ export const normalizeSettings = (
   const legacyMetrics = normalizeMetricList(settings.metrics ?? []);
   const metricOrder = normalizeMetricOrder(
     settings.metricOrder?.length ? settings.metricOrder : legacyMetrics,
+    unavailableMetrics,
   );
   const visibleMetrics = normalizeVisibleMetrics(
     settings.visibleMetrics?.length ? settings.visibleMetrics : legacyMetrics,
     metricOrder,
+    unavailableMetrics,
   );
   const updateIntervalSecs = settings.updateIntervalSecs;
 
@@ -344,11 +351,16 @@ export const normalizeSettings = (
   };
 };
 
-export const normalizeMetricOrder = (metrics: TrayMetric[]) => {
-  const metricOrder = normalizeMetricList(metrics);
+export const normalizeMetricOrder = (
+  metrics: TrayMetric[],
+  unavailableMetrics: TrayMetric[] = [],
+) => {
+  const metricOrder = normalizeMetricList(metrics).filter(
+    (metric) => !unavailableMetrics.includes(metric),
+  );
 
   for (const metric of CONFIGURABLE_METRICS) {
-    if (!metricOrder.includes(metric)) {
+    if (!unavailableMetrics.includes(metric) && !metricOrder.includes(metric)) {
       metricOrder.push(metric);
     }
   }
@@ -359,12 +371,17 @@ export const normalizeMetricOrder = (metrics: TrayMetric[]) => {
 export const normalizeVisibleMetrics = (
   metrics: TrayMetric[],
   metricOrder: TrayMetric[],
+  unavailableMetrics: TrayMetric[] = [],
 ) => {
-  const visibleMetrics = normalizeMetricList(metrics).filter((metric) =>
-    metricOrder.includes(metric),
+  const visibleMetrics = normalizeMetricList(metrics).filter(
+    (metric) =>
+      metricOrder.includes(metric) && !unavailableMetrics.includes(metric),
+  );
+  const fallbackMetrics = metricOrder.filter(
+    (metric) => !unavailableMetrics.includes(metric),
   );
 
-  return visibleMetrics.length > 0 ? visibleMetrics : metricOrder;
+  return visibleMetrics.length > 0 ? visibleMetrics : fallbackMetrics;
 };
 
 const normalizeMetricList = (metrics: TrayMetric[]) => {

--- a/src/features/settings/components/general/TrayWidgetSettings.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.tsx
@@ -34,6 +34,7 @@ import { commands } from "@/rspc/bindings";
 import { isError } from "@/types/result";
 
 export type TrayMetric = "cpu" | "gpu" | "gpu-temp";
+type PersistedTrayMetric = TrayMetric | "temp";
 
 export type TrayWidgetStore = {
   enabled: boolean;
@@ -43,7 +44,13 @@ export type TrayWidgetStore = {
   metrics?: TrayMetric[];
 };
 
-type PersistedTrayWidgetStore = Partial<TrayWidgetStore>;
+type PersistedTrayWidgetStore = Partial<
+  Omit<TrayWidgetStore, "metricOrder" | "visibleMetrics" | "metrics"> & {
+    metricOrder: PersistedTrayMetric[];
+    visibleMetrics: PersistedTrayMetric[];
+    metrics: PersistedTrayMetric[];
+  }
+>;
 
 const DEFAULT_TRAY_WIDGET_SETTINGS: TrayWidgetStore = {
   enabled: false,
@@ -352,7 +359,7 @@ export const normalizeSettings = (
 };
 
 export const normalizeMetricOrder = (
-  metrics: TrayMetric[],
+  metrics: PersistedTrayMetric[],
   unavailableMetrics: TrayMetric[] = [],
 ) => {
   const metricOrder = normalizeMetricList(metrics).filter(
@@ -369,7 +376,7 @@ export const normalizeMetricOrder = (
 };
 
 export const normalizeVisibleMetrics = (
-  metrics: TrayMetric[],
+  metrics: PersistedTrayMetric[],
   metricOrder: TrayMetric[],
   unavailableMetrics: TrayMetric[] = [],
 ) => {
@@ -384,10 +391,12 @@ export const normalizeVisibleMetrics = (
   return visibleMetrics.length > 0 ? visibleMetrics : fallbackMetrics;
 };
 
-const normalizeMetricList = (metrics: TrayMetric[]) => {
+const normalizeMetricList = (metrics: PersistedTrayMetric[]) => {
   const normalized: TrayMetric[] = [];
 
-  for (const metric of metrics) {
+  for (const persistedMetric of metrics) {
+    const metric = persistedMetric === "temp" ? "gpu-temp" : persistedMetric;
+
     if (CONFIGURABLE_METRICS.includes(metric) && !normalized.includes(metric)) {
       normalized.push(metric);
     }

--- a/src/features/tray/TrayWidgetFlyout.test.tsx
+++ b/src/features/tray/TrayWidgetFlyout.test.tsx
@@ -6,7 +6,7 @@ import { TrayWidgetFlyout } from "@/features/tray/TrayWidgetFlyout";
 type TrayWidgetFrameEvent = {
   payload: {
     items: Array<{
-      metric: "cpu" | "gpu" | "temp";
+      metric: "cpu" | "gpu" | "gpu-temp";
       value: string;
       state: "normal" | "warning" | "critical";
     }>;
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
     "trayWidgetFlyout.noMetrics": "No tray metrics available",
     "trayWidgetFlyout.metric.cpu": "CPU usage",
     "trayWidgetFlyout.metric.gpu": "GPU usage",
-    "trayWidgetFlyout.metric.temp": "Temperature",
+    "trayWidgetFlyout.metric.gpu-temp": "GPU temperature",
   } as Record<string, string>,
 }));
 
@@ -77,7 +77,7 @@ describe("TrayWidgetFlyout", () => {
       payload: {
         items: [
           { metric: "cpu", value: "42%", state: "normal" },
-          { metric: "temp", value: "84C", state: "warning" },
+          { metric: "gpu-temp", value: "84C", state: "warning" },
         ],
         tooltip: "CPU usage: 42%",
       },
@@ -85,7 +85,7 @@ describe("TrayWidgetFlyout", () => {
 
     expect(screen.getByText("CPU usage")).toBeInTheDocument();
     expect(screen.getByText("42%")).toBeInTheDocument();
-    expect(screen.getByText("Temperature")).toBeInTheDocument();
+    expect(screen.getByText("GPU temperature")).toBeInTheDocument();
     expect(screen.getByText("84C")).toBeInTheDocument();
   });
 

--- a/src/features/tray/TrayWidgetFlyout.tsx
+++ b/src/features/tray/TrayWidgetFlyout.tsx
@@ -7,7 +7,7 @@ const EVENT_TRAY_WIDGET_FRAME = "tray-widget-frame";
 const EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED = "tray-widget-open-main-requested";
 const EVENT_TRAY_WIDGET_HIDE_REQUESTED = "tray-widget-hide-requested";
 
-type TrayMetric = "cpu" | "gpu" | "temp";
+type TrayMetric = "cpu" | "gpu" | "gpu-temp";
 type TrayMetricState = "normal" | "warning" | "critical";
 
 type TrayWidgetFlyoutItem = {
@@ -123,7 +123,7 @@ const MetricRow = ({ item }: { item: TrayWidgetFlyoutItem }) => {
 const metricIcon = {
   cpu: Cpu,
   gpu: Gpu,
-  temp: Thermometer,
+  "gpu-temp": Thermometer,
 };
 
 const stateTextClass: Record<TrayMetricState, string> = {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -121,7 +121,7 @@
     "metric": {
       "cpu": "CPU usage",
       "gpu": "GPU usage",
-      "temp": "Temperature"
+      "gpu-temp": "GPU temperature"
     }
   },
 
@@ -229,7 +229,7 @@
           "metric": {
             "cpu": "CPU usage",
             "gpu": "GPU usage",
-            "temp": "Temperature"
+            "gpu-temp": "GPU temperature"
           }
         },
         "autostart": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -121,7 +121,7 @@
     "metric": {
       "cpu": "CPU使用率",
       "gpu": "GPU使用率",
-      "temp": "温度"
+      "gpu-temp": "GPU温度"
     }
   },
 
@@ -229,7 +229,7 @@
           "metric": {
             "cpu": "CPU使用率",
             "gpu": "GPU使用率",
-            "temp": "温度"
+            "gpu-temp": "GPU温度"
           }
         },
         "autostart": {


### PR DESCRIPTION
## Summary
- Rename the tray widget temperature metric key from `temp` to `gpu-temp` across frontend and backend tray code.
- Rename the user-facing tray widget temperature label to `GPU temperature` / `GPU温度`.
- Hide the GPU temperature metric from tray widget settings on macOS, where GPU temperature is not available.

## Validation
- `npx biome check src/features/settings/components/general/TrayWidgetSettings.tsx src/features/settings/components/general/TrayWidgetSettings.test.tsx src/features/tray/TrayWidgetFlyout.tsx src/features/tray/TrayWidgetFlyout.test.tsx src/lang/en.json src/lang/ja.json`
- `npx vitest run src/features/settings/components/general/TrayWidgetSettings.test.tsx src/features/tray/TrayWidgetFlyout.test.tsx`
- `cargo test -p hardware_visualizer tray::widget`
- `cargo fmt -p hardware_visualizer --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware tray metrics: OS-specific availability (macOS hides GPU temperature control).

* **Bug Fixes**
  * Temperature metric clarified as GPU temperature, preserves legacy settings/keys, and ensures GPU temperature values, labels and unit formatting display consistently.

* **Documentation**
  * Updated English and Japanese labels to show "GPU temperature" in the UI.

* **Tests**
  * Updated tests and UI specs to reflect the GPU temperature metric, legacy migration, ordering/visibility rules, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->