### PR TITLE
fix: prevent dashboard visibility hydration loop

### DIFF
--- a/src/features/hardware/dashboard/hooks/useDashboardSelector.ts
+++ b/src/features/hardware/dashboard/hooks/useDashboardSelector.ts
@@ -18,10 +18,11 @@ export const useDashboardSelector = () => {
   const { toggleTitleIconVisibility } = useTitleIconVisualSelector();
 
   useEffect(() => {
-    toggleTitleIconVisibility(
-      "dashboard",
-      visibleItems?.includes("title") || false,
-    );
+    if (visibleItems == null) {
+      return;
+    }
+
+    toggleTitleIconVisibility("dashboard", visibleItems.includes("title"));
   }, [visibleItems, toggleTitleIconVisibility]);
 
   const toggleItem = async (item: DashboardSelectItemType) => {

--- a/src/features/hardware/hooks/dashboard/useDashboardSelector.test.ts
+++ b/src/features/hardware/hooks/dashboard/useDashboardSelector.test.ts
@@ -228,6 +228,18 @@ describe("useDashboardSelector", () => {
     );
   });
 
+  it("does not sync title visibility while visibleItems is still loading", () => {
+    // Keep useTauriStore pending so visibleItems remains null.
+    fakeStore.has = vi.fn(() => new Promise<boolean>(() => {}));
+
+    const { result } = renderHook(() => useDashboardSelector(), {
+      wrapper: Provider,
+    });
+
+    expect(result.current.visibleItems).toBeNull();
+    expect(mockToggleTitleIconVisibility).not.toHaveBeenCalled();
+  });
+
   it("toggleItem returns early without modifying the store when visibleItems is null", async () => {
     // Replace has() with a never-resolving Promise so useTauriStore keeps
     // visibleItems as null (still pending) for the duration of this test.

--- a/src/hooks/useTitleIconVisualSelector.test.ts
+++ b/src/hooks/useTitleIconVisualSelector.test.ts
@@ -87,4 +87,22 @@ describe("useTitleIconVisualSelector", () => {
     ).length;
     expect(afterCount).toBe(beforeCount);
   });
+
+  it("toggleTitleIconVisibility(type, false) keeps state identity when the type is already hidden", () => {
+    const { result } = renderHook(() => useTitleIconVisualSelector(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.toggleTitleIconVisibility("usage", false);
+    });
+
+    const hiddenVisibleTypes = result.current.visibleTypes;
+
+    act(() => {
+      result.current.toggleTitleIconVisibility("usage", false);
+    });
+
+    expect(result.current.visibleTypes).toBe(hiddenVisibleTypes);
+  });
 });

--- a/src/hooks/useTitleIconVisualSelector.ts
+++ b/src/hooks/useTitleIconVisualSelector.ts
@@ -1,4 +1,5 @@
 import { atom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
 import type { SelectedDisplayType } from "@/types/ui";
 
 const showTitleIconAtom = atom<SelectedDisplayType[]>([
@@ -12,24 +13,34 @@ export const useTitleIconVisualSelector = () => {
   const setShowTitleIcon = useSetAtom(showTitleIconAtom);
   const visibleTypes = useAtomValue(showTitleIconAtom);
 
-  const isTitleIconVisible = (type: SelectedDisplayType): boolean => {
-    return visibleTypes.includes(type);
-  };
+  const isTitleIconVisible = useCallback(
+    (type: SelectedDisplayType): boolean => {
+      return visibleTypes.includes(type);
+    },
+    [visibleTypes],
+  );
 
-  const toggleTitleIconVisibility = (
-    type: SelectedDisplayType,
-    visible: boolean,
-  ) => {
-    setShowTitleIcon((prev) => {
-      if (visible) {
-        if (!prev.includes(type)) {
-          return [...prev, type];
+  const toggleTitleIconVisibility = useCallback(
+    (type: SelectedDisplayType, visible: boolean) => {
+      setShowTitleIcon((prev) => {
+        const isVisible = prev.includes(type);
+
+        if (visible) {
+          if (!isVisible) {
+            return [...prev, type];
+          }
+          return prev;
         }
-        return prev;
-      }
-      return prev.filter((t) => t !== type);
-    });
-  };
+
+        if (!isVisible) {
+          return prev;
+        }
+
+        return prev.filter((t) => t !== type);
+      });
+    },
+    [setShowTitleIcon],
+  );
 
   return { visibleTypes, isTitleIconVisible, toggleTitleIconVisibility };
 };


### PR DESCRIPTION
## Summary

- avoid syncing dashboard title visibility while `dashboardVisibleItems` is still loading from Tauri Store
- make title visibility callbacks stable and preserve atom state identity for no-op visibility updates
- add regression coverage for the pending-store path and repeated no-op hide calls

## Context

This was found while validating native first-run E2E in #1627. There is no known user bug report yet; this is treated as a latent first-launch bug that is easier to surface under cold app-data conditions.

The observed failure was React error #185 after the first-run close-to-tray dialog was dismissed, before the smoke could open Settings. The likely trigger is an Effect updating title visibility while the Dashboard store value is still pending, combined with no-op visibility updates returning equivalent-but-new arrays.

Closes #1628.

## Validation

- `npx.cmd vitest run src/features/hardware/hooks/dashboard/useDashboardSelector.test.ts src/hooks/useTitleIconVisualSelector.test.ts`
- `npm.cmd run lint:ci`
- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed title icon visibility sync to properly handle loading states, preventing operations from triggering before data is ready.
  * Improved state consistency for title icon visibility when toggling visibility multiple times.

* **Tests**
  * Added tests verifying dashboard selector doesn't trigger state updates during initial data loading.
  * Added tests ensuring title icon visibility state remains consistent when toggled multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->