### PR TITLE
feat: show storage health summary on dashboard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,14 @@ _Avoid_: SMART display, dashboard health row
 A daily record of storage device health signals for one storage device on one local date.
 _Avoid_: Storage Health Snapshot, Hardware archive, raw SMART data, dashboard item
 
+**Storage Wear**:
+A storage health signal estimating how much of a storage device's expected lifetime has been consumed, distinct from capacity usage.
+_Avoid_: Used, disk usage, capacity used, storage utilization
+
 **Storage Health Display**:
 Presenting already available Storage Health Records in the user interface, including dashboard summaries and historical views.
 _Avoid_: SMART collection, storage health acquisition
+
+**Focus Storage Device**:
+The storage device surfaced first in a Storage Health Display because its health state most needs the user's attention.
+_Avoid_: Representative drive, selected disk, SMART target

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -48,7 +48,10 @@ import { isError } from "@/types/result";
 import { useProcessInfo } from "../../hooks/useProcessInfo";
 import {
   buildStorageHealthSummary,
+  formatStorageHealthMetricValue,
   type StorageHealthDeviceViewModel,
+  type StorageHealthMetric,
+  type StorageHealthSummaryViewModel,
 } from "../utils/storageHealthSummary";
 import { MiniLineChart } from "./MiniLineChart";
 import { StorageHealthStatusIcon } from "./StorageHealthStatusIcon";
@@ -390,9 +393,8 @@ export const StorageDataInfo = () => {
   const { hardwareInfo } = useHardwareInfoAtom();
   const os = useMemo(() => platform(), []);
   const storageHealthErrorShownRef = useRef(false);
-  const [storageHealthDevices, setStorageHealthDevices] = useState<
-    StorageHealthDeviceViewModel[]
-  >([]);
+  const [storageHealthSummary, setStorageHealthSummary] =
+    useState<StorageHealthSummaryViewModel | null>(null);
 
   // Sort by drive name
   const sortedStorage = hardwareInfo.storage.sort((a, b) =>
@@ -430,7 +432,7 @@ export const StorageDataInfo = () => {
           "Failed to fetch storage health dashboard records",
           result.error,
         );
-        setStorageHealthDevices([]);
+        setStorageHealthSummary(null);
         if (!storageHealthErrorShownRef.current) {
           storageHealthErrorShownRef.current = true;
           void error(
@@ -441,7 +443,7 @@ export const StorageDataInfo = () => {
       }
 
       storageHealthErrorShownRef.current = false;
-      setStorageHealthDevices(buildStorageHealthSummary(result.data).devices);
+      setStorageHealthSummary(buildStorageHealthSummary(result.data));
     };
 
     loadStorageHealthDevices();
@@ -455,7 +457,7 @@ export const StorageDataInfo = () => {
 
   return (
     <div className="pt-2">
-      <StorageDeviceHealthOverview devices={storageHealthDevices} />
+      <StorageHealthOverview summary={storageHealthSummary} />
       <div
         className={storageDataInfoGridVariants({ isWindows: os === "windows" })}
       >
@@ -505,6 +507,107 @@ export const StorageDataInfo = () => {
   );
 };
 
+const storageHealthMetricLabelKeys = {
+  temperatureCelsius: "pages.dashboard.storageHealth.metrics.temperature",
+  percentageUsed: "pages.dashboard.storageHealth.metrics.wear",
+  availableSparePercent: "pages.dashboard.storageHealth.metrics.spare",
+  powerOnHours: "pages.dashboard.storageHealth.metrics.powerOn",
+  reallocatedSectorCount:
+    "pages.dashboard.storageHealth.metrics.reallocatedSectors",
+  currentPendingSectorCount:
+    "pages.dashboard.storageHealth.metrics.pendingSectors",
+  offlineUncorrectableCount:
+    "pages.dashboard.storageHealth.metrics.uncorrectableSectors",
+  mediaErrors: "pages.dashboard.storageHealth.metrics.mediaErrors",
+  errorLogEntries: "pages.dashboard.storageHealth.metrics.errorLogEntries",
+  unsafeShutdownCount: "pages.dashboard.storageHealth.metrics.unsafeShutdowns",
+} as const satisfies Record<StorageHealthMetric["type"], string>;
+
+const StorageHealthOverview = ({
+  summary,
+}: {
+  summary: StorageHealthSummaryViewModel | null;
+}) => {
+  const { t } = useTranslation();
+
+  if (!summary || summary.driveCount === 0) return null;
+
+  const focusDeviceLabel =
+    summary.focusDevice?.model?.trim() ||
+    summary.focusDevice?.displayName ||
+    null;
+
+  return (
+    <div
+      className={cn(
+        "mb-3 space-y-2 border-border/60 border-b pb-3",
+        summary.isStale && "opacity-70",
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <StorageHealthStatusIcon status={summary.status} size={17} />
+          <span className="shrink-0 font-medium text-sm">
+            {t("pages.dashboard.storageHealth.title")}
+          </span>
+          {focusDeviceLabel && (
+            <span
+              className="truncate text-muted-foreground text-xs"
+              title={focusDeviceLabel}
+            >
+              {focusDeviceLabel}
+            </span>
+          )}
+          {summary.isStale && (
+            <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {t("pages.dashboard.storageHealth.stale")}
+            </span>
+          )}
+        </div>
+        {summary.latestDate && (
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {t("pages.dashboard.storageHealth.lastRecorded", {
+              date: summary.latestDate,
+            })}
+          </span>
+        )}
+      </div>
+
+      {summary.metrics.length > 0 && (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {summary.metrics.map((metric) => (
+            <div
+              key={metric.type}
+              className="min-w-0 rounded-sm bg-muted/40 px-2 py-1"
+            >
+              <div className="truncate text-[10px] text-muted-foreground">
+                {t(storageHealthMetricLabelKeys[metric.type])}
+              </div>
+              <div className="truncate font-mono text-xs">
+                {formatStorageHealthMetricValue(metric)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {summary.reasons.length > 0 && (
+        <ul className="space-y-0.5 text-amber-600 text-xs dark:text-amber-400">
+          {summary.reasons.map((reason) => (
+            <li key={reason} className="truncate" title={reason}>
+              {reason}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {summary.devices.length > 1 && (
+        <StorageDeviceHealthOverview devices={summary.devices} />
+      )}
+    </div>
+  );
+};
+
 const StorageDeviceHealthOverview = ({
   devices,
 }: {
@@ -513,7 +616,7 @@ const StorageDeviceHealthOverview = ({
   if (devices.length === 0) return null;
 
   return (
-    <div className="mb-2 grid max-h-20 grid-cols-1 gap-x-4 gap-y-1 overflow-y-auto border-border/60 border-b pb-2 sm:grid-cols-2">
+    <div className="grid max-h-20 grid-cols-1 gap-x-4 gap-y-1 overflow-y-auto sm:grid-cols-2">
       {devices.map((device) => (
         <div
           key={device.deviceId}

--- a/src/features/hardware/dashboard/utils/storageHealthSummary.test.ts
+++ b/src/features/hardware/dashboard/utils/storageHealthSummary.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { StorageHealthRecord } from "@/rspc/bindings";
-import { buildStorageHealthSummary } from "./storageHealthSummary";
+import {
+  buildStorageHealthSummary,
+  formatStorageHealthMetricValue,
+} from "./storageHealthSummary";
 
 const record = (
   overrides: Partial<StorageHealthRecord> = {},
@@ -103,13 +106,72 @@ describe("buildStorageHealthSummary", () => {
       "Temperature is elevated (47°C)",
     ]);
     expect(summary.metrics).toEqual([
-      { type: "percentageUsed", value: 82 },
       { type: "temperatureCelsius", value: 47 },
+      { type: "percentageUsed", value: 82 },
+      { type: "powerOnHours", value: 100 },
     ]);
     expect(summary.devices[0]).toEqual({
       deviceId: "disk-b",
       label: "Example SSD",
       status: "warning",
+    });
+  });
+
+  it("exposes healthy storage health metrics when values were collected", () => {
+    const summary = buildStorageHealthSummary(
+      [
+        record({
+          temperatureCelsius: 44,
+          percentageUsed: 0,
+          availableSparePercent: 100,
+          powerOnHours: 118,
+        }),
+      ],
+      new Date("2026-05-10T10:00:00"),
+    );
+
+    expect(summary.metrics).toEqual([
+      { type: "temperatureCelsius", value: 44 },
+      { type: "percentageUsed", value: 0 },
+      { type: "availableSparePercent", value: 100 },
+      { type: "powerOnHours", value: 118 },
+    ]);
+  });
+
+  it("only exposes nonzero storage health counter metrics", () => {
+    const summary = buildStorageHealthSummary(
+      [
+        record({
+          currentPendingSectorCount: 0,
+          offlineUncorrectableCount: 0,
+          reallocatedSectorCount: 2,
+          mediaErrors: 0,
+          errorLogEntries: 3,
+          unsafeShutdownCount: 6,
+        }),
+      ],
+      new Date("2026-05-10T10:00:00"),
+    );
+
+    expect(summary.metrics).toContainEqual({
+      type: "reallocatedSectorCount",
+      value: 2,
+    });
+    expect(summary.metrics).toContainEqual({
+      type: "errorLogEntries",
+      value: 3,
+    });
+    expect(summary.metrics).toContainEqual({
+      type: "unsafeShutdownCount",
+      value: 6,
+    });
+    expect(summary.metrics).not.toContainEqual({
+      type: "currentPendingSectorCount",
+      value: 0,
+    });
+    expect(summary.metrics).not.toContainEqual({
+      type: "mediaErrors",
+      value: 0,
     });
   });
 
@@ -194,5 +256,65 @@ describe("buildStorageHealthSummary", () => {
         status: "unknown",
       },
     ]);
+  });
+
+  it("excludes records from devices missing in the latest collection date", () => {
+    const summary = buildStorageHealthSummary(
+      [
+        record({
+          deviceId: "disk-a",
+          displayName: "Current Disk",
+          date: "2026-05-10",
+          healthStatus: "good",
+          warningLevel: "none",
+        }),
+        record({
+          deviceId: "disk-b",
+          displayName: "Removed Disk",
+          date: "2026-05-08",
+          healthStatus: "critical",
+          warningLevel: "critical",
+          warningReasons: ["Current pending sectors are present"],
+        }),
+      ],
+      new Date("2026-05-10T10:00:00"),
+    );
+
+    expect(summary.status).toBe("good");
+    expect(summary.driveCount).toBe(1);
+    expect(summary.focusDevice?.displayName).toBe("Current Disk");
+    expect(summary.devices).toEqual([
+      {
+        deviceId: "disk-a",
+        label: "Example SSD",
+        status: "good",
+      },
+    ]);
+  });
+});
+
+describe("formatStorageHealthMetricValue", () => {
+  it("formats dashboard storage health metric values with compact units", () => {
+    expect(
+      formatStorageHealthMetricValue({
+        type: "temperatureCelsius",
+        value: 44.4,
+      }),
+    ).toBe("44°C");
+    expect(
+      formatStorageHealthMetricValue({ type: "percentageUsed", value: 0 }),
+    ).toBe("0%");
+    expect(
+      formatStorageHealthMetricValue({
+        type: "availableSparePercent",
+        value: 99.6,
+      }),
+    ).toBe("100%");
+    expect(
+      formatStorageHealthMetricValue({ type: "powerOnHours", value: 118 }),
+    ).toBe("118 h");
+    expect(
+      formatStorageHealthMetricValue({ type: "mediaErrors", value: 3 }),
+    ).toBe("3");
   });
 });

--- a/src/features/hardware/dashboard/utils/storageHealthSummary.ts
+++ b/src/features/hardware/dashboard/utils/storageHealthSummary.ts
@@ -3,13 +3,16 @@ import type { StorageHealthRecord, StorageHealthStatus } from "@/rspc/bindings";
 export const STORAGE_HEALTH_STALE_AFTER_DAYS = 2;
 
 export type StorageHealthMetric =
-  | { type: "percentageUsed"; value: number }
   | { type: "temperatureCelsius"; value: number }
+  | { type: "percentageUsed"; value: number }
   | { type: "availableSparePercent"; value: number }
+  | { type: "powerOnHours"; value: number }
   | { type: "reallocatedSectorCount"; value: number }
   | { type: "currentPendingSectorCount"; value: number }
   | { type: "offlineUncorrectableCount"; value: number }
-  | { type: "mediaErrors"; value: number };
+  | { type: "mediaErrors"; value: number }
+  | { type: "errorLogEntries"; value: number }
+  | { type: "unsafeShutdownCount"; value: number };
 
 export type StorageHealthDeviceViewModel = {
   deviceId: string;
@@ -60,13 +63,16 @@ export const buildStorageHealthSummary = (
     (latest, record) => (record.date > latest ? record.date : latest),
     records[0].date,
   );
-  const lastCollectedAt = records.reduce(
+  const recordsForDisplay = records.filter(
+    (record) => record.date === latestDate,
+  );
+  const lastCollectedAt = recordsForDisplay.reduce(
     (latest, record) =>
       record.collectedAt > latest ? record.collectedAt : latest,
-    records[0].collectedAt,
+    recordsForDisplay[0].collectedAt,
   );
   const maxTemperatureCelsius = maxNumber(
-    records.map((record) => record.temperatureCelsius),
+    recordsForDisplay.map((record) => record.temperatureCelsius),
   );
   const isStale =
     daysBetweenDateKeys(toLocalDateKey(now), latestDate) >
@@ -75,7 +81,7 @@ export const buildStorageHealthSummary = (
   if (isStale) {
     return {
       status: "unknown",
-      driveCount: records.length,
+      driveCount: recordsForDisplay.length,
       maxTemperatureCelsius,
       lastCollectedAt,
       latestDate,
@@ -83,11 +89,11 @@ export const buildStorageHealthSummary = (
       focusDevice: null,
       reasons: [],
       metrics: [],
-      devices: buildDeviceList(records, true),
+      devices: buildDeviceList(recordsForDisplay, true),
     };
   }
 
-  const orderedRecords = [...records].sort((a, b) => {
+  const orderedRecords = [...recordsForDisplay].sort((a, b) => {
     const rankDiff = healthRank[b.healthStatus] - healthRank[a.healthStatus];
     if (rankDiff !== 0) return rankDiff;
     return a.displayName.localeCompare(b.displayName);
@@ -96,16 +102,14 @@ export const buildStorageHealthSummary = (
 
   return {
     status: focusDevice?.healthStatus ?? "unknown",
-    driveCount: records.length,
+    driveCount: recordsForDisplay.length,
     maxTemperatureCelsius,
     lastCollectedAt,
     latestDate,
     isStale: false,
     focusDevice,
     reasons: focusDevice?.warningReasons.slice(0, 2) ?? [],
-    metrics: focusDevice
-      ? collectMetrics(focusDevice, maxTemperatureCelsius)
-      : [],
+    metrics: focusDevice ? collectMetrics(focusDevice) : [],
     devices: buildDeviceList(orderedRecords, false),
   };
 };
@@ -121,20 +125,17 @@ const buildDeviceList = (
   }));
 };
 
-const collectMetrics = (
-  record: StorageHealthRecord,
-  maxTemperatureCelsius: number | null,
-): StorageHealthMetric[] => {
+const collectMetrics = (record: StorageHealthRecord): StorageHealthMetric[] => {
   const metrics: StorageHealthMetric[] = [];
 
-  if (record.percentageUsed != null) {
-    metrics.push({ type: "percentageUsed", value: record.percentageUsed });
-  }
-  if (maxTemperatureCelsius != null) {
+  if (record.temperatureCelsius != null) {
     metrics.push({
       type: "temperatureCelsius",
-      value: maxTemperatureCelsius,
+      value: record.temperatureCelsius,
     });
+  }
+  if (record.percentageUsed != null) {
+    metrics.push({ type: "percentageUsed", value: record.percentageUsed });
   }
   if (record.availableSparePercent != null) {
     metrics.push({
@@ -142,29 +143,68 @@ const collectMetrics = (
       value: record.availableSparePercent,
     });
   }
-  if (record.currentPendingSectorCount != null) {
+  if (record.powerOnHours != null) {
+    metrics.push({
+      type: "powerOnHours",
+      value: record.powerOnHours,
+    });
+  }
+  if (hasCount(record.currentPendingSectorCount)) {
     metrics.push({
       type: "currentPendingSectorCount",
       value: record.currentPendingSectorCount,
     });
   }
-  if (record.offlineUncorrectableCount != null) {
+  if (hasCount(record.offlineUncorrectableCount)) {
     metrics.push({
       type: "offlineUncorrectableCount",
       value: record.offlineUncorrectableCount,
     });
   }
-  if (record.reallocatedSectorCount != null) {
+  if (hasCount(record.reallocatedSectorCount)) {
     metrics.push({
       type: "reallocatedSectorCount",
       value: record.reallocatedSectorCount,
     });
   }
-  if (record.mediaErrors != null) {
+  if (hasCount(record.mediaErrors)) {
     metrics.push({ type: "mediaErrors", value: record.mediaErrors });
   }
+  if (hasCount(record.errorLogEntries)) {
+    metrics.push({ type: "errorLogEntries", value: record.errorLogEntries });
+  }
+  if (hasCount(record.unsafeShutdownCount)) {
+    metrics.push({
+      type: "unsafeShutdownCount",
+      value: record.unsafeShutdownCount,
+    });
+  }
 
-  return metrics.slice(0, 2);
+  return metrics;
+};
+
+const hasCount = (value: number | null | undefined): value is number =>
+  value != null && value > 0;
+
+export const formatStorageHealthMetricValue = (
+  metric: StorageHealthMetric,
+): string => {
+  switch (metric.type) {
+    case "temperatureCelsius":
+      return `${Math.round(metric.value)}°C`;
+    case "percentageUsed":
+    case "availableSparePercent":
+      return `${Math.round(metric.value)}%`;
+    case "powerOnHours":
+      return `${Math.round(metric.value)} h`;
+    case "reallocatedSectorCount":
+    case "currentPendingSectorCount":
+    case "offlineUncorrectableCount":
+    case "mediaErrors":
+    case "errorLogEntries":
+    case "unsafeShutdownCount":
+      return `${Math.round(metric.value)}`;
+  }
 };
 
 const maxNumber = (values: Array<number | null | undefined>) => {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -172,8 +172,23 @@
         "label": "Select GPU"
       },
       "storageHealth": {
+        "title": "Storage Health",
+        "stale": "Stale",
+        "lastRecorded": "Last recorded {{date}}",
         "errors": {
           "fetchLatest": "Failed to fetch storage health data."
+        },
+        "metrics": {
+          "temperature": "Temp",
+          "wear": "Wear",
+          "spare": "Spare",
+          "powerOn": "Power-on",
+          "reallocatedSectors": "Reallocated",
+          "pendingSectors": "Pending",
+          "uncorrectableSectors": "Uncorrectable",
+          "mediaErrors": "Media errors",
+          "errorLogEntries": "Error log",
+          "unsafeShutdowns": "Unsafe shutdowns"
         },
         "status": {
           "good": "Good",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -172,8 +172,23 @@
         "label": "GPU を選択"
       },
       "storageHealth": {
+        "title": "ストレージヘルス",
+        "stale": "古い",
+        "lastRecorded": "最終記録 {{date}}",
         "errors": {
           "fetchLatest": "ストレージの健康状態データの取得に失敗しました。"
+        },
+        "metrics": {
+          "temperature": "温度",
+          "wear": "消耗率",
+          "spare": "予備領域",
+          "powerOn": "電源投入",
+          "reallocatedSectors": "代替済み",
+          "pendingSectors": "保留中",
+          "uncorrectableSectors": "訂正不能",
+          "mediaErrors": "メディアエラー",
+          "errorLogEntries": "エラーログ",
+          "unsafeShutdowns": "異常シャットダウン"
         },
         "status": {
           "good": "正常",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -161,8 +161,23 @@
         "label": "Выберите ГП"
       },
       "storageHealth": {
+        "title": "Состояние накопителя",
+        "stale": "Устарело",
+        "lastRecorded": "Последняя запись {{date}}",
         "errors": {
           "fetchLatest": "Не удалось получить данные о состоянии накопителя."
+        },
+        "metrics": {
+          "temperature": "Темп.",
+          "wear": "Износ",
+          "spare": "Резерв",
+          "powerOn": "Время работы",
+          "reallocatedSectors": "Переназн.",
+          "pendingSectors": "Ожидают",
+          "uncorrectableSectors": "Неисправ.",
+          "mediaErrors": "Ошибки носителя",
+          "errorLogEntries": "Журнал ошибок",
+          "unsafeShutdowns": "Авар. выкл."
         },
         "status": {
           "good": "Хорошо",


### PR DESCRIPTION
## Summary
- show a compact Storage Health summary at the top of the Storage dashboard card
- hide devices that are missing from the latest collection date while keeping historical records intact
- expose collected health metrics such as temperature, wear, spare, power-on hours, and nonzero health counters
- add Storage Health terminology and dashboard labels for en/ja/ru

## Validation
- pnpm exec vitest run src/features/hardware/dashboard/utils/storageHealthSummary.test.ts
- pnpm exec tsc --noEmit
- pnpm exec biome check src/features/hardware/dashboard/components/DashboardItems.tsx src/features/hardware/dashboard/utils/storageHealthSummary.ts src/features/hardware/dashboard/utils/storageHealthSummary.test.ts src/lang/en.json src/lang/ja.json src/lang/ru.json CONTEXT.md
- pnpm run lint
- pnpm test

## Notes
- Browser-only preview still fails outside Tauri because existing app startup expects Tauri APIs such as window metadata, store, and dialog plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Storage Health Display now shows comprehensive metrics including temperature, wear status, power-on hours, and sector/error information
  * Added "last recorded" timestamp and stale data indicator to storage health section
  * Enhanced UI displays multiple health metrics as individual cards for better visibility

* **Documentation**
  * Updated glossary with storage-wear and focus-device terminology
  * Added localization support for new storage health indicators in English, Japanese, and Russian

<!-- end of auto-generated comment: release notes by coderabbit.ai -->