### PR TITLE
fix: prevent duplicate tray instances on relaunch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-sql",
  "tauri-plugin-store",
  "tauri-plugin-updater",
@@ -5807,6 +5808,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ async-trait = "0.1"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-opener = "2.5.3"
+tauri-plugin-single-instance = "2.4.2"
 
 [dependencies.uuid]
 version = "1.23.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,9 @@ pub fn run() {
 
   let mut tauri_builder = tauri::Builder::<Wry>::default()
     .invoke_handler(builder.invoke_handler())
+    .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+      lifecycle::on_second_instance(app);
+    }))
     .setup(move |app| {
       let path_resolver = app.path();
 

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -93,6 +93,11 @@ pub fn on_close_requested(window: &Window) {
   });
 }
 
+/// Hook into second launch attempts while this process is already running.
+pub fn on_second_instance(app: &tauri::AppHandle) {
+  restore_main_window(app);
+}
+
 /// Hook into app-level runtime events that affect the main window lifecycle.
 pub fn on_run_event(app: &tauri::AppHandle, event: tauri::RunEvent) {
   #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Add Tauri's single-instance plugin so a second launch is routed to the existing process.
- Restore the existing main window when a second launch attempt is received.

## Why

On Windows, close-to-tray keeps the first process alive. Launching the app again created a second process, which registered another tray icon and caused tray icon duplication.

This PR is stacked on #1457 so it can reuse `lifecycle::restore_main_window` without duplicating the macOS Dock reopen changes.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml lifecycle::tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-instance behavior: launching the app while it's already running now restores the existing window instead of opening a duplicate instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->