### PR TITLE
fix: enhance draft release handling in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,53 @@ on:
 permissions: read-all
 
 jobs:
+  prepare-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-slim
+    outputs:
+      release-id: ${{ steps.release.outputs.release_id }}
+    steps:
+      - name: Create or find draft release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_tag="${GITHUB_REF_NAME}"
+          is_prerelease=false
+          if [[ "$release_tag" == *-* ]]; then
+            is_prerelease=true
+          fi
+
+          echo "Looking for draft release with tag ${release_tag}..."
+          draft_release_id="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq ".[] | select(.tag_name == \"${release_tag}\" and .draft == true) | .id" \
+              | head -n 1
+          )"
+
+          if [ -z "$draft_release_id" ]; then
+            echo "No draft release found. Creating ${release_tag}..."
+            draft_release_id="$(
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
+                -f tag_name="$release_tag" \
+                -f name="$release_tag" \
+                -F draft=true \
+                -F prerelease="$is_prerelease" \
+                -F generate_release_notes=true \
+                --jq ".id"
+            )"
+          else
+            echo "Using existing draft release ${draft_release_id}."
+          fi
+
+          echo "release_id=$draft_release_id" >> "$GITHUB_OUTPUT"
+
   publish-tauri:
+    needs: prepare-release
     permissions:
       contents: write
     env:
@@ -132,10 +178,8 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
+          releaseId: ${{ needs.prepare-release.outputs.release-id }}
           tagName: ${{ github.ref_name }}
-          releaseName: ${{ github.ref_name }}
-          releaseDraft: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
           args: ${{ matrix.args }}
 
       - if: ${{ matrix.platform == 'windows-latest' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   prepare-release:
     permissions:
@@ -24,22 +28,27 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            echo "This workflow must be run on a tag ref." >&2
+            exit 1
+          fi
+
           release_tag="${GITHUB_REF_NAME}"
           is_prerelease=false
           if [[ "$release_tag" == *-* ]]; then
             is_prerelease=true
           fi
 
-          echo "Looking for draft release with tag ${release_tag}..."
-          draft_release_id="$(
+          echo "Looking for release with tag ${release_tag}..."
+          release_id="$(
             gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
-              --jq ".[] | select(.tag_name == \"${release_tag}\" and .draft == true) | .id" \
+              --jq ".[] | select(.tag_name == \"${release_tag}\") | .id" \
               | head -n 1
           )"
 
-          if [ -z "$draft_release_id" ]; then
-            echo "No draft release found. Creating ${release_tag}..."
-            draft_release_id="$(
+          if [ -z "$release_id" ]; then
+            echo "No release found. Creating draft release ${release_tag}..."
+            release_id="$(
               gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
                 -f tag_name="$release_tag" \
                 -f name="$release_tag" \
@@ -49,10 +58,10 @@ jobs:
                 --jq ".id"
             )"
           else
-            echo "Using existing draft release ${draft_release_id}."
+            echo "Using existing release ${release_id}."
           fi
 
-          echo "release_id=$draft_release_id" >> "$GITHUB_OUTPUT"
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
   publish-tauri:
     needs: prepare-release
@@ -202,7 +211,7 @@ jobs:
 
       - if: ${{ matrix.platform == 'windows-latest' }}
         name: Upload MSI via gh CLI
-        run: gh release upload "${{ github.ref_name }}" dist/offline/*.msi
+        run: gh release upload "${{ github.ref_name }}" dist/offline/*.msi --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -210,7 +219,7 @@ jobs:
       - name: Upload THIRD_PARTY_NOTICES.md
         run: |
           mv ./tmp/THIRD_PARTY_NOTICES.md ./tmp/THIRD_PARTY_NOTICES_${{ matrix.os-name }}.md
-          gh release upload "${{ github.ref_name }}" ./tmp/THIRD_PARTY_NOTICES_${{ matrix.os-name }}.md
+          gh release upload "${{ github.ref_name }}" ./tmp/THIRD_PARTY_NOTICES_${{ matrix.os-name }}.md --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash


### PR DESCRIPTION
## Summary

Enhance the publish workflow to improve handling of draft releases by creating or finding existing draft releases based on the release tag.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->

## Type of Change

- [x] Bug fix (`fix/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

- [x] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation: publishes are now serialized per tag to avoid concurrent conflicts.
  * Workflow auto-creates draft releases (with prerelease set for dashed versions) when needed and links release creation to the publish step.
  * Release asset uploads now safely overwrite existing files to ensure the latest artifacts are attached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->