### PR TITLE
Refine OSV release scan gating

### DIFF
--- a/.github/scripts/fail-on-osv-high-or-critical.mjs
+++ b/.github/scripts/fail-on-osv-high-or-critical.mjs
@@ -1,0 +1,422 @@
+import fs from "node:fs";
+
+const HIGH_OR_CRITICAL_SCORE = 7.0;
+const SUMMARY_FINDING_LIMIT = 50;
+const severityRank = new Map([
+  ["NONE", 0],
+  ["UNKNOWN", 0],
+  ["LOW", 1],
+  ["MEDIUM", 2],
+  ["MODERATE", 2],
+  ["HIGH", 3],
+  ["IMPORTANT", 3],
+  ["CRITICAL", 4],
+]);
+
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asObject(value) {
+  return isObject(value) ? value : {};
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function cvssRoundUp(value) {
+  return Math.ceil((value - 1e-10) * 10) / 10;
+}
+
+function parseVector(vector) {
+  return Object.fromEntries(
+    vector
+      .split("/")
+      .map((part) => part.split(":"))
+      .filter(([key, value]) => key && value),
+  );
+}
+
+function cvssV3Score(vector) {
+  const metrics = parseVector(vector);
+  const scope = metrics.S;
+
+  const av = { N: 0.85, A: 0.62, L: 0.55, P: 0.2 }[metrics.AV];
+  const ac = { L: 0.77, H: 0.44 }[metrics.AC];
+  const pr =
+    scope === "C"
+      ? { N: 0.85, L: 0.68, H: 0.5 }[metrics.PR]
+      : { N: 0.85, L: 0.62, H: 0.27 }[metrics.PR];
+  const ui = { N: 0.85, R: 0.62 }[metrics.UI];
+  const c = { H: 0.56, L: 0.22, N: 0 }[metrics.C];
+  const i = { H: 0.56, L: 0.22, N: 0 }[metrics.I];
+  const a = { H: 0.56, L: 0.22, N: 0 }[metrics.A];
+
+  if (
+    [av, ac, pr, ui, c, i, a].some((metric) => typeof metric !== "number") ||
+    (scope !== "U" && scope !== "C")
+  ) {
+    return null;
+  }
+
+  const impactSubScore = 1 - (1 - c) * (1 - i) * (1 - a);
+  const impact =
+    scope === "U"
+      ? 6.42 * impactSubScore
+      : 7.52 * (impactSubScore - 0.029) - 3.25 * (impactSubScore - 0.02) ** 15;
+  const exploitability = 8.22 * av * ac * pr * ui;
+
+  if (impact <= 0) {
+    return 0;
+  }
+
+  const rawScore =
+    scope === "U"
+      ? Math.min(impact + exploitability, 10)
+      : Math.min(1.08 * (impact + exploitability), 10);
+
+  return cvssRoundUp(rawScore);
+}
+
+function cvssV2Score(vector) {
+  const metrics = parseVector(vector);
+
+  const av = { L: 0.395, A: 0.646, N: 1 }[metrics.AV];
+  const ac = { H: 0.35, M: 0.61, L: 0.71 }[metrics.AC];
+  const au = { M: 0.45, S: 0.56, N: 0.704 }[metrics.Au];
+  const c = { N: 0, P: 0.275, C: 0.66 }[metrics.C];
+  const i = { N: 0, P: 0.275, C: 0.66 }[metrics.I];
+  const a = { N: 0, P: 0.275, C: 0.66 }[metrics.A];
+
+  if ([av, ac, au, c, i, a].some((metric) => typeof metric !== "number")) {
+    return null;
+  }
+
+  const impact = 10.41 * (1 - (1 - c) * (1 - i) * (1 - a));
+  const exploitability = 20 * av * ac * au;
+  const impactFactor = impact === 0 ? 0 : 1.176;
+
+  return (
+    Math.round(
+      (0.6 * impact + 0.4 * exploitability - 1.5) * impactFactor * 10,
+    ) / 10
+  );
+}
+
+function severityFromScore(score) {
+  if (score >= 9.0) return { label: "CRITICAL", rank: 4, score };
+  if (score >= HIGH_OR_CRITICAL_SCORE) return { label: "HIGH", rank: 3, score };
+  if (score >= 4.0) return { label: "MEDIUM", rank: 2, score };
+  if (score > 0) return { label: "LOW", rank: 1, score };
+  return { label: "NONE", rank: 0, score };
+}
+
+function normalizeSeverityLabel(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value
+    .trim()
+    .toUpperCase()
+    .replace(/[-_\s]+/g, "_");
+  const label = normalized === "MEDIUM" ? "MEDIUM" : normalized;
+  const rank = severityRank.get(label);
+
+  return rank === undefined ? null : { label, rank };
+}
+
+function severityFromSignal(value, type = "") {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return severityFromScore(value);
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const label = normalizeSeverityLabel(value);
+  if (label) {
+    return label;
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return severityFromScore(numeric);
+  }
+
+  if (value.startsWith("CVSS:3.")) {
+    const score = cvssV3Score(value);
+    return score === null ? null : severityFromScore(score);
+  }
+
+  if (type.includes("CVSS_V2")) {
+    const score = cvssV2Score(value);
+    return score === null ? null : severityFromScore(score);
+  }
+
+  if (type.includes("CVSS_V3")) {
+    const score = cvssV3Score(value);
+    return score === null ? null : severityFromScore(score);
+  }
+
+  return null;
+}
+
+function collectSeveritySignals(vulnerability) {
+  const signals = [];
+  const databaseSpecific = asObject(vulnerability.database_specific);
+  const ecosystemSpecific = asObject(vulnerability.ecosystem_specific);
+  const cvss = asObject(databaseSpecific.cvss);
+
+  signals.push([databaseSpecific.severity]);
+  signals.push([databaseSpecific.cvss_score]);
+  signals.push([ecosystemSpecific.severity]);
+  signals.push([cvss.score]);
+  signals.push([cvss.base_score]);
+  signals.push([cvss.vector]);
+  signals.push([cvss.vector_string]);
+  signals.push([cvss.vectorString]);
+
+  if (!Array.isArray(vulnerability.severity)) {
+    signals.push([vulnerability.severity]);
+  }
+
+  for (const item of asArray(vulnerability.severity)) {
+    const severity = asObject(item);
+    signals.push([severity.score, String(severity.type ?? "")]);
+  }
+
+  return signals;
+}
+
+function highestSeverity(vulnerability) {
+  let highest = null;
+
+  for (const [value, type = ""] of collectSeveritySignals(vulnerability)) {
+    const severity = severityFromSignal(value, type);
+    if (!severity) {
+      continue;
+    }
+
+    if (!highest || severity.rank > highest.rank) {
+      highest = severity;
+    }
+  }
+
+  return highest;
+}
+
+function packageName(packageResult) {
+  const metadata = asObject(packageResult.package ?? packageResult.Package);
+  const name = metadata.name ?? metadata.Name ?? "(unknown package)";
+  const version = metadata.version ?? metadata.Version;
+
+  return version ? `${name}@${version}` : String(name);
+}
+
+function sourcePath(result) {
+  const source = asObject(result.source ?? result.packageSource);
+  return typeof source.path === "string" ? source.path : "";
+}
+
+function vulnerabilityId(vulnerability) {
+  if (typeof vulnerability.id === "string") {
+    return vulnerability.id;
+  }
+
+  const alias = asArray(vulnerability.aliases).find(
+    (value) => typeof value === "string",
+  );
+
+  return alias ?? "(unknown advisory)";
+}
+
+function escapeMarkdownCell(value) {
+  return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+}
+
+function advisoryMarkdown(id) {
+  const escaped = escapeMarkdownCell(id);
+
+  if (id.startsWith("(")) {
+    return escaped;
+  }
+
+  return `[${escaped}](https://osv.dev/vulnerability/${encodeURIComponent(id)})`;
+}
+
+function severityLabel(severity) {
+  return severity?.label ?? "UNKNOWN";
+}
+
+function severityScore(severity) {
+  return typeof severity?.score === "number" ? severity.score : null;
+}
+
+function compareFindings(a, b) {
+  const severityDiff = b.rank - a.rank;
+  if (severityDiff !== 0) {
+    return severityDiff;
+  }
+
+  const scoreDiff = (b.score ?? -1) - (a.score ?? -1);
+  if (scoreDiff !== 0) {
+    return scoreDiff;
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+function countBySeverity(findings) {
+  const counts = new Map();
+
+  for (const finding of findings) {
+    counts.set(finding.severity, (counts.get(finding.severity) ?? 0) + 1);
+  }
+
+  return [...counts.entries()].sort(
+    ([left], [right]) =>
+      (severityRank.get(right) ?? 0) - (severityRank.get(left) ?? 0),
+  );
+}
+
+function summaryTable(findings) {
+  const visibleFindings = findings.slice(0, SUMMARY_FINDING_LIMIT);
+  const rows = visibleFindings.map((finding) => {
+    const score =
+      typeof finding.score === "number" ? finding.score.toFixed(1) : "";
+
+    return [
+      escapeMarkdownCell(finding.severity),
+      escapeMarkdownCell(score),
+      advisoryMarkdown(finding.id),
+      escapeMarkdownCell(finding.package),
+      escapeMarkdownCell(finding.source),
+    ].join(" | ");
+  });
+
+  return [
+    "| Severity | Score | Advisory | Package | Source |",
+    "| --- | ---: | --- | --- | --- |",
+    ...rows.map((row) => `| ${row} |`),
+  ].join("\n");
+}
+
+function writeStepSummary({ allFindings, blockingFindings, releaseTag }) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+
+  const sortedFindings = [...allFindings].sort(compareFindings);
+  const lines = [
+    "## OSV release tag scan",
+    "",
+    `Release tag: \`${releaseTag || "(not provided)"}\``,
+    "Failure threshold: High or Critical",
+    `Detected vulnerabilities: ${allFindings.length}`,
+    `High or Critical vulnerabilities: ${blockingFindings.length}`,
+    "",
+  ];
+
+  if (allFindings.length === 0) {
+    lines.push("No OSV vulnerabilities were reported for this release tag.");
+    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+    return;
+  }
+
+  lines.push("### Severity Counts", "");
+  lines.push("| Severity | Count |", "| --- | ---: |");
+
+  for (const [severity, count] of countBySeverity(sortedFindings)) {
+    lines.push(`| ${escapeMarkdownCell(severity)} | ${count} |`);
+  }
+
+  lines.push("", "### Detected Vulnerabilities", "");
+  lines.push(summaryTable(sortedFindings));
+
+  if (sortedFindings.length > SUMMARY_FINDING_LIMIT) {
+    lines.push(
+      "",
+      `Showing ${SUMMARY_FINDING_LIMIT} of ${sortedFindings.length} vulnerabilities. Download the SARIF artifact for the full report.`,
+    );
+  }
+
+  fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+}
+
+function loadResults(path) {
+  const raw = fs.readFileSync(path, "utf8");
+  return JSON.parse(raw);
+}
+
+function main() {
+  const path = process.argv[2] ?? "latest-release-results.json";
+  const data = loadResults(path);
+  const allFindings = [];
+  const blockingFindings = [];
+  const releaseTag = process.env.OSV_RELEASE_TAG ?? "";
+  let vulnerabilityCount = 0;
+
+  for (const result of asArray(data.results)) {
+    const source = sourcePath(asObject(result));
+
+    for (const packageResult of asArray(asObject(result).packages)) {
+      const pkg = packageName(asObject(packageResult));
+
+      for (const vulnerability of asArray(
+        asObject(packageResult).vulnerabilities,
+      )) {
+        vulnerabilityCount++;
+        const severity = highestSeverity(asObject(vulnerability));
+        const finding = {
+          id: vulnerabilityId(asObject(vulnerability)),
+          package: pkg,
+          rank: severity?.rank ?? 0,
+          score: severityScore(severity),
+          severity: severityLabel(severity),
+          source,
+        };
+
+        allFindings.push(finding);
+
+        if (finding.rank >= severityRank.get("HIGH")) {
+          blockingFindings.push(finding);
+        }
+      }
+    }
+  }
+
+  writeStepSummary({ allFindings, blockingFindings, releaseTag });
+
+  console.log(`Checked ${vulnerabilityCount} OSV vulnerabilities.`);
+
+  if (blockingFindings.length === 0) {
+    console.log("No High or Critical OSV vulnerabilities found.");
+    return;
+  }
+
+  console.error(
+    `::error::Found ${blockingFindings.length} High or Critical OSV vulnerabilities.`,
+  );
+
+  for (const finding of blockingFindings.sort(compareFindings)) {
+    const score =
+      typeof finding.score === "number" ? ` (${finding.score.toFixed(1)})` : "";
+    const source = finding.source ? ` from ${finding.source}` : "";
+    console.error(
+      `- [${finding.severity}${score}] ${finding.id} in ${finding.package}${source}`,
+    );
+  }
+
+  process.exit(1);
+}
+
+try {
+  main();
+} catch (e) {
+  console.error(e instanceof Error ? e.message : String(e));
+  process.exit(1);
+}

--- a/.github/scripts/fail-on-osv-high-or-critical.ts
+++ b/.github/scripts/fail-on-osv-high-or-critical.ts
@@ -1,8 +1,31 @@
 import fs from "node:fs";
 
+type JsonObject = Record<string, unknown>;
+type SeverityRank = 0 | 1 | 2 | 3 | 4;
+type SeverityInfo = {
+  label: string;
+  rank: SeverityRank;
+  score?: number;
+};
+type Signal = [value: unknown, type?: string];
+type Finding = {
+  id: string;
+  package: string;
+  rank: SeverityRank;
+  score: number | null;
+  severity: string;
+  source: string;
+};
+type StepSummaryInput = {
+  allFindings: Finding[];
+  blockingFindings: Finding[];
+  releaseTag: string;
+};
+
 const HIGH_OR_CRITICAL_SCORE = 7.0;
+const HIGH_SEVERITY_RANK = 3 satisfies SeverityRank;
 const SUMMARY_FINDING_LIMIT = 50;
-const severityRank = new Map([
+const severityRank = new Map<string, SeverityRank>([
   ["NONE", 0],
   ["UNKNOWN", 0],
   ["LOW", 1],
@@ -13,23 +36,23 @@ const severityRank = new Map([
   ["CRITICAL", 4],
 ]);
 
-function isObject(value) {
+function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function asObject(value) {
+function asObject(value: unknown): JsonObject {
   return isObject(value) ? value : {};
 }
 
-function asArray(value) {
+function asArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
 }
 
-function cvssRoundUp(value) {
+function cvssRoundUp(value: number): number {
   return Math.ceil((value - 1e-10) * 10) / 10;
 }
 
-function parseVector(vector) {
+function parseVector(vector: string): Record<string, string> {
   return Object.fromEntries(
     vector
       .split("/")
@@ -38,20 +61,20 @@ function parseVector(vector) {
   );
 }
 
-function cvssV3Score(vector) {
+function cvssV3Score(vector: string): number | null {
   const metrics = parseVector(vector);
   const scope = metrics.S;
 
-  const av = { N: 0.85, A: 0.62, L: 0.55, P: 0.2 }[metrics.AV];
-  const ac = { L: 0.77, H: 0.44 }[metrics.AC];
+  const av = valueFor(metrics.AV, { N: 0.85, A: 0.62, L: 0.55, P: 0.2 });
+  const ac = valueFor(metrics.AC, { L: 0.77, H: 0.44 });
   const pr =
     scope === "C"
-      ? { N: 0.85, L: 0.68, H: 0.5 }[metrics.PR]
-      : { N: 0.85, L: 0.62, H: 0.27 }[metrics.PR];
-  const ui = { N: 0.85, R: 0.62 }[metrics.UI];
-  const c = { H: 0.56, L: 0.22, N: 0 }[metrics.C];
-  const i = { H: 0.56, L: 0.22, N: 0 }[metrics.I];
-  const a = { H: 0.56, L: 0.22, N: 0 }[metrics.A];
+      ? valueFor(metrics.PR, { N: 0.85, L: 0.68, H: 0.5 })
+      : valueFor(metrics.PR, { N: 0.85, L: 0.62, H: 0.27 });
+  const ui = valueFor(metrics.UI, { N: 0.85, R: 0.62 });
+  const c = valueFor(metrics.C, { H: 0.56, L: 0.22, N: 0 });
+  const i = valueFor(metrics.I, { H: 0.56, L: 0.22, N: 0 });
+  const a = valueFor(metrics.A, { H: 0.56, L: 0.22, N: 0 });
 
   if (
     [av, ac, pr, ui, c, i, a].some((metric) => typeof metric !== "number") ||
@@ -60,12 +83,21 @@ function cvssV3Score(vector) {
     return null;
   }
 
-  const impactSubScore = 1 - (1 - c) * (1 - i) * (1 - a);
+  const [avScore, acScore, prScore, uiScore, cScore, iScore, aScore] = [
+    av,
+    ac,
+    pr,
+    ui,
+    c,
+    i,
+    a,
+  ] as number[];
+  const impactSubScore = 1 - (1 - cScore) * (1 - iScore) * (1 - aScore);
   const impact =
     scope === "U"
       ? 6.42 * impactSubScore
       : 7.52 * (impactSubScore - 0.029) - 3.25 * (impactSubScore - 0.02) ** 15;
-  const exploitability = 8.22 * av * ac * pr * ui;
+  const exploitability = 8.22 * avScore * acScore * prScore * uiScore;
 
   if (impact <= 0) {
     return 0;
@@ -79,22 +111,34 @@ function cvssV3Score(vector) {
   return cvssRoundUp(rawScore);
 }
 
-function cvssV2Score(vector) {
+function valueFor(key: string | undefined, values: Record<string, number>) {
+  return key ? values[key] : undefined;
+}
+
+function cvssV2Score(vector: string): number | null {
   const metrics = parseVector(vector);
 
-  const av = { L: 0.395, A: 0.646, N: 1 }[metrics.AV];
-  const ac = { H: 0.35, M: 0.61, L: 0.71 }[metrics.AC];
-  const au = { M: 0.45, S: 0.56, N: 0.704 }[metrics.Au];
-  const c = { N: 0, P: 0.275, C: 0.66 }[metrics.C];
-  const i = { N: 0, P: 0.275, C: 0.66 }[metrics.I];
-  const a = { N: 0, P: 0.275, C: 0.66 }[metrics.A];
+  const av = valueFor(metrics.AV, { L: 0.395, A: 0.646, N: 1 });
+  const ac = valueFor(metrics.AC, { H: 0.35, M: 0.61, L: 0.71 });
+  const au = valueFor(metrics.Au, { M: 0.45, S: 0.56, N: 0.704 });
+  const c = valueFor(metrics.C, { N: 0, P: 0.275, C: 0.66 });
+  const i = valueFor(metrics.I, { N: 0, P: 0.275, C: 0.66 });
+  const a = valueFor(metrics.A, { N: 0, P: 0.275, C: 0.66 });
 
   if ([av, ac, au, c, i, a].some((metric) => typeof metric !== "number")) {
     return null;
   }
 
-  const impact = 10.41 * (1 - (1 - c) * (1 - i) * (1 - a));
-  const exploitability = 20 * av * ac * au;
+  const [avScore, acScore, auScore, cScore, iScore, aScore] = [
+    av,
+    ac,
+    au,
+    c,
+    i,
+    a,
+  ] as number[];
+  const impact = 10.41 * (1 - (1 - cScore) * (1 - iScore) * (1 - aScore));
+  const exploitability = 20 * avScore * acScore * auScore;
   const impactFactor = impact === 0 ? 0 : 1.176;
 
   return (
@@ -104,7 +148,7 @@ function cvssV2Score(vector) {
   );
 }
 
-function severityFromScore(score) {
+function severityFromScore(score: number): SeverityInfo {
   if (score >= 9.0) return { label: "CRITICAL", rank: 4, score };
   if (score >= HIGH_OR_CRITICAL_SCORE) return { label: "HIGH", rank: 3, score };
   if (score >= 4.0) return { label: "MEDIUM", rank: 2, score };
@@ -112,7 +156,7 @@ function severityFromScore(score) {
   return { label: "NONE", rank: 0, score };
 }
 
-function normalizeSeverityLabel(value) {
+function normalizeSeverityLabel(value: unknown): SeverityInfo | null {
   if (typeof value !== "string") {
     return null;
   }
@@ -127,7 +171,7 @@ function normalizeSeverityLabel(value) {
   return rank === undefined ? null : { label, rank };
 }
 
-function severityFromSignal(value, type = "") {
+function severityFromSignal(value: unknown, type = ""): SeverityInfo | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return severityFromScore(value);
   }
@@ -164,8 +208,8 @@ function severityFromSignal(value, type = "") {
   return null;
 }
 
-function collectSeveritySignals(vulnerability) {
-  const signals = [];
+function collectSeveritySignals(vulnerability: JsonObject): Signal[] {
+  const signals: Signal[] = [];
   const databaseSpecific = asObject(vulnerability.database_specific);
   const ecosystemSpecific = asObject(vulnerability.ecosystem_specific);
   const cvss = asObject(databaseSpecific.cvss);
@@ -191,8 +235,8 @@ function collectSeveritySignals(vulnerability) {
   return signals;
 }
 
-function highestSeverity(vulnerability) {
-  let highest = null;
+function highestSeverity(vulnerability: JsonObject): SeverityInfo | null {
+  let highest: SeverityInfo | null = null;
 
   for (const [value, type = ""] of collectSeveritySignals(vulnerability)) {
     const severity = severityFromSignal(value, type);
@@ -208,7 +252,7 @@ function highestSeverity(vulnerability) {
   return highest;
 }
 
-function packageName(packageResult) {
+function packageName(packageResult: JsonObject): string {
   const metadata = asObject(packageResult.package ?? packageResult.Package);
   const name = metadata.name ?? metadata.Name ?? "(unknown package)";
   const version = metadata.version ?? metadata.Version;
@@ -216,12 +260,12 @@ function packageName(packageResult) {
   return version ? `${name}@${version}` : String(name);
 }
 
-function sourcePath(result) {
+function sourcePath(result: JsonObject): string {
   const source = asObject(result.source ?? result.packageSource);
   return typeof source.path === "string" ? source.path : "";
 }
 
-function vulnerabilityId(vulnerability) {
+function vulnerabilityId(vulnerability: JsonObject): string {
   if (typeof vulnerability.id === "string") {
     return vulnerability.id;
   }
@@ -233,11 +277,11 @@ function vulnerabilityId(vulnerability) {
   return alias ?? "(unknown advisory)";
 }
 
-function escapeMarkdownCell(value) {
+function escapeMarkdownCell(value: unknown): string {
   return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
 }
 
-function advisoryMarkdown(id) {
+function advisoryMarkdown(id: string): string {
   const escaped = escapeMarkdownCell(id);
 
   if (id.startsWith("(")) {
@@ -247,15 +291,15 @@ function advisoryMarkdown(id) {
   return `[${escaped}](https://osv.dev/vulnerability/${encodeURIComponent(id)})`;
 }
 
-function severityLabel(severity) {
+function severityLabel(severity: SeverityInfo | null): string {
   return severity?.label ?? "UNKNOWN";
 }
 
-function severityScore(severity) {
+function severityScore(severity: SeverityInfo | null): number | null {
   return typeof severity?.score === "number" ? severity.score : null;
 }
 
-function compareFindings(a, b) {
+function compareFindings(a: Finding, b: Finding): number {
   const severityDiff = b.rank - a.rank;
   if (severityDiff !== 0) {
     return severityDiff;
@@ -269,8 +313,8 @@ function compareFindings(a, b) {
   return a.id.localeCompare(b.id);
 }
 
-function countBySeverity(findings) {
-  const counts = new Map();
+function countBySeverity(findings: Finding[]): [string, number][] {
+  const counts = new Map<string, number>();
 
   for (const finding of findings) {
     counts.set(finding.severity, (counts.get(finding.severity) ?? 0) + 1);
@@ -282,7 +326,7 @@ function countBySeverity(findings) {
   );
 }
 
-function summaryTable(findings) {
+function summaryTable(findings: Finding[]): string {
   const visibleFindings = findings.slice(0, SUMMARY_FINDING_LIMIT);
   const rows = visibleFindings.map((finding) => {
     const score =
@@ -304,7 +348,11 @@ function summaryTable(findings) {
   ].join("\n");
 }
 
-function writeStepSummary({ allFindings, blockingFindings, releaseTag }) {
+function writeStepSummary({
+  allFindings,
+  blockingFindings,
+  releaseTag,
+}: StepSummaryInput) {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) {
     return;
@@ -347,16 +395,16 @@ function writeStepSummary({ allFindings, blockingFindings, releaseTag }) {
   fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
 }
 
-function loadResults(path) {
+function loadResults(path: string): JsonObject {
   const raw = fs.readFileSync(path, "utf8");
-  return JSON.parse(raw);
+  return asObject(JSON.parse(raw));
 }
 
 function main() {
   const path = process.argv[2] ?? "latest-release-results.json";
   const data = loadResults(path);
-  const allFindings = [];
-  const blockingFindings = [];
+  const allFindings: Finding[] = [];
+  const blockingFindings: Finding[] = [];
   const releaseTag = process.env.OSV_RELEASE_TAG ?? "";
   let vulnerabilityCount = 0;
 
@@ -382,7 +430,7 @@ function main() {
 
         allFindings.push(finding);
 
-        if (finding.rank >= severityRank.get("HIGH")) {
+        if (finding.rank >= HIGH_SEVERITY_RANK) {
           blockingFindings.push(finding);
         }
       }

--- a/.github/scripts/fail-on-osv-high-or-critical.ts
+++ b/.github/scripts/fail-on-osv-high-or-critical.ts
@@ -278,7 +278,10 @@ function vulnerabilityId(vulnerability: JsonObject): string {
 }
 
 function escapeMarkdownCell(value: unknown): string {
-  return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/\r?\n/g, " ")
+    .replace(/\|/g, "\\|");
 }
 
 function advisoryMarkdown(id: string): string {

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -2,6 +2,11 @@ name: OSV dependency scan
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to scan. Defaults to the latest release."
+        required: false
+        type: string
   schedule:
     # Daily 09:00 JST (00:00 UTC)
     - cron: "0 0 * * *"
@@ -31,37 +36,40 @@ jobs:
       upload-sarif: true
       fail-on-vuln: false
 
-  resolve-latest-release:
-    name: Resolve latest release
+  resolve-release-tag:
+    name: Resolve release tag
     runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
-      latest-tag: ${{ steps.release.outputs.latest_tag }}
+      release-tag: ${{ steps.release.outputs.release_tag }}
     steps:
-      - name: Resolve latest release tag
+      - name: Resolve release tag
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
+          REQUESTED_RELEASE_TAG: ${{ inputs.release_tag || '' }}
         shell: bash
         run: |
           set -euo pipefail
 
-          latest_tag=""
-          if latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq ".tag_name" 2>/dev/null)"; then
-            if [ -n "$latest_tag" ]; then
-              echo "Latest release tag: $latest_tag"
+          release_tag="${REQUESTED_RELEASE_TAG}"
+          if [ -n "$release_tag" ]; then
+            echo "Requested release tag: $release_tag"
+          elif release_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq ".tag_name" 2>/dev/null)"; then
+            if [ -n "$release_tag" ]; then
+              echo "Latest release tag: $release_tag"
             else
               echo "Latest release endpoint returned an empty tag."
             fi
           else
-            echo "No latest release found. Skipping latest release OSV scan."
+            echo "No release tag found. Skipping release OSV scan."
           fi
 
-          echo "latest_tag=$latest_tag" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
-  upload-default-branch-osv-config:
-    name: Upload default branch OSV config
+  upload-default-branch-osv-assets:
+    name: Upload default branch OSV assets
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -72,35 +80,38 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
-      - name: Upload OSV config
+      - name: Upload OSV scan assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: default-branch-osv-config
-          path: osv-scanner.toml
+          name: default-branch-osv-scan-assets
+          path: |
+            osv-scanner.toml
+            .github/scripts/fail-on-osv-high-or-critical.mjs
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 1
 
-  scan-latest-release:
-    name: Scan latest release
+  scan-release-tag:
+    name: Scan release tag
     needs:
-      - resolve-latest-release
-      - upload-default-branch-osv-config
-    if: needs.resolve-latest-release.outputs.latest-tag != ''
+      - resolve-release-tag
+      - upload-default-branch-osv-assets
+    if: needs.resolve-release-tag.outputs.release-tag != ''
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
     steps:
-      - name: Checkout latest release
+      - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-          ref: ${{ needs.resolve-latest-release.outputs.latest-tag }}
+          ref: ${{ needs.resolve-release-tag.outputs.release-tag }}
 
-      - name: Download default branch OSV config
+      - name: Download default branch OSV scan assets
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          name: default-branch-osv-config
+          name: default-branch-osv-scan-assets
           path: ./
 
       - name: Run OSV scanner
@@ -108,30 +119,30 @@ jobs:
         continue-on-error: true
         with:
           scan-args: |-
-            --output=latest-release-results.json
+            --output=release-results.json
             --format=json
             -r ./
 
       - name: Generate OSV SARIF report
         id: osv-reporter
         uses: google/osv-scanner-action/osv-reporter-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-        continue-on-error: true
         with:
           scan-args: |-
-            --output=latest-release-osv-results.sarif
-            --new=latest-release-results.json
+            --output=release-osv-results.sarif
+            --new=release-results.json
             --gh-annotations=false
-            --fail-on-vuln=true
+            --fail-on-vuln=false
 
-      - name: Upload latest release OSV SARIF artifact
+      - name: Upload release OSV SARIF artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: latest-release-OSV Scanner SARIF file
-          path: latest-release-osv-results.sarif
+          name: release-OSV Scanner SARIF file
+          path: release-osv-results.sarif
           if-no-files-found: error
           retention-days: 5
 
-      - name: Fail on latest release vulnerabilities
-        if: steps.osv-reporter.outcome == 'failure'
-        run: exit 1
+      - name: Fail on High or Critical release vulnerabilities
+        run: node .github/scripts/fail-on-osv-high-or-critical.mjs release-results.json
+        env:
+          OSV_RELEASE_TAG: ${{ needs.resolve-release-tag.outputs.release-tag }}

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -86,7 +86,7 @@ jobs:
           name: default-branch-osv-scan-assets
           path: |
             osv-scanner.toml
-            .github/scripts/fail-on-osv-high-or-critical.mjs
+            .github/scripts/fail-on-osv-high-or-critical.ts
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 1
@@ -143,6 +143,6 @@ jobs:
           retention-days: 5
 
       - name: Fail on High or Critical release vulnerabilities
-        run: node .github/scripts/fail-on-osv-high-or-critical.mjs release-results.json
+        run: node --experimental-strip-types .github/scripts/fail-on-osv-high-or-critical.ts release-results.json
         env:
           OSV_RELEASE_TAG: ${{ needs.resolve-release-tag.outputs.release-tag }}


### PR DESCRIPTION
## Summary

- Add a manual `release_tag` input to the OSV dependency scan workflow while keeping latest-release scanning as the default.
- Change release tag scan gating so the workflow fails only when High or Critical vulnerabilities are found.
- Add a GitHub Actions step summary with severity counts and an advisory table linking to OSV entries.

## Validation

- `npm run lint:ci`
- `node --check .github/scripts/fail-on-osv-high-or-critical.mjs`
- `git diff --check`
- Local sample JSON checks for Low passing and Critical failing, including step summary output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated security scanning for releases with improved detection and reporting of critical vulnerabilities in dependencies.
  * Upgraded release workflow to explicitly fail when high/critical severity issues are detected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shm11C3/HardwareVisualizer/pull/1505)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->