### PR TITLE
fix: raise Windows app-memory perf threshold to 80 MB

### DIFF
--- a/perf-monitor/README.md
+++ b/perf-monitor/README.md
@@ -61,22 +61,22 @@ Per-platform threshold overrides can be specified under `[platforms.<os>]`:
 
 ```toml
 [platforms.windows]
-max_avg_app_memory_mb = 70.0
+max_avg_app_memory_mb = 80.0
 max_p95_app_memory_mb = 100.0
-max_avg_memory_mb = 450.0
-max_p95_memory_mb = 500.0
+max_avg_memory_mb = 600.0
+max_p95_memory_mb = 600.0
 
 [platforms.linux]
 max_avg_app_memory_mb = 150.0
 max_p95_app_memory_mb = 150.0
-max_avg_memory_mb = 450.0
-max_p95_memory_mb = 500.0
+max_avg_memory_mb = 550.0
+max_p95_memory_mb = 550.0
 
 [platforms.macos]
 max_avg_app_memory_mb = 150.0
 max_p95_app_memory_mb = 150.0
-max_avg_memory_mb = 550.0
-max_p95_memory_mb = 600.0
+max_avg_memory_mb = 600.0
+max_p95_memory_mb = 650.0
 ```
 
 Only the fields you specify are overridden; others inherit from `[thresholds]`.

--- a/perf-thresholds.toml
+++ b/perf-thresholds.toml
@@ -14,7 +14,10 @@ measurement_seconds = 30
 sample_interval_ms = 1000
 
 [platforms.windows]
-max_avg_app_memory_mb = 70.0
+# Parent-process RSS on windows-latest runners holds steady at 67-72 MB
+# (observed 2026-05/06); keep ~10% headroom so day-to-day runner variance
+# does not trip the gate while real regressions still do.
+max_avg_app_memory_mb = 80.0
 max_p95_app_memory_mb = 100.0
 max_avg_memory_mb = 600.0
 max_p95_memory_mb = 600.0


### PR DESCRIPTION
## Summary

Root-cause analysis and fix for the recurring "Performance test threshold exceeded" failures tracked in #1626.

## Root cause

Issue #1626 covers two distinct failures:

**1. 2026-06-08 run ([27160054051](https://github.com/shm11C3/HardwareVisualizer/actions/runs/27160054051)) — real regression, already fixed.**
The `npm update` lockfile bump (#1624) broke the production Dashboard (Rolldown chunk self-references + visibility hydration loop, #1628). WebView memory grew **+167.8 MB during the 30 s window**, failing the process-tree growth gate (50 MB). This was fixed by #1629 and #1630 — the 2026-06-09 run shows WebView growth back to a stable 24.7 MB.

**2. 2026-06-09 run ([27228485855](https://github.com/shm11C3/HardwareVisualizer/actions/runs/27228485855)) — threshold has no headroom.**
The Windows `max_avg_app_memory_mb = 70.0` gate sits *inside* the parent process's actual steady-state band. History of the parent-process avg RSS on `windows-latest`:

| Date | Result | Parent avg (MB) | Failed check |
|---|---|---|---|
| 05-26 | FAIL | **70.10** | app avg (+0.10 MB over) |
| 05-30 | FAIL | **70.08** | app avg (+0.08 MB over) |
| 06-04 | PASS | 69.16 | — (barely) |
| 06-06 | PASS | 68.59 | — |
| 06-07 | PASS | 67.39 | — |
| 06-08 | FAIL | 65.21 | tree growth (WebView loop, see above) |
| 06-09 | FAIL | **71.38** | app avg (+1.38 MB over) |

The threshold predates the 06-06 measurement split (#1591): the old parent-only `max_avg_memory_mb = 70.0` was carried over verbatim to `max_avg_app_memory_mb`. It had already produced two sub-1% false alarms in May. After #1629/#1630 restored full chart rendering, steady state shifted from ~67–68 MB to ~71.4 MB (growth ≈ 0.07 MB — flat, not a leak) and the gate now trips every night.

## Fix

- Raise `platforms.windows.max_avg_app_memory_mb` from **70 → 80 MB** (~10% headroom over the observed 67–72 MB band). Real regressions remain covered: the p95 gate (100 MB), the app growth gate (50 MB), and the process-tree growth gate (which correctly caught the 06-08 WebView leak) are unchanged.
- Sync the platform-override example in `perf-monitor/README.md` with the actual `perf-thresholds.toml` values (it had drifted on several fields).

## Validation

- `cargo test --manifest-path perf-monitor/Cargo.toml` — 21 passed (config parsing incl. platform overrides).
- The next scheduled perf run (daily 18:00 UTC) should pass: latest measured values vs gates — app avg 71.4 < 80, p95 71.5 < 100, app growth 0.07 < 50, tree avg 511.6 < 600, tree growth 24.7 < 50.

Closes #1626

https://claude.ai/code/session_01EVcn3nK4enDMVuz1G9WqY5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVcn3nK4enDMVuz1G9WqY5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance memory thresholds across Windows, Linux, and macOS platforms to improve monitoring stability and reduce false alerts during performance testing.
  * Adjusted memory limit configurations to provide better headroom for performance gate operations.
  * Updated documentation to reflect the new threshold values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->