### PR TITLE
ci: resolve winget releases without checkout

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -52,7 +52,7 @@ jobs:
             $tag = $env:INPUT_TAG
           }
           if ([string]::IsNullOrWhiteSpace($tag)) {
-            $tag = gh release view --json tagName --jq '.tagName'
+            $tag = gh release view --repo $env:GITHUB_REPOSITORY --json tagName --jq '.tagName'
           }
           if ([string]::IsNullOrWhiteSpace($tag)) {
             throw 'Could not resolve a release tag.'
@@ -70,7 +70,7 @@ jobs:
           }
           if ([string]::IsNullOrWhiteSpace($installerUrl)) {
             $assetName = "HardwareVisualizer_${version}_x64_en-US.msi"
-            $release = gh release view $tag --json assets | ConvertFrom-Json
+            $release = gh release view $tag --repo $env:GITHUB_REPOSITORY --json assets | ConvertFrom-Json
             $asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
             if ($null -eq $asset) {
               throw "Release asset '$assetName' was not found on '$tag'."


### PR DESCRIPTION
## Summary
- Pass `--repo $env:GITHUB_REPOSITORY` to `gh release view` in the WinGet submission workflow
- Fix manual workflow runs where `gh` cannot infer the repository because the job does not checkout the repo

## Validation
- Ran `actionlint` against `.github/workflows/winget.yml`
- Verified `gh release view v1.8.0 --repo shm11C3/HardwareVisualizer --json assets` finds `HardwareVisualizer_1.8.0_x64_en-US.msi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Winget release workflow to explicitly specify repository context when fetching release information, improving workflow reliability and consistency across different execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->