### PR TITLE
ci: use default branch OSV config for release scans

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -60,9 +60,31 @@ jobs:
 
           echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
 
+  upload-default-branch-osv-config:
+    name: Upload default branch OSV config
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Upload OSV config
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: default-branch-osv-config
+          path: osv-scanner.toml
+          if-no-files-found: error
+          retention-days: 1
+
   scan-latest-release:
     name: Scan latest release
-    needs: resolve-latest-release
+    needs:
+      - resolve-latest-release
+      - upload-default-branch-osv-config
     if: needs.resolve-latest-release.outputs.latest-tag != ''
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     permissions:
@@ -71,6 +93,7 @@ jobs:
       security-events: write
     with:
       ref: ${{ needs.resolve-latest-release.outputs.latest-tag }}
+      download-artifact: default-branch-osv-config
       scan-args: |-
         -r ./
       matrix-property: latest-release-


### PR DESCRIPTION
## Summary

- Add a small setup job that uploads `osv-scanner.toml` from the default branch.
- Make the latest stable release OSV scan download that artifact before scanning.
- Keep dependency discovery on the release tag while applying the current default-branch OSV ignore configuration.

## Validation

- `actionlint .github/workflows/osv-scan.yml`
- YAML parse check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration workflow for security scanning. Enhanced automated configuration artifact management to ensure consistent security verification across release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->