### PR TITLE
ci: avoid release OSV code scanning churn

### DIFF
--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -90,7 +90,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: write
     with:
       ref: ${{ needs.resolve-latest-release.outputs.latest-tag }}
       download-artifact: default-branch-osv-config
@@ -98,5 +97,5 @@ jobs:
         -r ./
       matrix-property: latest-release-
       results-file-name: osv-results.sarif
-      upload-sarif: true
-      fail-on-vuln: false
+      upload-sarif: false
+      fail-on-vuln: true


### PR DESCRIPTION
## Summary

- Stop uploading latest stable release OSV scan results to Code Scanning.
- Keep default branch OSV results in Code Scanning for ongoing `develop` visibility.
- Make latest stable release scans fail the scheduled workflow when unignored vulnerabilities are found.
- Remove `security-events: write` from the release scan job because it no longer uploads SARIF.

## Why

The latest release scan is intended to answer whether shipped assets have newly disclosed vulnerabilities and whether maintainers should cut a follow-up release sooner. Uploading release scan SARIF to Code Scanning causes alert churn against the default branch results, so the release signal is better represented as a scheduled Actions failure plus SARIF artifact.

## Validation

- `actionlint .github/workflows/osv-scan.yml`
- YAML parse check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration and permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->