### PR TITLE
docs(specs): add clean-room sensor spec documents for PawnIO monitoring (#1635)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ documentation.
 
 - [Backend architecture](architecture/backend.md)
 - [Architecture decision records](adr/)
+- [Sensor hardware specs (clean-room)](specs/sensors/)
 - [Frontend architecture](../src/README.md)
 - [Core crate guide](../core/README.md)
 - [Tauri app crate guide](../src-tauri/README.md)
@@ -27,6 +28,8 @@ docs/
 ├── adr/                            # Architecture decision records
 ├── architecture/                   # Architecture documents
 ├── development/                    # Developer task guides
+├── specs/                          # Clean-room hardware specification documents
+│   └── sensors/                    # Sensor specs for PawnIO-based monitoring
 ├── third-party-notices/            # Generated and manual third-party notices
 ├── download-verification.md        # Download verification guide
 ├── download-verification.ja.md     # Japanese download verification guide

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -96,6 +96,10 @@ resolved and the Phase 0 guardrails are merged.
         reviewing this implementation.
   ```
 
+  Reviewers copy this checklist, with both boxes checked, into their
+  approval review comment. The implementation PR template carries the
+  checklist as a reminder of this requirement.
+
 ## Current documents
 
 | Document | Covers | Issue phase |

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -1,0 +1,84 @@
+# Sensor Hardware Specifications (Clean-Room)
+
+This directory is the specification library for native CPU and Super I/O
+sensor monitoring via [PawnIO](https://github.com/namazso/PawnIO)
+(issue #1635). Every document here is a **fact-only hardware/interface
+specification** produced by the "spec author" role of the clean-room
+process described below.
+
+These documents are the **only** external technical input the
+implementation role is allowed to use. Keeping them factual, sourced,
+and free of third-party code is what lets the resulting Rust code stay
+MIT-licensed.
+
+## Clean-room process (two roles)
+
+| Role | May read | Must not do |
+| --- | --- | --- |
+| Spec author ("dirty room") | Vendor datasheets and manuals (primary); hardware dumps; MPL/GPL/LGPL implementations **only to extract facts** (register addresses, bit layouts, procedures, quirks) | Copy code excerpts, code structure, or implementation identifier names into spec documents |
+| Implementer ("clean room") | `docs/specs/sensors/**` and this repository only | Read LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors sources, or any decompiled monitoring tool |
+
+Names that are part of a public API contract (for example PawnIO module
+function names such as `ioctl_read_msr`) are interface facts required
+for interoperability, not implementation identifiers; they may appear
+in spec documents.
+
+## Hard rules for documents in this directory
+
+- State **facts**, with a source note (provenance) for each fact or
+  fact group: document title, document/order number, and section or
+  page where known. Use `TODO(provenance)` when a page-level citation
+  still needs to be pinned.
+- No code excerpts, no code structure, and no identifier names taken
+  from copyrighted implementations.
+- Facts extracted from MPL/GPL/LGPL sources are allowed but must be
+  recorded as factual statements with the source named.
+- Anything uncertain goes in the document's **Open questions** section,
+  not in the fact tables.
+- Read-only orientation: documents describe register *reads*. Writes
+  are documented only where a read transaction requires them (for
+  example configuration-mode entry keys or bank selection), and must be
+  marked as such.
+
+## Document conventions
+
+- One document per access domain or chip family, lowercase kebab-case
+  filenames (see [`docs/documentation-guide.md`](../../documentation-guide.md)).
+- Start from [`spec-template.md`](spec-template.md).
+- Each document carries a **revision number** and a revision history
+  table. Any change to facts increments the revision.
+- Implementation PRs must pin the spec they were built from in the PR
+  body, e.g.:
+
+  ```text
+  Implemented from docs/specs/sensors/cpu-amd-zen-smn.md revision 1
+  (commit <sha>). No other external sensor documentation was used.
+  ```
+
+  This is the audit trail demonstrating clean-room provenance.
+
+## Current documents
+
+| Document | Covers | Issue phase |
+| --- | --- | --- |
+| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, licensing facts | Phase 1 |
+| [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 |
+| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 |
+| [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) |
+
+Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) are
+**not yet written**; they are the Phase 3 / Phase 4 deliverables and
+will be added as separate documents validated against user-submitted
+register dumps.
+
+## Safety policy (applies to all documents and implementations)
+
+- Read-only register access. No writes that alter chip configuration,
+  fan control, limits, or power state in any phase of #1635.
+- Honor the ecosystem mutex conventions
+  (`Global\Access_ISABUS.HTP.Method`, `Global\Access_PCI`) so that
+  concurrent monitors (HWiNFO, LibreHardwareMonitor, FanControl) do not
+  corrupt each other's multi-step read transactions. Details in
+  [`pawnio-interface.md`](pawnio-interface.md).
+- When PawnIO is not installed, the application degrades gracefully to
+  the ACPI thermal-zone path introduced by PR #1633.

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -15,7 +15,7 @@ MIT-licensed.
 
 | Role | May read | Must not do |
 | --- | --- | --- |
-| Spec author ("dirty room") | Vendor datasheets and manuals (primary); hardware dumps; MPL/GPL/LGPL implementations **only to extract facts** (register addresses, bit layouts, procedures, quirks) | Copy code excerpts, code structure, or implementation identifier names into spec documents |
+| Spec author ("dirty room") | Vendor datasheets and manuals (primary); public hardware specifications; independently collected hardware dumps; MPL/GPL/LGPL implementations **only as non-normative leads** | Copy code excerpts, code structure, or implementation identifier names into spec documents |
 | Implementer ("clean room") | `docs/specs/sensors/**` and this repository only | Read LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors sources, or any decompiled monitoring tool |
 
 Names that are part of a public API contract (for example PawnIO module
@@ -31,8 +31,15 @@ in spec documents.
   still needs to be pinned.
 - No code excerpts, no code structure, and no identifier names taken
   from copyrighted implementations.
-- Facts extracted from MPL/GPL/LGPL sources are allowed but must be
-  recorded as factual statements with the source named.
+- MPL/GPL/LGPL implementations may be used **only as non-normative
+  leads**. Normative spec facts must be backed by vendor
+  documentation, public hardware specifications, or independently
+  collected hardware dumps. Copyleft sources consulted as leads must
+  still be listed in the document's Sources table, explicitly marked
+  non-normative; no fact may rest solely on them.
+- If a quirk is known only from a copyleft implementation, it must
+  stay in the document's **Open questions** section until
+  independently verified.
 - Anything uncertain goes in the document's **Open questions** section,
   not in the fact tables.
 - Read-only orientation: documents describe register *reads*. Writes
@@ -56,6 +63,38 @@ in spec documents.
   ```
 
   This is the audit trail demonstrating clean-room provenance.
+
+## Document status and implementation gate
+
+These documents are currently **draft specifications**. They are not
+implementation-ready clean-room inputs until all provenance TODOs are
+resolved and the Phase 0 guardrails are merged.
+
+- A document containing `TODO(provenance)` markers must carry
+  `Status: Draft — not implementation-ready` and must not be used as
+  the sole clean-room input for implementation until all markers are
+  resolved and primary-source section/page references are pinned (or
+  the facts are otherwise independently verified, e.g. against
+  hardware dumps).
+- No implementation PR may be opened or reviewed as clean-room work
+  until all of the following Phase 0 guardrails exist:
+  - `.github/instructions/` contains the prohibited-source list
+  - `CLAUDE.md` references the clean-room implementer restrictions
+  - the PR template requires spec revision pinning
+  - the PR template requires a provenance attestation
+  - the PR template requires the reviewer attestation below
+- Reviewer contamination policy: reviewers can also breach the
+  clean-room boundary. Implementation PR reviews must include this
+  attestation:
+
+  ```markdown
+  - [ ] I reviewed this implementation only against
+        `docs/specs/sensors/**`, this repository, and the pinned spec
+        revision.
+  - [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
+        Linux kernel, lm-sensors, or decompiled monitoring tools while
+        reviewing this implementation.
+  ```
 
 ## Current documents
 

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -3,8 +3,8 @@
 | Field | Value |
 | --- | --- |
 | Revision | 1 |
-| Status | Draft |
-| Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2), Family 19h (Zen 3/Zen 4), and Family 1Ah (Zen 5) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
+| Status | Draft — not implementation-ready |
+| Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2) and Family 19h (Zen 3/Zen 4) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Family 1Ah (Zen 5) is recognized but disabled by default pending verification (see Detection). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
 | Issue phase | Phase 1 (#1635) |
 
 ## Sources
@@ -14,8 +14,8 @@
 | S1 | AMD, *Processor Programming Reference (PPR) for AMD Family 17h Models 00h-0Fh Processors*, document no. 54945, register `SMU::THM::THM_TCON_CUR_TMP` | Primary |
 | S2 | AMD, *PPR for AMD Family 19h Model 01h, Revision B1 Processors*, document no. 55898 Vol 2 (same THM register) | Primary |
 | S3 | AMD public statements on Tctl offsets: "AMD Ryzen™ Community Update #3" (R. Hallock, Apr 2017) and 2nd-gen Ryzen launch documentation | Primary for offsets |
-| S4 | Linux `k10temp` hwmon driver (GPL-2.0) | Facts only (offset table corroboration, family coverage). No code was copied. |
-| S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Interface facts only (allowed SMN windows, family gate, mutex) |
+| S4 | Linux `k10temp` hwmon driver (GPL-2.0) | **Non-normative corroboration only.** No fact in this document relies solely on this source. No code, structure, identifiers, or tables were copied. |
+| S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls across the IOCTL boundary (allowed SMN windows, family gate, mutex). Not used as a source for any hardware register fact. No code was copied. |
 
 `TODO(provenance)`: pin PPR section/page numbers; the family 1Ah PPR
 reference still needs to be identified (see Open questions).
@@ -25,8 +25,18 @@ reference still needs to be identified (see Open questions).
 | Fact | Source |
 | --- | --- |
 | CPU vendor string is `AuthenticAMD` (CPUID leaf 0) | AMD APM / CPUID convention |
-| Effective family = `BaseFamily + ExtendedFamily` (CPUID leaf 1; extended family is added when base family is `0xF`); supported values: `0x17`, `0x19`, `0x1A` | AMD CPUID convention; S5 gates on exactly these |
-| The PawnIO `RyzenSMU` module itself rejects other vendors/families with an error status, providing a second layer of gating | S5 |
+| Effective family = `BaseFamily + ExtendedFamily` (CPUID leaf 1; extended family is added when base family is `0xF`) | AMD CPUID convention |
+| The PawnIO `RyzenSMU` module accepts families `0x17`, `0x19`, `0x1A` and rejects other vendors/families with an error status, providing a second layer of gating | S5 |
+
+"Recognized by the PawnIO module" and "enabled by this project" are
+separate decisions. This spec enables a family only once its THM
+register facts are verified against a primary source:
+
+| Family | Status | Default enablement |
+| --- | --- | --- |
+| `0x17` | `THM_TCON_CUR_TMP` verified against AMD PPR (S1) | Enabled |
+| `0x19` | `THM_TCON_CUR_TMP` verified against AMD PPR (S2) | Enabled |
+| `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Disabled until PPR or hardware-dump verification |
 
 ## Register map (facts)
 
@@ -43,9 +53,9 @@ register. See [`pawnio-interface.md`](pawnio-interface.md).
 Notes:
 
 - The same register address and layout are documented for Family 17h
-  (S1) and Family 19h (S2). Family 1Ah is expected to match (the
-  PawnIO module exposes the same window for it) but is unverified —
-  see Open questions. (S5)
+  (S1) and Family 19h (S2). Family 1Ah is not yet verified by this
+  spec and stays disabled by default — see Detection and Open
+  questions.
 - SMN is reached through an index/data register pair in the host
   bridge PCI configuration space; the PawnIO module handles this and
   serializes on the `Access_PCI` mutant. The client performs no raw
@@ -53,33 +63,26 @@ Notes:
 
 ## Read procedure and decode
 
-1. Confirm detection facts above.
-2. Read 32-bit `value` from SMN `0x00059800`.
-3. Decode Tctl:
-
-   ```text
-   raw   = (value >> 21) & 0x7FF
-   tctl  = raw * 0.125                # °C
-   if (value >> 19) & 1: tctl -= 49   # CUR_TEMP_RANGE_SEL
-   ```
-
-4. Decode Tdie by subtracting the model's Tctl offset (table below);
-   models not listed have offset 0 and `tdie == tctl`:
-
-   ```text
-   tdie = tctl - tctl_offset(model)
-   ```
-
-5. Publish Tdie as the CPU temperature. Plausibility gate (this
+1. Confirm detection facts above (including the per-family enablement
+   table).
+2. Read the 32-bit value of `THM_TCON_CUR_TMP` from SMN `0x00059800`.
+3. Decoding rules (hardware semantics):
+   - Extract `CUR_TEMP` from bits 31:21.
+   - Tctl = `CUR_TEMP` × 0.125 °C.
+   - If `CUR_TEMP_RANGE_SEL` (bit 19) is 1, subtract 49 °C from Tctl.
+   - Tdie = Tctl − the model's Tctl offset (table below); models not
+     listed have offset 0, so Tdie equals Tctl.
+4. Publish Tdie as the CPU temperature. Plausibility gate (this
    project's own policy, not a PPR fact): accept only
-   `-40 ≤ tdie ≤ 120` °C and drop all-zero register reads.
+   −40 ≤ Tdie ≤ 120 °C and drop all-zero register reads.
 
 ## Quirks
 
 Tctl is a unitless control input deliberately offset above the
 measured die temperature on some first/second-generation parts so that
 cooling policies stay uniform across the lineup. AMD published the
-offsets (S3); the same table ships as facts in `k10temp` (S4):
+offsets (S3, normative); `k10temp` corroborates them (S4,
+non-normative):
 
 | Product | Tctl − Tdie offset |
 | --- | --- |
@@ -90,7 +93,7 @@ offsets (S3); the same table ships as facts in `k10temp` (S4):
 | All other Zen-family products (incl. Zen 2 and newer) | 0 °C |
 
 - Offset matching is by product name (OPN), not by family/model
-  numbers alone. (S3, S4)
+  numbers alone. (S3; corroborated by S4)
 - `CUR_TEMP_RANGE_SEL = 1` (the −49 °C range) is the normal case on
   many desktop parts; the decode in step 3 must always honor the bit
   rather than assume either range. (S1)

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -1,0 +1,132 @@
+# Spec: AMD Zen CPU temperature (Tctl/Tdie) via SMN thermal controller
+
+| Field | Value |
+| --- | --- |
+| Revision | 1 |
+| Status | Draft |
+| Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2), Family 19h (Zen 3/Zen 4), and Family 1Ah (Zen 5) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
+| Issue phase | Phase 1 (#1635) |
+
+## Sources
+
+| ID | Source | Notes |
+| --- | --- | --- |
+| S1 | AMD, *Processor Programming Reference (PPR) for AMD Family 17h Models 00h-0Fh Processors*, document no. 54945, register `SMU::THM::THM_TCON_CUR_TMP` | Primary |
+| S2 | AMD, *PPR for AMD Family 19h Model 01h, Revision B1 Processors*, document no. 55898 Vol 2 (same THM register) | Primary |
+| S3 | AMD public statements on Tctl offsets: "AMD Ryzen™ Community Update #3" (R. Hallock, Apr 2017) and 2nd-gen Ryzen launch documentation | Primary for offsets |
+| S4 | Linux `k10temp` hwmon driver (GPL-2.0) | Facts only (offset table corroboration, family coverage). No code was copied. |
+| S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Interface facts only (allowed SMN windows, family gate, mutex) |
+
+`TODO(provenance)`: pin PPR section/page numbers; the family 1Ah PPR
+reference still needs to be identified (see Open questions).
+
+## Detection
+
+| Fact | Source |
+| --- | --- |
+| CPU vendor string is `AuthenticAMD` (CPUID leaf 0) | AMD APM / CPUID convention |
+| Effective family = `BaseFamily + ExtendedFamily` (CPUID leaf 1; extended family is added when base family is `0xF`); supported values: `0x17`, `0x19`, `0x1A` | AMD CPUID convention; S5 gates on exactly these |
+| The PawnIO `RyzenSMU` module itself rejects other vendors/families with an error status, providing a second layer of gating | S5 |
+
+## Register map (facts)
+
+Access is performed with the PawnIO `RyzenSMU` module's
+`ioctl_read_smu_register` (input: SMN address; output: 32-bit value).
+The module's allowed SMN window `0x56000`–`0x5AFFF` contains this
+register. See [`pawnio-interface.md`](pawnio-interface.md).
+
+| SMN address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
+| --- | --- | --- | --- | --- | --- |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 31:21 | `CUR_TEMP` — current reported temperature | 0.125 °C per LSB, unsigned 11-bit | S1, S2 |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 19 | `CUR_TEMP_RANGE_SEL` — selects the reporting range | 0 → 0…225 °C; 1 → −49…206 °C | S1, S2 |
+
+Notes:
+
+- The same register address and layout are documented for Family 17h
+  (S1) and Family 19h (S2). Family 1Ah is expected to match (the
+  PawnIO module exposes the same window for it) but is unverified —
+  see Open questions. (S5)
+- SMN is reached through an index/data register pair in the host
+  bridge PCI configuration space; the PawnIO module handles this and
+  serializes on the `Access_PCI` mutant. The client performs no raw
+  PCI configuration access. (S5)
+
+## Read procedure and decode
+
+1. Confirm detection facts above.
+2. Read 32-bit `value` from SMN `0x00059800`.
+3. Decode Tctl:
+
+   ```text
+   raw   = (value >> 21) & 0x7FF
+   tctl  = raw * 0.125                # °C
+   if (value >> 19) & 1: tctl -= 49   # CUR_TEMP_RANGE_SEL
+   ```
+
+4. Decode Tdie by subtracting the model's Tctl offset (table below);
+   models not listed have offset 0 and `tdie == tctl`:
+
+   ```text
+   tdie = tctl - tctl_offset(model)
+   ```
+
+5. Publish Tdie as the CPU temperature. Plausibility gate (this
+   project's own policy, not a PPR fact): accept only
+   `-40 ≤ tdie ≤ 120` °C and drop all-zero register reads.
+
+## Quirks
+
+Tctl is a unitless control input deliberately offset above the
+measured die temperature on some first/second-generation parts so that
+cooling policies stay uniform across the lineup. AMD published the
+offsets (S3); the same table ships as facts in `k10temp` (S4):
+
+| Product | Tctl − Tdie offset |
+| --- | --- |
+| Ryzen 7 1700X / 1800X | 20 °C |
+| Ryzen Threadripper 1900X / 1920X / 1950X | 27 °C |
+| Ryzen 7 2700X | 10 °C |
+| Ryzen Threadripper 2920X / 2950X / 2970WX / 2990WX | 27 °C |
+| All other Zen-family products (incl. Zen 2 and newer) | 0 °C |
+
+- Offset matching is by product name (OPN), not by family/model
+  numbers alone. (S3, S4)
+- `CUR_TEMP_RANGE_SEL = 1` (the −49 °C range) is the normal case on
+  many desktop parts; the decode in step 3 must always honor the bit
+  rather than assume either range. (S1)
+- A read returning all zeros indicates a failed SMN transaction rather
+  than 0 °C (or −49 °C); treat as an invalid sample. (Project policy;
+  consistent with the plausibility gate.)
+
+## Safety notes
+
+- Read-only: only `ioctl_read_smu_register` is used. The module's SMU
+  write/command surfaces (`ioctl_write_smu_register`,
+  `ioctl_send_smu_command`) are never invoked by this project.
+- PCI/SMN serialization relies on the module's `Access_PCI` mutant
+  handling; a single register read is one IOCTL, so no multi-call
+  client-side critical section is required for Tctl. (S5)
+
+## Future extensions (recorded, not yet specified)
+
+- Per-CCD temperature registers (`THM_DIE*_TEMP`) exist in the same
+  THM block; their addresses vary by model and need PPR verification
+  before a spec revision adds them.
+- SMU PM-table reads (`ioctl_*_pm_table`) expose richer telemetry
+  (per-core power, voltages) but are version-dependent; out of scope
+  for Phase 1.
+
+## Open questions
+
+- Family 1Ah (Zen 5): confirm `THM_TCON_CUR_TMP` address/layout from
+  an AMD PPR when available, or validate against a Phase 2 register
+  dump from real hardware before enabling by default.
+- Threadripper / EPYC multi-die parts: whether `0x59800` reports the
+  hottest die or a specific die needs verification on such hardware
+  (Phase 2 dumps).
+
+## Revision history
+
+| Revision | Date | Change |
+| --- | --- | --- |
+| 1 | 2026-06-10 | Initial version |

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -90,7 +90,7 @@ non-normative):
 | Ryzen Threadripper 1900X / 1920X / 1950X | 27 °C |
 | Ryzen 7 2700X | 10 °C |
 | Ryzen Threadripper 2920X / 2950X / 2970WX / 2990WX | 27 °C |
-| All other Zen-family products (incl. Zen 2 and newer) | 0 °C |
+| Products without a primary-source documented positive Tctl offset (incl. Zen 2 and newer) | 0 °C, subject to per-family verification before this document reaches implementation-ready status |
 
 - Offset matching is by product name (OPN), not by family/model
   numbers alone. (S3; corroborated by S4)

--- a/docs/specs/sensors/cpu-intel-dts-msr.md
+++ b/docs/specs/sensors/cpu-intel-dts-msr.md
@@ -72,8 +72,10 @@ Notes:
    (`0x19C`) on the target core; use the value only when bit 31
    (Reading Valid) is 1; decode with the same subtraction.
 5. Plausibility gate before publishing (defensive, this project's own
-   policy, not an SDM fact): accept only `0 < temp ≤ t_target` and
-   `t_target` within 50–120 °C; otherwise drop the sample.
+   policy, not an SDM fact): accept only `0 < temp ≤ t_target`
+   (inclusive — a readout of 0 decodes to `temp == t_target` and
+   passes the gate) and `t_target` within 50–120 °C; otherwise drop
+   the sample.
 
 ## Quirks
 
@@ -82,11 +84,13 @@ Notes:
   parts are **out of scope**: the `t_target == 0` / fault rule above
   excludes them. (S2)
 - The digital readout saturates: values at or above TCC activation
-  read as 0 °C below target. A readout of 0 therefore means "at TjMax",
-  which on an idle machine indicates a bad read rather than a real
-  temperature — the plausibility gate drops `temp == t_target` only if
-  load context makes it implausible; implementers may publish it as-is
-  with the valid bit set. (S1)
+  read as 0 °C below target. A readout of 0 therefore decodes to
+  `temp == t_target` ("at TjMax"); the plausibility gate accepts it
+  and implementations publish it as-is (with the Reading Valid bit
+  checked where the register defines one). Sustained zero readouts on
+  an otherwise idle system indicate a stuck or failed sensor read and
+  are worth surfacing in logs, but this spec does not require dropping
+  them. (S1)
 - Whether the digital readout is referenced to `Temperature Target`
   alone or to `Temperature Target − TCC Activation Offset` is not
   explicitly stated by the SDM; common practice is to use bits 23:16

--- a/docs/specs/sensors/cpu-intel-dts-msr.md
+++ b/docs/specs/sensors/cpu-intel-dts-msr.md
@@ -1,0 +1,123 @@
+# Spec: Intel CPU temperature via digital thermal sensor MSRs
+
+| Field | Value |
+| --- | --- |
+| Revision | 1 |
+| Status | Draft |
+| Scope | Package (and per-core) temperature on Intel x86-64 CPUs using the architectural digital thermal sensor (DTS) MSRs. Covers Nehalem-and-newer Core/Xeon/Atom parts that expose `MSR_TEMPERATURE_TARGET`. Excludes: pre-Nehalem TjMax estimation, thermal interrupt configuration, RAPL. |
+| Issue phase | Phase 1 (#1635) |
+
+## Sources
+
+| ID | Source | Notes |
+| --- | --- | --- |
+| S1 | Intel, *Intel® 64 and IA-32 Architectures Software Developer's Manual*, Volume 3B, chapter "Thermal Monitoring and Protection" (section "Reading the Digital Sensor"). Combined-volume order no. 325462. | Primary; semantics |
+| S2 | Intel SDM Volume 4, *Model-Specific Registers*, Table 2-2 (architectural MSRs) and per-model tables for `MSR_TEMPERATURE_TARGET`. Order no. 335592. | Primary; register layouts |
+| S3 | Intel SDM Volume 2, `CPUID` instruction reference (leaf `06H`). | Primary; feature detection |
+
+`TODO(provenance)`: pin SDM revision number and page numbers at
+implementation review time (the SDM is revised quarterly; field
+layouts cited here are stable architectural definitions).
+
+## Detection
+
+| Fact | Source |
+| --- | --- |
+| CPU vendor string is `GenuineIntel` (CPUID leaf 0) | S3 |
+| `CPUID.06H:EAX[0] = 1` — digital thermal sensor (DTS) supported; `IA32_THERM_STATUS` readout is valid to use | S3 |
+| `CPUID.06H:EAX[6] = 1` — package thermal management (PTM) supported; `IA32_PACKAGE_THERM_STATUS` exists | S3 |
+| `MSR_TEMPERATURE_TARGET` (`0x1A2`) is model-specific; treat a faulted read or a zero `Temperature Target` field as "not supported" and fall back | S2 |
+
+## Register map (facts)
+
+All registers are read with `RDMSR` (via the PawnIO `IntelMSR` module,
+see [`pawnio-interface.md`](pawnio-interface.md); all three MSRs are on
+its read allow-list).
+
+| MSR | Name | Bits | Meaning | Units / encoding | Source |
+| --- | --- | --- | --- | --- | --- |
+| `0x19C` | `IA32_THERM_STATUS` | 22:16 | Digital Readout: temperature **below** the TCC activation temperature | °C, unsigned | S1, S2 |
+| `0x19C` | `IA32_THERM_STATUS` | 30:27 | Resolution of the readout | °C | S2 |
+| `0x19C` | `IA32_THERM_STATUS` | 31 | Reading Valid (1 = digital readout is valid) | flag | S2 |
+| `0x1B1` | `IA32_PACKAGE_THERM_STATUS` | 22:16 | Package Digital Readout: package temperature below package TCC activation | °C, unsigned | S2 |
+| `0x1A2` | `MSR_TEMPERATURE_TARGET` | 23:16 | Temperature Target: TCC activation temperature (commonly called TjMax) | °C | S2 |
+| `0x1A2` | `MSR_TEMPERATURE_TARGET` | 27:24 or 29:24 (model-dependent width) | TCC Activation Offset: lowers the throttle activation point below the Temperature Target | °C | S2 |
+
+Notes:
+
+- `IA32_THERM_STATUS` is a **per-core** register; the readout reflects
+  the core the `RDMSR` executes on. (S1)
+- `IA32_PACKAGE_THERM_STATUS` is **package-scope**: any logical CPU of
+  the package reads the same value. It has **no** Reading Valid bit.
+  (S2)
+- The `TCC Activation Offset` field width differs between models
+  (4-bit on many client models, 6-bit on some); consult the SDM Vol. 4
+  row for each supported model before using it. (S2)
+
+## Read procedure and decode
+
+1. Confirm detection facts above.
+2. Read `MSR_TEMPERATURE_TARGET` (`0x1A2`) once per session; let
+   `t_target = bits[23:16]`. If the read faults or `t_target == 0`,
+   report "unsupported" (caller falls back to ACPI zones per #1633).
+3. Package temperature (preferred for Phase 1): read
+   `IA32_PACKAGE_THERM_STATUS` (`0x1B1`); let
+   `readout = bits[22:16]`; temperature in °C:
+
+   ```text
+   temp_pkg = t_target - readout
+   ```
+
+4. Per-core temperature (optional, later): read `IA32_THERM_STATUS`
+   (`0x19C`) on the target core; use the value only when bit 31
+   (Reading Valid) is 1; decode with the same subtraction.
+5. Plausibility gate before publishing (defensive, this project's own
+   policy, not an SDM fact): accept only `0 < temp ≤ t_target` and
+   `t_target` within 50–120 °C; otherwise drop the sample.
+
+## Quirks
+
+- Pre-Nehalem parts (e.g. Core 2) do not document a usable
+  `MSR_TEMPERATURE_TARGET`; tools of that era guessed TjMax. Such
+  parts are **out of scope**: the `t_target == 0` / fault rule above
+  excludes them. (S2)
+- The digital readout saturates: values at or above TCC activation
+  read as 0 °C below target. A readout of 0 therefore means "at TjMax",
+  which on an idle machine indicates a bad read rather than a real
+  temperature — the plausibility gate drops `temp == t_target` only if
+  load context makes it implausible; implementers may publish it as-is
+  with the valid bit set. (S1)
+- Whether the digital readout is referenced to `Temperature Target`
+  alone or to `Temperature Target − TCC Activation Offset` is not
+  explicitly stated by the SDM; common practice is to use bits 23:16
+  without subtracting the offset. Recorded as an open question. (S1,
+  S2)
+- Multi-package systems: `0x1B1` must be read once per package, with
+  the reading thread affinity-pinned to a core of each package. Phase
+  1 targets single-package consumer machines (package 0). (S2)
+
+## Safety notes
+
+- Read-only: `RDMSR` of the three listed MSRs only. No `WRMSR` in any
+  phase. The PawnIO `IntelMSR` module's write surface is not used.
+- MSR reads have no bus-level side effects requiring the ISA or PCI
+  mutex conventions.
+
+## Open questions
+
+- TCC Activation Offset interaction with the readout reference (see
+  Quirks). Resolution requires checking the SDM "Setting Thermal
+  Targets" subsection wording against an offset-programmed machine.
+- Which logical CPU PawnIO executes `RDMSR` on (tracked in
+  [`pawnio-interface.md`](pawnio-interface.md)); package-scope reads
+  make this moot for Phase 1 on single-package machines.
+- Hybrid (P/E-core) parts: per-core readouts differ per core type;
+  package readout is defined identically. Verify no additional
+  enumeration is needed beyond CPUID leaf `06H` on a hybrid test
+  machine.
+
+## Revision history
+
+| Revision | Date | Change |
+| --- | --- | --- |
+| 1 | 2026-06-10 | Initial version |

--- a/docs/specs/sensors/cpu-intel-dts-msr.md
+++ b/docs/specs/sensors/cpu-intel-dts-msr.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Revision | 1 |
-| Status | Draft |
+| Status | Draft — not implementation-ready |
 | Scope | Package (and per-core) temperature on Intel x86-64 CPUs using the architectural digital thermal sensor (DTS) MSRs. Covers Nehalem-and-newer Core/Xeon/Atom parts that expose `MSR_TEMPERATURE_TARGET`. Excludes: pre-Nehalem TjMax estimation, thermal interrupt configuration, RAPL. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -57,17 +57,15 @@ Notes:
 ## Read procedure and decode
 
 1. Confirm detection facts above.
-2. Read `MSR_TEMPERATURE_TARGET` (`0x1A2`) once per session; let
-   `t_target = bits[23:16]`. If the read faults or `t_target == 0`,
-   report "unsupported" (caller falls back to ACPI zones per #1633).
+2. Read `MSR_TEMPERATURE_TARGET` (`0x1A2`) once per session and
+   extract the Temperature Target (`t_target`) from bits 23:16. If
+   the read faults or `t_target` is 0, report "unsupported" (caller
+   falls back to ACPI zones per #1633).
 3. Package temperature (preferred for Phase 1): read
-   `IA32_PACKAGE_THERM_STATUS` (`0x1B1`); let
-   `readout = bits[22:16]`; temperature in °C:
-
-   ```text
-   temp_pkg = t_target - readout
-   ```
-
+   `IA32_PACKAGE_THERM_STATUS` (`0x1B1`). Decoding rules (hardware
+   semantics):
+   - Extract the Package Digital Readout from bits 22:16.
+   - Package temperature = `t_target` − readout, in °C.
 4. Per-core temperature (optional, later): read `IA32_THERM_STATUS`
    (`0x19C`) on the target core; use the value only when bit 31
    (Reading Valid) is 1; decode with the same subtraction.

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Revision | 1 |
-| Status | Draft |
+| Status | Draft — not implementation-ready |
 | Scope | Facts needed to integrate a Rust user-mode client with PawnIO: installation/detection, the PawnIOLib API, the module execution model, and the IOCTL contracts of the `IntelMSR`, `RyzenSMU`, and `LpcIO` modules. Excludes: writing new Pawn modules, driver internals. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -15,7 +15,7 @@
 | S2 | namazso, *PawnIO.Modules* repository, <https://github.com/namazso/PawnIO.Modules> | Primary; module list, license |
 | S3 | PawnIO.Modules wiki, "Using PawnIO Modules", <https://github.com/namazso/PawnIO.Modules/wiki/Using-PawnIO-Modules> | Primary; user-mode API |
 | S4 | PawnIO.Modules wiki, "Getting started with PawnIO", <https://github.com/namazso/PawnIO.Modules/wiki/Getting-started-with-PawnIO> | Primary; toolchain, signing |
-| S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Interface facts only (public `ioctl_*` contracts, allow-lists, mutex names). No code was copied. |
+| S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Upstream-published interface definitions of the API this project calls across the IOCTL boundary (public `ioctl_*` contracts, allow-lists, mutex names); the PawnIO project is the authoritative source for its own interfaces. Not used as a source for any hardware register fact. No code was copied. |
 
 ## Licensing facts
 
@@ -121,7 +121,8 @@ Target: AMD x86-64 CPUs, families `0x17`, `0x19`, `0x1A` only.
 - Internally the module performs SMN access through an index/data
   register pair in the host bridge PCI configuration space (bus 0,
   device 0, function 0); the client never performs raw PCI access
-  itself. (S5)
+  itself. (S5; informative internal detail, not a contract this
+  project depends on)
 - The module synchronizes several operations on the named kernel
   mutant `\BaseNamedObjects\Access_PCI`. (S5)
 

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -1,0 +1,183 @@
+# Spec: PawnIO driver, library, and module IOCTL interface
+
+| Field | Value |
+| --- | --- |
+| Revision | 1 |
+| Status | Draft |
+| Scope | Facts needed to integrate a Rust user-mode client with PawnIO: installation/detection, the PawnIOLib API, the module execution model, and the IOCTL contracts of the `IntelMSR`, `RyzenSMU`, and `LpcIO` modules. Excludes: writing new Pawn modules, driver internals. |
+| Issue phase | Phase 1 (#1635) |
+
+## Sources
+
+| ID | Source | Notes |
+| --- | --- | --- |
+| S1 | namazso, *PawnIO* repository, <https://github.com/namazso/PawnIO> (README / LICENSE) | Primary; license facts |
+| S2 | namazso, *PawnIO.Modules* repository, <https://github.com/namazso/PawnIO.Modules> | Primary; module list, license |
+| S3 | PawnIO.Modules wiki, "Using PawnIO Modules", <https://github.com/namazso/PawnIO.Modules/wiki/Using-PawnIO-Modules> | Primary; user-mode API |
+| S4 | PawnIO.Modules wiki, "Getting started with PawnIO", <https://github.com/namazso/PawnIO.Modules/wiki/Getting-started-with-PawnIO> | Primary; toolchain, signing |
+| S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Interface facts only (public `ioctl_*` contracts, allow-lists, mutex names). No code was copied. |
+
+## Licensing facts
+
+- The PawnIO driver is licensed **GPL-2.0 with an exception** that
+  explicitly permits combining it with independent modules that
+  communicate "through the device IO control interface", and with
+  LGPL code. A user-mode client that only talks to the driver via
+  IOCTLs is such an independent module. (S1)
+- The modules in PawnIO.Modules are **LGPL-2.1-or-later**. Our client
+  invokes them through the driver's IOCTL interface and ships none of
+  their code, so MIT licensing of this repository's code is unaffected.
+  Redistributing the compiled module blobs with the installer requires
+  complying with LGPL-2.1 distribution terms (source offer /
+  attribution in third-party notices). (S1, S2)
+- PawnIO is the WinRing0 replacement adopted by LibreHardwareMonitor,
+  FanControl, and OpenRGB after WinRing0 was added to Microsoft's
+  vulnerable-driver blocklist. (Issue #1635 background; S1)
+
+## Installation and detection
+
+- PawnIO ships as a signed driver with an installer; installation
+  requires administrator rights once. (S1, S4)
+- The installed location of PawnIOLib is discovered via the registry
+  value `InstallLocation` under
+  `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO`,
+  with `%ProgramFiles%\PawnIO` as the documented fallback. (S3)
+- The production (signed) driver validates module signatures; loading
+  unsigned modules requires the separate "unrestricted" build of the
+  driver plus Windows test-signing mode. An end-user deployment
+  therefore uses the signed driver with the signed module blobs
+  released by the PawnIO project. (S4)
+- Absence of PawnIO is a supported state: the client must detect the
+  missing library/driver and report "unavailable" so the caller can
+  fall back to the ACPI thermal-zone source (PR #1633).
+
+## PawnIOLib user-mode API
+
+Facts from S3. The normative reference for exact prototypes is
+`PawnIOLib.h` shipped in the PawnIO installation directory
+(`TODO(provenance)`: pin exact signatures from the installed header
+during implementation).
+
+- The library is loaded dynamically and functions are resolved by
+  name (e.g. via `GetProcAddress`).
+- Call sequence:
+  1. `pawnio_open(&handle)` — obtain a handle to the driver.
+  2. `pawnio_load(handle, blob, blob_size)` — load a compiled module
+     blob (`.amx`) into that handle's context.
+  3. `pawnio_execute(handle, "ioctl_<name>", in_buf, in_count,
+     out_buf, out_count, &return_size)` — invoke a module function by
+     its string name with input/output buffers.
+- Module functions are addressed by **string name** following the
+  `ioctl_*` convention. (S3)
+- Buffers are arrays of **64-bit cells**: PawnIO only supports a
+  64-bit cell size (modules are compiled with `-C64`). Sizes are given
+  in cells, not bytes. (S3, S4)
+- Functions return NTSTATUS-style status codes; module-level denials
+  observed in the module sources use `STATUS_ACCESS_DENIED` /
+  `STATUS_NOT_SUPPORTED`. (S5)
+- One handle holds one loaded module; use one handle per module.
+  (`TODO(provenance)`: confirm against `PawnIOLib.h` whether a handle
+  may reload a different blob; also confirm the close/cleanup function
+  name, expected to be `pawnio_close`.)
+
+## Module IOCTL contracts
+
+Interface facts extracted from the public surfaces of the modules
+(S5). Cell layouts: `in[i]` / `out[i]` are 64-bit cells.
+
+### `IntelMSR`
+
+Target: Intel x86-64 CPUs only; other vendors get
+`STATUS_NOT_SUPPORTED`.
+
+| Function | Input cells | Output cells | Semantics |
+| --- | --- | --- | --- |
+| `ioctl_read_msr` | `in[0]` = MSR index | `out[0]` = MSR value | Read an allow-listed MSR |
+| `ioctl_write_msr` | `in[0]` = MSR index, `in[1]` = value | — | Write an allow-listed MSR (NOT used by this project — read-only policy) |
+
+- The read allow-list includes the thermal MSRs this project needs:
+  `0x19C` (IA32_THERM_STATUS), `0x1B1` (IA32_PACKAGE_THERM_STATUS),
+  `0x1A2` (MSR_TEMPERATURE_TARGET). Reads of MSRs outside the
+  allow-list fail with `STATUS_ACCESS_DENIED`. (S5)
+- The write allow-list is small (power-limit / mailbox registers) and
+  is irrelevant here; this project performs no MSR writes.
+
+### `RyzenSMU`
+
+Target: AMD x86-64 CPUs, families `0x17`, `0x19`, `0x1A` only.
+
+| Function | Input cells | Output cells | Semantics |
+| --- | --- | --- | --- |
+| `ioctl_read_smu_register` | `in[0]` = SMN address | `out[0]` = 32-bit register value | Read a validated SMN register |
+| `ioctl_get_code_name` | — | `out[0]` = codename enum | CPU codename detected by the module |
+| `ioctl_get_smu_version` | — | `out[0]` = version | SMU firmware version |
+| `ioctl_resolve_pm_table` / `ioctl_update_pm_table` / `ioctl_read_pm_table` | — | table metadata / contents | PM-table access (not needed for Phase 1) |
+| `ioctl_write_smu_register`, `ioctl_send_smu_command` | … | … | Write paths (NOT used — read-only policy) |
+
+- SMN reads are validated against allowed address windows, including
+  `0x56000`–`0x5AFFF`, which contains the thermal controller register
+  `0x59800` used for Tctl (see
+  [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md)). (S5)
+- Internally the module performs SMN access through an index/data
+  register pair in the host bridge PCI configuration space (bus 0,
+  device 0, function 0); the client never performs raw PCI access
+  itself. (S5)
+- The module synchronizes several operations on the named kernel
+  mutant `\BaseNamedObjects\Access_PCI`. (S5)
+
+### `LpcIO`
+
+Target: x86-64 systems; provides port I/O for Super I/O chips.
+
+| Function | Input cells | Output cells | Semantics |
+| --- | --- | --- | --- |
+| `ioctl_select_slot` | `in[0]` = slot (0 or 1) | — | Select config port pair: slot 0 → `0x2E`/`0x2F`, slot 1 → `0x4E`/`0x4F` |
+| `ioctl_find_bars` | — | — | Discover and allow the I/O BAR ranges of the selected chip |
+| `ioctl_superio_inb` | `in[0]` = config register | `out[0]` = byte | Read a Super I/O configuration register |
+| `ioctl_superio_inw` | `in[0]` = config register | `out[0]` = word | 16-bit configuration read |
+| `ioctl_superio_outb` | `in[0]` = config register, `in[1]` = byte | — | Write a Super I/O configuration register |
+| `ioctl_pio_inb` | `in[0]` = port | `out[0]` = byte | Read an allowed I/O port (config pair or discovered BARs) |
+| `ioctl_pio_outb` | `in[0]` = port, `in[1]` = byte | — | Write an allowed I/O port |
+
+- Port access is restricted to the selected configuration register
+  pair and BAR ranges discovered by `ioctl_find_bars` (clamped to
+  8-byte-aligned windows). (S5)
+- The module takes the named kernel mutant
+  `\BaseNamedObjects\Access_ISABUS.HTP.Method` around its operations.
+  (S5)
+
+## Mutex conventions
+
+- The Windows user-mode name `Global\X` and the kernel object path
+  `\BaseNamedObjects\X` denote the same named object. The ecosystem
+  conventions are therefore:
+  - **ISA / Super I/O:** `Global\Access_ISABUS.HTP.Method`
+  - **PCI / SMN:** `Global\Access_PCI`
+- The modules acquire these mutants **per IOCTL call** (S5). A Super
+  I/O read transaction spans many IOCTLs (enter config mode, select
+  bank, read index/data, exit), so per-call locking alone cannot keep
+  the transaction atomic. The client must additionally hold the
+  corresponding `Global\…` mutex in user mode for the whole multi-step
+  transaction, matching the behavior of HWiNFO / LibreHardwareMonitor /
+  FanControl. (Convention; issue #1635)
+- Mutex acquisition must use a bounded timeout and treat timeout as a
+  failed (skipped) sample, never as permission to proceed unlocked.
+
+## Open questions
+
+- On which logical CPU does `IntelMSR::ioctl_read_msr` execute the
+  read? Expected: the calling thread's current processor, making
+  per-core readings controllable via thread affinity. Phase 1 only
+  needs the package-scope MSR (any core of the package), but this must
+  be verified before adding per-core readings.
+- Exact `PawnIOLib.h` prototypes (including the close function and
+  version query) need to be pinned from an installed copy.
+- Module blob file names and installed locations of the signed module
+  releases (needed for installer integration) need to be confirmed
+  from a PawnIO release package.
+
+## Revision history
+
+| Revision | Date | Change |
+| --- | --- | --- |
+| 1 | 2026-06-10 | Initial version |

--- a/docs/specs/sensors/spec-template.md
+++ b/docs/specs/sensors/spec-template.md
@@ -9,17 +9,26 @@ Rules: docs/specs/sensors/README.md
 | Field | Value |
 | --- | --- |
 | Revision | 1 |
-| Status | Draft |
+| Status | Draft — not implementation-ready |
 | Scope | <what this document specifies, and what it deliberately excludes> |
 | Issue phase | <phase from #1635> |
+
+<!--
+Status stays "Draft — not implementation-ready" while any
+TODO(provenance) marker is unresolved. See README.md "Document status
+and implementation gate".
+-->
 
 ## Sources
 
 <!--
-Primary sources first (vendor datasheets / manuals). For facts taken
-from MPL/GPL/LGPL implementations, name the project and state that only
-facts were extracted. Pin page/section where possible; otherwise add
-TODO(provenance).
+Primary sources first (vendor datasheets / manuals / public hardware
+specifications / independently collected hardware dumps).
+MPL/GPL/LGPL implementations are non-normative leads only: list them,
+mark them non-normative, and never let a normative fact rest solely on
+them. A quirk known only from a copyleft implementation belongs in
+Open questions until independently verified. Pin page/section where
+possible; otherwise add TODO(provenance).
 -->
 
 | ID | Source | Notes |
@@ -55,8 +64,9 @@ ordering, validity checks, and the exact decode formula with units.
 
 <!--
 Per-model deviations, errata, offsets. Each entry: factual statement +
-source note. Quirks learned from GPL/MPL sources are facts with the
-project named.
+source note backed by a primary source. A quirk known only from a
+copyleft implementation must live in Open questions, not here, until
+independently verified.
 -->
 
 ## Safety notes

--- a/docs/specs/sensors/spec-template.md
+++ b/docs/specs/sensors/spec-template.md
@@ -1,0 +1,80 @@
+# Spec: <Domain / Chip family — short title>
+
+<!--
+Copy this file to a new lowercase kebab-case name and fill every
+section. Delete the HTML comments. Keep facts and sources together.
+Rules: docs/specs/sensors/README.md
+-->
+
+| Field | Value |
+| --- | --- |
+| Revision | 1 |
+| Status | Draft |
+| Scope | <what this document specifies, and what it deliberately excludes> |
+| Issue phase | <phase from #1635> |
+
+## Sources
+
+<!--
+Primary sources first (vendor datasheets / manuals). For facts taken
+from MPL/GPL/LGPL implementations, name the project and state that only
+facts were extracted. Pin page/section where possible; otherwise add
+TODO(provenance).
+-->
+
+| ID | Source | Notes |
+| --- | --- | --- |
+| S1 | <Vendor>, *<Document title>*, document/order no. <N>, rev. <R>, §<section>/p.<page> | Primary |
+| S2 | … | … |
+
+## Detection
+
+<!--
+How an implementation decides this document applies: CPUID checks,
+chip ID registers, presence probes. Each fact tagged with a source ID.
+-->
+
+## Register map (facts)
+
+<!--
+Tables only. Address, name (vendor mnemonic), bit fields, units,
+access width, source tag. No prose interpretation here.
+-->
+
+| Address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
+| --- | --- | --- | --- | --- | --- |
+
+## Read procedure and decode
+
+<!--
+Ordered factual steps (prose / arithmetic, no code), including required
+ordering, validity checks, and the exact decode formula with units.
+-->
+
+## Quirks
+
+<!--
+Per-model deviations, errata, offsets. Each entry: factual statement +
+source note. Quirks learned from GPL/MPL sources are facts with the
+project named.
+-->
+
+## Safety notes
+
+<!--
+Which operations write anything (e.g. bank select), mutex requirements,
+and what must never be written.
+-->
+
+## Open questions
+
+<!--
+Anything not yet verified against a primary source, with what evidence
+exists so far. Implementers must treat these as unresolved.
+-->
+
+## Revision history
+
+| Revision | Date | Change |
+| --- | --- | --- |
+| 1 | <YYYY-MM-DD> | Initial version |

--- a/docs/specs/sensors/superio-access.md
+++ b/docs/specs/sensors/superio-access.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Revision | 1 |
-| Status | Draft |
+| Status | Draft — not implementation-ready |
 | Scope | The generic LPC/ISA access mechanism shared by PC Super I/O chips: configuration port pairs, vendor enter/exit key sequences, logical-device selection, chip identification, and locating the hardware-monitor I/O block. Applies to Nuvoton NCT67xx and ITE IT86xx/87xx families. Excludes: per-chip register maps (temperatures, fans, voltages) — those are the Phase 3/4 documents. |
 | Issue phase | Phases 2–4 (#1635) — mechanism shared by all of them |
 
@@ -13,7 +13,7 @@
 | --- | --- | --- |
 | S1 | Nuvoton, *NCT6779D* datasheet (representative of the NCT67xx family): "Extended Function Registers" and "Hardware Monitor" chapters | Primary for Nuvoton facts. `TODO(provenance)`: pin section/page numbers per chip in the Phase 3 documents |
 | S2 | ITE, *IT8728F Preliminary Specification* (representative of the IT87xx family): "MB PnP Mode" and "Environment Controller" chapters | Primary for ITE facts. `TODO(provenance)`: pin per chip in Phase 4 |
-| S3 | PawnIO `LpcIO.p` module source (LGPL-2.1-or-later) | Interface facts only (slot mapping, allowed ports, mutex name) |
+| S3 | PawnIO `LpcIO.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls (interoperability facts: slot mapping, allowed ports, mutex name). Not used as a source for any chip register fact. No code was copied. |
 
 Facts below are uniform across the respective vendors' datasheet
 series; each per-chip Phase 3/4 document must still re-verify them
@@ -115,9 +115,10 @@ Writes are limited to exactly:
 - hardware-monitor/EC **address** port (index selection),
 - Nuvoton bank select (hardware-monitor register `0x4E`).
 
-No other configuration register, and no hardware-monitor data
-register, is ever written: no fan control, no limits, no alarm
-configuration, in any phase of #1635.
+No hardware-monitor data register is written except the documented
+Nuvoton bank-select register (`0x4E`) above. No sensor value,
+fan-control, limit, alarm, or other configuration data register is
+written in any phase of #1635.
 
 ## Open questions
 

--- a/docs/specs/sensors/superio-access.md
+++ b/docs/specs/sensors/superio-access.md
@@ -1,0 +1,139 @@
+# Spec: Super I/O configuration access and chip detection
+
+| Field | Value |
+| --- | --- |
+| Revision | 1 |
+| Status | Draft |
+| Scope | The generic LPC/ISA access mechanism shared by PC Super I/O chips: configuration port pairs, vendor enter/exit key sequences, logical-device selection, chip identification, and locating the hardware-monitor I/O block. Applies to Nuvoton NCT67xx and ITE IT86xx/87xx families. Excludes: per-chip register maps (temperatures, fans, voltages) — those are the Phase 3/4 documents. |
+| Issue phase | Phases 2–4 (#1635) — mechanism shared by all of them |
+
+## Sources
+
+| ID | Source | Notes |
+| --- | --- | --- |
+| S1 | Nuvoton, *NCT6779D* datasheet (representative of the NCT67xx family): "Extended Function Registers" and "Hardware Monitor" chapters | Primary for Nuvoton facts. `TODO(provenance)`: pin section/page numbers per chip in the Phase 3 documents |
+| S2 | ITE, *IT8728F Preliminary Specification* (representative of the IT87xx family): "MB PnP Mode" and "Environment Controller" chapters | Primary for ITE facts. `TODO(provenance)`: pin per chip in Phase 4 |
+| S3 | PawnIO `LpcIO.p` module source (LGPL-2.1-or-later) | Interface facts only (slot mapping, allowed ports, mutex name) |
+
+Facts below are uniform across the respective vendors' datasheet
+series; each per-chip Phase 3/4 document must still re-verify them
+against the exact datasheet for that chip before implementation relies
+on chip-specific values.
+
+## Configuration port pairs
+
+| Fact | Source |
+| --- | --- |
+| Super I/O chips are configured through an index/data port pair: primary `0x2E` (index) / `0x2F` (data), secondary `0x4E` / `0x4F`. A board straps the chip to one pair | S1, S2 |
+| PawnIO `LpcIO` exposes the pairs as slot 0 (`0x2E`/`0x2F`) and slot 1 (`0x4E`/`0x4F`) via `ioctl_select_slot` | S3 |
+
+## Vendor key sequences (configuration mode)
+
+These are **writes**, permitted because reading any configuration
+register requires them. They alter no monitoring/control state.
+
+| Vendor | Enter configuration (extended function / MB PnP) mode | Exit | Source |
+| --- | --- | --- | --- |
+| Nuvoton (NCT67xx; Winbond lineage) | write `0x87`, `0x87` to the index port | write `0xAA` to the index port | S1 |
+| ITE (IT86xx/87xx) | at `0x2E`: write `0x87`, `0x01`, `0x55`, `0x55` to the index port; at `0x4E`: write `0x87`, `0x01`, `0x55`, `0xAA` | set bit 1 of configuration register `0x02` (write index `0x02`, then data `0x02`) | S2 |
+
+## Common configuration registers
+
+Once in configuration mode, registers are read by writing the register
+index to the index port and reading the data port.
+
+| Index | Meaning | Source |
+| --- | --- | --- |
+| `0x07` | Logical device select (write the logical device number; **write required** for device-scoped registers) | S1, S2 |
+| `0x20` | Chip ID, high byte | S1, S2 |
+| `0x21` | Chip ID, low byte | S1, S2 |
+| `0x60` / `0x61` | Selected logical device's base address, high/low byte | S1, S2 |
+
+- ITE chip IDs literally encode the part number (example: the IT8728F
+  reads `0x87`/`0x28`). (S2)
+- Nuvoton chip IDs are family-specific opaque values; the per-chip
+  Phase 3 document carries the exact ID table with datasheet
+  citations. (S1)
+- Reading `0xFF` (or `0x00`) from both ID registers on both port pairs
+  means no responding Super I/O chip; detection reports "absent".
+
+## Hardware-monitor I/O block
+
+| Vendor | Logical device | Register access | Source |
+| --- | --- | --- | --- |
+| Nuvoton NCT67xx | `0x0B` ("Hardware Monitor") | address port = base + `0x05`, data port = base + `0x06`; banked register space — write the bank number to hardware-monitor register `0x4E` (**write required**), then address registers within the bank | S1 |
+| ITE IT86xx/87xx | `0x04` ("Environment Controller", EC) | address port = base + `0x05`, data port = base + `0x06`; flat register space (no banks) | S2 |
+
+- The base address is read from configuration registers
+  `0x60`/`0x61` of the selected logical device. A base of `0x0000`
+  or `0xFFFF` means the block is not mapped; detection reports
+  "absent". (S1, S2)
+- PawnIO `LpcIO` only allows port reads/writes within the
+  configuration pair and the BAR ranges it discovered via
+  `ioctl_find_bars`; the hardware-monitor base must therefore be
+  discovered through `LpcIO` itself before its ports are accessible.
+  (S3)
+
+## Detection procedure
+
+For each slot (0, then 1):
+
+1. Acquire the ISA mutex (below); select the slot
+   (`ioctl_select_slot`).
+2. Try each vendor's enter sequence in turn; after each, read chip ID
+   registers `0x20`/`0x21`.
+3. On a recognized ID: select the vendor's hardware-monitor logical
+   device (`0x07` ← device number), read the base address
+   (`0x60`/`0x61`), run `ioctl_find_bars`, then exit configuration
+   mode.
+4. On no recognized ID: exit configuration mode (best-effort with the
+   matching vendor exit) and continue.
+5. Release the mutex. Cache the detection result; re-detection on
+   every sample is unnecessary.
+
+## Concurrency and the ISA mutex
+
+- The whole transaction — enter key, configuration reads, bank select,
+  hardware-monitor index/data reads, exit — must execute under the
+  ecosystem mutex `Global\Access_ISABUS.HTP.Method`, because the
+  index/data port protocol is stateful: an interleaved write from
+  another monitor changes the selected index/bank between our write
+  and read. (Issue #1635 convention; see
+  [`pawnio-interface.md`](pawnio-interface.md))
+- The PawnIO `LpcIO` module additionally acquires the same named
+  mutant per IOCTL (S3); that does not make multi-IOCTL sequences
+  atomic, so the client-side mutex above is mandatory.
+- Acquisition uses a bounded timeout; on timeout the sample is skipped
+  (never proceed unlocked).
+
+## Safety notes
+
+Writes are limited to exactly:
+
+- vendor enter/exit key sequences,
+- logical device select (`0x07`),
+- hardware-monitor/EC **address** port (index selection),
+- Nuvoton bank select (hardware-monitor register `0x4E`).
+
+No other configuration register, and no hardware-monitor data
+register, is ever written: no fan control, no limits, no alarm
+configuration, in any phase of #1635.
+
+## Open questions
+
+- Some boards' embedded controllers or firmware claim the `0x2E`/`0x2F`
+  pair (or mirror a different device); the Phase 2 dump tool should
+  capture both slots' raw ID bytes so unknown responders can be
+  triaged from user dumps before any chip-specific logic runs.
+- Whether ITE's exit (`0x02` bit 1) is required-or-harmful when the
+  enter sequence matched a Nuvoton chip (and vice versa) — the
+  detection loop above exits with the vendor sequence matching the
+  attempted enter key; verify on hardware via Phase 2 dumps.
+- Per-chip ID tables and hardware-monitor register maps: deferred to
+  the Phase 3 (Nuvoton) / Phase 4 (ITE) documents.
+
+## Revision history
+
+| Revision | Date | Change |
+| --- | --- | --- |
+| 1 | 2026-06-10 | Initial version |


### PR DESCRIPTION
## Summary

Adds the `docs/specs/sensors/` specification library required by the AI-driven clean-room process of #1635. These are the **fact-only spec documents** ("dirty room" output) that the clean-room implementer role will build the Rust PawnIO client from. No implementation code is included.

> **Draft status:** all documents are explicitly marked `Draft — not implementation-ready`. They must not be used as clean-room implementation inputs until all `TODO(provenance)` markers are resolved and the Phase 0 guardrails are merged (see "Implementation gate" below).

| Document | Covers | Issue phase |
| --- | --- | --- |
| `docs/specs/sensors/README.md` | Two-role clean-room process, hard rules for spec docs, document status + implementation gate, reviewer contamination policy, spec revision pinning convention | Phase 0 (partial) |
| `docs/specs/sensors/spec-template.md` | Template for future spec documents | Phase 0 (partial) |
| `docs/specs/sensors/pawnio-interface.md` | PawnIO licensing facts (GPL-2.0 + IOCTL-interface exception → MIT client OK), PawnIOLib API, `IntelMSR` / `RyzenSMU` / `LpcIO` module IOCTL contracts, `Access_ISABUS.HTP.Method` / `Access_PCI` mutex conventions | Phase 1 |
| `docs/specs/sensors/cpu-intel-dts-msr.md` | Intel DTS via `IA32_THERM_STATUS` (0x19C), `IA32_PACKAGE_THERM_STATUS` (0x1B1), `MSR_TEMPERATURE_TARGET` (0x1A2): bit layouts, decode rules, quirks | Phase 1 |
| `docs/specs/sensors/cpu-amd-zen-smn.md` | AMD Zen `THM_TCON_CUR_TMP` (SMN 0x00059800): CUR_TEMP / RANGE_SEL layout, Tctl/Tdie decode rules, published Tctl→Tdie offset table; family 17h/19h enabled, 1Ah recognized-but-disabled until verified | Phase 1 |
| `docs/specs/sensors/superio-access.md` | Generic Super I/O config access (0x2E/0x4E pairs, Nuvoton/ITE enter-exit keys, chip ID, HWM/EC block discovery), detection procedure, ISA mutex policy, explicit write allow-list (Nuvoton bank-select is the only HWM-register write exception) | Phases 2–4 (mechanism) |

`docs/README.md` is updated to index the new directory.

### Clean-room source policy (tightened per review)

- **Copyleft implementations (MPL/GPL/LGPL) are non-normative leads only.** Normative spec facts must be backed by vendor documentation, public hardware specifications, or independently collected hardware dumps. A quirk known only from a copyleft implementation stays in **Open questions** until independently verified.
- Consulted sources remain cited: `k10temp` is kept in the AMD spec's Sources table but marked **non-normative corroboration only** (no fact relies solely on it).
- PawnIO module sources are documented as **upstream-published interface definitions** — the API contract this project calls across the licensed IOCTL boundary — never as sources for hardware register facts.

### Implementation gate (documented in the specs README)

No implementation PR may be opened or reviewed as clean-room work until:

- `.github/instructions/` contains the prohibited-source list
- `CLAUDE.md` references the clean-room implementer restrictions
- the PR template requires spec revision pinning
- the PR template requires a provenance attestation
- the PR template requires the reviewer attestation (reviewers attest they did not consult prohibited sources while reviewing)

### Provenance / verification status

- PawnIO facts (API, module IOCTL contracts, allow-listed MSRs / SMN windows, mutex names, licenses) were verified against the PawnIO / PawnIO.Modules repositories and wiki during authoring. Only interface facts were extracted; no code was copied.
- Intel SDM and AMD PPR register facts are cited by document/order number; `TODO(provenance)` markers note where page-level pins are still required — documents stay not implementation-ready until resolved.
- Anything not yet verified against a primary source is listed under each document's **Open questions** section (e.g. PawnIOLib exact prototypes, family 1Ah THM address, MSR read CPU affinity) rather than stated as fact.
- Per-chip Super I/O register maps (NCT67xx / IT87xx) are deliberately **not** included — they are the Phase 3/4 deliverables and will be validated against Phase 2 user-submitted dumps.

### Out of scope (follow-ups from #1635 Phase 0)

The guardrail *artifacts* themselves (agent definitions / skills, prohibited-source instruction file, `CLAUDE.md` reference, PR template checklist). The specs README now blocks implementation work until they exist.

## Related Issues

Refs #1635 (delivers the spec-document portion; the issue stays open for the guardrail and implementation phases)

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (documentation only)

## Test Plan

- [x] Manual testing — reviewed rendered Markdown and internal links; verified PawnIO interface facts against the upstream repositories/wiki during authoring
- [ ] Unit tests — N/A (no code changes)

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass — N/A (docs-only; Biome / cargo target `src/**` and Rust crates, not `docs/**`)
- [ ] Tests pass — N/A (no code changes)
- [x] No new warnings or errors

https://claude.ai/code/session_01R7Uxj8EFfCprg2pEqb6k6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new sensor hardware specs section and index entry.
  * Added a clean-room README with roles, provenance rules, reviewer attestation checklist, and safety policy.
  * Added AMD Zen and Intel DTS CPU temperature monitoring specifications.
  * Added PawnIO driver/client integration and Super I/O access/detection specifications.
  * Added a reusable sensor-spec template and authoring/conventions guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->