### PR TITLE
fix: restore hidden window from macOS dock

### DIFF
--- a/src-tauri/src/adapters/tray.rs
+++ b/src-tauri/src/adapters/tray.rs
@@ -153,42 +153,6 @@ fn current_temperature_unit(app_handle: &AppHandle) -> TemperatureUnit {
     .unwrap_or(TemperatureUnit::Celsius)
 }
 
-pub(crate) fn restore_main_window(app: &AppHandle) {
-  let Some(window) = app.get_webview_window("main") else {
-    log_warn!(
-      "main window not found while handling tray Open",
-      "adapters::tray::restore_main_window",
-      None::<&str>
-    );
-    return;
-  };
-
-  // Best-effort: each call may legitimately fail (window already
-  // visible, already in the foreground, OS denying focus) without
-  // affecting the others. Logging keeps the trail without aborting.
-  if let Err(e) = window.show() {
-    log_warn!(
-      &format!("failed to show main window from tray: {e}"),
-      "adapters::tray::restore_main_window",
-      None::<&str>
-    );
-  }
-  if let Err(e) = window.unminimize() {
-    log_warn!(
-      &format!("failed to unminimize main window from tray: {e}"),
-      "adapters::tray::restore_main_window",
-      None::<&str>
-    );
-  }
-  if let Err(e) = window.set_focus() {
-    log_warn!(
-      &format!("failed to focus main window from tray: {e}"),
-      "adapters::tray::restore_main_window",
-      None::<&str>
-    );
-  }
-}
-
 pub(crate) fn spawn_quit(app: AppHandle) {
   // `request_quit` is async (it awaits worker termination); the menu
   // callback runs on the main thread and must return promptly, so we

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,6 +309,7 @@ pub fn run() {
   }
 
   tauri_builder
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .build(tauri::generate_context!())
+    .expect("error while building tauri application")
+    .run(lifecycle::on_run_event);
 }

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -93,6 +93,57 @@ pub fn on_close_requested(window: &Window) {
   });
 }
 
+/// Hook into app-level runtime events that affect the main window lifecycle.
+pub fn on_run_event(app: &tauri::AppHandle, event: tauri::RunEvent) {
+  #[cfg(target_os = "macos")]
+  if let tauri::RunEvent::Reopen {
+    has_visible_windows: false,
+    ..
+  } = event
+  {
+    restore_main_window(app);
+  }
+
+  #[cfg(not(target_os = "macos"))]
+  let _ = (app, event);
+}
+
+pub fn restore_main_window(app: &AppHandle) {
+  let Some(window) = app.get_webview_window("main") else {
+    log_warn!(
+      "main window not found while restoring app window",
+      "lifecycle::restore_main_window",
+      None::<&str>
+    );
+    return;
+  };
+
+  // Best-effort: each call may legitimately fail (window already
+  // visible, already in the foreground, OS denying focus) without
+  // affecting the others. Logging keeps the trail without aborting.
+  if let Err(e) = window.show() {
+    log_warn!(
+      &format!("failed to show main window: {e}"),
+      "lifecycle::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.unminimize() {
+    log_warn!(
+      &format!("failed to unminimize main window: {e}"),
+      "lifecycle::restore_main_window",
+      None::<&str>
+    );
+  }
+  if let Err(e) = window.set_focus() {
+    log_warn!(
+      &format!("failed to focus main window: {e}"),
+      "lifecycle::restore_main_window",
+      None::<&str>
+    );
+  }
+}
+
 /// Decide what closing the main window means.
 async fn handle_close_request(app: AppHandle, window: Window) {
   if should_close_to_background() {

--- a/src-tauri/src/tray/surface/macos.rs
+++ b/src-tauri/src/tray/surface/macos.rs
@@ -461,7 +461,7 @@ define_class!(
     fn perform(&self, _sender: Option<&AnyObject>) {
       match self.ivars().command {
         MacosTrayMenuCommand::Open => {
-          crate::adapters::tray::restore_main_window(&self.ivars().app_handle);
+          crate::lifecycle::restore_main_window(&self.ivars().app_handle);
         }
         MacosTrayMenuCommand::Quit => {
           crate::adapters::tray::spawn_quit(self.ivars().app_handle.clone());
@@ -522,7 +522,7 @@ define_class!(
     #[unsafe(method(mouseUp:))]
     fn mouse_up(&self, _event: &objc2_app_kit::NSEvent) {
       self.highlight(false);
-      crate::adapters::tray::restore_main_window(&self.ivars().app_handle);
+      crate::lifecycle::restore_main_window(&self.ivars().app_handle);
     }
 
     #[unsafe(method(rightMouseDown:))]

--- a/src-tauri/src/tray/surface/tauri_surface.rs
+++ b/src-tauri/src/tray/surface/tauri_surface.rs
@@ -70,7 +70,7 @@ impl TraySurface for TauriTraySurface {
 
 fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
   match event.id.as_ref() {
-    MENU_OPEN_ID => crate::adapters::tray::restore_main_window(app),
+    MENU_OPEN_ID => crate::lifecycle::restore_main_window(app),
     MENU_QUIT_ID => crate::adapters::tray::spawn_quit(app.clone()),
     other => {
       log_warn!(
@@ -92,6 +92,6 @@ fn handle_tray_event(tray: &TrayIcon, event: TrayIconEvent) {
     ..
   } = event
   {
-    crate::adapters::tray::restore_main_window(tray.app_handle());
+    crate::lifecycle::restore_main_window(tray.app_handle());
   }
 }

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -138,7 +138,7 @@ fn ensure_flyout_window(app_handle: &AppHandle) -> tauri::Result<WebviewWindow> 
 fn register_flyout_event_handlers(app_handle: &AppHandle) {
   let open_app = app_handle.clone();
   app_handle.listen_any(EVENT_TRAY_WIDGET_OPEN_MAIN_REQUESTED, move |_| {
-    crate::adapters::tray::restore_main_window(&open_app);
+    crate::lifecycle::restore_main_window(&open_app);
     hide_flyout_window(&open_app);
   });
 
@@ -150,7 +150,7 @@ fn register_flyout_event_handlers(app_handle: &AppHandle) {
 
 fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
   match event.id.as_ref() {
-    MENU_OPEN_ID => crate::adapters::tray::restore_main_window(app),
+    MENU_OPEN_ID => crate::lifecycle::restore_main_window(app),
     MENU_QUIT_ID => crate::adapters::tray::spawn_quit(app.clone()),
     other => {
       log_warn!(
@@ -179,7 +179,7 @@ fn handle_tray_event(
       toggle_flyout_window(app_handle, state, position, rect);
     } else {
       hide_flyout_window(app_handle);
-      crate::adapters::tray::restore_main_window(app_handle);
+      crate::lifecycle::restore_main_window(app_handle);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Handle macOS app reopen events so the hidden main window is restored when the Dock icon is clicked.
- Move the shared main-window restore behavior into `lifecycle::restore_main_window` and reuse it from tray surfaces.

## Why

When close-to-tray hides the main window on macOS, clicking the Dock icon emits Tauri's macOS `RunEvent::Reopen`. The app did not handle that event, so the window stayed hidden unless the user restored it from the menu bar tray icon.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml lifecycle::tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized app startup and lifecycle event handling to improve window restoration behavior. Enhanced macOS support for restoring the main window when reopening the application with no visible windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->