### PR TITLE
fix: avoid repeated CPU thermal sensor renders

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,10 @@ _Avoid_: Snapshot, storage health snapshot, live metrics snapshot, screenshot
 
 ### Persistence And History
 
+**Live Metrics Buffer**:
+A short-lived, non-persisted buffer of recent hardware utilization used for current-value displays and Usage Graphs.
+_Avoid_: Hardware Archive, history, telemetry buffer, dashboard state
+
 **Hardware Archive**:
 Persisted CPU, memory, GPU, and process utilization history used to power Hardware Insights.
 _Avoid_: Storage health history, live history, dashboard state, settings archive

--- a/docs/adr/0007-external-live-metrics-buffer.md
+++ b/docs/adr/0007-external-live-metrics-buffer.md
@@ -1,0 +1,7 @@
+# External Live Metrics Buffer for 1Hz Frontend Metrics
+
+HardwareVisualizer receives 1Hz CPU, memory, GPU, and processor utilization updates for the main window. We decided to keep these high-frequency live metrics in an external Live Metrics Buffer instead of writing each tick through Jotai atoms, so React state updates are limited to components that intentionally subscribe to a metric channel.
+
+Jotai remains the owner for settings, display selection, GPU selection, hardware information, and other low-frequency UI state. Usage Graphs and current-value displays read live metrics through explicit subscriptions, and chart renderers may subscribe directly when React re-rendering is unnecessary. The Tray Widget is outside this frontend buffer because it already renders from the Core metrics stream without going through the main-window React tree.
+
+This decision trades some state-management simplicity for lower steady-state rendering cost. Render-count regression tests should guard the boundary so future changes do not accidentally fan 1Hz updates back out through unrelated Dashboard, Usage, or CPU detail UI.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,3 +14,4 @@ implementation guidance belongs in the architecture documents.
 - [0004 Separate Storage Health History](0004-separate-storage-health-history.md)
 - [0005 Storage Health Naming](0005-storage-health-naming.md)
 - [0006 Live Storage Health on Demand](0006-live-storage-health-on-demand.md)
+- [0007 External Live Metrics Buffer for 1Hz Frontend Metrics](0007-external-live-metrics-buffer.md)

--- a/src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx
@@ -21,6 +21,7 @@ const counters = vi.hoisted(() => ({
     | null,
   infoTableRenders: 0,
   thermalSensorTableRenders: 0,
+  thermalSensorRowRenderWork: 0,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -48,14 +49,16 @@ vi.mock("@/components/shared/InfoTable", () => ({
     className?: string;
     data: Record<string, React.ReactNode>;
   }) => {
+    const keys = Object.keys(data);
     counters.infoTableRenders += 1;
-    if (Object.keys(data).some((key) => key.startsWith("Thermal Zone"))) {
+    if (keys.some((key) => key.startsWith("Thermal Zone"))) {
       counters.thermalSensorTableRenders += 1;
+      counters.thermalSensorRowRenderWork += keys.length;
     }
 
     return (
       <div className={className} data-testid="info-table">
-        {Object.keys(data).join(",")}
+        {keys.join(",")}
       </div>
     );
   },
@@ -152,15 +155,21 @@ const CpuDashboardProbe = () => {
   return <CPUInfo />;
 };
 
+const unchangedSensorTemperatures = Array.from({ length: 24 }, (_, index) => ({
+  name: `Thermal Zone ${index}`,
+  value: 50 + (index % 3),
+}));
+
 describe("Dashboard live metrics render fanout", () => {
   beforeEach(() => {
     counters.capturedHardwareUpdateListener = null;
     counters.infoTableRenders = 0;
     counters.thermalSensorTableRenders = 0;
+    counters.thermalSensorRowRenderWork = 0;
     setDocumentHidden(false);
   });
 
-  it("does not re-render unchanged CPU thermal sensor rows on live metric ticks", () => {
+  it("does not amplify unchanged CPU thermal sensor payloads into per-tick row render work", () => {
     render(
       <Provider>
         <CpuDashboardProbe />
@@ -172,12 +181,13 @@ describe("Dashboard live metrics render fanout", () => {
         makePayload({
           cpuUsage: 10,
           cpuTemperature: 50,
-          sensorTemperatures: [{ name: "Thermal Zone 0", value: 50 }],
+          sensorTemperatures: unchangedSensorTemperatures,
         }),
       );
     });
 
     counters.thermalSensorTableRenders = 0;
+    counters.thermalSensorRowRenderWork = 0;
 
     for (let i = 0; i < 5; i += 1) {
       act(() => {
@@ -185,12 +195,12 @@ describe("Dashboard live metrics render fanout", () => {
           makePayload({
             cpuUsage: 20 + i,
             cpuTemperature: 50,
-            sensorTemperatures: [{ name: "Thermal Zone 0", value: 50 }],
+            sensorTemperatures: unchangedSensorTemperatures,
           }),
         );
       });
     }
 
-    expect(counters.thermalSensorTableRenders).toBe(0);
+    expect(counters.thermalSensorRowRenderWork).toBe(0);
   });
 });

--- a/src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx
@@ -1,0 +1,196 @@
+import { act, render } from "@testing-library/react";
+import { Provider } from "jotai";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
+import type {
+  GpuMonitorData,
+  HardwareMonitorUpdate,
+  SysInfo,
+} from "@/rspc/bindings";
+import { CPUInfo } from "./DashboardItems";
+
+type HardwareMonitorUpdateWithOptionalThermals = HardwareMonitorUpdate & {
+  cpuTemperature?: number | null;
+  sensorTemperatures?: { name: string; value: number }[];
+};
+
+const counters = vi.hoisted(() => ({
+  capturedHardwareUpdateListener: null as
+    | ((event: { payload: HardwareMonitorUpdate }) => void)
+    | null,
+  infoTableRenders: 0,
+  thermalSensorTableRenders: 0,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/rspc/bindings", () => ({
+  events: {
+    hardwareMonitorUpdate: {
+      listen: vi.fn(
+        (listener: (event: { payload: HardwareMonitorUpdate }) => void) => {
+          counters.capturedHardwareUpdateListener = listener;
+          return Promise.resolve(vi.fn());
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/components/shared/InfoTable", () => ({
+  InfoTable: ({
+    className,
+    data,
+  }: {
+    className?: string;
+    data: Record<string, React.ReactNode>;
+  }) => {
+    counters.infoTableRenders += 1;
+    if (Object.keys(data).some((key) => key.startsWith("Thermal Zone"))) {
+      counters.thermalSensorTableRenders += 1;
+    }
+
+    return (
+      <div className={className} data-testid="info-table">
+        {Object.keys(data).join(",")}
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/charts/DoughnutChart", () => ({
+  DoughnutChart: () => <div data-testid="doughnut-chart" />,
+}));
+
+vi.mock("@/features/settings/hooks/useSettingsAtom", () => ({
+  useSettingsAtom: () => ({
+    settings: {
+      temperatureUnit: "C",
+    },
+  }),
+}));
+
+vi.mock("./MiniLineChart", () => ({
+  MiniLineChart: () => <div data-testid="mini-line-chart" />,
+}));
+
+const hardwareInfo = {
+  cpu: {
+    name: "Test CPU",
+    vendor: "Test Vendor",
+    coreCount: 8,
+    clock: 3200,
+    clockUnit: "MHz",
+    cpuName: "Test CPU",
+  },
+  memory: null,
+  gpus: null,
+  storage: [],
+  motherboard: null,
+} satisfies SysInfo;
+
+vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
+  useHardwareInfoAtom: () => ({
+    hardwareInfo,
+  }),
+}));
+
+vi.mock("@/features/hardware/hooks/useProcessInfo", () => ({
+  useProcessInfo: () => [],
+}));
+
+const makeGpu = (overrides: Partial<GpuMonitorData> = {}): GpuMonitorData => ({
+  gpuId: "gpu:0",
+  gpuName: "Test GPU",
+  gpuUsage: 70,
+  gpuTemperature: 65,
+  gpuSource: "Test",
+  gpuDedicatedMemoryUsageKb: null,
+  gpuCoolerLevel: null,
+  ...overrides,
+});
+
+const makePayload = (
+  overrides: Partial<
+    Omit<HardwareMonitorUpdateWithOptionalThermals, "gpus">
+  > & {
+    gpus?: GpuMonitorData[];
+  } = {},
+): HardwareMonitorUpdate => {
+  const { gpus, ...rest } = overrides;
+
+  return {
+    cpuUsage: 50,
+    memoryUsage: 60,
+    gpus: gpus ?? [makeGpu()],
+    processorsUsage: [40, 50],
+    ...rest,
+  } as HardwareMonitorUpdate;
+};
+
+const emitHardwareUpdate = (payload: HardwareMonitorUpdate) => {
+  if (!counters.capturedHardwareUpdateListener) {
+    throw new Error("hardware update listener was not registered");
+  }
+
+  counters.capturedHardwareUpdateListener({ payload });
+};
+
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+};
+
+const CpuDashboardProbe = () => {
+  useHardwareEventListener();
+
+  return <CPUInfo />;
+};
+
+describe("Dashboard live metrics render fanout", () => {
+  beforeEach(() => {
+    counters.capturedHardwareUpdateListener = null;
+    counters.infoTableRenders = 0;
+    counters.thermalSensorTableRenders = 0;
+    setDocumentHidden(false);
+  });
+
+  it("does not re-render unchanged CPU thermal sensor rows on live metric ticks", () => {
+    render(
+      <Provider>
+        <CpuDashboardProbe />
+      </Provider>,
+    );
+
+    act(() => {
+      emitHardwareUpdate(
+        makePayload({
+          cpuUsage: 10,
+          cpuTemperature: 50,
+          sensorTemperatures: [{ name: "Thermal Zone 0", value: 50 }],
+        }),
+      );
+    });
+
+    counters.thermalSensorTableRenders = 0;
+
+    for (let i = 0; i < 5; i += 1) {
+      act(() => {
+        emitHardwareUpdate(
+          makePayload({
+            cpuUsage: 20 + i,
+            cpuTemperature: 50,
+            sensorTemperatures: [{ name: "Thermal Zone 0", value: 50 }],
+          }),
+        );
+      });
+    }
+
+    expect(counters.thermalSensorTableRenders).toBe(0);
+  });
+});

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -1,6 +1,6 @@
 import { platform } from "@tauri-apps/plugin-os";
 import { useAtom } from "jotai";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import {
@@ -60,16 +60,13 @@ import { StorageHealthStatusIcon } from "./StorageHealthStatusIcon";
 
 export const CPUInfo = () => {
   const { t } = useTranslation();
-  const { settings } = useSettingsAtom();
   const [cpuUsageHistory] = useAtom(cpuUsageHistoryAtom);
   const [cpuTemp] = useAtom(cpuTempAtom);
-  const [sensorTemps] = useAtom(sensorTempsAtom);
   const { hardwareInfo } = useHardwareInfoAtom();
   const processes = useProcessInfo();
   const [processorsUsageHistory] = useAtom(processorsUsageHistoryAtom);
 
   const cpuTemperature = cpuTemp[0]?.value;
-  const temperatureUnit = settings.temperatureUnit === "C" ? "°C" : "°F";
 
   return (
     <>
@@ -102,24 +99,35 @@ export const CPUInfo = () => {
         <Skeleton className="h-[188px] w-full rounded-md" />
       )}
 
-      {sensorTemps.length > 0 && (
-        <div className="mt-2 ml-2">
-          <h4 className="font-bold text-sm md:text-md">
-            {t("shared.thermalSensors")}
-          </h4>
-          <InfoTable
-            data={Object.fromEntries(
-              sensorTemps.map((sensor) => [
-                sensor.name,
-                `${sensor.value} ${temperatureUnit}`,
-              ]),
-            )}
-          />
-        </div>
-      )}
+      <CpuThermalSensors />
     </>
   );
 };
+
+const CpuThermalSensors = memo(() => {
+  const { t } = useTranslation();
+  const { settings } = useSettingsAtom();
+  const [sensorTemps] = useAtom(sensorTempsAtom);
+  const temperatureUnit = settings.temperatureUnit === "C" ? "°C" : "°F";
+
+  if (sensorTemps.length === 0) return null;
+
+  return (
+    <div className="mt-2 ml-2">
+      <h4 className="font-bold text-sm md:text-md">
+        {t("shared.thermalSensors")}
+      </h4>
+      <InfoTable
+        data={Object.fromEntries(
+          sensorTemps.map((sensor) => [
+            sensor.name,
+            `${sensor.value} ${temperatureUnit}`,
+          ]),
+        )}
+      />
+    </div>
+  );
+});
 
 export const GPUInfo = () => {
   const { t } = useTranslation();

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -16,12 +16,24 @@ import {
 } from "@/features/hardware/store/chart";
 import { events } from "@/rspc/bindings";
 
+type NameValue = { name: string; value: number };
+
 const padHistory = (arr: (number | null)[]): (number | null)[] => {
   const padded = Array(Math.max(chartConfig.historyLengthSec - arr.length, 0))
     .fill(null)
     .concat(arr);
   return padded.slice(-chartConfig.historyLengthSec);
 };
+
+const areNameValuesEqual = (
+  current: readonly NameValue[],
+  next: readonly NameValue[],
+) =>
+  current.length === next.length &&
+  current.every(
+    (item, index) =>
+      item.name === next[index]?.name && item.value === next[index]?.value,
+  );
 
 /**
  * Listen for hardware monitor update events pushed from the backend.
@@ -76,12 +88,18 @@ export const useHardwareEventListener = () => {
       setMemoryHistory((prev) => padHistory([...prev, memoryUsage]));
 
       // CPU temperature (Windows thermal zones; null where unsupported)
-      setCpuTemp(
-        cpuTemperature != null ? [{ name: "CPU", value: cpuTemperature }] : [],
+      const nextCpuTemp =
+        cpuTemperature != null ? [{ name: "CPU", value: cpuTemperature }] : [];
+      setCpuTemp((prev) =>
+        areNameValuesEqual(prev, nextCpuTemp) ? prev : nextCpuTemp,
       );
 
       // All named temperature sensors (thermal zones)
-      setSensorTemps(sensorTemperatures);
+      setSensorTemps((prev) =>
+        areNameValuesEqual(prev, sensorTemperatures)
+          ? prev
+          : sensorTemperatures,
+      );
 
       // Per-GPU usage histories
       setGpuHistories((prev) =>


### PR DESCRIPTION
## Summary

Adds the first render fanout regression guard for #1638 and fixes the hot path it exposes.

- Defines the `Live Metrics Buffer` glossary term and records the external-buffer decision in ADR 0007.
- Adds a deterministic Dashboard CPU card render-work test for unchanged CPU thermal sensor payloads.
- Skips unchanged CPU temperature and thermal sensor atom updates so identical hardware snapshots reuse the previous Jotai values.
- Isolates thermal sensor rows behind a memoized component so CPU usage ticks do not re-render unchanged sensor rows.
- Leaves the broader Live Metrics Buffer / external store migration as follow-up work for #1638.

Self-review of the performance test:

- This is a deterministic render-count / render-work test, not a wall-clock benchmark, so it should be stable in CI.
- It uses the real `useHardwareEventListener` + `CPUInfo` path and only mocks heavy visual leaves / fixed app services.
- It is scoped to the CPU thermal sensor regression introduced after `v1.8.1`; it does not claim to cover the broader pre-existing CPU usage chart fanout.
- It models a realistic high-fanout case: 24 unchanged thermal sensor rows over 5 live ticks.
- It failed on current `develop` before the fix with `expected 120 to be 0`, passes when copied onto `v1.8.1`, and now passes on this branch.
- The implementation is intentionally narrow: unchanged live values no longer notify subscribers, while changed values and temperature unit changes still render normally.

## Related Issues

Refs #1638

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

Note: this branch was opened as a test-first branch before the fix commit was added; the PR title and latest commit now reflect the fix scope.

## Screenshots / Videos

N/A

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Commands run:

- `pnpm exec biome check src/features/hardware/hooks/useHardwareEventListener.ts src/features/hardware/dashboard/components/DashboardItems.tsx src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx` passes
- `pnpm exec vitest run src/features/hardware/dashboard/components/DashboardItems.renderFanout.test.tsx` passes
- `pnpm exec vitest run src/features/hardware/hooks/useHardwareEventListener.test.ts` passes
- `pnpm exec tsc --noEmit` passes
- Same render fanout test copied to `v1.8.1` worktree passes

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

Notes:

- Targeted lint/type/test checks pass for the changed frontend paths. Full `npm test` / `npm run lint` were not run for this iteration.
