### PR TITLE
ci: fail fast when winget fork sync fails

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -126,6 +126,9 @@ jobs:
               throw 'WINGET_CREATE_GITHUB_TOKEN repository secret is required when submit is enabled.'
             }
             gh repo sync "$env:GITHUB_REPOSITORY_OWNER/winget-pkgs" --source microsoft/winget-pkgs --branch master
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Failed to sync the winget-pkgs fork. Ensure WINGET_CREATE_GITHUB_TOKEN has the public_repo and workflow scopes, or sync the fork manually before retrying.'
+            }
             $args += @('-t', $env:WINGET_CREATE_TOKEN, '--submit')
           }
 


### PR DESCRIPTION
## Summary
- Stop the WinGet submission workflow immediately when `gh repo sync` fails
- Surface a clearer message that `WINGET_CREATE_GITHUB_TOKEN` needs `public_repo` and `workflow` scopes, or that the fork must be synced manually

## Validation
- Ran `actionlint` against `.github/workflows/winget.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in the WinGet manifest update workflow with improved diagnostic messages for sync failures, including guidance on potential token scope issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->