### PR TITLE
perf: add process stats timestamp index

### DIFF
--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -95,6 +95,12 @@ pub fn get_migrations() -> Vec<Migration> {
       "#,
       kind: MigrationKind::Up,
     },
+    Migration {
+      version: 8,
+      description: "add_process_stats_timestamp_index",
+      sql: "CREATE INDEX IF NOT EXISTS idx_process_stats_timestamp ON PROCESS_STATS(timestamp);",
+      kind: MigrationKind::Up,
+    },
     // Down Migrations
     Migration {
       version: 4,
@@ -118,6 +124,12 @@ pub fn get_migrations() -> Vec<Migration> {
         ALTER TABLE storage_health_daily_records
         RENAME TO storage_smart_daily_snapshots;
       "#,
+      kind: MigrationKind::Down,
+    },
+    Migration {
+      version: 8,
+      description: "drop_process_stats_timestamp_index",
+      sql: "DROP INDEX IF EXISTS idx_process_stats_timestamp;",
       kind: MigrationKind::Down,
     },
   ]
@@ -165,8 +177,20 @@ mod tests {
   }
 
   #[test]
+  fn migration_v8_adds_process_stats_timestamp_index() {
+    let migrations = get_migrations();
+    let v8 = migrations
+      .iter()
+      .find(|m| m.version == 8 && matches!(m.kind, MigrationKind::Up))
+      .expect("Version 8 up migration must exist");
+    assert!(v8.sql.contains("CREATE INDEX IF NOT EXISTS"));
+    assert!(v8.sql.contains("idx_process_stats_timestamp"));
+    assert!(v8.sql.contains("PROCESS_STATS(timestamp)"));
+  }
+
+  #[test]
   fn max_migration_version() {
-    assert_eq!(get_max_migration_version(), 7);
+    assert_eq!(get_max_migration_version(), 8);
   }
 
   #[test]
@@ -176,7 +200,7 @@ mod tests {
       .iter()
       .filter(|m| matches!(m.kind, MigrationKind::Up))
       .count();
-    assert_eq!(up_count, 7);
+    assert_eq!(up_count, 8);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Adds migration v8 to create `idx_process_stats_timestamp` on `PROCESS_STATS(timestamp)`.
- Adds a matching down migration and updates migration tests for the new max version.
- Improves process insight range queries and retention pruning by allowing timestamp-indexed lookups instead of full table scans.

## Related Issues

Closes #1572

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`perf/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Validated with:

- `cargo fmt --check`
- `cargo test migration`
- `npm run lint`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database performance for process statistics queries, improving overall application responsiveness and speed when accessing system process information.

* **Tests**
  * Updated unit tests to validate new database migration structure and ensure proper functionality across all database versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->