### PR TITLE
docs: add Live Storage Health on-demand ADR and glossary terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,3 +109,11 @@ _Avoid_: SMART collection, storage health acquisition
 **Focus Storage Device**:
 The storage device surfaced first in a Storage Health Display because its health state most needs the user's attention.
 _Avoid_: Representative drive, selected disk, SMART target
+
+**Live Storage Health**:
+Current storage device health signals collected for immediate display and not retained as history, distinct from the daily Storage Health Record.
+_Avoid_: Storage Health Record, storage health snapshot, realtime SMART
+
+**Storage Device Refresh**:
+The user-initiated action that re-detects connected storage devices, collects current health signals, updates today's Storage Health Record, and reflects added or removed devices in displays.
+_Avoid_: Rescan, reload, auto-detection, live polling

--- a/docs/adr/0006-live-storage-health-on-demand.md
+++ b/docs/adr/0006-live-storage-health-on-demand.md
@@ -1,0 +1,9 @@
+# Live Storage Health on Demand
+
+Live Storage Health is current storage device health signals collected for immediate display, distinct from the retained daily Storage Health Record. We decided to deliver Live Storage Health on demand — a command invoked while a Storage Health Display is visible — instead of adding storage signals to the continuous metrics stream that carries CPU and GPU utilization. Collection therefore happens only while something is actually showing the data, and nothing is persisted.
+
+This is a deliberate asymmetry with GPU temperature, which streams continuously. The metrics stream collects whether or not any view needs storage signals, and storage health reads are not uniformly cheap: outside the native Windows path they spawn external processes (`smartctl`) or open WMI connections. Polling those on a stream cadence would run exactly the kind of background work the on-demand shape avoids. A core-side minimum-interval guard deduplicates reads when multiple views poll at once.
+
+Live reads use only the cheap native path (Windows `DeviceIoControl`, one IOCTL per device against a cached device list) with no fallback chain. Devices or platforms without a cheap path simply have no live signal, and displays fall back to the daily Storage Health Record — the prior behavior. The daily collection keeps its full fallback chain because it runs once a day, where heavier sources are acceptable.
+
+Device enumeration is separated from reading: enumeration (WMI) runs at startup and on an explicit Storage Device Refresh, never on the live read cadence. Storage Device Refresh is also the only operation that deactivates devices that are no longer enumerated; a failed or empty enumeration never deactivates anything, so a transient collection failure cannot silently empty the device list.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,4 @@ implementation guidance belongs in the architecture documents.
 - [0003 Storage Health Device Identity](0003-storage-health-device-identity.md)
 - [0004 Separate Storage Health History](0004-separate-storage-health-history.md)
 - [0005 Storage Health Naming](0005-storage-health-naming.md)
+- [0006 Live Storage Health on Demand](0006-live-storage-health-on-demand.md)


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

Design-only PR recording the agreed direction for live storage temperature on the Hardware Dashboard and Storage Device Refresh, ahead of implementation.

- **ADR 0006 — Live Storage Health on Demand** (`docs/adr/0006-live-storage-health-on-demand.md`):
  - Live Storage Health is delivered on demand (command invoked while a Storage Health Display is visible), deliberately *not* via the continuous metrics stream that carries CPU/GPU — collection only runs while something displays it, and nothing is persisted.
  - Live reads use only the cheap native path (Windows `DeviceIoControl` against a cached device list, one IOCTL per device) with no fallback chain; unsupported devices/platforms fall back to the daily Storage Health Record.
  - Device enumeration is separated from reading: enumeration runs at startup and on an explicit Storage Device Refresh, never on the live read cadence. Only Storage Device Refresh deactivates missing devices, and a failed/empty enumeration never deactivates anything.
- **`CONTEXT.md`**: adds the glossary terms **Live Storage Health** and **Storage Device Refresh**.
- **`docs/adr/README.md`**: index entry for ADR 0006.

Implementation is broken into tracer-bullet issues: #1600 (core collection + IPC), #1601 (dashboard live temperature), #1602 (Storage Device Refresh).

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

Related: #1600, #1601, #1602

Background: #1567, PR #1599

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

N/A (documentation only)

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

Documentation-only change; no code paths affected.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated glossary with storage health terminology.
  * Added architectural decision record for live storage health design approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->