### PR TITLE
fix: include WebView memory in perf monitor

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         platform:
           - windows-latest
-          - ubuntu-latest
-          - macos-latest
+
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         platform:
           - windows-latest
-          # - ubuntu-22.04
-          # - macos-latest
+          - ubuntu-latest
+          - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository

--- a/perf-monitor/README.md
+++ b/perf-monitor/README.md
@@ -89,7 +89,7 @@ Only the fields you specify are overridden; others inherit from `[thresholds]`.
 4. **Terminate** - Kills the process (RAII guard ensures cleanup on errors)
 5. **Report** - Computes statistics (avg, max, P95, memory growth) and checks against thresholds
 
-Memory samples track both the launched app process RSS and the total process-tree RSS that includes associated helper processes. Windows and Linux helpers are discovered by walking the `parent()` chain from the launched PID. Windows and macOS also include WebView helper processes created after launch, because WebView helpers are not always reliably parented under the app PID.
+Memory samples track both the launched app process RSS and the total process-tree RSS that includes associated helper processes. Helpers are discovered by walking the `parent()` chain from the launched PID. Windows and macOS also include WebView helper processes that were created after launch and expose the target app identity in process metadata, because WebView helpers are not always reliably parented under the app PID.
 
 ### Metrics
 
@@ -120,7 +120,7 @@ Stop-Process -Name hardware-visualizer
 The GitHub Actions workflow (`.github/workflows/perf-test.yml`) runs daily at 03:00 JST:
 
 - Builds the app and perf-monitor on the active performance matrix
-- Currently runs the performance gate on Windows; Linux and macOS commands are present in the workflow but their matrix entries are disabled
+- Currently runs the performance gate on Windows only
 - Uploads JSON results as artifacts
 - Creates a GitHub Issue labeled `performance-regression` if any threshold is exceeded
 

--- a/perf-monitor/README.md
+++ b/perf-monitor/README.md
@@ -32,6 +32,8 @@ cargo perf-test -- --binary path/to/hardware-visualizer --warmup 5 --duration 10
 cargo perf-test -- --binary path/to/hardware-visualizer --output json > results.json
 ```
 
+When `--output json` is used, machine-readable JSON is written to stdout and the normal text report is written to stderr. This keeps redirected JSON artifacts valid while still showing the full performance result in CI logs.
+
 ## Configuration
 
 Thresholds are defined in `perf-thresholds.toml` at the repository root.
@@ -40,9 +42,12 @@ Thresholds are defined in `perf-thresholds.toml` at the repository root.
 [thresholds]
 max_avg_cpu_percent = 5.0      # Average CPU (normalized 0-100%)
 max_p95_cpu_percent = 10.0     # 95th percentile CPU
-max_avg_memory_mb = 100.0      # Average RSS in MB
-max_p95_memory_mb = 100.0      # 95th percentile RSS in MB
-max_memory_growth_mb = 50.0    # Memory growth over measurement (leak detection)
+max_avg_app_memory_mb = 100.0  # Average launched app process RSS in MB
+max_p95_app_memory_mb = 100.0  # 95th percentile launched app process RSS in MB
+max_app_memory_growth_mb = 50.0 # App process memory growth over measurement
+max_avg_memory_mb = 450.0      # Average process-tree RSS in MB, including WebView
+max_p95_memory_mb = 500.0      # 95th percentile process-tree RSS in MB, including WebView
+max_memory_growth_mb = 50.0    # Process-tree memory growth over measurement
 
 [timing]
 warmup_seconds = 10            # Skip initial startup spike
@@ -56,44 +61,66 @@ Per-platform threshold overrides can be specified under `[platforms.<os>]`:
 
 ```toml
 [platforms.windows]
-max_avg_memory_mb = 70.0
+max_avg_app_memory_mb = 70.0
+max_p95_app_memory_mb = 100.0
+max_avg_memory_mb = 450.0
+max_p95_memory_mb = 500.0
 
 [platforms.linux]
-max_avg_memory_mb = 70.0
+max_avg_app_memory_mb = 150.0
+max_p95_app_memory_mb = 150.0
+max_avg_memory_mb = 450.0
+max_p95_memory_mb = 500.0
 
 [platforms.macos]
-max_avg_memory_mb = 70.0
+max_avg_app_memory_mb = 150.0
+max_p95_app_memory_mb = 150.0
+max_avg_memory_mb = 550.0
+max_p95_memory_mb = 600.0
 ```
 
 Only the fields you specify are overridden; others inherit from `[thresholds]`.
 
 ## How It Works
 
-1. **Launch** — Spawns the target binary as a subprocess
-2. **Warmup** — Waits for the app to stabilize (skips initialization spike)
-3. **Measure** — Samples CPU and memory at `sample_interval_ms` intervals using `sysinfo`
-4. **Terminate** — Kills the process (RAII guard ensures cleanup on errors)
-5. **Report** — Computes statistics (avg, max, P95, memory growth) and checks against thresholds
+1. **Launch** - Spawns the target binary as a subprocess
+2. **Warmup** - Waits for the app to stabilize (skips initialization spike)
+3. **Measure** - Samples CPU and process-tree RSS at `sample_interval_ms` intervals using `sysinfo`
+4. **Terminate** - Kills the process (RAII guard ensures cleanup on errors)
+5. **Report** - Computes statistics (avg, max, P95, memory growth) and checks against thresholds
+
+Memory samples track both the launched app process RSS and the total process-tree RSS that includes associated helper processes. Windows and Linux helpers are discovered by walking the `parent()` chain from the launched PID. Windows and macOS also include WebView helper processes created after launch, because WebView helpers are not always reliably parented under the app PID.
 
 ### Metrics
 
-| Metric           | Description                                                |
-| ---------------- | ---------------------------------------------------------- |
-| CPU Avg / P95    | Process CPU usage normalized by logical CPU count (0-100%) |
-| Memory Avg / P95 | Resident Set Size (RSS) in MB                              |
-| Memory Growth    | Last sample minus first sample (detects obvious leaks)     |
+| Metric           | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------ |
+| CPU Avg / P95    | Launched process CPU usage normalized by logical CPU count (0-100%)      |
+| App Memory Avg / P95 | Launched app process Resident Set Size (RSS) in MB                   |
+| Total Memory Avg / P95 | Total process-tree RSS in MB, including WebView                  |
+| Memory Growth    | Last RSS sample minus first sample for each memory budget                 |
+| Memory Breakdown | Parent, WebView, and other helper RSS breakdown in text and JSON reports |
 
 ### Exit Code
 
-- `0` — All thresholds passed
-- `1` — One or more thresholds exceeded, or an error occurred
+- `0` - All thresholds passed
+- `1` - One or more thresholds exceeded, or an error occurred
+
+### Troubleshooting
+
+If the monitor fails with `Process exited during warmup (exit status: exit code: 0)`, check for an already-running HardwareVisualizer instance. The app uses Tauri's single-instance plugin, so a second launch can hand off to the existing instance and exit before sampling begins.
+
+```powershell
+Get-Process hardware-visualizer -ErrorAction SilentlyContinue
+Stop-Process -Name hardware-visualizer
+```
 
 ## CI Integration
 
 The GitHub Actions workflow (`.github/workflows/perf-test.yml`) runs daily at 03:00 JST:
 
-- Builds the app and perf-monitor on Windows, Linux, and macOS
-- Runs performance tests on each platform (Linux uses `xvfb-run` for virtual display)
+- Builds the app and perf-monitor on the active performance matrix
+- Currently runs the performance gate on Windows; Linux and macOS commands are present in the workflow but their matrix entries are disabled
 - Uploads JSON results as artifacts
 - Creates a GitHub Issue labeled `performance-regression` if any threshold is exceeded
 

--- a/perf-monitor/src/config.rs
+++ b/perf-monitor/src/config.rs
@@ -19,6 +19,9 @@ pub struct Config {
 pub struct Thresholds {
   pub max_avg_cpu_percent: f32,
   pub max_p95_cpu_percent: f32,
+  pub max_avg_app_memory_mb: f64,
+  pub max_p95_app_memory_mb: f64,
+  pub max_app_memory_growth_mb: f64,
   pub max_avg_memory_mb: f64,
   pub max_p95_memory_mb: f64,
   pub max_memory_growth_mb: f64,
@@ -35,6 +38,9 @@ pub struct Timing {
 pub struct PlatformOverride {
   pub max_avg_cpu_percent: Option<f32>,
   pub max_p95_cpu_percent: Option<f32>,
+  pub max_avg_app_memory_mb: Option<f64>,
+  pub max_p95_app_memory_mb: Option<f64>,
+  pub max_app_memory_growth_mb: Option<f64>,
   pub max_avg_memory_mb: Option<f64>,
   pub max_p95_memory_mb: Option<f64>,
   pub max_memory_growth_mb: Option<f64>,
@@ -97,6 +103,15 @@ impl Config {
       }
       if let Some(v) = overrides.max_p95_cpu_percent {
         thresholds.max_p95_cpu_percent = v;
+      }
+      if let Some(v) = overrides.max_avg_app_memory_mb {
+        thresholds.max_avg_app_memory_mb = v;
+      }
+      if let Some(v) = overrides.max_p95_app_memory_mb {
+        thresholds.max_p95_app_memory_mb = v;
+      }
+      if let Some(v) = overrides.max_app_memory_growth_mb {
+        thresholds.max_app_memory_growth_mb = v;
       }
       if let Some(v) = overrides.max_avg_memory_mb {
         thresholds.max_avg_memory_mb = v;

--- a/perf-monitor/src/monitor.rs
+++ b/perf-monitor/src/monitor.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
-use std::io::Read as _;
+use std::io::Read;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::thread;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use sysinfo::{Pid, Process, ProcessesToUpdate, System};
@@ -10,6 +11,8 @@ use sysinfo::{Pid, Process, ProcessesToUpdate, System};
 use crate::config::Timing;
 
 const BYTES_PER_MIB: f64 = 1024.0 * 1024.0;
+const STDERR_BUFFER_LIMIT_BYTES: usize = 64 * 1024;
+const STDERR_READ_CHUNK_BYTES: usize = 8 * 1024;
 const WEBVIEW_PROCESS_MARKERS: &[&str] = &[
   "msedgewebview2",
   "webkitwebprocess",
@@ -66,11 +69,11 @@ struct ProcessTracker {
   root_pid: Pid,
   #[cfg(any(target_os = "windows", target_os = "macos"))]
   preexisting_webview_pids: HashSet<Pid>,
-  #[cfg(target_os = "macos")]
+  #[cfg(any(target_os = "windows", target_os = "macos"))]
   app_identity: AppIdentity,
 }
 
-#[cfg(any(test, target_os = "macos"))]
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 #[derive(Debug)]
 struct AppIdentity {
   tokens: Vec<String>,
@@ -94,13 +97,91 @@ struct ProcessMemoryBreakdown {
 }
 
 /// RAII guard that ensures the child process is terminated on drop.
-struct ProcessGuard(Child);
+struct ProcessGuard {
+  child: Child,
+  stderr_buffer: StderrBuffer,
+  stderr_reader: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone, Debug)]
+struct StderrBuffer {
+  inner: Arc<Mutex<Vec<u8>>>,
+  limit_bytes: usize,
+}
+
+impl StderrBuffer {
+  fn new(limit_bytes: usize) -> Self {
+    Self {
+      inner: Arc::new(Mutex::new(Vec::new())),
+      limit_bytes,
+    }
+  }
+
+  fn append(&self, bytes: &[u8]) {
+    if bytes.is_empty() || self.limit_bytes == 0 {
+      return;
+    }
+
+    let mut buffer = self
+      .inner
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if bytes.len() >= self.limit_bytes {
+      buffer.clear();
+      buffer.extend_from_slice(&bytes[bytes.len() - self.limit_bytes..]);
+      return;
+    }
+
+    let overflow = buffer
+      .len()
+      .saturating_add(bytes.len())
+      .saturating_sub(self.limit_bytes);
+    if overflow > 0 {
+      buffer.drain(..overflow);
+    }
+    buffer.extend_from_slice(bytes);
+  }
+
+  fn to_string_lossy(&self) -> Option<String> {
+    let buffer = self
+      .inner
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if buffer.is_empty() {
+      None
+    } else {
+      Some(String::from_utf8_lossy(&buffer).into_owned())
+    }
+  }
+}
+
+impl ProcessGuard {
+  fn new(mut child: Child) -> Self {
+    let stderr_buffer = StderrBuffer::new(STDERR_BUFFER_LIMIT_BYTES);
+    let stderr_reader = child
+      .stderr
+      .take()
+      .map(|stderr| spawn_stderr_reader(stderr, stderr_buffer.clone()));
+
+    Self {
+      child,
+      stderr_buffer,
+      stderr_reader,
+    }
+  }
+}
 
 impl Drop for ProcessGuard {
   fn drop(&mut self) {
     eprintln!("Terminating process...");
-    let _ = self.0.kill();
-    let _ = self.0.wait();
+    let _ = self.child.kill();
+    let _ = self.child.wait();
+
+    if let Some(reader) = self.stderr_reader.take() {
+      let _ = reader.join();
+    }
   }
 }
 
@@ -110,8 +191,8 @@ pub fn run_monitor(
 ) -> Result<MonitorResult, Box<dyn std::error::Error>> {
   let preexisting_webview_pids = collect_preexisting_webview_pids();
 
-  let mut guard = ProcessGuard(launch_process(binary_path)?);
-  let pid = Pid::from_u32(guard.0.id());
+  let mut guard = launch_process(binary_path)?;
+  let pid = Pid::from_u32(guard.child.id());
   let tracker = ProcessTracker::new(pid, binary_path, preexisting_webview_pids);
   let num_cpus = thread::available_parallelism()
     .map(|n| n.get() as f32)
@@ -127,7 +208,7 @@ pub fn run_monitor(
   // Warmup phase: wait for app to stabilize
   for _ in 0..timing.warmup_seconds {
     thread::sleep(Duration::from_secs(1));
-    if guard.0.try_wait()?.is_some() {
+    if guard.child.try_wait()?.is_some() {
       return Err(format_exit_error(&mut guard, "warmup", binary_path));
     }
     system.refresh_processes(ProcessesToUpdate::All, true);
@@ -146,7 +227,7 @@ pub fn run_monitor(
   for _ in 0..total_samples {
     thread::sleep(interval);
 
-    if guard.0.try_wait()?.is_some() {
+    if guard.child.try_wait()?.is_some() {
       return Err(format_exit_error(&mut guard, "measurement", binary_path));
     }
 
@@ -155,7 +236,7 @@ pub fn run_monitor(
     if let Some(sample) = tracker.sample(&system, num_cpus) {
       samples.push(sample);
     } else {
-      if guard.0.try_wait()?.is_some() {
+      if guard.child.try_wait()?.is_some() {
         return Err(format_exit_error(&mut guard, "measurement", binary_path));
       }
       return Err("Process disappeared during measurement".into());
@@ -193,10 +274,10 @@ impl ProcessTracker {
 
     #[cfg(target_os = "windows")]
     {
-      let _ = binary_path;
       Self {
         root_pid,
         preexisting_webview_pids,
+        app_identity: AppIdentity::from_binary_path(binary_path),
       }
     }
 
@@ -279,11 +360,16 @@ impl ProcessTracker {
 
   #[cfg(target_os = "windows")]
   fn is_associated_windows_webview(&self, pid: Pid, process: &ProcessSnapshot) -> bool {
-    is_associated_webview_snapshot(&self.preexisting_webview_pids, pid, process)
+    is_associated_webview_snapshot(
+      &self.preexisting_webview_pids,
+      Some(&self.app_identity),
+      pid,
+      process,
+    )
   }
 }
 
-#[cfg(any(test, target_os = "macos"))]
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 impl AppIdentity {
   fn from_binary_path(binary_path: &Path) -> Self {
     let mut tokens = Vec::new();
@@ -315,7 +401,7 @@ impl AppIdentity {
   }
 }
 
-#[cfg(any(test, target_os = "macos"))]
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 fn push_identity_token(tokens: &mut Vec<String>, token: &str) {
   let normalized = token.to_ascii_lowercase();
   if !normalized.is_empty() && !tokens.contains(&normalized) {
@@ -328,7 +414,7 @@ fn push_identity_token(tokens: &mut Vec<String>, token: &str) {
   }
 }
 
-#[cfg(any(test, target_os = "macos"))]
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 fn compact_token(token: &str) -> String {
   token
     .chars()
@@ -337,10 +423,28 @@ fn compact_token(token: &str) -> String {
     .collect()
 }
 
-fn launch_process(binary_path: &Path) -> Result<Child, Box<dyn std::error::Error>> {
+fn launch_process(
+  binary_path: &Path,
+) -> Result<ProcessGuard, Box<dyn std::error::Error>> {
   let child = Command::new(binary_path).stderr(Stdio::piped()).spawn()?;
   eprintln!("Launched process with PID: {}", child.id());
-  Ok(child)
+  Ok(ProcessGuard::new(child))
+}
+
+fn spawn_stderr_reader<R>(mut stderr: R, buffer: StderrBuffer) -> JoinHandle<()>
+where
+  R: Read + Send + 'static,
+{
+  thread::spawn(move || {
+    let mut chunk = [0; STDERR_READ_CHUNK_BYTES];
+    loop {
+      match stderr.read(&mut chunk) {
+        Ok(0) => break,
+        Ok(bytes_read) => buffer.append(&chunk[..bytes_read]),
+        Err(_) => break,
+      }
+    }
+  })
 }
 
 fn format_exit_error(
@@ -348,12 +452,8 @@ fn format_exit_error(
   phase: &str,
   binary_path: &Path,
 ) -> Box<dyn std::error::Error> {
-  let status = guard.0.try_wait().ok().flatten();
-  let stderr = guard.0.stderr.take().and_then(|mut s| {
-    let mut buf = String::new();
-    s.read_to_string(&mut buf).ok()?;
-    if buf.is_empty() { None } else { Some(buf) }
-  });
+  let status = guard.child.try_wait().ok().flatten();
+  let stderr = guard.stderr_buffer.to_string_lossy();
 
   format_exit_message(
     phase,
@@ -503,40 +603,23 @@ fn is_associated_macos_webview_snapshot(
   pid: Pid,
   process: &ProcessSnapshot,
 ) -> bool {
+  is_associated_webview_snapshot(preexisting_webview_pids, app_identity, pid, process)
+}
+
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
+fn is_associated_webview_snapshot(
+  preexisting_webview_pids: &HashSet<Pid>,
+  app_identity: Option<&AppIdentity>,
+  pid: Pid,
+  process: &ProcessSnapshot,
+) -> bool {
   if preexisting_webview_pids.contains(&pid)
     || !is_webview_process_text(&process.search_text)
   {
     return false;
   }
 
-  if app_identity.is_some_and(|identity| identity.matches_text(&process.search_text)) {
-    return true;
-  }
-
-  // sysinfo does not expose macOS responsibility metadata. The monitor runs in
-  // an isolated CI session, so newly-created WebKit helpers are treated as
-  // associated after excluding helpers that existed before launch.
-  true
-}
-
-#[cfg(any(test, target_os = "windows"))]
-fn is_associated_webview_snapshot(
-  preexisting_webview_pids: &HashSet<Pid>,
-  pid: Pid,
-  process: &ProcessSnapshot,
-) -> bool {
-  if preexisting_webview_pids.contains(&pid) {
-    return false;
-  }
-
-  // WebView2 helper processes are not always reported as descendants of the
-  // launched app process. In the isolated perf-monitor run, newly-created
-  // WebView helpers are part of the app footprint.
-  if !is_webview_process_text(&process.search_text) {
-    return false;
-  }
-
-  true
+  app_identity.is_some_and(|identity| identity.matches_text(&process.search_text))
 }
 
 fn process_search_text(process: &Process) -> String {
@@ -826,25 +909,41 @@ mod tests {
 
   #[test]
   fn webview_association_excludes_preexisting_helpers() {
+    let identity = AppIdentity::from_binary_path(Path::new("hardware-visualizer.exe"));
     let preexisting = HashSet::from([pid(42)]);
     let existing_webview = snapshot(None, 100, 0.0, "msedgewebview2.exe");
-    let new_webview = snapshot(None, 100, 0.0, "msedgewebview2.exe");
+    let new_webview_without_identity = snapshot(None, 100, 0.0, "msedgewebview2.exe");
+    let new_webview_with_identity = snapshot(
+      None,
+      100,
+      0.0,
+      r"msedgewebview2.exe --user-data-dir=C:\Users\ci\AppData\Local\HardwareVisualizer",
+    );
     let non_webview = snapshot(None, 100, 0.0, "hardware-visualizer.exe");
 
     assert!(!is_associated_webview_snapshot(
       &preexisting,
+      Some(&identity),
       pid(42),
       &existing_webview,
     ));
     assert!(!is_associated_webview_snapshot(
       &preexisting,
+      Some(&identity),
       pid(43),
       &non_webview,
     ));
+    assert!(!is_associated_webview_snapshot(
+      &preexisting,
+      Some(&identity),
+      pid(44),
+      &new_webview_without_identity,
+    ));
     assert!(is_associated_webview_snapshot(
       &preexisting,
-      pid(44),
-      &new_webview,
+      Some(&identity),
+      pid(45),
+      &new_webview_with_identity,
     ));
   }
 
@@ -853,7 +952,15 @@ mod tests {
   fn tracked_pids_include_new_windows_webview_helpers_without_parent_link() {
     let processes = HashMap::from([
       (pid(10), snapshot(None, 50, 20.0, "hardware-visualizer.exe")),
-      (pid(11), snapshot(None, 200, 0.0, "msedgewebview2.exe")),
+      (
+        pid(11),
+        snapshot(
+          None,
+          200,
+          0.0,
+          r"msedgewebview2.exe --user-data-dir=C:\Users\ci\AppData\Local\HardwareVisualizer",
+        ),
+      ),
       (pid(12), snapshot(None, 100, 0.0, "msedgewebview2.exe")),
     ]);
     let tracker = ProcessTracker::new(
@@ -874,7 +981,14 @@ mod tests {
     ));
     let preexisting = HashSet::from([pid(42)]);
     let existing_webkit = snapshot(None, 100, 0.0, "com.apple.WebKit.WebContent");
-    let new_webkit = snapshot(None, 100, 0.0, "com.apple.WebKit.WebContent");
+    let new_webkit_without_identity =
+      snapshot(None, 100, 0.0, "com.apple.WebKit.WebContent");
+    let new_webkit_with_identity = snapshot(
+      None,
+      100,
+      0.0,
+      "com.apple.WebKit.WebContent /Users/ci/Library/Application Support/HardwareVisualizer",
+    );
     let non_webkit = snapshot(None, 100, 0.0, "hardware-visualizer.exe");
 
     assert!(!is_associated_macos_webview_snapshot(
@@ -889,12 +1003,29 @@ mod tests {
       pid(43),
       &non_webkit,
     ));
-    assert!(is_associated_macos_webview_snapshot(
+    assert!(!is_associated_macos_webview_snapshot(
       &preexisting,
       Some(&identity),
       pid(44),
-      &new_webkit,
+      &new_webkit_without_identity,
     ));
+    assert!(is_associated_macos_webview_snapshot(
+      &preexisting,
+      Some(&identity),
+      pid(45),
+      &new_webkit_with_identity,
+    ));
+  }
+
+  #[test]
+  fn stderr_buffer_keeps_latest_bounded_output() {
+    let buffer = StderrBuffer::new(8);
+
+    buffer.append(b"abcdefghij");
+    assert_eq!(buffer.to_string_lossy().as_deref(), Some("cdefghij"));
+
+    buffer.append(b"kl");
+    assert_eq!(buffer.to_string_lossy().as_deref(), Some("efghijkl"));
   }
 
   #[test]

--- a/perf-monitor/src/monitor.rs
+++ b/perf-monitor/src/monitor.rs
@@ -1,17 +1,45 @@
+use std::collections::{HashMap, HashSet};
 use std::io::Read as _;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
-use sysinfo::{Pid, ProcessesToUpdate, System};
+use sysinfo::{Pid, Process, ProcessesToUpdate, System};
 
 use crate::config::Timing;
+
+const BYTES_PER_MIB: f64 = 1024.0 * 1024.0;
+const WEBVIEW_PROCESS_MARKERS: &[&str] = &[
+  "msedgewebview2",
+  "webkitwebprocess",
+  "webkitwebproces",
+  "webkitnetworkprocess",
+  "webkitnetwork",
+  "webkitnetworkp",
+  "webkitgpu",
+  "com.apple.webkit.webcontent",
+  "com.apple.webkit.networking",
+  "com.apple.webkit.gpu",
+];
 
 #[derive(Debug)]
 pub struct ProcessMetrics {
   pub cpu_usage: f32,
   pub memory_rss_mb: f64,
+  pub parent_memory_rss_mb: f64,
+  pub webview_memory_rss_mb: f64,
+  pub other_process_memory_rss_mb: f64,
+  pub process_count: usize,
+  pub webview_process_count: usize,
+}
+
+#[derive(Debug)]
+pub struct MemoryStats {
+  pub avg_mb: f64,
+  pub max_mb: f64,
+  pub p95_mb: f64,
+  pub growth_mb: f64,
 }
 
 #[derive(Debug)]
@@ -24,8 +52,45 @@ pub struct MonitorResult {
   pub max_memory_mb: f64,
   pub p95_memory_mb: f64,
   pub memory_growth_mb: f64,
+  pub parent_memory: MemoryStats,
+  pub webview_memory: MemoryStats,
+  pub other_process_memory: MemoryStats,
+  pub max_process_count: usize,
+  pub max_webview_process_count: usize,
   pub duration_seconds: u64,
   pub warmup_seconds: u64,
+}
+
+#[derive(Debug)]
+struct ProcessTracker {
+  root_pid: Pid,
+  #[cfg(any(target_os = "windows", target_os = "macos"))]
+  preexisting_webview_pids: HashSet<Pid>,
+  #[cfg(target_os = "macos")]
+  app_identity: AppIdentity,
+}
+
+#[cfg(any(test, target_os = "macos"))]
+#[derive(Debug)]
+struct AppIdentity {
+  tokens: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ProcessSnapshot {
+  parent: Option<Pid>,
+  memory_bytes: u64,
+  cpu_usage: f32,
+  search_text: String,
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct ProcessMemoryBreakdown {
+  parent_memory_bytes: u64,
+  webview_memory_bytes: u64,
+  other_process_memory_bytes: u64,
+  process_count: usize,
+  webview_process_count: usize,
 }
 
 /// RAII guard that ensures the child process is terminated on drop.
@@ -43,16 +108,19 @@ pub fn run_monitor(
   binary_path: &Path,
   timing: &Timing,
 ) -> Result<MonitorResult, Box<dyn std::error::Error>> {
+  let preexisting_webview_pids = collect_preexisting_webview_pids();
+
   let mut guard = ProcessGuard(launch_process(binary_path)?);
   let pid = Pid::from_u32(guard.0.id());
+  let tracker = ProcessTracker::new(pid, binary_path, preexisting_webview_pids);
   let num_cpus = thread::available_parallelism()
     .map(|n| n.get() as f32)
     .unwrap_or(1.0);
 
   let mut system = System::new();
 
-  // Initial refresh to establish CPU baseline
-  system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+  // Initial refresh to establish CPU baselines and discover helper processes.
+  system.refresh_processes(ProcessesToUpdate::All, true);
 
   eprintln!("Warming up for {} seconds...", timing.warmup_seconds);
 
@@ -60,9 +128,9 @@ pub fn run_monitor(
   for _ in 0..timing.warmup_seconds {
     thread::sleep(Duration::from_secs(1));
     if guard.0.try_wait()?.is_some() {
-      return Err(format_exit_error(&mut guard, "warmup"));
+      return Err(format_exit_error(&mut guard, "warmup", binary_path));
     }
-    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system.refresh_processes(ProcessesToUpdate::All, true);
   }
 
   eprintln!(
@@ -79,20 +147,17 @@ pub fn run_monitor(
     thread::sleep(interval);
 
     if guard.0.try_wait()?.is_some() {
-      return Err(format_exit_error(&mut guard, "measurement"));
+      return Err(format_exit_error(&mut guard, "measurement", binary_path));
     }
 
-    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system.refresh_processes(ProcessesToUpdate::All, true);
 
-    if let Some(process) = system.process(pid) {
-      let cpu_normalized = process.cpu_usage() / num_cpus;
-      let memory_mb = process.memory() as f64 / (1024.0 * 1024.0);
-
-      samples.push(ProcessMetrics {
-        cpu_usage: cpu_normalized,
-        memory_rss_mb: memory_mb,
-      });
+    if let Some(sample) = tracker.sample(&system, num_cpus) {
+      samples.push(sample);
     } else {
+      if guard.0.try_wait()?.is_some() {
+        return Err(format_exit_error(&mut guard, "measurement", binary_path));
+      }
       return Err("Process disappeared during measurement".into());
     }
   }
@@ -111,10 +176,169 @@ pub fn run_monitor(
   ))
 }
 
+impl ProcessTracker {
+  fn new(
+    root_pid: Pid,
+    binary_path: &Path,
+    preexisting_webview_pids: HashSet<Pid>,
+  ) -> Self {
+    #[cfg(target_os = "macos")]
+    {
+      Self {
+        root_pid,
+        preexisting_webview_pids,
+        app_identity: AppIdentity::from_binary_path(binary_path),
+      }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+      let _ = binary_path;
+      Self {
+        root_pid,
+        preexisting_webview_pids,
+      }
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+      let _ = binary_path;
+      let _ = preexisting_webview_pids;
+      Self { root_pid }
+    }
+  }
+
+  fn sample(&self, system: &System, num_cpus: f32) -> Option<ProcessMetrics> {
+    let processes = snapshot_processes(system);
+    self.sample_from_snapshots(&processes, num_cpus)
+  }
+
+  fn sample_from_snapshots(
+    &self,
+    processes: &HashMap<Pid, ProcessSnapshot>,
+    num_cpus: f32,
+  ) -> Option<ProcessMetrics> {
+    let root_process = processes.get(&self.root_pid)?;
+    let tracked_pids = self.tracked_pids_from_snapshots(processes);
+    let breakdown = process_memory_breakdown(&tracked_pids, self.root_pid, processes);
+    let total_memory_bytes = breakdown.parent_memory_bytes
+      + breakdown.webview_memory_bytes
+      + breakdown.other_process_memory_bytes;
+
+    Some(ProcessMetrics {
+      // Keep CPU semantics scoped to the launched process; issue #1579 changes
+      // the RSS accounting that feeds memory thresholds.
+      cpu_usage: root_process.cpu_usage / num_cpus,
+      memory_rss_mb: bytes_to_mib(total_memory_bytes),
+      parent_memory_rss_mb: bytes_to_mib(breakdown.parent_memory_bytes),
+      webview_memory_rss_mb: bytes_to_mib(breakdown.webview_memory_bytes),
+      other_process_memory_rss_mb: bytes_to_mib(breakdown.other_process_memory_bytes),
+      process_count: breakdown.process_count,
+      webview_process_count: breakdown.webview_process_count,
+    })
+  }
+
+  fn tracked_pids_from_snapshots(
+    &self,
+    processes: &HashMap<Pid, ProcessSnapshot>,
+  ) -> HashSet<Pid> {
+    let mut pids = HashSet::from([self.root_pid]);
+
+    for pid in processes.keys().copied() {
+      if pid != self.root_pid && is_descendant_snapshot(processes, pid, self.root_pid) {
+        pids.insert(pid);
+      }
+    }
+
+    #[cfg(target_os = "macos")]
+    for (pid, process) in processes {
+      if !pids.contains(pid) && self.is_associated_macos_webview(*pid, process) {
+        pids.insert(*pid);
+      }
+    }
+
+    #[cfg(target_os = "windows")]
+    for (pid, process) in processes {
+      if !pids.contains(pid) && self.is_associated_windows_webview(*pid, process) {
+        pids.insert(*pid);
+      }
+    }
+
+    pids
+  }
+
+  #[cfg(target_os = "macos")]
+  fn is_associated_macos_webview(&self, pid: Pid, process: &ProcessSnapshot) -> bool {
+    is_associated_macos_webview_snapshot(
+      &self.preexisting_webview_pids,
+      Some(&self.app_identity),
+      pid,
+      process,
+    )
+  }
+
+  #[cfg(target_os = "windows")]
+  fn is_associated_windows_webview(&self, pid: Pid, process: &ProcessSnapshot) -> bool {
+    is_associated_webview_snapshot(&self.preexisting_webview_pids, pid, process)
+  }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+impl AppIdentity {
+  fn from_binary_path(binary_path: &Path) -> Self {
+    let mut tokens = Vec::new();
+
+    if let Some(stem) = binary_path.file_stem().and_then(|s| s.to_str()) {
+      push_identity_token(&mut tokens, stem);
+    }
+
+    for component in binary_path.components() {
+      let Some(component) = component.as_os_str().to_str() else {
+        continue;
+      };
+
+      if let Some(bundle_name) = component.strip_suffix(".app") {
+        push_identity_token(&mut tokens, bundle_name);
+      }
+    }
+
+    Self { tokens }
+  }
+
+  fn matches_text(&self, text: &str) -> bool {
+    let compact_text = compact_token(text);
+
+    self
+      .tokens
+      .iter()
+      .any(|token| text.contains(token) || compact_text.contains(token))
+  }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn push_identity_token(tokens: &mut Vec<String>, token: &str) {
+  let normalized = token.to_ascii_lowercase();
+  if !normalized.is_empty() && !tokens.contains(&normalized) {
+    tokens.push(normalized);
+  }
+
+  let compact = compact_token(token);
+  if !compact.is_empty() && !tokens.contains(&compact) {
+    tokens.push(compact);
+  }
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn compact_token(token: &str) -> String {
+  token
+    .chars()
+    .filter(|c| c.is_ascii_alphanumeric())
+    .flat_map(char::to_lowercase)
+    .collect()
+}
+
 fn launch_process(binary_path: &Path) -> Result<Child, Box<dyn std::error::Error>> {
-  let child = Command::new(binary_path)
-    .stderr(Stdio::piped())
-    .spawn()?;
+  let child = Command::new(binary_path).stderr(Stdio::piped()).spawn()?;
   eprintln!("Launched process with PID: {}", child.id());
   Ok(child)
 }
@@ -122,26 +346,220 @@ fn launch_process(binary_path: &Path) -> Result<Child, Box<dyn std::error::Error
 fn format_exit_error(
   guard: &mut ProcessGuard,
   phase: &str,
+  binary_path: &Path,
 ) -> Box<dyn std::error::Error> {
   let status = guard.0.try_wait().ok().flatten();
-  let stderr = guard
-    .0
-    .stderr
-    .take()
-    .and_then(|mut s| {
-      let mut buf = String::new();
-      s.read_to_string(&mut buf).ok()?;
-      if buf.is_empty() { None } else { Some(buf) }
-    });
+  let stderr = guard.0.stderr.take().and_then(|mut s| {
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).ok()?;
+    if buf.is_empty() { None } else { Some(buf) }
+  });
 
+  format_exit_message(
+    phase,
+    status.as_ref().map(ToString::to_string).as_deref(),
+    status.as_ref().is_some_and(|st| st.success()),
+    stderr.as_deref(),
+    binary_path,
+  )
+  .into()
+}
+
+fn format_exit_message(
+  phase: &str,
+  status: Option<&str>,
+  exited_successfully: bool,
+  stderr: Option<&str>,
+  binary_path: &Path,
+) -> String {
   let mut msg = format!("Process exited during {phase}");
   if let Some(st) = status {
     msg.push_str(&format!(" (exit status: {st})"));
   }
+  if exited_successfully {
+    msg.push_str(
+      "\n\nHint: the target exited successfully before monitoring completed. \
+       If HardwareVisualizer is already running, Tauri's single-instance \
+       plugin can hand this launch off to the existing instance and exit the \
+       measured process. Close existing `hardware-visualizer` processes and \
+       rerun the perf test.",
+    );
+    msg.push_str(&format!("\nTarget: {}", binary_path.display()));
+  }
   if let Some(err) = stderr {
     msg.push_str(&format!("\n--- process stderr ---\n{err}"));
   }
-  msg.into()
+  msg
+}
+
+fn collect_preexisting_webview_pids() -> HashSet<Pid> {
+  #[cfg(any(target_os = "windows", target_os = "macos"))]
+  {
+    let mut system = System::new();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    collect_webview_pids(&system)
+  }
+
+  #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+  {
+    HashSet::new()
+  }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn collect_webview_pids(system: &System) -> HashSet<Pid> {
+  system
+    .processes()
+    .iter()
+    .filter_map(|(pid, process)| {
+      is_webview_process_text(&process_search_text(process)).then_some(*pid)
+    })
+    .collect()
+}
+
+fn snapshot_processes(system: &System) -> HashMap<Pid, ProcessSnapshot> {
+  system
+    .processes()
+    .iter()
+    .map(|(pid, process)| {
+      (
+        *pid,
+        ProcessSnapshot {
+          parent: process.parent(),
+          memory_bytes: process.memory(),
+          cpu_usage: process.cpu_usage(),
+          search_text: process_search_text(process),
+        },
+      )
+    })
+    .collect()
+}
+
+fn is_descendant_snapshot(
+  processes: &HashMap<Pid, ProcessSnapshot>,
+  pid: Pid,
+  root_pid: Pid,
+) -> bool {
+  let mut current_pid = pid;
+  let mut visited = HashSet::new();
+
+  while let Some(process) = processes.get(&current_pid) {
+    let Some(parent_pid) = process.parent else {
+      return false;
+    };
+
+    if parent_pid == root_pid {
+      return true;
+    }
+
+    if !visited.insert(parent_pid) {
+      return false;
+    }
+
+    current_pid = parent_pid;
+  }
+
+  false
+}
+
+fn process_memory_breakdown(
+  pids: &HashSet<Pid>,
+  root_pid: Pid,
+  processes: &HashMap<Pid, ProcessSnapshot>,
+) -> ProcessMemoryBreakdown {
+  let mut breakdown = ProcessMemoryBreakdown::default();
+
+  for pid in pids {
+    let Some(process) = processes.get(pid) else {
+      continue;
+    };
+
+    breakdown.process_count += 1;
+
+    if *pid == root_pid {
+      breakdown.parent_memory_bytes += process.memory_bytes;
+    } else if is_webview_process_text(&process.search_text) {
+      breakdown.webview_memory_bytes += process.memory_bytes;
+      breakdown.webview_process_count += 1;
+    } else {
+      breakdown.other_process_memory_bytes += process.memory_bytes;
+    }
+  }
+
+  breakdown
+}
+
+fn is_webview_process_text(text: &str) -> bool {
+  let text = text.to_ascii_lowercase();
+  WEBVIEW_PROCESS_MARKERS
+    .iter()
+    .any(|marker| text.contains(marker))
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn is_associated_macos_webview_snapshot(
+  preexisting_webview_pids: &HashSet<Pid>,
+  app_identity: Option<&AppIdentity>,
+  pid: Pid,
+  process: &ProcessSnapshot,
+) -> bool {
+  if preexisting_webview_pids.contains(&pid)
+    || !is_webview_process_text(&process.search_text)
+  {
+    return false;
+  }
+
+  if app_identity.is_some_and(|identity| identity.matches_text(&process.search_text)) {
+    return true;
+  }
+
+  // sysinfo does not expose macOS responsibility metadata. The monitor runs in
+  // an isolated CI session, so newly-created WebKit helpers are treated as
+  // associated after excluding helpers that existed before launch.
+  true
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn is_associated_webview_snapshot(
+  preexisting_webview_pids: &HashSet<Pid>,
+  pid: Pid,
+  process: &ProcessSnapshot,
+) -> bool {
+  if preexisting_webview_pids.contains(&pid) {
+    return false;
+  }
+
+  // WebView2 helper processes are not always reported as descendants of the
+  // launched app process. In the isolated perf-monitor run, newly-created
+  // WebView helpers are part of the app footprint.
+  if !is_webview_process_text(&process.search_text) {
+    return false;
+  }
+
+  true
+}
+
+fn process_search_text(process: &Process) -> String {
+  let mut parts = Vec::new();
+
+  parts.push(process.name().to_string_lossy().into_owned());
+
+  if let Some(exe) = process.exe() {
+    parts.push(exe.to_string_lossy().into_owned());
+  }
+
+  parts.extend(
+    process
+      .cmd()
+      .iter()
+      .map(|arg| arg.to_string_lossy().into_owned()),
+  );
+
+  parts.join(" ").to_ascii_lowercase()
+}
+
+fn bytes_to_mib(bytes: u64) -> f64 {
+  bytes as f64 / BYTES_PER_MIB
 }
 
 fn compute_result(
@@ -161,32 +579,61 @@ fn compute_result(
     95.0,
   );
 
-  let n_f64 = samples.len() as f64;
-  let avg_memory_mb = samples.iter().map(|s| s.memory_rss_mb).sum::<f64>() / n_f64;
-  let max_memory_mb = samples
+  let total_memory = memory_stats(&samples, |s| s.memory_rss_mb);
+  let parent_memory = memory_stats(&samples, |s| s.parent_memory_rss_mb);
+  let webview_memory = memory_stats(&samples, |s| s.webview_memory_rss_mb);
+  let other_process_memory = memory_stats(&samples, |s| s.other_process_memory_rss_mb);
+  let max_process_count = samples.iter().map(|s| s.process_count).max().unwrap_or(0);
+  let max_webview_process_count = samples
     .iter()
-    .map(|s| s.memory_rss_mb)
-    .fold(f64::NEG_INFINITY, f64::max);
-  let p95_memory_mb = percentile_f64(
-    &samples.iter().map(|s| s.memory_rss_mb).collect::<Vec<_>>(),
-    95.0,
-  );
-
-  let first_memory = samples.first().map(|s| s.memory_rss_mb).unwrap_or(0.0);
-  let last_memory = samples.last().map(|s| s.memory_rss_mb).unwrap_or(0.0);
-  let memory_growth_mb = last_memory - first_memory;
+    .map(|s| s.webview_process_count)
+    .max()
+    .unwrap_or(0);
 
   MonitorResult {
     samples,
     avg_cpu,
     max_cpu,
     p95_cpu,
-    avg_memory_mb,
-    max_memory_mb,
-    p95_memory_mb,
-    memory_growth_mb,
+    avg_memory_mb: total_memory.avg_mb,
+    max_memory_mb: total_memory.max_mb,
+    p95_memory_mb: total_memory.p95_mb,
+    memory_growth_mb: total_memory.growth_mb,
+    parent_memory,
+    webview_memory,
+    other_process_memory,
+    max_process_count,
+    max_webview_process_count,
     duration_seconds,
     warmup_seconds,
+  }
+}
+
+fn memory_stats<F>(samples: &[ProcessMetrics], value: F) -> MemoryStats
+where
+  F: Fn(&ProcessMetrics) -> f64,
+{
+  if samples.is_empty() {
+    return MemoryStats {
+      avg_mb: 0.0,
+      max_mb: 0.0,
+      p95_mb: 0.0,
+      growth_mb: 0.0,
+    };
+  }
+
+  let values = samples.iter().map(value).collect::<Vec<_>>();
+  let avg_mb = values.iter().sum::<f64>() / values.len() as f64;
+  let max_mb = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+  let p95_mb = percentile_f64(&values, 95.0);
+  let first_mb = values.first().copied().unwrap_or(0.0);
+  let last_mb = values.last().copied().unwrap_or(0.0);
+
+  MemoryStats {
+    avg_mb,
+    max_mb,
+    p95_mb,
+    growth_mb: last_mb - first_mb,
   }
 }
 
@@ -262,9 +709,9 @@ mod tests {
   #[test]
   fn compute_result_basic_statistics() {
     let samples = vec![
-      ProcessMetrics { cpu_usage: 10.0, memory_rss_mb: 100.0 },
-      ProcessMetrics { cpu_usage: 20.0, memory_rss_mb: 200.0 },
-      ProcessMetrics { cpu_usage: 30.0, memory_rss_mb: 150.0 },
+      sample(10.0, 100.0, 80.0, 15.0, 5.0),
+      sample(20.0, 200.0, 90.0, 100.0, 10.0),
+      sample(30.0, 150.0, 85.0, 60.0, 5.0),
     ];
 
     let result = compute_result(samples, 3, 5);
@@ -280,5 +727,275 @@ mod tests {
     assert!((result.avg_memory_mb - 150.0).abs() < 0.01);
     // growth = last - first = 150 - 100 = 50
     assert!((result.memory_growth_mb - 50.0).abs() < 0.01);
+  }
+
+  #[test]
+  fn compute_result_tracks_memory_breakdown() {
+    let samples = vec![
+      sample(10.0, 100.0, 80.0, 15.0, 5.0),
+      sample(20.0, 200.0, 90.0, 100.0, 10.0),
+      sample(30.0, 150.0, 85.0, 60.0, 5.0),
+    ];
+
+    let result = compute_result(samples, 3, 5);
+
+    assert!((result.parent_memory.avg_mb - 85.0).abs() < 0.01);
+    assert!((result.webview_memory.avg_mb - 58.33).abs() < 0.01);
+    assert!((result.other_process_memory.max_mb - 10.0).abs() < 0.01);
+    assert!((result.webview_memory.growth_mb - 45.0).abs() < 0.01);
+    assert_eq!(result.max_process_count, 3);
+    assert_eq!(result.max_webview_process_count, 1);
+  }
+
+  #[test]
+  fn tracked_pids_include_root_children_and_grandchildren_only() {
+    let processes = HashMap::from([
+      (pid(10), snapshot(None, 50, 20.0, "hardware-visualizer.exe")),
+      (pid(11), snapshot(Some(pid(10)), 10, 0.0, "child.exe")),
+      (pid(12), snapshot(Some(pid(11)), 10, 0.0, "grandchild.exe")),
+      (pid(20), snapshot(None, 10, 0.0, "unrelated.exe")),
+      (
+        pid(21),
+        snapshot(Some(pid(20)), 10, 0.0, "unrelated-child.exe"),
+      ),
+    ]);
+
+    let tracked = tracker().tracked_pids_from_snapshots(&processes);
+
+    assert_eq!(tracked, HashSet::from([pid(10), pid(11), pid(12)]));
+  }
+
+  #[test]
+  fn descendant_detection_stops_on_missing_parent_and_cycles() {
+    let processes = HashMap::from([
+      (pid(10), snapshot(None, 50, 20.0, "hardware-visualizer.exe")),
+      (
+        pid(30),
+        snapshot(Some(pid(99)), 10, 0.0, "missing-parent.exe"),
+      ),
+      (pid(40), snapshot(Some(pid(41)), 10, 0.0, "cycle-a.exe")),
+      (pid(41), snapshot(Some(pid(40)), 10, 0.0, "cycle-b.exe")),
+    ]);
+
+    assert!(!is_descendant_snapshot(&processes, pid(30), pid(10)));
+    assert!(!is_descendant_snapshot(&processes, pid(40), pid(10)));
+  }
+
+  #[test]
+  fn sample_from_snapshots_sums_parent_webview_and_other_processes() {
+    let processes = HashMap::from([
+      (pid(10), snapshot(None, 50, 20.0, "hardware-visualizer.exe")),
+      (
+        pid(11),
+        snapshot(Some(pid(10)), 200, 0.0, "msedgewebview2.exe"),
+      ),
+      (
+        pid(12),
+        snapshot(Some(pid(10)), 25, 0.0, "hardware-helper.exe"),
+      ),
+      (
+        pid(20),
+        snapshot(None, 100, 0.0, "unrelated-msedgewebview2.exe"),
+      ),
+    ]);
+
+    let sample = tracker_with_preexisting_webviews(HashSet::from([pid(20)]))
+      .sample_from_snapshots(&processes, 2.0)
+      .expect("root process should be present");
+
+    assert!((sample.cpu_usage - 10.0).abs() < 0.01);
+    assert!((sample.memory_rss_mb - 275.0).abs() < 0.01);
+    assert!((sample.parent_memory_rss_mb - 50.0).abs() < 0.01);
+    assert!((sample.webview_memory_rss_mb - 200.0).abs() < 0.01);
+    assert!((sample.other_process_memory_rss_mb - 25.0).abs() < 0.01);
+    assert_eq!(sample.process_count, 3);
+    assert_eq!(sample.webview_process_count, 1);
+  }
+
+  #[test]
+  fn webview_process_text_matches_known_helper_names() {
+    assert!(is_webview_process_text(
+      r"C:\Program Files\WebView2\msedgewebview2.exe"
+    ));
+    assert!(is_webview_process_text("WebKitWebProcess"));
+    assert!(is_webview_process_text("WebKitNetworkProcess"));
+    assert!(is_webview_process_text("com.apple.WebKit.WebContent"));
+    assert!(is_webview_process_text("com.apple.WebKit.Networking"));
+    assert!(!is_webview_process_text("hardware-visualizer.exe"));
+  }
+
+  #[test]
+  fn webview_association_excludes_preexisting_helpers() {
+    let preexisting = HashSet::from([pid(42)]);
+    let existing_webview = snapshot(None, 100, 0.0, "msedgewebview2.exe");
+    let new_webview = snapshot(None, 100, 0.0, "msedgewebview2.exe");
+    let non_webview = snapshot(None, 100, 0.0, "hardware-visualizer.exe");
+
+    assert!(!is_associated_webview_snapshot(
+      &preexisting,
+      pid(42),
+      &existing_webview,
+    ));
+    assert!(!is_associated_webview_snapshot(
+      &preexisting,
+      pid(43),
+      &non_webview,
+    ));
+    assert!(is_associated_webview_snapshot(
+      &preexisting,
+      pid(44),
+      &new_webview,
+    ));
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn tracked_pids_include_new_windows_webview_helpers_without_parent_link() {
+    let processes = HashMap::from([
+      (pid(10), snapshot(None, 50, 20.0, "hardware-visualizer.exe")),
+      (pid(11), snapshot(None, 200, 0.0, "msedgewebview2.exe")),
+      (pid(12), snapshot(None, 100, 0.0, "msedgewebview2.exe")),
+    ]);
+    let tracker = ProcessTracker::new(
+      pid(10),
+      Path::new("hardware-visualizer.exe"),
+      HashSet::from([pid(12)]),
+    );
+
+    let tracked = tracker.tracked_pids_from_snapshots(&processes);
+
+    assert_eq!(tracked, HashSet::from([pid(10), pid(11)]));
+  }
+
+  #[test]
+  fn macos_webview_association_excludes_preexisting_helpers() {
+    let identity = AppIdentity::from_binary_path(Path::new(
+      "/Applications/HardwareVisualizer.app/Contents/MacOS/hardware-visualizer",
+    ));
+    let preexisting = HashSet::from([pid(42)]);
+    let existing_webkit = snapshot(None, 100, 0.0, "com.apple.WebKit.WebContent");
+    let new_webkit = snapshot(None, 100, 0.0, "com.apple.WebKit.WebContent");
+    let non_webkit = snapshot(None, 100, 0.0, "hardware-visualizer.exe");
+
+    assert!(!is_associated_macos_webview_snapshot(
+      &preexisting,
+      Some(&identity),
+      pid(42),
+      &existing_webkit,
+    ));
+    assert!(!is_associated_macos_webview_snapshot(
+      &preexisting,
+      Some(&identity),
+      pid(43),
+      &non_webkit,
+    ));
+    assert!(is_associated_macos_webview_snapshot(
+      &preexisting,
+      Some(&identity),
+      pid(44),
+      &new_webkit,
+    ));
+  }
+
+  #[test]
+  fn successful_early_exit_message_mentions_single_instance_hint() {
+    let message = format_exit_message(
+      "warmup",
+      Some("exit code: 0"),
+      true,
+      None,
+      Path::new("target/release/hardware-visualizer.exe"),
+    );
+
+    assert!(message.contains("Process exited during warmup"));
+    assert!(message.contains("exit code: 0"));
+    assert!(message.contains("HardwareVisualizer is already running"));
+    assert!(message.contains("single-instance"));
+    assert!(message.contains("target/release/hardware-visualizer.exe"));
+  }
+
+  #[test]
+  fn failing_early_exit_message_keeps_stderr_without_single_instance_hint() {
+    let message = format_exit_message(
+      "measurement",
+      Some("exit code: 1"),
+      false,
+      Some("startup failed"),
+      Path::new("target/release/hardware-visualizer.exe"),
+    );
+
+    assert!(message.contains("Process exited during measurement"));
+    assert!(message.contains("exit code: 1"));
+    assert!(message.contains("--- process stderr ---"));
+    assert!(message.contains("startup failed"));
+    assert!(!message.contains("HardwareVisualizer is already running"));
+  }
+
+  #[test]
+  fn compact_token_removes_separators() {
+    assert_eq!(
+      compact_token("Hardware-Visualizer.app"),
+      "hardwarevisualizerapp"
+    );
+  }
+
+  #[test]
+  fn identity_tokens_include_binary_and_bundle_variants() {
+    let identity = AppIdentity::from_binary_path(Path::new(
+      "/Applications/HardwareVisualizer.app/Contents/MacOS/hardware-visualizer",
+    ));
+
+    assert!(identity.tokens.contains(&"hardware-visualizer".to_string()));
+    assert!(identity.tokens.contains(&"hardwarevisualizer".to_string()));
+  }
+
+  fn pid(value: u32) -> Pid {
+    Pid::from_u32(value)
+  }
+
+  fn tracker() -> ProcessTracker {
+    tracker_with_preexisting_webviews(HashSet::new())
+  }
+
+  fn tracker_with_preexisting_webviews(
+    preexisting_webview_pids: HashSet<Pid>,
+  ) -> ProcessTracker {
+    ProcessTracker::new(
+      pid(10),
+      Path::new("hardware-visualizer.exe"),
+      preexisting_webview_pids,
+    )
+  }
+
+  fn snapshot(
+    parent: Option<Pid>,
+    memory_mb: u64,
+    cpu_usage: f32,
+    search_text: &str,
+  ) -> ProcessSnapshot {
+    ProcessSnapshot {
+      parent,
+      memory_bytes: memory_mb * 1024 * 1024,
+      cpu_usage,
+      search_text: search_text.to_ascii_lowercase(),
+    }
+  }
+
+  fn sample(
+    cpu_usage: f32,
+    memory_rss_mb: f64,
+    parent_memory_rss_mb: f64,
+    webview_memory_rss_mb: f64,
+    other_process_memory_rss_mb: f64,
+  ) -> ProcessMetrics {
+    ProcessMetrics {
+      cpu_usage,
+      memory_rss_mb,
+      parent_memory_rss_mb,
+      webview_memory_rss_mb,
+      other_process_memory_rss_mb,
+      process_count: 3,
+      webview_process_count: 1,
+    }
   }
 }

--- a/perf-monitor/src/report.rs
+++ b/perf-monitor/src/report.rs
@@ -12,9 +12,12 @@ pub enum OutputFormat {
 struct CheckResult {
   cpu_avg_ok: bool,
   cpu_p95_ok: bool,
-  mem_avg_ok: bool,
-  mem_p95_ok: bool,
-  mem_growth_ok: bool,
+  app_mem_avg_ok: bool,
+  app_mem_p95_ok: bool,
+  app_mem_growth_ok: bool,
+  tree_mem_avg_ok: bool,
+  tree_mem_p95_ok: bool,
+  tree_mem_growth_ok: bool,
   all_passed: bool,
 }
 
@@ -41,6 +44,14 @@ struct CpuReport {
 
 #[derive(Debug, Serialize)]
 struct MemoryReport {
+  app: MemoryBudgetReport,
+  process_tree: MemoryBudgetReport,
+  breakdown: MemoryBreakdownReport,
+  process_count: ProcessCountReport,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryBudgetReport {
   avg_mb: f64,
   max_mb: f64,
   p95_mb: f64,
@@ -53,6 +64,27 @@ struct MemoryReport {
   growth_passed: bool,
 }
 
+#[derive(Debug, Serialize)]
+struct MemoryBreakdownReport {
+  parent: MemoryComponentReport,
+  webview: MemoryComponentReport,
+  other: MemoryComponentReport,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryComponentReport {
+  avg_mb: f64,
+  max_mb: f64,
+  p95_mb: f64,
+  growth_mb: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct ProcessCountReport {
+  max_total: usize,
+  max_webview: usize,
+}
+
 /// Formats and prints the report. Returns `true` if all checks passed.
 pub fn format_report(
   result: &MonitorResult,
@@ -63,7 +95,10 @@ pub fn format_report(
 
   match format {
     OutputFormat::Text => print_text_report(result, thresholds, &check),
-    OutputFormat::Json => print_json_report(result, thresholds, &check),
+    OutputFormat::Json => {
+      print_json_report(result, thresholds, &check);
+      print_log_summary(result, thresholds, &check);
+    }
   }
 
   check.all_passed
@@ -73,17 +108,31 @@ impl CheckResult {
   fn new(result: &MonitorResult, thresholds: &Thresholds) -> Self {
     let cpu_avg_ok = result.avg_cpu <= thresholds.max_avg_cpu_percent;
     let cpu_p95_ok = result.p95_cpu <= thresholds.max_p95_cpu_percent;
-    let mem_avg_ok = result.avg_memory_mb <= thresholds.max_avg_memory_mb;
-    let mem_p95_ok = result.p95_memory_mb <= thresholds.max_p95_memory_mb;
-    let mem_growth_ok = result.memory_growth_mb <= thresholds.max_memory_growth_mb;
+    let app_mem_avg_ok = result.parent_memory.avg_mb <= thresholds.max_avg_app_memory_mb;
+    let app_mem_p95_ok = result.parent_memory.p95_mb <= thresholds.max_p95_app_memory_mb;
+    let app_mem_growth_ok =
+      result.parent_memory.growth_mb <= thresholds.max_app_memory_growth_mb;
+    let tree_mem_avg_ok = result.avg_memory_mb <= thresholds.max_avg_memory_mb;
+    let tree_mem_p95_ok = result.p95_memory_mb <= thresholds.max_p95_memory_mb;
+    let tree_mem_growth_ok = result.memory_growth_mb <= thresholds.max_memory_growth_mb;
 
     Self {
       cpu_avg_ok,
       cpu_p95_ok,
-      mem_avg_ok,
-      mem_p95_ok,
-      mem_growth_ok,
-      all_passed: cpu_avg_ok && cpu_p95_ok && mem_avg_ok && mem_p95_ok && mem_growth_ok,
+      app_mem_avg_ok,
+      app_mem_p95_ok,
+      app_mem_growth_ok,
+      tree_mem_avg_ok,
+      tree_mem_p95_ok,
+      tree_mem_growth_ok,
+      all_passed: cpu_avg_ok
+        && cpu_p95_ok
+        && app_mem_avg_ok
+        && app_mem_p95_ok
+        && app_mem_growth_ok
+        && tree_mem_avg_ok
+        && tree_mem_p95_ok
+        && tree_mem_growth_ok,
     }
   }
 }
@@ -97,49 +146,122 @@ fn print_text_report(
   thresholds: &Thresholds,
   check: &CheckResult,
 ) {
-  println!();
-  println!("=== Performance Test Results ===");
-  println!(
+  print!("{}", text_report(result, thresholds, check));
+}
+
+fn text_report(
+  result: &MonitorResult,
+  thresholds: &Thresholds,
+  check: &CheckResult,
+) -> String {
+  use std::fmt::Write as _;
+
+  let mut report = String::new();
+  let _ = writeln!(report);
+  let _ = writeln!(report, "=== Performance Test Results ===");
+  let _ = writeln!(
+    report,
     "Duration: {}s (after {}s warmup)",
     result.duration_seconds, result.warmup_seconds
   );
-  println!("Samples: {}", result.samples.len());
-  println!();
-  println!("CPU Usage:");
-  println!(
+  let _ = writeln!(report, "Samples: {}", result.samples.len());
+  let _ = writeln!(report);
+  let _ = writeln!(report, "CPU Usage:");
+  let _ = writeln!(
+    report,
     "  Average: {:>6.1}%  (threshold: {:>5.1}%)  {}",
     result.avg_cpu,
     thresholds.max_avg_cpu_percent,
     status_label(check.cpu_avg_ok)
   );
-  println!(
+  let _ = writeln!(
+    report,
     "  P95:     {:>6.1}%  (threshold: {:>5.1}%)  {}",
     result.p95_cpu,
     thresholds.max_p95_cpu_percent,
     status_label(check.cpu_p95_ok)
   );
-  println!();
-  println!("Memory (RSS):");
-  println!(
+  let _ = writeln!(report);
+  let _ = writeln!(report, "Memory (RSS, app process):");
+  let _ = writeln!(
+    report,
+    "  Average: {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
+    result.parent_memory.avg_mb,
+    thresholds.max_avg_app_memory_mb,
+    status_label(check.app_mem_avg_ok)
+  );
+  let _ = writeln!(
+    report,
+    "  P95:     {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
+    result.parent_memory.p95_mb,
+    thresholds.max_p95_app_memory_mb,
+    status_label(check.app_mem_p95_ok)
+  );
+  let _ = writeln!(
+    report,
+    "  Growth:  {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
+    result.parent_memory.growth_mb,
+    thresholds.max_app_memory_growth_mb,
+    status_label(check.app_mem_growth_ok)
+  );
+  let _ = writeln!(report);
+  let _ = writeln!(report, "Memory (RSS, process tree incl. WebView):");
+  let _ = writeln!(
+    report,
     "  Average: {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
     result.avg_memory_mb,
     thresholds.max_avg_memory_mb,
-    status_label(check.mem_avg_ok)
+    status_label(check.tree_mem_avg_ok)
   );
-  println!(
+  let _ = writeln!(
+    report,
     "  P95:     {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
     result.p95_memory_mb,
     thresholds.max_p95_memory_mb,
-    status_label(check.mem_p95_ok)
+    status_label(check.tree_mem_p95_ok)
   );
-  println!(
+  let _ = writeln!(
+    report,
     "  Growth:  {:>7.1} MB  (threshold: {:>6.1} MB)  {}",
     result.memory_growth_mb,
     thresholds.max_memory_growth_mb,
-    status_label(check.mem_growth_ok)
+    status_label(check.tree_mem_growth_ok)
   );
-  println!();
-  println!("Result: {}", if check.all_passed { "PASS" } else { "FAIL" });
+  let _ = writeln!(
+    report,
+    "  Processes: total max {}, WebView max {}",
+    result.max_process_count, result.max_webview_process_count
+  );
+  let _ = writeln!(report, "  Breakdown:");
+  let _ = writeln!(
+    report,
+    "    Parent:  avg {:>7.1} MB, p95 {:>7.1} MB, growth {:>7.1} MB",
+    result.parent_memory.avg_mb,
+    result.parent_memory.p95_mb,
+    result.parent_memory.growth_mb
+  );
+  let _ = writeln!(
+    report,
+    "    WebView: avg {:>7.1} MB, p95 {:>7.1} MB, growth {:>7.1} MB",
+    result.webview_memory.avg_mb,
+    result.webview_memory.p95_mb,
+    result.webview_memory.growth_mb
+  );
+  let _ = writeln!(
+    report,
+    "    Other:   avg {:>7.1} MB, p95 {:>7.1} MB, growth {:>7.1} MB",
+    result.other_process_memory.avg_mb,
+    result.other_process_memory.p95_mb,
+    result.other_process_memory.growth_mb
+  );
+  let _ = writeln!(report);
+  let _ = writeln!(
+    report,
+    "Result: {}",
+    if check.all_passed { "PASS" } else { "FAIL" }
+  );
+
+  report
 }
 
 fn print_json_report(
@@ -161,16 +283,54 @@ fn print_json_report(
       p95_passed: check.cpu_p95_ok,
     },
     memory: MemoryReport {
-      avg_mb: result.avg_memory_mb,
-      max_mb: result.max_memory_mb,
-      p95_mb: result.p95_memory_mb,
-      growth_mb: result.memory_growth_mb,
-      threshold_avg_mb: thresholds.max_avg_memory_mb,
-      threshold_p95_mb: thresholds.max_p95_memory_mb,
-      threshold_growth_mb: thresholds.max_memory_growth_mb,
-      avg_passed: check.mem_avg_ok,
-      p95_passed: check.mem_p95_ok,
-      growth_passed: check.mem_growth_ok,
+      app: MemoryBudgetReport {
+        avg_mb: result.parent_memory.avg_mb,
+        max_mb: result.parent_memory.max_mb,
+        p95_mb: result.parent_memory.p95_mb,
+        growth_mb: result.parent_memory.growth_mb,
+        threshold_avg_mb: thresholds.max_avg_app_memory_mb,
+        threshold_p95_mb: thresholds.max_p95_app_memory_mb,
+        threshold_growth_mb: thresholds.max_app_memory_growth_mb,
+        avg_passed: check.app_mem_avg_ok,
+        p95_passed: check.app_mem_p95_ok,
+        growth_passed: check.app_mem_growth_ok,
+      },
+      process_tree: MemoryBudgetReport {
+        avg_mb: result.avg_memory_mb,
+        max_mb: result.max_memory_mb,
+        p95_mb: result.p95_memory_mb,
+        growth_mb: result.memory_growth_mb,
+        threshold_avg_mb: thresholds.max_avg_memory_mb,
+        threshold_p95_mb: thresholds.max_p95_memory_mb,
+        threshold_growth_mb: thresholds.max_memory_growth_mb,
+        avg_passed: check.tree_mem_avg_ok,
+        p95_passed: check.tree_mem_p95_ok,
+        growth_passed: check.tree_mem_growth_ok,
+      },
+      breakdown: MemoryBreakdownReport {
+        parent: MemoryComponentReport {
+          avg_mb: result.parent_memory.avg_mb,
+          max_mb: result.parent_memory.max_mb,
+          p95_mb: result.parent_memory.p95_mb,
+          growth_mb: result.parent_memory.growth_mb,
+        },
+        webview: MemoryComponentReport {
+          avg_mb: result.webview_memory.avg_mb,
+          max_mb: result.webview_memory.max_mb,
+          p95_mb: result.webview_memory.p95_mb,
+          growth_mb: result.webview_memory.growth_mb,
+        },
+        other: MemoryComponentReport {
+          avg_mb: result.other_process_memory.avg_mb,
+          max_mb: result.other_process_memory.max_mb,
+          p95_mb: result.other_process_memory.p95_mb,
+          growth_mb: result.other_process_memory.growth_mb,
+        },
+      },
+      process_count: ProcessCountReport {
+        max_total: result.max_process_count,
+        max_webview: result.max_webview_process_count,
+      },
     },
     passed: check.all_passed,
   };
@@ -180,6 +340,83 @@ fn print_json_report(
     Err(e) => {
       eprintln!("Error: failed to serialize report: {e}");
       std::process::exit(1);
+    }
+  }
+}
+
+fn print_log_summary(
+  result: &MonitorResult,
+  thresholds: &Thresholds,
+  check: &CheckResult,
+) {
+  eprint!("{}", text_report(result, thresholds, check));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::monitor::{MemoryStats, ProcessMetrics};
+
+  #[test]
+  fn text_report_contains_threshold_status_and_memory_breakdown() {
+    let result = MonitorResult {
+      samples: vec![ProcessMetrics {
+        cpu_usage: 1.0,
+        memory_rss_mb: 275.0,
+        parent_memory_rss_mb: 50.0,
+        webview_memory_rss_mb: 200.0,
+        other_process_memory_rss_mb: 25.0,
+        process_count: 3,
+        webview_process_count: 1,
+      }],
+      avg_cpu: 1.0,
+      max_cpu: 1.0,
+      p95_cpu: 1.0,
+      avg_memory_mb: 275.0,
+      max_memory_mb: 275.0,
+      p95_memory_mb: 275.0,
+      memory_growth_mb: 0.0,
+      parent_memory: memory_stats(50.0),
+      webview_memory: memory_stats(200.0),
+      other_process_memory: memory_stats(25.0),
+      max_process_count: 3,
+      max_webview_process_count: 1,
+      duration_seconds: 10,
+      warmup_seconds: 5,
+    };
+    let thresholds = Thresholds {
+      max_avg_cpu_percent: 5.0,
+      max_p95_cpu_percent: 10.0,
+      max_avg_app_memory_mb: 100.0,
+      max_p95_app_memory_mb: 100.0,
+      max_app_memory_growth_mb: 50.0,
+      max_avg_memory_mb: 450.0,
+      max_p95_memory_mb: 500.0,
+      max_memory_growth_mb: 50.0,
+    };
+    let check = CheckResult::new(&result, &thresholds);
+
+    let report = text_report(&result, &thresholds, &check);
+
+    assert!(report.contains("=== Performance Test Results ==="));
+    assert!(report.contains("Duration: 10s (after 5s warmup)"));
+    assert!(report.contains("CPU Usage:"));
+    assert!(report.contains("Average:    1.0%  (threshold:   5.0%)  PASS"));
+    assert!(report.contains("Memory (RSS, app process):"));
+    assert!(report.contains("Average:    50.0 MB  (threshold:  100.0 MB)  PASS"));
+    assert!(report.contains("Memory (RSS, process tree incl. WebView):"));
+    assert!(report.contains("Average:   275.0 MB  (threshold:  450.0 MB)  PASS"));
+    assert!(report.contains("Processes: total max 3, WebView max 1"));
+    assert!(report.contains("Parent:  avg    50.0 MB"));
+    assert!(report.contains("WebView: avg   200.0 MB"));
+  }
+
+  fn memory_stats(value: f64) -> MemoryStats {
+    MemoryStats {
+      avg_mb: value,
+      max_mb: value,
+      p95_mb: value,
+      growth_mb: 0.0,
     }
   }
 }

--- a/perf-thresholds.toml
+++ b/perf-thresholds.toml
@@ -1,8 +1,11 @@
 [thresholds]
 max_avg_cpu_percent = 5.0
 max_p95_cpu_percent = 10.0
-max_avg_memory_mb = 100.0
-max_p95_memory_mb = 100.0
+max_avg_app_memory_mb = 100.0
+max_p95_app_memory_mb = 100.0
+max_app_memory_growth_mb = 50.0
+max_avg_memory_mb = 450.0
+max_p95_memory_mb = 500.0
 max_memory_growth_mb = 50.0
 
 [timing]
@@ -11,12 +14,19 @@ measurement_seconds = 30
 sample_interval_ms = 1000
 
 [platforms.windows]
-max_avg_memory_mb = 70.0
+max_avg_app_memory_mb = 70.0
+max_p95_app_memory_mb = 100.0
+max_avg_memory_mb = 600.0
+max_p95_memory_mb = 600.0
 
 [platforms.linux]
-max_avg_memory_mb = 150.0
-max_p95_memory_mb = 150.0
+max_avg_app_memory_mb = 150.0
+max_p95_app_memory_mb = 150.0
+max_avg_memory_mb = 550.0
+max_p95_memory_mb = 550.0
 
 [platforms.macos]
-max_avg_memory_mb = 150.0
-max_p95_memory_mb = 150.0
+max_avg_app_memory_mb = 150.0
+max_p95_app_memory_mb = 150.0
+max_avg_memory_mb = 600.0
+max_p95_memory_mb = 650.0


### PR DESCRIPTION
## Summary
- aggregate perf-monitor memory samples across the launched app process and associated helper processes, including WebView helpers
- report and gate app-process RSS separately from process-tree RSS that includes WebView
- emit the normal text report to stderr when --output json is redirected, and improve early-exit diagnostics for Tauri single-instance handoff

## Self-review
- Found during self-review that Windows WebView2 helpers may not appear under the launched PID parent chain, so the monitor now baselines pre-existing WebView helpers and includes newly-created WebView helpers.
- Kept untracked esults.json out of the commit.

## Validation
- cargo fmt --manifest-path perf-monitor/Cargo.toml -- --check
- cargo test --manifest-path perf-monitor/Cargo.toml
- cargo clippy --manifest-path perf-monitor/Cargo.toml -- -D warnings
- cargo build --release --manifest-path perf-monitor/Cargo.toml
- git -c safe.directory=C:/Users/shoum/Develop/HardwareVisualizer diff --check
- smoke: perf-monitor.exe --binary target/release/hardware-visualizer.exe --warmup 1 --duration 2 --output json > temp.json 2> temp.err

Closes #1579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced memory monitoring: separate app-process and process-tree metrics with breakdowns (parent/WebView/other) and process-count reporting; richer JSON and text reports including per-bucket stats.

* **Documentation**
  * Clarified JSON vs text output (JSON to stdout, human-readable to stderr); expanded configuration examples, platform overrides, how-it-works, metrics table, and troubleshooting; CI gating/matrix guidance.

* **Chores**
  * Performance test matrix extended to run on Linux and macOS alongside Windows; thresholds updated with per-platform app and total-memory limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->