### PR TITLE
ci: sync winget-pkgs fork before submit

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -107,6 +107,7 @@ jobs:
           INSTALLER_URL: ${{ steps.release.outputs.installer-url }}
           VERSION: ${{ steps.release.outputs.version }}
           SHOULD_SUBMIT: ${{ inputs.submit || github.event_name == 'release' }}
+          GH_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
           WINGET_CREATE_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
         shell: pwsh
         run: |
@@ -124,6 +125,7 @@ jobs:
             if ([string]::IsNullOrWhiteSpace($env:WINGET_CREATE_TOKEN)) {
               throw 'WINGET_CREATE_GITHUB_TOKEN repository secret is required when submit is enabled.'
             }
+            gh repo sync "$env:GITHUB_REPOSITORY_OWNER/winget-pkgs" --source microsoft/winget-pkgs --branch master
             $args += @('-t', $env:WINGET_CREATE_TOKEN, '--submit')
           }
 


### PR DESCRIPTION
## Summary
- Sync the `winget-pkgs` fork with `microsoft/winget-pkgs` before running `wingetcreate --submit`
- Avoid submission failures when winget-create cannot sync the fork itself

## Validation
- Ran `actionlint` against `.github/workflows/winget.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the package submission workflow with improved repository synchronization and authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->