### PR TITLE
fix: fall back to English for untranslated Russian text

### DIFF
--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -28,13 +28,14 @@ describe("i18n configuration", () => {
 
   it("should fall back to English for untranslated Russian keys", async () => {
     await i18n.changeLanguage("ru");
-
-    expect(i18n.t("pages.settings.general.trayWidget.name")).toBe(
-      "Tray widget",
-    );
-
-    // Reset to English for other tests
-    await i18n.changeLanguage("en");
+    try {
+      expect(i18n.t("pages.settings.general.trayWidget.name")).toBe(
+        "Tray widget",
+      );
+    } finally {
+      // Reset to English for other tests
+      await i18n.changeLanguage("en");
+    }
   });
 
   it("should have escapeValue disabled for interpolation", () => {

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -26,8 +26,23 @@ describe("i18n configuration", () => {
     await i18n.changeLanguage("en");
   });
 
+  it("should fall back to English for untranslated Russian keys", async () => {
+    await i18n.changeLanguage("ru");
+
+    expect(i18n.t("pages.settings.general.trayWidget.name")).toBe(
+      "Tray widget",
+    );
+
+    // Reset to English for other tests
+    await i18n.changeLanguage("en");
+  });
+
   it("should have escapeValue disabled for interpolation", () => {
     expect(i18n.options.interpolation?.escapeValue).toBe(false);
+  });
+
+  it("should fall back to English for empty translations", () => {
+    expect(i18n.options.returnEmptyString).toBe(false);
   });
 
   it("should use react-i18next plugin", () => {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -19,6 +19,8 @@ const resources = {
 i18n.use(initReactI18next).init({
   resources,
   lng: "en",
+  fallbackLng: "en",
+  returnEmptyString: false,
   interpolation: {
     escapeValue: false,
   },


### PR DESCRIPTION
## Summary

- Configure i18next to fall back to English when a Russian translation key is missing.
- Treat empty translation strings as missing so English text is shown instead.
- Add tests covering untranslated Russian keys and empty-string fallback behavior.

## Why

Russian localization is community-maintained and not fully supported. Untranslated UI should remain readable in English instead of showing raw translation keys or blank text.

## Validation

- `npx vitest run src/lib/i18n.test.ts`
- `npx biome check src/lib/i18n.ts src/lib/i18n.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering translation fallback to English and handling of empty translation strings.

* **Chores**
  * i18n configuration updated to fall back to English for missing translations and to avoid showing empty translation strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->