### PR TITLE
perf: gate window updates by visibility

### DIFF
--- a/src-tauri/src/adapters/window.rs
+++ b/src-tauri/src/adapters/window.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use hardviz_core::models::{GpuMetric, MetricsSnapshot};
 use tauri::Manager as _;
 use tokio::sync::broadcast::{Receiver, error::RecvError};
@@ -19,17 +21,41 @@ use tauri_specta::Event as _;
 pub struct WindowAdapter {
   handle: tauri::async_runtime::JoinHandle<()>,
   stop_tx: watch::Sender<bool>,
+  latest_snapshot: LatestWindowSnapshot,
+}
+
+#[derive(Clone, Default)]
+struct LatestWindowSnapshot {
+  inner: Arc<Mutex<Option<MetricsSnapshot>>>,
+}
+
+impl LatestWindowSnapshot {
+  fn store(&self, snapshot: MetricsSnapshot) {
+    if let Ok(mut latest) = self.inner.lock() {
+      latest.replace(snapshot);
+    }
+  }
+
+  fn load(&self) -> Option<MetricsSnapshot> {
+    self.inner.lock().ok().and_then(|latest| latest.clone())
+  }
 }
 
 impl WindowAdapter {
   pub fn setup(app_handle: tauri::AppHandle, mut rx: Receiver<MetricsSnapshot>) -> Self {
     let (stop_tx, mut stop_rx) = watch::channel(false);
+    let latest_snapshot = LatestWindowSnapshot::default();
+    let latest_for_task = latest_snapshot.clone();
 
     let handle = tauri::async_runtime::spawn(async move {
       loop {
         tokio::select! {
           result = rx.recv() => match result {
-            Ok(snapshot) => emit_snapshot(&app_handle, snapshot),
+            Ok(snapshot) => {
+              let snapshot = to_window_snapshot(snapshot);
+              latest_for_task.store(snapshot.clone());
+              emit_snapshot(&app_handle, snapshot);
+            }
             Err(RecvError::Lagged(skipped)) => {
               log_warn!(
                 &format!("WindowAdapter lagged, dropped {skipped} snapshot(s)"),
@@ -48,7 +74,17 @@ impl WindowAdapter {
       }
     });
 
-    Self { handle, stop_tx }
+    Self {
+      handle,
+      stop_tx,
+      latest_snapshot,
+    }
+  }
+
+  pub fn emit_latest_if_visible(&self, app_handle: &tauri::AppHandle) {
+    if let Some(snapshot) = self.latest_snapshot.load() {
+      emit_snapshot(app_handle, snapshot);
+    }
   }
 
   pub async fn terminate(self) {
@@ -57,7 +93,16 @@ impl WindowAdapter {
   }
 }
 
+fn to_window_snapshot(mut snapshot: MetricsSnapshot) -> MetricsSnapshot {
+  snapshot.processes.clear();
+  snapshot
+}
+
 fn emit_snapshot(app_handle: &tauri::AppHandle, snapshot: MetricsSnapshot) {
+  if !should_emit_for_main_window(main_window_state(app_handle)) {
+    return;
+  }
+
   let temp_unit = current_temperature_unit(app_handle);
   let payload = to_hardware_monitor_update(snapshot, &temp_unit);
   if let Err(e) = payload.emit(app_handle) {
@@ -67,6 +112,24 @@ fn emit_snapshot(app_handle: &tauri::AppHandle, snapshot: MetricsSnapshot) {
       None::<&str>
     );
   }
+}
+
+#[derive(Clone, Copy)]
+struct MainWindowState {
+  is_visible: bool,
+  is_minimized: bool,
+}
+
+fn main_window_state(app_handle: &tauri::AppHandle) -> Option<MainWindowState> {
+  let window = app_handle.get_webview_window("main")?;
+  Some(MainWindowState {
+    is_visible: window.is_visible().ok()?,
+    is_minimized: window.is_minimized().ok()?,
+  })
+}
+
+fn should_emit_for_main_window(state: Option<MainWindowState>) -> bool {
+  state.is_some_and(|state| state.is_visible && !state.is_minimized)
 }
 
 /// Read the user's preferred temperature unit from `settings::AppState`.
@@ -135,6 +198,16 @@ mod tests {
       gpu_source: "Test".to_string(),
       gpu_dedicated_memory_usage_kb: Some(1024.0),
       gpu_cooler_level: Some(40),
+    }
+  }
+
+  fn make_snapshot(cpu_usage: f32) -> MetricsSnapshot {
+    MetricsSnapshot {
+      cpu_usage,
+      memory_usage: 67.0,
+      processors_usage: vec![10.0, 20.0],
+      gpus: vec![],
+      processes: vec![],
     }
   }
 
@@ -262,5 +335,51 @@ mod tests {
       convert_temperature(-40.0, &TemperatureUnit::Fahrenheit),
       -40.0
     );
+  }
+
+  #[test]
+  fn main_window_visibility_gates_emission() {
+    assert!(should_emit_for_main_window(Some(MainWindowState {
+      is_visible: true,
+      is_minimized: false,
+    })));
+    assert!(!should_emit_for_main_window(Some(MainWindowState {
+      is_visible: false,
+      is_minimized: false,
+    })));
+    assert!(!should_emit_for_main_window(Some(MainWindowState {
+      is_visible: true,
+      is_minimized: true,
+    })));
+    assert!(!should_emit_for_main_window(None));
+  }
+
+  #[test]
+  fn latest_window_snapshot_keeps_the_most_recent_snapshot() {
+    let latest = LatestWindowSnapshot::default();
+    assert!(latest.load().is_none());
+
+    latest.store(make_snapshot(1.0));
+    latest.store(make_snapshot(2.0));
+
+    assert_eq!(latest.load().unwrap().cpu_usage, 2.0);
+  }
+
+  #[test]
+  fn window_snapshot_omits_process_samples() {
+    let mut snapshot = make_snapshot(1.0);
+    snapshot
+      .processes
+      .push(hardviz_core::models::ProcessSample {
+        pid: 42,
+        name: "test-process".into(),
+        cpu_usage: 5.0,
+        memory_kb: 1024.0,
+        run_time_secs: 60,
+      });
+
+    let snapshot = to_window_snapshot(snapshot);
+
+    assert!(snapshot.processes.is_empty());
   }
 }

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -147,6 +147,27 @@ pub fn restore_main_window(app: &AppHandle) {
       None::<&str>
     );
   }
+
+  emit_latest_window_snapshot(app);
+}
+
+fn emit_latest_window_snapshot(app: &AppHandle) {
+  let Some(workers) = app.try_state::<WorkersState>() else {
+    return;
+  };
+
+  let Ok(adapter) = workers.window_adapter.lock() else {
+    log_warn!(
+      "failed to lock window adapter while restoring app window",
+      "lifecycle::emit_latest_window_snapshot",
+      None::<&str>
+    );
+    return;
+  };
+
+  if let Some(adapter) = adapter.as_ref() {
+    adapter.emit_latest_if_visible(app);
+  }
 }
 
 /// Decide what closing the main window means.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { SideMenu } from "./features/menu/SideMenu";
 import { useSettingsAtom } from "./features/settings/hooks/useSettingsAtom";
 import { useBackgroundImage } from "./hooks/useBgImage";
 import { useColorTheme } from "./hooks/useColorTheme";
+import { useDocumentVisibilityClass } from "./hooks/useDocumentVisibilityClass";
 import type { SelectedDisplayType } from "./types/ui";
 import "@/lib/i18n";
 import {
@@ -108,6 +109,7 @@ const AppContent = () => {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
 
   useErrorModalListener();
+  useDocumentVisibilityClass();
   useHardwareEventListener();
   useSelectedGpuPersistence();
   const { hardwareInfo } = useHardwareInfoAtom();

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -73,12 +73,20 @@ const makePayload = (
   };
 };
 
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+};
+
 // ── Tests ──
 
 describe("useHardwareEventListener", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedCallback = null;
+    setDocumentHidden(false);
   });
 
   // ── Listener registration / cleanup ──
@@ -119,6 +127,22 @@ describe("useHardwareEventListener", () => {
     const history = result.current;
     expect(history).toHaveLength(chartConfig.historyLengthSec);
     expect(history[history.length - 1]).toBe(42);
+  });
+
+  it("ignores hardware update events while the document is hidden", () => {
+    const { result } = renderHook(
+      () => {
+        useHardwareEventListener();
+        const [history] = useAtom(cpuUsageHistoryAtom);
+        return history;
+      },
+      { wrapper: Provider },
+    );
+
+    setDocumentHidden(true);
+    act(() => emit(makePayload({ cpuUsage: 42 })));
+
+    expect(result.current).toEqual([]);
   });
 
   // ── Memory history ──

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -53,6 +53,10 @@ export const useHardwareEventListener = () => {
         processorsUsage: number[];
       };
     }) => {
+      if (document.hidden) {
+        return;
+      }
+
       const { cpuUsage, memoryUsage, gpus, processorsUsage } = event.payload;
 
       setCpuHistory((prev) => padHistory([...prev, cpuUsage]));

--- a/src/hooks/useDocumentVisibilityClass.test.ts
+++ b/src/hooks/useDocumentVisibilityClass.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useDocumentVisibilityClass } from "@/hooks/useDocumentVisibilityClass";
+
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+};
+
+describe("useDocumentVisibilityClass", () => {
+  beforeEach(() => {
+    setDocumentHidden(false);
+    document.documentElement.classList.remove("hardviz-document-hidden");
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove("hardviz-document-hidden");
+  });
+
+  it("reflects document visibility on the root element", () => {
+    renderHook(() => useDocumentVisibilityClass());
+
+    expect(
+      document.documentElement.classList.contains("hardviz-document-hidden"),
+    ).toBe(false);
+
+    setDocumentHidden(true);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(
+      document.documentElement.classList.contains("hardviz-document-hidden"),
+    ).toBe(true);
+
+    setDocumentHidden(false);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(
+      document.documentElement.classList.contains("hardviz-document-hidden"),
+    ).toBe(false);
+  });
+});

--- a/src/hooks/useDocumentVisibilityClass.ts
+++ b/src/hooks/useDocumentVisibilityClass.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+const DOCUMENT_HIDDEN_CLASS = "hardviz-document-hidden";
+
+export const useDocumentVisibilityClass = (
+  className = DOCUMENT_HIDDEN_CLASS,
+) => {
+  useEffect(() => {
+    const root = document.documentElement;
+    const syncVisibilityClass = () => {
+      root.classList.toggle(className, document.hidden);
+    };
+
+    syncVisibilityClass();
+    document.addEventListener("visibilitychange", syncVisibilityClass);
+
+    return () => {
+      document.removeEventListener("visibilitychange", syncVisibilityClass);
+      root.classList.remove(className);
+    };
+  }, [className]);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -172,6 +172,11 @@
   }
 }
 
+.hardviz-document-hidden .burnin-drift-x,
+.hardviz-document-hidden .burnin-drift-y {
+  animation-play-state: paused;
+}
+
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still


### PR DESCRIPTION
## Summary

Gate window-side hardware update work when the main window is hidden or minimized.

- Skip `HardwareMonitorUpdate` emits while the main window is not visible or is minimized.
- Keep the latest window snapshot and replay it when the main window is restored.
- Ignore frontend hardware events while `document.hidden` is true.
- Pause burn-in drift animation while the document is hidden.

This keeps sampling, tray updates, and persistence running while reducing hidden-window IPC, atom updates, chart churn, and CSS animation work.

## Related Issues

Closes #1570

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`perf/` branch): performance improvement

## Screenshots / Videos

N/A

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Commands run:

- `cargo test -p hardware_visualizer adapters::window --locked --offline`
- `npx vitest run src/features/hardware/hooks/useHardwareEventListener.test.ts src/hooks/useDocumentVisibilityClass.test.ts`
- `env HOME=/private/tmp/hardviz-test-home RUSTUP_HOME=/Users/shm11c3/.rustup CARGO_HOME=/Users/shm11c3/.cargo cargo test --workspace --locked --offline`
- `npm test`
- `npm run lint`
- `git diff --check`

Note: in this sandbox, the plain `cargo test --workspace --locked --offline` cannot write macOS app settings under `~/Library/Application Support/...`, so the full Rust suite was run with `HOME` pointed at `/private/tmp/hardviz-test-home` while keeping `RUSTUP_HOME` and `CARGO_HOME` on the installed toolchain/cache.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now respects window visibility and minimized state; metrics are only emitted when the main window is visible and active
  * Burn-in animations automatically pause when the page/tab is hidden, reducing resource consumption
  * Latest metrics snapshots are cached for on-demand emission
  * Hardware monitor updates are skipped when the document is not visible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->