### PR TITLE
fix: keep chart dependencies in one production chunk

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,10 @@ export default defineConfig(async ({ mode }) => ({
         codeSplitting: {
           groups: [
             {
+              name: "vendor-chart",
+              test: /[\\/]node_modules[\\/](recharts|d3-[^\\/]+|victory-vendor|es-toolkit)[\\/]/,
+            },
+            {
               name: "vendor-react",
               test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
             },


### PR DESCRIPTION
## Summary

- Keep Recharts, D3, victory-vendor, and es-toolkit in a dedicated Rolldown `vendor-chart` chunk.
- Prevent the production Dashboard lazy chunk from generating broken CommonJS helper references such as `require_identity()` / `n is not a function`.
- Opened as Draft so CI can validate the production bundle behavior before unblocking the native E2E smoke PR.

## Related Issues

Related to #1627

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [x] Unit tests
- `TAURI_ENV_PLATFORM=linux npm.cmd run build`
- `Dashboard` / `Insights` dist chunk import smoke
- `npm.cmd run lint:ci`
- `npm.cmd test`
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors

Note: Vite still reports the existing `@rolldown/plugin-babel` plugin timing warning during build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build process by refining code splitting strategy for charting libraries. This improves bundle efficiency and caching behavior, potentially reducing initial load times and enhancing overall application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->