### PR TITLE
test(e2e): add Playwright mock capture harness

### DIFF
--- a/.github/scripts/comment-e2e-captures.sh
+++ b/.github/scripts/comment-e2e-captures.sh
@@ -14,41 +14,65 @@ set -euo pipefail
 
 CAPTURES_DIR="${CAPTURES_DIR:-test-results/captures}"
 BRANCH="${CAPTURES_BRANCH:-e2e-captures}"
+PR_DIR="pr-${PR_NUMBER}"
 ROOT_DIR="$PWD"
+REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
 if ! ls "$CAPTURES_DIR"/*.png >/dev/null 2>&1; then
   echo "No captures found in $CAPTURES_DIR; skipping PR comment."
   exit 0
 fi
 
-# --- 1. Publish captures to the dedicated branch (single orphan commit) ---
-WORKTREE="$(mktemp -d)"
-REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+# --- 1. Publish captures to the dedicated branch ---
+#
+# The branch is a single parentless commit shared by every PR (each under its
+# own pr-<number>/ directory). Concurrent runs therefore race on it, so build
+# the new tree from a fresh fetch and push with --force-with-lease: if another
+# run advanced the branch between our fetch and push, the lease fails and we
+# retry on the new tip instead of clobbering its captures.
+publish_captures() {
+  local worktree attempt lease
+  for attempt in 1 2 3 4 5; do
+    worktree="$(mktemp -d)"
+    git init -q "$worktree"
+    git -C "$worktree" config user.name "github-actions[bot]"
+    git -C "$worktree" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    git -C "$worktree" remote add origin "$REMOTE_URL"
 
-git init -q "$WORKTREE"
-cd "$WORKTREE"
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git remote add origin "$REMOTE_URL"
+    # Fetch into the remote-tracking ref so --force-with-lease has an anchor.
+    if git -C "$worktree" fetch -q --depth 1 \
+      origin "$BRANCH:refs/remotes/origin/$BRANCH" 2>/dev/null; then
+      git -C "$worktree" checkout -q "refs/remotes/origin/$BRANCH"
+      lease="--force-with-lease=$BRANCH:refs/remotes/origin/$BRANCH"
+    else
+      lease="--force" # branch does not exist yet
+    fi
 
-# Start from the current branch tree when it exists so other PR directories
-# survive, but always create a fresh parentless commit and force-push:
-# the branch history stays at exactly one commit.
-if git fetch -q --depth 1 origin "$BRANCH" 2>/dev/null; then
-  git checkout -q FETCH_HEAD
+    # Replace only this PR's directory; other PRs' captures carry over.
+    git -C "$worktree" checkout -q --orphan "$BRANCH"
+    rm -rf "${worktree:?}/$PR_DIR"
+    mkdir -p "$worktree/$PR_DIR"
+    cp "$ROOT_DIR/$CAPTURES_DIR"/*.png "$worktree/$PR_DIR/"
+
+    git -C "$worktree" add -A
+    git -C "$worktree" commit -q -m "e2e captures (auto-generated, do not edit)"
+
+    if git -C "$worktree" push -q "$lease" origin "$BRANCH"; then
+      rm -rf "$worktree"
+      return 0
+    fi
+
+    echo "Push rejected (attempt ${attempt}/5); refetching and retrying..."
+    rm -rf "$worktree"
+    sleep "$((attempt * 2))"
+  done
+  return 1
+}
+
+if ! publish_captures; then
+  echo "Failed to publish captures after retries; skipping PR comment." >&2
+  exit 0
 fi
-git checkout -q --orphan "$BRANCH"
-
-PR_DIR="pr-${PR_NUMBER}"
-rm -rf "$PR_DIR"
-mkdir -p "$PR_DIR"
-cp "$ROOT_DIR/$CAPTURES_DIR"/*.png "$PR_DIR/"
-
-git add -A
-git commit -q -m "e2e captures (auto-generated, do not edit)"
-git push -q --force origin "$BRANCH"
-cd "$ROOT_DIR"
-rm -rf "$WORKTREE"
 echo "Published captures to ${BRANCH}/${PR_DIR}."
 
 # --- 2. Upsert the sticky PR comment ---

--- a/.github/scripts/comment-e2e-captures.sh
+++ b/.github/scripts/comment-e2e-captures.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Publish E2E capture PNGs to the `e2e-captures` branch and upsert a sticky
+# PR comment that embeds them inline.
+#
+# Required environment:
+#   GH_TOKEN          - token with contents:write + pull-requests:write
+#   GITHUB_REPOSITORY - owner/repo
+#   PR_NUMBER         - pull request number
+#   HEAD_SHA          - PR head commit SHA (used for cache busting)
+# Optional:
+#   CAPTURES_DIR      - capture source dir (default: test-results/captures)
+#   CAPTURES_BRANCH   - publishing branch (default: e2e-captures)
+set -euo pipefail
+
+CAPTURES_DIR="${CAPTURES_DIR:-test-results/captures}"
+BRANCH="${CAPTURES_BRANCH:-e2e-captures}"
+ROOT_DIR="$PWD"
+
+if ! ls "$CAPTURES_DIR"/*.png >/dev/null 2>&1; then
+  echo "No captures found in $CAPTURES_DIR; skipping PR comment."
+  exit 0
+fi
+
+# --- 1. Publish captures to the dedicated branch (single orphan commit) ---
+WORKTREE="$(mktemp -d)"
+REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+git init -q "$WORKTREE"
+cd "$WORKTREE"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git remote add origin "$REMOTE_URL"
+
+# Start from the current branch tree when it exists so other PR directories
+# survive, but always create a fresh parentless commit and force-push:
+# the branch history stays at exactly one commit.
+if git fetch -q --depth 1 origin "$BRANCH" 2>/dev/null; then
+  git checkout -q FETCH_HEAD
+fi
+git checkout -q --orphan "$BRANCH"
+
+PR_DIR="pr-${PR_NUMBER}"
+rm -rf "$PR_DIR"
+mkdir -p "$PR_DIR"
+cp "$ROOT_DIR/$CAPTURES_DIR"/*.png "$PR_DIR/"
+
+git add -A
+git commit -q -m "e2e captures (auto-generated, do not edit)"
+git push -q --force origin "$BRANCH"
+cd "$ROOT_DIR"
+rm -rf "$WORKTREE"
+echo "Published captures to ${BRANCH}/${PR_DIR}."
+
+# --- 2. Upsert the sticky PR comment ---
+MARKER="<!-- e2e-captures-comment -->"
+RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${BRANCH}/${PR_DIR}"
+
+BODY="${MARKER}
+## E2E captures
+
+Evidence captures for \`${HEAD_SHA}\` (also available as the \`e2e-captures\` workflow artifact).
+"
+for file in "$CAPTURES_DIR"/*.png; do
+  name="$(basename "$file" .png)"
+  BODY+="
+<details><summary><code>${name}</code></summary>
+
+![${name}](${RAW_BASE}/${name}.png?rev=${HEAD_SHA})
+
+</details>
+"
+done
+
+COMMENT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+  --paginate --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty")"
+
+if [ -n "$COMMENT_ID" ]; then
+  gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+    -f body="$BODY" >/dev/null
+  echo "Updated capture comment ${COMMENT_ID}."
+else
+  gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+    -f body="$BODY" >/dev/null
+  echo "Posted capture comment."
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,10 @@ jobs:
           filters: |
             frontend:
               - 'src/**'
+              - 'e2e/**'
               - 'package*.json'
               - 'vite.config.ts'
+              - 'playwright.config.ts'
               - 'tsconfig*.json'
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -471,6 +473,45 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
           json-summary-path: coverage/coverage-summary.json
+
+  #
+  # Frontend E2E captures (Playwright web/mock harness, issue #1609)
+  #
+  test-e2e-web:
+    needs: change-detection
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E capture tests
+        run: npm run test:e2e
+
+      # Keep evidence captures even when the suite fails after launch.
+      - name: Upload capture artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-captures
+          path: test-results/captures/
+          if-no-files-found: warn
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-report
+          path: |
+            test-results/report/
+            test-results/output/
+          if-no-files-found: ignore
 
   #
   # Frontend Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,9 @@ jobs:
   test-e2e-web:
     needs: change-detection
     if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -512,6 +515,16 @@ jobs:
             test-results/report/
             test-results/output/
           if-no-files-found: ignore
+
+      # Publish captures to the e2e-captures branch and embed them in a
+      # sticky PR comment. Same-repo PRs only (forks get a read-only token).
+      - name: Comment captures on PR
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/comment-e2e-captures.sh
 
   #
   # Frontend Build
@@ -600,6 +613,7 @@ jobs:
       - test-build
       - lint-frontend
       - test-frontend
+      - test-e2e-web
       - build-frontend
       - license-check-npm
       - license-check-cargo

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist-ssr
 coverage
 licenses.json
 
+# Playwright E2E output (captures, reports, traces)
+test-results
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ documentation.
 - [Core crate guide](../core/README.md)
 - [Tauri app crate guide](../src-tauri/README.md)
 - [Add a new language](development/add-language.md)
+- [E2E capture harness](development/e2e-captures.md)
 - [Download verification](download-verification.md)
 - [Documentation guide](documentation-guide.md)
 

--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -1,0 +1,107 @@
+# E2E capture harness (Playwright web/mock)
+
+Automated E2E scenario runs that save PNG evidence captures of the UI.
+This is the web-only harness from issue #1609: it runs the React frontend in
+a plain Chromium browser with **mocked Tauri IPC and events**, so no Rust
+backend, live hardware data, or Tauri runtime is required.
+
+## Scope
+
+- In scope: deterministic scenario runs + PNG capture artifacts.
+- Out of scope: **visual snapshot regression / baseline comparison** is
+  intentionally not part of this harness. Captures are evidence for human
+  review, not compared against golden images.
+- The native Tauri smoke path (tauri-driver/WebDriver) is tracked separately
+  in issue #1610. Note that tauri-driver only supports Linux and Windows;
+  macOS has no WKWebView driver.
+
+## Running locally
+
+```bash
+npm run test:e2e
+```
+
+Playwright starts its own Vite dev server on port `1521` with
+`VITE_E2E_MOCK=true` (a regular `npm run dev` server on `1520` is never
+reused). Captures are written to:
+
+```text
+test-results/captures/<scenario>.png
+```
+
+The first page load pays Vite's cold module-transform cost
+(babel + react-compiler) and can take >10 seconds; specs use an extended
+timeout for the initial render assertion.
+
+## How the mocks work
+
+- `src/main.tsx` installs the mocks before importing the app, only when
+  `VITE_E2E_MOCK=true`. The branch is statically false in production builds,
+  so the mock code is dead-code eliminated from release bundles.
+- `src/e2e/mocks/installTauriMocks.ts` is the single mock entry point:
+  - `mockIPC(..., { shouldMockEvents: true })` from `@tauri-apps/api/mocks`
+    intercepts every `invoke()` (generated tauri-specta commands and
+    `plugin:<name>|<command>` plugin calls) and implements
+    `plugin:event|listen/emit/unlisten`.
+  - `mockWindows("main")` fakes the current window label.
+  - `window.__TAURI_OS_PLUGIN_INTERNALS__` is set directly because
+    `platform()` from `@tauri-apps/plugin-os` is a synchronous global read,
+    not an IPC call.
+  - The Tauri store plugin is backed by an in-memory `Map`, seeded from
+    `src/e2e/fixtures/store.ts`.
+  - Unhandled commands throw `[e2e-mock] Unhandled invoke: <cmd>` so coverage
+    gaps surface immediately when new screens are added to scenarios.
+- Fixture data lives in `src/e2e/fixtures/` (settings, hardware info,
+  process list, storage health, and a deterministic
+  `hardware-monitor-update` series built from fixed sine waves).
+- Tests push hardware events through `window.__E2E__.emitHardwareUpdate` /
+  `emitHardwareUpdateSeries`, exposed by the mock installer.
+
+## Covered scenarios
+
+| Spec | Captures |
+|------|----------|
+| `e2e/dashboard.spec.ts` | `dashboard`, `dashboard-gpu-secondary` (GPU tab switch) |
+| `e2e/usage.spec.ts` | `usage` (mixed CPU/RAM/GPU chart) |
+| `e2e/cpu-detail.spec.ts` | `cpu-detail` (info table + per-core charts) |
+| `e2e/insights.spec.ts` | `insights-main`, `insights-process` |
+| `e2e/settings.spec.ts` | `settings` (General/About sections) |
+
+Insights pins the clock with `page.clock.setFixedTime(...)` because its
+archive query ranges derive from `Date.now()`; the mocked archive commands
+synthesize records from the requested start/end range
+(`src/e2e/fixtures/archive.ts`), so charts stay deterministic.
+
+Pass criteria are DOM-level: fixture content visible via accessible
+selectors, interactions reflected in ARIA state, and captures saved.
+Pixels are not compared (no baselines). One targeted style guard exists:
+the usage spec compares the **computed** stroke of each chart series
+against the fixture colors, catching invalid color plumbing that would
+render series black while remaining "visible" to all other assertions.
+
+## Writing a scenario
+
+Specs live in `e2e/*.spec.ts` (outside `src/`, so Vitest does not pick them
+up). Shared helpers live in `e2e/helpers.ts`. The shape of a scenario:
+
+1. `await gotoApp(page)` — loads `/` and waits for fixture content
+   (first load can take >10s, see above).
+2. Seed chart history: `await seedHardwareHistory(page)`.
+3. Navigate with `await navigateTo(page, "<screen>")` (clicks the side
+   menu's accessible `open <type>` buttons) and interact via accessible
+   selectors (`getByRole("tab", ...)`, aria-labels, headings).
+4. Save the capture: `await page.screenshot({ path: capturePath("<name>") })`
+   (`capturePath` resolves into `test-results/captures/`).
+
+Determinism rules:
+
+- Locked viewport (1280x800), `deviceScaleFactor: 1`, dark color scheme,
+  `en-US` locale, UTC timezone, reduced motion (see `playwright.config.ts`).
+- Use fixture data only — never live hardware values.
+
+## CI
+
+The `test-e2e-web` job in `.github/workflows/ci.yml` runs the suite on
+`ubuntu-latest` and uploads `test-results/captures/` as the `e2e-captures`
+artifact with `if: always()`, so captures survive failed runs. The Playwright
+HTML report and per-test output are uploaded only on failure.

--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -105,3 +105,10 @@ The `test-e2e-web` job in `.github/workflows/ci.yml` runs the suite on
 `ubuntu-latest` and uploads `test-results/captures/` as the `e2e-captures`
 artifact with `if: always()`, so captures survive failed runs. The Playwright
 HTML report and per-test output are uploaded only on failure.
+
+For same-repo pull requests the job also posts the captures inline as a
+sticky PR comment (`.github/scripts/comment-e2e-captures.sh`): images are
+force-pushed to the single-commit `e2e-captures` branch under
+`pr-<number>/` and embedded via raw.githubusercontent.com URLs. The branch
+is disposable — it can be deleted at any time and will be recreated by the
+next run. Fork PRs are skipped (their token is read-only).

--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -90,8 +90,9 @@ up). Shared helpers live in `e2e/helpers.ts`. The shape of a scenario:
 3. Navigate with `await navigateTo(page, "<screen>")` (clicks the side
    menu's accessible `open <type>` buttons) and interact via accessible
    selectors (`getByRole("tab", ...)`, aria-labels, headings).
-4. Save the capture: `await page.screenshot({ path: capturePath("<name>") })`
-   (`capturePath` resolves into `test-results/captures/`).
+4. Save the capture: `await saveCapture(page, "<name>")` — writes a
+   full-page PNG (the whole scrollable page, not just the viewport) into
+   `test-results/captures/`.
 
 Determinism rules:
 

--- a/e2e/cpu-detail.spec.ts
+++ b/e2e/cpu-detail.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "@playwright/test";
 import { sysInfoFixture } from "../src/e2e/fixtures/hardware";
 import {
   BOOTSTRAP_TIMEOUT,
-  capturePath,
   gotoApp,
   navigateTo,
+  saveCapture,
   seedHardwareHistory,
 } from "./helpers";
 
@@ -25,6 +25,6 @@ test.describe("cpu detail captures", () => {
     });
     await page.waitForTimeout(600);
 
-    await page.screenshot({ path: capturePath("cpu-detail") });
+    await saveCapture(page, "cpu-detail");
   });
 });

--- a/e2e/cpu-detail.spec.ts
+++ b/e2e/cpu-detail.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { sysInfoFixture } from "../src/e2e/fixtures/hardware";
+import {
+  BOOTSTRAP_TIMEOUT,
+  capturePath,
+  gotoApp,
+  navigateTo,
+  seedHardwareHistory,
+} from "./helpers";
+
+const CPU_NAME = sysInfoFixture.cpu?.name ?? "";
+
+test.describe("cpu detail captures", () => {
+  test("cpu detail shows fixture info and per-core charts", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    await navigateTo(page, "cpuDetail");
+
+    // Info table renders the fixture CPU name on the detail screen.
+    await expect(page.getByText(CPU_NAME).first()).toBeVisible({
+      timeout: BOOTSTRAP_TIMEOUT,
+    });
+    await page.waitForTimeout(600);
+
+    await page.screenshot({ path: capturePath("cpu-detail") });
+  });
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+import { GPU_FIXTURES } from "../src/e2e/fixtures/hardware";
+import { capturePath, gotoApp, seedHardwareHistory } from "./helpers";
+
+test.describe("dashboard captures", () => {
+  test("dashboard renders fixture hardware data", async ({ page }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    // GPU selector tablist renders because the fixture exposes two GPUs.
+    await expect(
+      page.getByRole("tab", { name: GPU_FIXTURES[0].name }),
+    ).toBeVisible();
+
+    await page.screenshot({ path: capturePath("dashboard") });
+  });
+
+  test("gpu selector switches via accessible tab roles", async ({ page }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    const secondaryGpuTab = page.getByRole("tab", {
+      name: GPU_FIXTURES[1].name,
+    });
+    await secondaryGpuTab.click();
+    await expect(secondaryGpuTab).toHaveAttribute("aria-selected", "true");
+
+    await page.screenshot({ path: capturePath("dashboard-gpu-secondary") });
+  });
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { GPU_FIXTURES } from "../src/e2e/fixtures/hardware";
-import { capturePath, gotoApp, seedHardwareHistory } from "./helpers";
+import { gotoApp, saveCapture, seedHardwareHistory } from "./helpers";
 
 test.describe("dashboard captures", () => {
   test("dashboard renders fixture hardware data", async ({ page }) => {
@@ -12,7 +12,7 @@ test.describe("dashboard captures", () => {
       page.getByRole("tab", { name: GPU_FIXTURES[0].name }),
     ).toBeVisible();
 
-    await page.screenshot({ path: capturePath("dashboard") });
+    await saveCapture(page, "dashboard");
   });
 
   test("gpu selector switches via accessible tab roles", async ({ page }) => {
@@ -25,6 +25,6 @@ test.describe("dashboard captures", () => {
     await secondaryGpuTab.click();
     await expect(secondaryGpuTab).toHaveAttribute("aria-selected", "true");
 
-    await page.screenshot({ path: capturePath("dashboard-gpu-secondary") });
+    await saveCapture(page, "dashboard-gpu-secondary");
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -13,6 +13,13 @@ export const capturePath = (name: string) =>
   path.join("test-results", "captures", `${name}.png`);
 
 /**
+ * Save a full-page evidence capture (the whole scrollable page, not just the
+ * viewport) under `test-results/captures/<name>.png`.
+ */
+export const saveCapture = (page: Page, name: string) =>
+  page.screenshot({ path: capturePath(name), fullPage: true });
+
+/**
  * The first page load pays Vite's cold module-transform cost
  * (babel + react-compiler), which can take >10s — hence the long timeout.
  */

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+import { expect, type Page } from "@playwright/test";
+import { sysInfoFixture } from "../src/e2e/fixtures/hardware";
+// Type-only import: pulls in the `window.__E2E__` global declaration without
+// bundling app code into the test runner.
+import type {} from "../src/e2e/mocks/installTauriMocks";
+
+/**
+ * Evidence captures are written to a predictable directory so CI can upload
+ * them as artifacts (`test-results/captures/<name>.png`).
+ */
+export const capturePath = (name: string) =>
+  path.join("test-results", "captures", `${name}.png`);
+
+/**
+ * The first page load pays Vite's cold module-transform cost
+ * (babel + react-compiler), which can take >10s — hence the long timeout.
+ */
+export const BOOTSTRAP_TIMEOUT = 30_000;
+
+const CPU_NAME = sysInfoFixture.cpu?.name ?? "";
+
+/**
+ * Load the app and wait until the dashboard rendered fixture data,
+ * i.e. settings/mock bootstrap completed.
+ */
+export const gotoApp = async (page: Page) => {
+  await page.goto("/");
+  await expect(page.getByText(CPU_NAME).first()).toBeVisible({
+    timeout: BOOTSTRAP_TIMEOUT,
+  });
+};
+
+/**
+ * Push a deterministic series of hardware-monitor-update events so charts
+ * render a stable history, then wait for the UI to settle.
+ */
+export const seedHardwareHistory = async (page: Page) => {
+  await page.evaluate(async () => {
+    await window.__E2E__?.emitHardwareUpdateSeries(30);
+  });
+  // Allow chart re-render/animation to settle before capturing.
+  await page.waitForTimeout(600);
+};
+
+/**
+ * Navigate via the closed side menu's accessible buttons
+ * (`aria-label="open <type>"`, see SideMenu.tsx).
+ */
+export const navigateTo = async (
+  page: Page,
+  type: "dashboard" | "usage" | "cpuDetail" | "insights" | "settings",
+) => {
+  await page.getByRole("button", { name: `open ${type}` }).click();
+};

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -43,8 +43,13 @@ export const gotoApp = async (page: Page) => {
  * render a stable history, then wait for the UI to settle.
  */
 export const seedHardwareHistory = async (page: Page) => {
+  // Fail loudly if the E2E mock bridge is missing rather than silently
+  // skipping the seed (which would surface later as an empty-chart capture).
   await page.evaluate(async () => {
-    await window.__E2E__?.emitHardwareUpdateSeries(30);
+    if (!window.__E2E__) {
+      throw new Error("window.__E2E__ is not installed (VITE_E2E_MOCK unset?)");
+    }
+    await window.__E2E__.emitHardwareUpdateSeries(30);
   });
   // Allow chart re-render/animation to settle before capturing.
   await page.waitForTimeout(600);

--- a/e2e/insights.spec.ts
+++ b/e2e/insights.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import {
+  BOOTSTRAP_TIMEOUT,
+  capturePath,
+  gotoApp,
+  navigateTo,
+  seedHardwareHistory,
+} from "./helpers";
+
+/**
+ * Insights derives its archive query ranges from `Date.now()`, so the clock
+ * is pinned to a fixed time. The mocked archive commands synthesize records
+ * from the requested start/end range, making charts fully deterministic.
+ */
+const FIXED_TIME = new Date("2026-01-15T12:00:00Z");
+
+test.describe("insights captures", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.clock.setFixedTime(FIXED_TIME);
+  });
+
+  test("insights main chart renders archive fixtures", async ({ page }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    await navigateTo(page, "insights");
+
+    await expect(page.getByRole("tab", { name: "CPU / Memory" })).toBeVisible({
+      timeout: BOOTSTRAP_TIMEOUT,
+    });
+    // Wait for the debounced archive query (250ms) + chart render.
+    await page.waitForTimeout(1_000);
+
+    await page.screenshot({ path: capturePath("insights-main") });
+  });
+
+  test("insights process tab lists fixture process stats", async ({ page }) => {
+    await gotoApp(page);
+    await navigateTo(page, "insights");
+
+    const processTab = page.getByRole("tab", { name: "Process" });
+    await expect(processTab).toBeVisible({ timeout: BOOTSTRAP_TIMEOUT });
+    await processTab.click();
+
+    await expect(page.getByText("hv-fixture-app").first()).toBeVisible();
+    await page.waitForTimeout(600);
+
+    await page.screenshot({ path: capturePath("insights-process") });
+  });
+});

--- a/e2e/insights.spec.ts
+++ b/e2e/insights.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 import {
   BOOTSTRAP_TIMEOUT,
-  capturePath,
   gotoApp,
   navigateTo,
+  saveCapture,
   seedHardwareHistory,
 } from "./helpers";
 
@@ -31,7 +31,7 @@ test.describe("insights captures", () => {
     // Wait for the debounced archive query (250ms) + chart render.
     await page.waitForTimeout(1_000);
 
-    await page.screenshot({ path: capturePath("insights-main") });
+    await saveCapture(page, "insights-main");
   });
 
   test("insights process tab lists fixture process stats", async ({ page }) => {
@@ -45,6 +45,6 @@ test.describe("insights captures", () => {
     await expect(page.getByText("hv-fixture-app").first()).toBeVisible();
     await page.waitForTimeout(600);
 
-    await page.screenshot({ path: capturePath("insights-process") });
+    await saveCapture(page, "insights-process");
   });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+import { BOOTSTRAP_TIMEOUT, capturePath, gotoApp, navigateTo } from "./helpers";
+
+test.describe("settings captures", () => {
+  test("settings sections render", async ({ page }) => {
+    await gotoApp(page);
+
+    await navigateTo(page, "settings");
+
+    // Section headings come from i18n (fixture language is "en").
+    await expect(page.getByRole("heading", { name: "General" })).toBeVisible({
+      timeout: BOOTSTRAP_TIMEOUT,
+    });
+    await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
+    await page.waitForTimeout(600);
+
+    await page.screenshot({ path: capturePath("settings") });
+  });
+});

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { BOOTSTRAP_TIMEOUT, capturePath, gotoApp, navigateTo } from "./helpers";
+import { BOOTSTRAP_TIMEOUT, gotoApp, navigateTo, saveCapture } from "./helpers";
 
 test.describe("settings captures", () => {
   test("settings sections render", async ({ page }) => {
@@ -14,6 +14,6 @@ test.describe("settings captures", () => {
     await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
     await page.waitForTimeout(600);
 
-    await page.screenshot({ path: capturePath("settings") });
+    await saveCapture(page, "settings");
   });
 });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../playwright.config.ts"]
+}

--- a/e2e/usage.spec.ts
+++ b/e2e/usage.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { settingsFixture } from "../src/e2e/fixtures/settings";
+import {
+  BOOTSTRAP_TIMEOUT,
+  capturePath,
+  gotoApp,
+  navigateTo,
+  seedHardwareHistory,
+} from "./helpers";
+
+test.describe("usage captures", () => {
+  test("usage charts render seeded history", async ({ page }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    await navigateTo(page, "usage");
+
+    // The mixed usage chart (SVG) renders with its CPU/RAM/GPU legend.
+    await expect(page.getByText("RAM", { exact: true })).toBeVisible({
+      timeout: BOOTSTRAP_TIMEOUT,
+    });
+    await expect(page.getByText("GPU", { exact: true })).toBeVisible();
+
+    // Guard against silently-broken series styling: compare the *computed*
+    // stroke of each area curve against the fixture colors. The browser
+    // parses the stroke attribute, so a malformed color (which once rendered
+    // every series black while all visibility assertions still passed)
+    // computes to rgb(0, 0, 0) and fails the comparison.
+    const expectedStrokes = (["cpu", "memory", "gpu"] as const).map(
+      (target) =>
+        `rgb(${settingsFixture.lineGraphColor[target]
+          .split(",")
+          .map((component) => component.trim())
+          .join(", ")})`,
+    );
+    const renderedStrokes = await page
+      .locator("path.recharts-area-curve")
+      .evaluateAll((elements) =>
+        elements.map((element) => getComputedStyle(element).stroke),
+      );
+    expect(renderedStrokes.sort()).toEqual([...expectedStrokes].sort());
+    await page.waitForTimeout(600);
+
+    await page.screenshot({ path: capturePath("usage") });
+  });
+});

--- a/e2e/usage.spec.ts
+++ b/e2e/usage.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "@playwright/test";
 import { settingsFixture } from "../src/e2e/fixtures/settings";
 import {
   BOOTSTRAP_TIMEOUT,
-  capturePath,
   gotoApp,
   navigateTo,
+  saveCapture,
   seedHardwareHistory,
 } from "./helpers";
 
@@ -41,6 +41,6 @@ test.describe("usage captures", () => {
     expect(renderedStrokes.sort()).toEqual([...expectedStrokes].sort());
     await page.waitForTimeout(600);
 
-    await page.screenshot({ path: capturePath("usage") });
+    await saveCapture(page, "usage");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
+        "@playwright/test": "^1.60.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "@tailwindcss/vite": "^4.3.0",
         "@tauri-apps/cli": "^2.11.2",
@@ -979,6 +980,22 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5560,6 +5577,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "lint": "biome lint && biome check && biome format --write",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "@playwright/test": "^1.60.0",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.3.0",
     "@tauri-apps/cli": "^2.11.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright web/mock E2E harness (issue #1609).
+ *
+ * Runs the Vite/React frontend in a plain browser with Tauri IPC and event
+ * mocks (see `src/e2e/mocks/installTauriMocks.ts`, enabled via
+ * `VITE_E2E_MOCK=true`). Captures PNG evidence screenshots under
+ * `test-results/captures/`.
+ *
+ * A dedicated port (1521) is used so a regular `npm run dev` server
+ * (1520, without mocks) is never reused by accident.
+ */
+const E2E_PORT = 1521;
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./test-results/output",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [
+        ["list"],
+        ["html", { outputFolder: "test-results/report", open: "never" }],
+      ]
+    : [["list"]],
+  use: {
+    baseURL: `http://localhost:${E2E_PORT}`,
+    colorScheme: "dark",
+    locale: "en-US",
+    timezoneId: "UTC",
+    contextOptions: { reducedMotion: "reduce" },
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // Locked viewport + scale factor for deterministic captures.
+        viewport: { width: 1280, height: 800 },
+        deviceScaleFactor: 1,
+      },
+    },
+  ],
+  webServer: {
+    command: `vite dev --port ${E2E_PORT} --strictPort`,
+    url: `http://localhost:${E2E_PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: { VITE_E2E_MOCK: "true" },
+  },
+});

--- a/src/e2e/fixtures/archive.ts
+++ b/src/e2e/fixtures/archive.ts
@@ -1,0 +1,71 @@
+import type { ArchiveRecord, ProcessStatRecord } from "@/rspc/bindings";
+
+/**
+ * Synthesize deterministic archive records for the requested time range.
+ * Values follow a fixed sine wave; the step is chosen so a range yields at
+ * most ~120 points. Timestamps are derived purely from the requested
+ * start/end args, so results are stable for a fixed test clock.
+ */
+export const buildArchiveRecords = (
+  start: string,
+  end: string,
+  base: number,
+  amplitude: number,
+): ArchiveRecord[] => {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+
+  if (Number.isNaN(startMs) || Number.isNaN(endMs) || endMs <= startMs) {
+    return [];
+  }
+
+  const stepMs = Math.max(60_000, Math.ceil((endMs - startMs) / 120));
+  const records: ArchiveRecord[] = [];
+
+  for (let t = startMs, i = 0; t <= endMs; t += stepMs, i++) {
+    records.push({
+      id: i + 1,
+      value: Math.round((base + amplitude * Math.sin(i / 5)) * 10) / 10,
+      timestamp: new Date(t).toISOString(),
+    });
+  }
+
+  return records;
+};
+
+export const buildProcessStats = (
+  latestTimestamp: string,
+): ProcessStatRecord[] => [
+  {
+    pid: 100,
+    process_name: "hv-fixture-app",
+    avg_cpu_usage: 12.5,
+    avg_memory_usage: 262_144,
+    total_execution_sec: 5400,
+    latest_timestamp: latestTimestamp,
+  },
+  {
+    pid: 200,
+    process_name: "fixture-browser",
+    avg_cpu_usage: 8.1,
+    avg_memory_usage: 1_258_291,
+    total_execution_sec: 3600,
+    latest_timestamp: latestTimestamp,
+  },
+  {
+    pid: 300,
+    process_name: "fixture-editor",
+    avg_cpu_usage: 4.4,
+    avg_memory_usage: 524_288,
+    total_execution_sec: 1800,
+    latest_timestamp: latestTimestamp,
+  },
+  {
+    pid: 400,
+    process_name: "fixture-daemon",
+    avg_cpu_usage: 1.2,
+    avg_memory_usage: 65_536,
+    total_execution_sec: 86_400,
+    latest_timestamp: latestTimestamp,
+  },
+];

--- a/src/e2e/fixtures/hardware.ts
+++ b/src/e2e/fixtures/hardware.ts
@@ -1,0 +1,156 @@
+import type {
+  HardwareMonitorUpdate,
+  ProcessInfo_Serialize,
+  StorageHealthRecord,
+  SysInfo,
+} from "@/rspc/bindings";
+
+/**
+ * GPU ids must match between `sysInfoFixture.gpus[].id` and the
+ * `hardware-monitor-update` payloads (`gpus[].gpuId`) — the dashboard joins
+ * them to resolve the selected GPU. Two GPUs are provided so the GPU selector
+ * tablist renders and can be driven via accessible selectors.
+ */
+export const GPU_FIXTURES = [
+  { id: "e2e-gpu-0", name: "HV Fixture GPU 8GB" },
+  { id: "e2e-gpu-1", name: "HV Fixture iGPU" },
+] as const;
+
+export const sysInfoFixture: SysInfo = {
+  cpu: {
+    name: "HV Fixture CPU 8-Core",
+    vendor: "FixtureVendor",
+    coreCount: 8,
+    clock: 3600,
+    clockUnit: "MHz",
+    cpuName: "HV Fixture CPU 8-Core",
+  },
+  memory: {
+    size: "32 GB",
+    clock: 4800,
+    clockUnit: "MHz",
+    memoryCount: 2,
+    totalSlots: 4,
+    memoryType: "DDR5",
+    isDetailed: false,
+  },
+  gpus: [
+    {
+      id: GPU_FIXTURES[0].id,
+      name: GPU_FIXTURES[0].name,
+      vendorName: "FixtureVendor",
+      clock: 2100,
+      memorySize: "8 GB",
+      memorySizeDedicated: "8 GB",
+      coreCount: null,
+    },
+    {
+      id: GPU_FIXTURES[1].id,
+      name: GPU_FIXTURES[1].name,
+      vendorName: "FixtureVendor",
+      clock: 1500,
+      memorySize: "2 GB",
+      memorySizeDedicated: "2 GB",
+      coreCount: null,
+    },
+  ],
+  storage: [
+    {
+      name: "Fixture SSD",
+      size: 953,
+      sizeUnit: "GB",
+      free: 512,
+      freeUnit: "GB",
+      storageType: "ssd",
+      fileSystem: "NTFS",
+    },
+    {
+      name: "Fixture HDD",
+      size: 3,
+      sizeUnit: "GB",
+      free: 1,
+      freeUnit: "GB",
+      storageType: "hdd",
+      fileSystem: "NTFS",
+    },
+  ],
+  motherboard: {
+    manufacturer: "FixtureVendor",
+    product: "HV Fixture Board",
+    version: "1.0",
+    serialNumber: "E2E-0000",
+    biosVendor: "FixtureVendor",
+    biosVersion: "1.0.0",
+    biosReleaseDate: "2024-01-01",
+  },
+};
+
+export const processListFixture: ProcessInfo_Serialize[] = [
+  { pid: 100, name: "hv-fixture-app", cpuUsage: "12.5", memoryUsage: "256 MB" },
+  { pid: 200, name: "fixture-browser", cpuUsage: "8.1", memoryUsage: "1.2 GB" },
+  { pid: 300, name: "fixture-editor", cpuUsage: "4.4", memoryUsage: "512 MB" },
+  { pid: 400, name: "fixture-daemon", cpuUsage: "1.2", memoryUsage: "64 MB" },
+  { pid: 500, name: "fixture-shell", cpuUsage: "0.3", memoryUsage: "32 MB" },
+];
+
+export const storageHealthFixture: StorageHealthRecord[] = [
+  {
+    deviceId: "e2e-disk-0",
+    displayName: "Fixture SSD",
+    model: "FIXTURE-SSD-1TB",
+    protocol: "NVMe",
+    capacityBytes: 1_024_000_000_000,
+    date: "2026-01-01",
+    healthStatus: "good",
+    warningLevel: "none",
+    temperatureCelsius: 38,
+    powerOnHours: 1234,
+    percentageUsed: 3,
+    availableSparePercent: 100,
+    reallocatedSectorCount: null,
+    currentPendingSectorCount: null,
+    offlineUncorrectableCount: null,
+    mediaErrors: 0,
+    errorLogEntries: 0,
+    unsafeShutdownCount: 2,
+    warningReasons: [],
+    collectedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+/**
+ * Build a deterministic series of `hardware-monitor-update` payloads.
+ * Values follow fixed sine waves so charts always render the same shape.
+ */
+export const buildHardwareUpdateSeries = (
+  length: number,
+): HardwareMonitorUpdate[] =>
+  Array.from({ length }, (_, i) => ({
+    cpuUsage: round1(45 + 25 * Math.sin(i / 4)),
+    memoryUsage: round1(62 + 6 * Math.sin(i / 6 + 1)),
+    gpus: [
+      {
+        gpuId: GPU_FIXTURES[0].id,
+        gpuName: GPU_FIXTURES[0].name,
+        gpuUsage: round1(55 + 35 * Math.sin(i / 3 + 2)),
+        gpuTemperature: round1(58 + 6 * Math.sin(i / 5)),
+        gpuSource: "fixture",
+        gpuDedicatedMemoryUsageKb: 4_194_304,
+        gpuCoolerLevel: 42,
+      },
+      {
+        gpuId: GPU_FIXTURES[1].id,
+        gpuName: GPU_FIXTURES[1].name,
+        gpuUsage: round1(20 + 10 * Math.sin(i / 4 + 1)),
+        gpuTemperature: round1(45 + 4 * Math.sin(i / 5 + 1)),
+        gpuSource: "fixture",
+        gpuDedicatedMemoryUsageKb: 1_048_576,
+        gpuCoolerLevel: 30,
+      },
+    ],
+    processorsUsage: Array.from({ length: 8 }, (_, core) =>
+      round1(40 + 30 * Math.sin(i / 4 + core)),
+    ),
+  }));
+
+const round1 = (value: number) => Math.round(value * 10) / 10;

--- a/src/e2e/fixtures/settings.ts
+++ b/src/e2e/fixtures/settings.ts
@@ -1,0 +1,61 @@
+import type { ClientSettings_Serialize } from "@/rspc/bindings";
+
+/**
+ * Deterministic settings returned by the mocked `get_settings` command.
+ *
+ * - `language: "en"` keeps captured text stable across machines.
+ * - `closeToTrayChoiceMade: true` suppresses the first-run tray dialog so it
+ *   never overlaps capture screenshots.
+ * - `selectedBackgroundImg: null` avoids loading a background image.
+ */
+export const settingsFixture: ClientSettings_Serialize = {
+  version: "1.0.0",
+  language: "en",
+  theme: "dark",
+  displayTargets: ["cpu", "memory", "gpu"],
+  graphSize: "xl",
+  lineGraphType: "default",
+  lineGraphBorder: true,
+  lineGraphFill: true,
+  // Comma-joined RGB components, matching the backend serialization
+  // (settings_service.rs joins [u8;3] with ","). Consumers wrap the value
+  // themselves: `rgb(${settings.lineGraphColor.cpu})` (LineChart.tsx).
+  lineGraphColor: {
+    cpu: "75,192,192",
+    memory: "255,99,132",
+    gpu: "255,206,86",
+  },
+  lineGraphMix: true,
+  lineGraphShowLegend: true,
+  lineGraphShowScale: false,
+  lineGraphShowTooltip: true,
+  backgroundImgOpacity: 50,
+  selectedBackgroundImg: null,
+  transparentUi: false,
+  windowOpacity: 86,
+  glassBlur: 10,
+  temperatureUnit: "C",
+  hardwareArchive: {
+    enabled: true,
+    scheduledDataDeletion: true,
+    retentionDays: 30,
+  },
+  storageHealth: {
+    enabled: true,
+    retentionDays: 1095,
+  },
+  burnInShift: false,
+  burnInShiftMode: "jump",
+  burnInShiftPreset: "aggressive",
+  burnInShiftIdleOnly: false,
+  burnInShiftOptions: null,
+  textSelectable: false,
+  closeToTray: false,
+  closeToTrayChoiceMade: true,
+  trayWidget: {
+    enabled: false,
+    metricOrder: ["cpu", "gpu", "gpu-temp"],
+    visibleMetrics: ["cpu", "gpu", "gpu-temp"],
+    updateIntervalSecs: 1,
+  },
+};

--- a/src/e2e/fixtures/store.ts
+++ b/src/e2e/fixtures/store.ts
@@ -1,0 +1,10 @@
+/**
+ * Initial contents of the mocked Tauri store (`store.json`).
+ * Keys not listed here fall back to the defaults each `useTauriStore`
+ * caller provides (and are then written into the in-memory store).
+ */
+export const storeFixture: Record<string, unknown> = {
+  window_decorated: true,
+  sideMenuOpen: false,
+  display: "dashboard",
+};

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -1,0 +1,183 @@
+import { emit } from "@tauri-apps/api/event";
+import { mockIPC, mockWindows } from "@tauri-apps/api/mocks";
+import type { HardwareMonitorUpdate } from "@/rspc/bindings";
+import { buildArchiveRecords, buildProcessStats } from "../fixtures/archive";
+import {
+  buildHardwareUpdateSeries,
+  GPU_FIXTURES,
+  processListFixture,
+  storageHealthFixture,
+  sysInfoFixture,
+} from "../fixtures/hardware";
+import { settingsFixture } from "../fixtures/settings";
+import { storeFixture } from "../fixtures/store";
+
+declare global {
+  interface Window {
+    __E2E__?: {
+      /** Emit a single `hardware-monitor-update` event (fixture payload by default). */
+      emitHardwareUpdate: (payload?: HardwareMonitorUpdate) => Promise<void>;
+      /** Emit a deterministic series of updates so charts build up history. */
+      emitHardwareUpdateSeries: (count?: number) => Promise<void>;
+    };
+  }
+}
+
+const STORE_RID = 1;
+
+/**
+ * Install Tauri IPC/event/window mocks so the React app runs in a plain
+ * browser with deterministic fixture data. Loaded from `src/main.tsx` only
+ * when `VITE_E2E_MOCK=true` (the branch is dead-code eliminated otherwise).
+ *
+ * Mock layers:
+ * - `mockWindows("main")` fakes the current window label.
+ * - `__TAURI_OS_PLUGIN_INTERNALS__` backs the synchronous `platform()` API
+ *   of @tauri-apps/plugin-os (not an IPC call).
+ * - `mockIPC(..., { shouldMockEvents: true })` routes commands to the
+ *   handler below and implements `plugin:event|listen/emit/unlisten`.
+ */
+export const installTauriMocks = () => {
+  mockWindows("main");
+
+  (
+    window as Window & { __TAURI_OS_PLUGIN_INTERNALS__?: unknown }
+  ).__TAURI_OS_PLUGIN_INTERNALS__ = {
+    platform: "windows",
+    version: "10.0.26100",
+    family: "windows",
+    os_type: "windows",
+    arch: "x86_64",
+    exe_extension: "exe",
+    eol: "\r\n",
+  };
+
+  const store = new Map<string, unknown>(Object.entries(storeFixture));
+
+  mockIPC(
+    (cmd: string, args?: unknown) => {
+      // --- @tauri-apps/plugin-store (rid-based key-value store) ---
+      if (cmd.startsWith("plugin:store|")) {
+        const a = args as { key?: string; value?: unknown };
+        switch (cmd) {
+          case "plugin:store|load":
+            return STORE_RID;
+          case "plugin:store|has":
+            return store.has(a.key as string);
+          case "plugin:store|get":
+            return [
+              store.get(a.key as string) ?? null,
+              store.has(a.key as string),
+            ];
+          case "plugin:store|set":
+            store.set(a.key as string, a.value);
+            return null;
+          case "plugin:store|delete":
+            return store.delete(a.key as string);
+          case "plugin:store|keys":
+            return [...store.keys()];
+          case "plugin:store|values":
+            return [...store.values()];
+          case "plugin:store|entries":
+            return [...store.entries()];
+          case "plugin:store|length":
+            return store.size;
+          case "plugin:store|save":
+          case "plugin:store|reload":
+          case "plugin:store|clear":
+          case "plugin:store|reset":
+            return null;
+        }
+      }
+
+      switch (cmd) {
+        // --- window/plugin surface ---
+        case "plugin:window|theme":
+          return "dark";
+        case "plugin:dialog|message":
+          return null;
+        case "plugin:autostart|is_enabled":
+          return false;
+        case "plugin:app|version":
+          return "1.0.0";
+
+        // --- generated commands (raw or typedError-boxed by bindings) ---
+        case "get_settings":
+          return settingsFixture;
+        case "get_hardware_info":
+          return sysInfoFixture;
+        case "get_process_list":
+          return processListFixture;
+        case "get_storage_health_latest_records":
+          return storageHealthFixture;
+        case "get_background_images":
+          return [];
+        case "get_network_info":
+          return [];
+        case "fetch_update":
+          // No pending update — keeps the updater UI out of captures.
+          return null;
+        case "is_close_to_tray_available":
+          // true keeps the settings capture free of the tray-unavailable
+          // warning, matching a typical desktop session.
+          return true;
+        case "mark_close_to_tray_listener_ready":
+          return null;
+
+        // --- insights archive commands (synthesized from requested range) ---
+        case "get_gpu_archive_names":
+          return GPU_FIXTURES.map((gpu) => gpu.name);
+        case "get_data_archive_records": {
+          const a = args as {
+            hardwareType: string;
+            start: string;
+            end: string;
+          };
+          return a.hardwareType === "cpu"
+            ? buildArchiveRecords(a.start, a.end, 45, 20)
+            : buildArchiveRecords(a.start, a.end, 60, 8);
+        }
+        case "get_gpu_archive_records": {
+          const a = args as { dataType: string; start: string; end: string };
+          if (a.dataType === "temp") {
+            return buildArchiveRecords(a.start, a.end, 58, 6);
+          }
+          if (a.dataType === "dedicatedMemory") {
+            return buildArchiveRecords(a.start, a.end, 4_194_304, 524_288);
+          }
+          return buildArchiveRecords(a.start, a.end, 55, 25);
+        }
+        case "get_process_stats": {
+          const a = args as { endAt: string };
+          return buildProcessStats(a.endAt);
+        }
+        case "get_process_stats_in_period": {
+          const a = args as { end: string };
+          return buildProcessStats(a.end);
+        }
+      }
+
+      // Settings mutators (`set_theme`, `set_language`, ...) succeed silently
+      // so settings-screen scenarios can interact without enumerating them.
+      if (cmd.startsWith("set_")) {
+        return null;
+      }
+
+      throw new Error(`[e2e-mock] Unhandled invoke: ${cmd}`);
+    },
+    { shouldMockEvents: true },
+  );
+
+  window.__E2E__ = {
+    emitHardwareUpdate: (payload) =>
+      emit(
+        "hardware-monitor-update",
+        payload ?? buildHardwareUpdateSeries(1)[0],
+      ),
+    emitHardwareUpdateSeries: async (count = 30) => {
+      for (const payload of buildHardwareUpdateSeries(count)) {
+        await emit("hardware-monitor-update", payload);
+      }
+    },
+  };
+};

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -56,8 +56,19 @@ const buildInvokeHandlers = (
   "plugin:store|length": () => store.size,
   "plugin:store|save": () => null,
   "plugin:store|reload": () => null,
-  "plugin:store|clear": () => null,
-  "plugin:store|reset": () => null,
+  // clear() empties the store; reset() restores the configured defaults
+  // (falling back to clear() when no defaults exist) — see plugin-store v2.
+  "plugin:store|clear": () => {
+    store.clear();
+    return null;
+  },
+  "plugin:store|reset": () => {
+    store.clear();
+    for (const [key, value] of Object.entries(storeFixture)) {
+      store.set(key, value);
+    }
+    return null;
+  },
 
   // --- window/plugin surface ---
   "plugin:window|theme": () => "dark",

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -23,7 +23,85 @@ declare global {
   }
 }
 
+type InvokeHandler = (args?: unknown) => unknown;
+
 const STORE_RID = 1;
+
+const storeKey = (args?: unknown) => (args as { key: string }).key;
+
+/**
+ * Dispatch table mapping invoke commands to their mocked handlers:
+ * Tauri plugin commands (`plugin:<name>|<command>`) and generated
+ * tauri-specta commands (raw or typedError-boxed by the bindings).
+ */
+const buildInvokeHandlers = (
+  store: Map<string, unknown>,
+): Record<string, InvokeHandler> => ({
+  // --- @tauri-apps/plugin-store (rid-based key-value store) ---
+  "plugin:store|load": () => STORE_RID,
+  "plugin:store|has": (args) => store.has(storeKey(args)),
+  "plugin:store|get": (args) => [
+    store.get(storeKey(args)) ?? null,
+    store.has(storeKey(args)),
+  ],
+  "plugin:store|set": (args) => {
+    const a = args as { key: string; value?: unknown };
+    store.set(a.key, a.value);
+    return null;
+  },
+  "plugin:store|delete": (args) => store.delete(storeKey(args)),
+  "plugin:store|keys": () => [...store.keys()],
+  "plugin:store|values": () => [...store.values()],
+  "plugin:store|entries": () => [...store.entries()],
+  "plugin:store|length": () => store.size,
+  "plugin:store|save": () => null,
+  "plugin:store|reload": () => null,
+  "plugin:store|clear": () => null,
+  "plugin:store|reset": () => null,
+
+  // --- window/plugin surface ---
+  "plugin:window|theme": () => "dark",
+  "plugin:dialog|message": () => null,
+  "plugin:autostart|is_enabled": () => false,
+  "plugin:app|version": () => "1.0.0",
+
+  // --- generated commands ---
+  get_settings: () => settingsFixture,
+  get_hardware_info: () => sysInfoFixture,
+  get_process_list: () => processListFixture,
+  get_storage_health_latest_records: () => storageHealthFixture,
+  get_background_images: () => [],
+  get_network_info: () => [],
+  // No pending update — keeps the updater UI out of captures.
+  fetch_update: () => null,
+  // true keeps the settings capture free of the tray-unavailable warning,
+  // matching a typical desktop session.
+  is_close_to_tray_available: () => true,
+  mark_close_to_tray_listener_ready: () => null,
+
+  // --- insights archive commands (synthesized from requested range) ---
+  get_gpu_archive_names: () => GPU_FIXTURES.map((gpu) => gpu.name),
+  get_data_archive_records: (args) => {
+    const a = args as { hardwareType: string; start: string; end: string };
+    return a.hardwareType === "cpu"
+      ? buildArchiveRecords(a.start, a.end, 45, 20)
+      : buildArchiveRecords(a.start, a.end, 60, 8);
+  },
+  get_gpu_archive_records: (args) => {
+    const a = args as { dataType: string; start: string; end: string };
+    if (a.dataType === "temp") {
+      return buildArchiveRecords(a.start, a.end, 58, 6);
+    }
+    if (a.dataType === "dedicatedMemory") {
+      return buildArchiveRecords(a.start, a.end, 4_194_304, 524_288);
+    }
+    return buildArchiveRecords(a.start, a.end, 55, 25);
+  },
+  get_process_stats: (args) =>
+    buildProcessStats((args as { endAt: string }).endAt),
+  get_process_stats_in_period: (args) =>
+    buildProcessStats((args as { end: string }).end),
+});
 
 /**
  * Install Tauri IPC/event/window mocks so the React app runs in a plain
@@ -35,7 +113,7 @@ const STORE_RID = 1;
  * - `__TAURI_OS_PLUGIN_INTERNALS__` backs the synchronous `platform()` API
  *   of @tauri-apps/plugin-os (not an IPC call).
  * - `mockIPC(..., { shouldMockEvents: true })` routes commands to the
- *   handler below and implements `plugin:event|listen/emit/unlisten`.
+ *   dispatch table above and implements `plugin:event|listen/emit/unlisten`.
  */
 export const installTauriMocks = () => {
   mockWindows("main");
@@ -53,108 +131,12 @@ export const installTauriMocks = () => {
   };
 
   const store = new Map<string, unknown>(Object.entries(storeFixture));
+  const handlers = buildInvokeHandlers(store);
 
   mockIPC(
     (cmd: string, args?: unknown) => {
-      // --- @tauri-apps/plugin-store (rid-based key-value store) ---
-      if (cmd.startsWith("plugin:store|")) {
-        const a = args as { key?: string; value?: unknown };
-        switch (cmd) {
-          case "plugin:store|load":
-            return STORE_RID;
-          case "plugin:store|has":
-            return store.has(a.key as string);
-          case "plugin:store|get":
-            return [
-              store.get(a.key as string) ?? null,
-              store.has(a.key as string),
-            ];
-          case "plugin:store|set":
-            store.set(a.key as string, a.value);
-            return null;
-          case "plugin:store|delete":
-            return store.delete(a.key as string);
-          case "plugin:store|keys":
-            return [...store.keys()];
-          case "plugin:store|values":
-            return [...store.values()];
-          case "plugin:store|entries":
-            return [...store.entries()];
-          case "plugin:store|length":
-            return store.size;
-          case "plugin:store|save":
-          case "plugin:store|reload":
-          case "plugin:store|clear":
-          case "plugin:store|reset":
-            return null;
-        }
-      }
-
-      switch (cmd) {
-        // --- window/plugin surface ---
-        case "plugin:window|theme":
-          return "dark";
-        case "plugin:dialog|message":
-          return null;
-        case "plugin:autostart|is_enabled":
-          return false;
-        case "plugin:app|version":
-          return "1.0.0";
-
-        // --- generated commands (raw or typedError-boxed by bindings) ---
-        case "get_settings":
-          return settingsFixture;
-        case "get_hardware_info":
-          return sysInfoFixture;
-        case "get_process_list":
-          return processListFixture;
-        case "get_storage_health_latest_records":
-          return storageHealthFixture;
-        case "get_background_images":
-          return [];
-        case "get_network_info":
-          return [];
-        case "fetch_update":
-          // No pending update — keeps the updater UI out of captures.
-          return null;
-        case "is_close_to_tray_available":
-          // true keeps the settings capture free of the tray-unavailable
-          // warning, matching a typical desktop session.
-          return true;
-        case "mark_close_to_tray_listener_ready":
-          return null;
-
-        // --- insights archive commands (synthesized from requested range) ---
-        case "get_gpu_archive_names":
-          return GPU_FIXTURES.map((gpu) => gpu.name);
-        case "get_data_archive_records": {
-          const a = args as {
-            hardwareType: string;
-            start: string;
-            end: string;
-          };
-          return a.hardwareType === "cpu"
-            ? buildArchiveRecords(a.start, a.end, 45, 20)
-            : buildArchiveRecords(a.start, a.end, 60, 8);
-        }
-        case "get_gpu_archive_records": {
-          const a = args as { dataType: string; start: string; end: string };
-          if (a.dataType === "temp") {
-            return buildArchiveRecords(a.start, a.end, 58, 6);
-          }
-          if (a.dataType === "dedicatedMemory") {
-            return buildArchiveRecords(a.start, a.end, 4_194_304, 524_288);
-          }
-          return buildArchiveRecords(a.start, a.end, 55, 25);
-        }
-        case "get_process_stats": {
-          const a = args as { endAt: string };
-          return buildProcessStats(a.endAt);
-        }
-        case "get_process_stats_in_period": {
-          const a = args as { end: string };
-          return buildProcessStats(a.end);
-        }
+      if (Object.hasOwn(handlers, cmd)) {
+        return handlers[cmd](args);
       }
 
       // Settings mutators (`set_theme`, `set_language`, ...) succeed silently

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,24 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { App } from "./App";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+const bootstrap = async () => {
+  // E2E-only: install Tauri IPC/event mocks before any app module runs.
+  // The condition is statically false in production builds, so the mock
+  // chunk is dead-code eliminated and never shipped.
+  if (import.meta.env.VITE_E2E_MOCK === "true") {
+    const { installTauriMocks } = await import("./e2e/mocks/installTauriMocks");
+    installTauriMocks();
+  }
+
+  const { App } = await import("./App");
+
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+};
+
+bootstrap().catch((error) => {
+  console.error("Failed to bootstrap the app:", error);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,4 +102,9 @@ export default defineConfig(async ({ mode }) => ({
       "@": path.resolve(__dirname, "src"),
     },
   },
+  optimizeDeps: {
+    // Pre-bundle the Tauri mock module so the E2E harness (VITE_E2E_MOCK)
+    // doesn't trigger a mid-session dependency re-optimization.
+    include: ["@tauri-apps/api/mocks"],
+  },
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: [
         "src/rspc/**",
+        "src/e2e/**",
         "src/**/*.test.*",
         "src/**/*.spec.*",
         "src/**/*.d.ts",


### PR DESCRIPTION
## Summary

Closes #1609 (Stage 1 of #1608).

Adds a web-only E2E capture harness: the React frontend runs in plain Chromium with mocked Tauri IPC/events and saves deterministic PNG evidence captures for the five main screens. No Rust backend, Tauri runtime, or live hardware data is required.

## Scenarios & captures (`test-results/captures/`)

| Spec | Captures |
|------|----------|
| `e2e/dashboard.spec.ts` | `dashboard`, `dashboard-gpu-secondary` (GPU tab switch via `role=tab`) |
| `e2e/usage.spec.ts` | `usage` (mixed CPU/RAM/GPU chart) |
| `e2e/cpu-detail.spec.ts` | `cpu-detail` (info table + per-core charts) |
| `e2e/insights.spec.ts` | `insights-main`, `insights-process` |
| `e2e/settings.spec.ts` | `settings` (General/About sections) |

## How it works

- **Mock entry point** — `src/main.tsx` installs `src/e2e/mocks/installTauriMocks.ts` only when `VITE_E2E_MOCK=true`. The condition is statically false in production builds, so the mock chunk is dead-code eliminated (verified by grepping `dist/`).
- **Mock layers** — `mockIPC(..., { shouldMockEvents: true })` for generated commands, plugin commands, and the event system; `mockWindows("main")`; `__TAURI_OS_PLUGIN_INTERNALS__` for the synchronous `platform()` API; an in-memory store plugin. Unhandled invokes throw `[e2e-mock] Unhandled invoke: <cmd>` so coverage gaps surface immediately.
- **Determinism** — fixture hardware data (2 GPUs), sine-wave `hardware-monitor-update` series, archive records synthesized from the requested time range, fixed clock in the insights spec (`page.clock.setFixedTime`), locked viewport/scale/locale/timezone/reduced-motion, dedicated port 1521 so a regular dev server is never reused.
- **Style guard** — the usage spec compares the *computed* stroke of each chart series against the fixture colors. This catches invalid color plumbing that renders series black while remaining "visible" to DOM assertions (verified with a negative test: a malformed fixture color fails the assertion).

## CI

New `test-e2e-web` job (ubuntu-latest): installs Chromium, runs `npm run test:e2e`, uploads `test-results/captures/` as the `e2e-captures` artifact with `if: always()` (captures survive failed runs), and the Playwright report/output only on failure. The change-detection frontend filter now includes `e2e/**` and `playwright.config.ts`.

## Out of scope (per #1608)

- Visual snapshot regression / baseline comparison — captures are evidence for human review; documented in `docs/development/e2e-captures.md`.
- Native Tauri smoke via tauri-driver/WebDriver — tracked separately in #1610.

## Verification

- `npm run test:e2e` — 7/7 passed (repeated runs), all captures visually inspected
- `npm run lint`, `npm test` (360 tests, coverage thresholds met), `npm run build` — all green
- Production bundle contains no mock code; `ci.yml` validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added browser E2E suites with deterministic mocks covering dashboard, CPU detail, usage, insights, and settings; each scenario saves PNG evidence.

* **Documentation**
  * Added an “E2E capture harness” guide covering local/CI runs, capture locations, determinism rules, and how to author scenarios.

* **Chores**
  * CI now runs web E2E on frontend changes, requires the E2E job for merges, always uploads captures, posts PR evidence for same-repo PRs, added an npm script and Playwright dev dependency, and ignores capture output in source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->