### PR TITLE
ci: add winget manifest submission workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: windows-latest
     env:
       PACKAGE_IDENTIFIER: shm11C3.HardwareVisualizer
+      WINGET_CREATE_VERSION: v1.12.8.0
+      WINGET_CREATE_SHA256: 8bd738851b524885410112678e3771b341c5c716de60fbbecb88ab0a363ed85d
       WINGET_CREATE_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
     steps:
       - name: Resolve release metadata
@@ -79,9 +81,18 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Download winget-create
+      - name: Download and verify winget-create
         shell: pwsh
-        run: Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $downloadUrl = "https://github.com/microsoft/winget-create/releases/download/$env:WINGET_CREATE_VERSION/wingetcreate.exe"
+          Invoke-WebRequest $downloadUrl -OutFile wingetcreate.exe
+
+          $actualHash = (Get-FileHash wingetcreate.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:WINGET_CREATE_SHA256) {
+            throw "wingetcreate.exe SHA256 mismatch. Expected $env:WINGET_CREATE_SHA256, got $actualHash."
+          }
 
       - name: Update WinGet manifest
         env:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -19,7 +19,8 @@ on:
         default: true
         type: boolean
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: winget-${{ github.event.release.tag_name || inputs.tag || 'latest' }}
@@ -34,7 +35,6 @@ jobs:
       PACKAGE_IDENTIFIER: shm11C3.HardwareVisualizer
       WINGET_CREATE_VERSION: v1.12.8.0
       WINGET_CREATE_SHA256: 8bd738851b524885410112678e3771b341c5c716de60fbbecb88ab0a363ed85d
-      WINGET_CREATE_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
     steps:
       - name: Resolve release metadata
         id: release
@@ -99,6 +99,7 @@ jobs:
           INSTALLER_URL: ${{ steps.release.outputs.installer-url }}
           VERSION: ${{ steps.release.outputs.version }}
           SHOULD_SUBMIT: ${{ inputs.submit || github.event_name == 'release' }}
+          WINGET_CREATE_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -65,7 +65,9 @@ jobs:
             if ($null -eq $asset) {
               throw "Release asset '$assetName' was not found on '$tag'."
             }
-            $installerUrl = $asset.url
+            $encodedTag = [System.Uri]::EscapeDataString($tag)
+            $encodedAssetName = [System.Uri]::EscapeDataString($assetName)
+            $installerUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$encodedTag/$encodedAssetName"
           }
 
           "tag=$tag" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -60,6 +60,14 @@ jobs:
 
           $version = $tag -replace '^v', ''
           $installerUrl = $env:INPUT_INSTALLER_URL
+          if (-not [string]::IsNullOrWhiteSpace($installerUrl)) {
+            if ($installerUrl -notmatch '^https://') {
+              throw 'inputs.installer-url must be an https:// URL to an .msi installer.'
+            }
+            if ($installerUrl -notmatch '\.msi($|[?#])') {
+              throw 'inputs.installer-url must be an https:// URL to an .msi installer.'
+            }
+          }
           if ([string]::IsNullOrWhiteSpace($installerUrl)) {
             $assetName = "HardwareVisualizer_${version}_x64_en-US.msi"
             $release = gh release view $tag --json assets | ConvertFrom-Json

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,108 @@
+name: Submit WinGet Manifest
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to submit, for example v1.7.0. Defaults to the latest release."
+        required: false
+        type: string
+      installer-url:
+        description: "Optional MSI URL override. Defaults to the release asset named HardwareVisualizer_{VERSION}_x64_en-US.msi."
+        required: false
+        type: string
+      submit:
+        description: "Submit a PR to microsoft/winget-pkgs. Disable for a dry run."
+        required: false
+        default: true
+        type: boolean
+
+permissions: read-all
+
+concurrency:
+  group: winget-${{ github.event.release.tag_name || inputs.tag || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  submit-winget:
+    name: Submit WinGet manifest
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: windows-latest
+    env:
+      PACKAGE_IDENTIFIER: shm11C3.HardwareVisualizer
+      WINGET_CREATE_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+    steps:
+      - name: Resolve release metadata
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_INSTALLER_URL: ${{ inputs['installer-url'] || '' }}
+          INPUT_TAG: ${{ inputs.tag || '' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $tag = $env:RELEASE_TAG
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            $tag = $env:INPUT_TAG
+          }
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            $tag = gh release view --json tagName --jq '.tagName'
+          }
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw 'Could not resolve a release tag.'
+          }
+
+          $version = $tag -replace '^v', ''
+          $installerUrl = $env:INPUT_INSTALLER_URL
+          if ([string]::IsNullOrWhiteSpace($installerUrl)) {
+            $assetName = "HardwareVisualizer_${version}_x64_en-US.msi"
+            $release = gh release view $tag --json assets | ConvertFrom-Json
+            $asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+            if ($null -eq $asset) {
+              throw "Release asset '$assetName' was not found on '$tag'."
+            }
+            $installerUrl = $asset.url
+          }
+
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "installer-url=$installerUrl" >> $env:GITHUB_OUTPUT
+
+      - name: Install .NET 6 runtime
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Download winget-create
+        shell: pwsh
+        run: Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Update WinGet manifest
+        env:
+          INSTALLER_URL: ${{ steps.release.outputs.installer-url }}
+          VERSION: ${{ steps.release.outputs.version }}
+          SHOULD_SUBMIT: ${{ inputs.submit || github.event_name == 'release' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $shouldSubmit = $env:SHOULD_SUBMIT -eq 'true'
+          $args = @(
+            'update',
+            $env:PACKAGE_IDENTIFIER,
+            '-u', $env:INSTALLER_URL,
+            '-v', $env:VERSION
+          )
+
+          if ($shouldSubmit) {
+            if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_TOKEN)) {
+              throw 'WINGET_CREATE_GITHUB_TOKEN repository secret is required when submit is enabled.'
+            }
+            $args += @('-t', $env:WINGET_CREATE_TOKEN, '--submit')
+          }
+
+          .\wingetcreate.exe @args


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that submits WinGet manifest updates with winget-create after stable GitHub Releases are published
- Resolve the MSI installer URL from the release asset named `HardwareVisualizer_{VERSION}_x64_en-US.msi`, with manual override support
- Skip automatic submission for GitHub pre-releases while keeping manual dispatch available

## Validation
- Ran `actionlint` against `.github/workflows/winget.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to submit or dry-run Windows Package Manager (WinGet) manifests when a release is published or manually triggered.
  * Supports specifying release tag, installer URL, and whether to perform an actual submission or a dry run.
  * Validates inputs, prepares required runtime/tooling, and requires a submission token for real submissions while defaulting to a safe dry run otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->