### PR TITLE
docs: accept storage health device identity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,10 @@ _Avoid_: SMART display, dashboard health row
 A daily record of storage device health signals for one storage device on one local date.
 _Avoid_: Storage Health Snapshot, Hardware archive, raw SMART data, dashboard item
 
+**Storage Health Device Identity**:
+A local, app-installation-scoped identifier used only to associate Storage Health Records for the same physical storage device across dates.
+_Avoid_: User identity, cross-device sync identity, raw serial number, globally stable storage device ID, externally shareable device identity
+
 **Storage Health Display**:
 Presenting already available Storage Health Records in the user interface, including dashboard summaries and historical views.
 _Avoid_: SMART collection, storage health acquisition

--- a/docs/adr/0003-storage-health-device-identity.md
+++ b/docs/adr/0003-storage-health-device-identity.md
@@ -1,6 +1,6 @@
 # Storage Health Device Identity
 
-Status: proposed
+Status: accepted
 
 Storage Health Records need to attach records to the same physical storage device over time, even when OS device paths change. During review of [#1483](https://github.com/shm11C3/HardwareVisualizer/pull/1483), the original unkeyed identifier hash was called out because structured hardware serial spaces can be brute-forced cheaply. We therefore identify storage devices with a locally keyed, versioned HMAC-derived identifier and store a keyed serial hash when a serial is available, instead of storing raw serial numbers or relying only on transient device paths.
 
@@ -8,4 +8,28 @@ The purpose of the identity is limited to tracking the health trend of the same 
 
 This is a local-app privacy hardening measure, not protection against full machine compromise: if both the database and the local HMAC key are exposed, the protection is weakened. It still avoids direct persistence of hardware serial numbers and makes a copied database or isolated snapshot less useful for recovering serials. If a serial is unavailable, the fallback identity may be less stable, but it still stays within the same privacy boundary.
 
-This decision is intentionally provisional because Storage Health has not shipped yet and the identity scheme may change before release.
+## Decision
+
+Keep the current locally keyed HMAC-derived identity scheme for the first Storage Health release:
+
+- Store a per-installation `storageHealthIdentity.hashKey` in `settings.json`.
+- When a normalized serial number is available, derive the device ID from the storage protocol and serial number.
+- Store a separate keyed serial hash when a serial number is available so future migrations can reason about serial-backed records without persisting the raw serial.
+- When no serial number is available, derive a best-effort fallback identity from protocol or device type, model, capacity, and device path.
+- Prefix derived identifiers with explicit versions so future schemes can be introduced without overloading old values.
+
+This keeps the identity local to one app installation and preserves enough stability for daily Storage Health Records without turning hardware serials into persisted product data.
+
+## Alternatives Considered
+
+- Store raw serial numbers locally: rejected because it widens the persisted data surface for a value that is not needed by the product UI.
+- Use unkeyed hashes: rejected because structured serial spaces can be brute-forced cheaply.
+- Use opaque local UUID mappings: rejected for the first release because rediscovery and migration rules would add state without improving the privacy boundary.
+- Use fallback-only protocol/model/capacity/device-path identities: rejected because this is less stable for normal serial-backed devices and can split history when paths change.
+- Introduce a hybrid migration now: rejected because Storage Health has not shipped and the current implementation already matches the accepted release behavior.
+
+## Consequences
+
+Existing development data that was written with the same local hash key remains readable. If the key is reset, lost, or moved separately from the database, later records enter a new local identity namespace and are not automatically linked back to earlier records.
+
+Serial-backed device identities should remain stable across OS device path changes. Serial-less fallback identities are explicitly best-effort: they may split records when the OS path changes and may be less precise for identical devices with the same model and capacity.


### PR DESCRIPTION
## Summary

- Accept ADR 0003 for the first Storage Health release.
- Document the locally keyed HMAC-derived device identity decision, rejected alternatives, and fallback limits.
- Add Storage Health Device Identity to CONTEXT.md so future changes keep the scope local and record-oriented.

This PR is stacked on #1592 because #1592 contains the Storage Health Record naming and core layout this documentation references. After #1592 merges, this PR can be retargeted to develop.

## Related Issues

Closes #1569
Depends on #1592

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Validation:

- `git diff --check`
- `npm run lint` passed; Biome still reports the existing `.codex/hooks.json` permission warning with exit 0.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors