### PR TITLE
fix: guard provider crash paths against null/empty/underflow

### DIFF
--- a/core/src/infrastructure/providers/macos/io_kit/io_report.rs
+++ b/core/src/infrastructure/providers/macos/io_kit/io_report.rs
@@ -199,35 +199,50 @@ impl GpuUsageIOReport {
     })
   }
 
-  fn raw_sample(&self) -> (CFDictionaryRef, Instant) {
-    (
-      unsafe { IOReportCreateSamples(self.subs, self.chan, null()) },
-      Instant::now(),
-    )
+  fn raw_sample(&self) -> WithError<(CFDictionaryRef, Instant)> {
+    let sample = unsafe { IOReportCreateSamples(self.subs, self.chan, null()) };
+    if sample.is_null() {
+      return Err("IOReportCreateSamples returned null".into());
+    }
+    Ok((sample, Instant::now()))
   }
 
   /// Returns usage for the interval since the previous call (keeps prev, delta-based).
   pub fn sample_usage(&mut self) -> WithError<f32> {
-    // Initialize prev if needed.
+    // Initialize prev if needed. A null sample (transient IOReport failure,
+    // e.g. the GPU is power-gated) is surfaced as an error rather than stored.
     let prev = match self.prev.take() {
       Some(p) => p,
-      None => self.raw_sample(),
+      None => self.raw_sample()?,
     };
 
-    // Next sample.
-    let next = self.raw_sample();
+    // Next sample. If it fails, release `prev` and reset state so the next
+    // call re-initialises, rather than feeding a null pointer to
+    // IOReportCreateSamplesDelta / CFRelease (both crash on null).
+    let next = match self.raw_sample() {
+      Ok(next) => next,
+      Err(e) => {
+        unsafe { CFRelease(prev.0 as _) };
+        return Err(e);
+      }
+    };
 
-    // Build delta (difference).
+    // Build delta (difference). Both inputs are guaranteed non-null here.
     let delta = unsafe { IOReportCreateSamplesDelta(prev.0, next.0, null()) };
     unsafe { CFRelease(prev.0 as _) };
 
-    // Keep for the next call.
+    // Keep the latest sample for the next call.
     self.prev = Some(next);
 
-    // Find GPU Perf States in the delta dictionary and compute usage.
-    let usage = compute_gpu_usage_from_delta(delta, &self.gpu_freqs)?;
+    if delta.is_null() {
+      return Err("IOReportCreateSamplesDelta returned null".into());
+    }
+
+    // Compute usage, then release `delta` on every path (success or error) so
+    // a failed computation does not leak a CF dictionary on each sample tick.
+    let usage = compute_gpu_usage_from_delta(delta, &self.gpu_freqs);
     unsafe { CFRelease(delta as _) };
-    Ok(usage)
+    usage
   }
 }
 

--- a/core/src/infrastructure/providers/windows/nvapi_provider.rs
+++ b/core/src/infrastructure/providers/windows/nvapi_provider.rs
@@ -102,9 +102,16 @@ pub async fn get_nvidia_gpu_temperature()
         nvapi::Status::Error
       })?;
 
+      // Some GPUs (e.g. headless / virtual NVIDIA devices) expose no thermal
+      // sensors, so the Vec can be empty — fall back to 0 instead of panicking.
+      let value = thermal_settings
+        .first()
+        .map(|t| t.current_temperature.0)
+        .unwrap_or(0);
+
       temperatures.push(models::hardware::NameValue {
         name: gpu.full_name().unwrap_or("Unknown".to_string()),
-        value: thermal_settings[0].current_temperature.0,
+        value,
       });
     }
 
@@ -258,7 +265,11 @@ pub fn get_gpu_temperature_from_physical_gpu(gpu: &nvapi::PhysicalGpu) -> i32 {
   });
 
   if let Ok(thermal_settings) = thermal_settings {
-    return thermal_settings[0].current_temperature.0;
+    // GPUs with no thermal sensor return an empty Vec; avoid indexing panic.
+    return thermal_settings
+      .first()
+      .map(|t| t.current_temperature.0)
+      .unwrap_or(0);
   }
 
   0
@@ -293,5 +304,10 @@ pub fn get_gpu_dedicated_memory_usage_from_physical_gpu(gpu: &nvapi::PhysicalGpu
     }
   };
 
-  memory.dedicated.0 - memory.dedicated_available_current.0
+  // NVAPI may transiently report `available > dedicated`; saturating_sub
+  // avoids an unsigned underflow panic (debug) / wraparound (release).
+  memory
+    .dedicated
+    .0
+    .saturating_sub(memory.dedicated_available_current.0)
 }

--- a/core/src/infrastructure/providers/windows/wmi_provider.rs
+++ b/core/src/infrastructure/providers/windows/wmi_provider.rs
@@ -49,15 +49,25 @@ pub async fn query_memory_info() -> Result<MemoryInfo, String> {
     None::<&str>
   );
 
+  // Win32_PhysicalMemory can come back empty (e.g. soldered RAM that WMI does
+  // not enumerate, or a transient WMI service failure). Return an error instead
+  // of indexing `[0]` and panicking.
+  let first_module = physical_memory
+    .first()
+    .ok_or_else(|| "Win32_PhysicalMemory returned no entries".to_string())?;
+
   let memory_info = MemoryInfo {
     size: formatter::format_size(physical_memory.iter().map(|mem| mem.capacity).sum(), 1),
-    clock: physical_memory[0].speed,
+    clock: first_module.speed,
     clock_unit: "MHz".to_string(),
     memory_count: physical_memory.len() as u32,
-    total_slots: physical_memory_array[0].memory_devices.unwrap_or(0),
+    total_slots: physical_memory_array
+      .first()
+      .and_then(|array| array.memory_devices)
+      .unwrap_or(0),
     memory_type: describe_memory_type_with_fallback(
-      physical_memory[0].memory_type,
-      physical_memory[0].smbios_memory_type,
+      first_module.memory_type,
+      first_module.smbios_memory_type,
     ),
     is_detailed: true,
   };


### PR DESCRIPTION
## Summary

Hardens three hardware-provider hot paths that can crash under **normal OS /
hardware states**, not just exceptional conditions. These are the confirmed
crash findings from a bug & vulnerability audit (multi-agent + adversarial
verification).

## Changes

### macOS — `core/.../macos/io_kit/io_report.rs`
- `IOReportCreateSamples` / `IOReportCreateSamplesDelta` can return null when the
  GPU is power-gated or during sleep transitions. Passing null to `CFRelease` /
  `CFDictionaryGetValue` crashes (per Apple docs).
- Null-check the samples before use.
- Release the `delta` dictionary on every path, fixing a leak that occurred each
  tick whenever the usage computation returned early with `?`.

### Windows — `core/.../windows/nvapi_provider.rs`
- GPUs with no thermal sensor (headless / virtual NVIDIA devices) return an empty
  Vec, so the per-tick `thermal_settings[0]` indexing panics. Use `.first()` with
  a 0 fallback (two call sites).
- Replace the dedicated-GPU-memory subtraction with `saturating_sub` to avoid
  unsigned underflow when NVAPI reports `available > dedicated`.

### Windows — `core/.../windows/wmi_provider.rs`
- `Win32_PhysicalMemory` can come back empty (soldered RAM, or a transient WMI
  failure). Return an error instead of indexing `[0]` and panicking.

## Verification
- ✅ macOS: `cargo check` / `cargo clippy` (no warnings) / `cargo fmt --check` / `io_report` unit tests (12 passed)
- ⚠️ The Windows providers are `#[cfg(target_os = "windows")]`-gated and are not compiled locally (macOS). Type-consistency and idioms were verified by review. **Recommend running `cargo tauri-test` on a Windows CI runner.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)