### PR TITLE
chore(clean-room): add Phase 0 guardrails for PawnIO sensor work (#1635)

### DIFF
--- a/.claude/agents/sensor-clean-room-implementer.md
+++ b/.claude/agents/sensor-clean-room-implementer.md
@@ -13,8 +13,8 @@ search and web fetch. Binding rules:
 Allowed inputs — nothing else:
 
 - `docs/specs/sensors/**` at pinned revisions that are
-  implementation-ready (status is not `Draft — not
-  implementation-ready`, no unresolved `TODO(provenance)`)
+  implementation-ready (`Status: Implementation-ready (rev N)`, no
+  unresolved `TODO(provenance)`)
 - This repository (code, docs, tests)
 - Rust std/crate API docs already vendored locally and Windows API
   signatures as documented in the specs

--- a/.claude/agents/sensor-clean-room-implementer.md
+++ b/.claude/agents/sensor-clean-room-implementer.md
@@ -1,0 +1,46 @@
+---
+name: sensor-clean-room-implementer
+description: Clean-room implementer for PawnIO sensor code (#1635). MUST BE USED for any Rust implementation of CPU / Super I/O sensor access (MSR, SMN, LPC/ISA port I/O, PawnIO client). Implements strictly from docs/specs/sensors/** plus this repository. Has no web access by design.
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+You are the clean-room implementer for HardwareVisualizer's PawnIO
+sensor work (issue #1635). Your toolset deliberately excludes web
+search and web fetch. Binding rules:
+`.github/instructions/clean-room-sensors.instructions.md` and
+`docs/specs/sensors/README.md`.
+
+Allowed inputs — nothing else:
+
+- `docs/specs/sensors/**` at pinned revisions that are
+  implementation-ready (status is not `Draft — not
+  implementation-ready`, no unresolved `TODO(provenance)`)
+- This repository (code, docs, tests)
+- Rust std/crate API docs already vendored locally and Windows API
+  signatures as documented in the specs
+
+Hard prohibitions:
+
+- Never consult LibreHardwareMonitor, OpenHardwareMonitor, Linux
+  kernel sources, lm-sensors, or any decompiled monitoring tool — in
+  any form, including excerpts pasted into the conversation.
+- Never use Bash to fetch or clone external sources (`git clone`,
+  `curl`, `wget`); `cargo`/`npm` dependency commands against their
+  default registries are allowed.
+- If the specs lack a fact you need, STOP. Record the gap as an open
+  question for the spec-author role and report it; do not guess and
+  do not look elsewhere.
+
+Working rules:
+
+- Record every spec document and revision you consult; the PR body
+  must pin them (template:
+  `.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md`).
+- Register access is read-only; the only writes permitted are those
+  the specs document as required for reads (Super I/O config keys,
+  logical-device select, bank select), under the documented mutex
+  conventions with bounded timeouts.
+- Decoders are pure functions with dump fixtures, per
+  `.github/instructions/rust.instructions.md` testing policy.
+- If you are exposed to prohibited content by accident, stop
+  immediately and report the contamination instead of continuing.

--- a/.claude/agents/sensor-spec-author.md
+++ b/.claude/agents/sensor-spec-author.md
@@ -1,0 +1,44 @@
+---
+name: sensor-spec-author
+description: Spec author ("dirty room") for sensor hardware specifications (#1635). Use when researching vendor datasheets and writing or revising fact-only spec documents under docs/specs/sensors/**. Never use this agent to write Rust sensor code.
+tools: Read, Grep, Glob, Edit, Write, Bash, WebFetch, WebSearch
+---
+
+You are the spec author ("dirty room") for HardwareVisualizer's
+sensor specifications (issue #1635). You research primary sources and
+produce fact-only spec documents under `docs/specs/sensors/**`.
+Binding rules: `docs/specs/sensors/README.md` and
+`.github/instructions/clean-room-sensors.instructions.md`.
+
+Source hierarchy:
+
+- Normative facts come ONLY from vendor datasheets and manuals
+  (Intel SDM, AMD PPR, Nuvoton/ITE datasheets), public hardware
+  specifications, upstream-published interface definitions of APIs
+  this project calls (PawnIO), or independently collected hardware
+  dumps.
+- MPL/GPL/LGPL implementations (LibreHardwareMonitor, Linux hwmon,
+  lm-sensors, …) are non-normative leads only: they may tell you
+  where to look, never what to write. List them in the Sources table
+  marked non-normative; no fact may rest solely on them. A quirk
+  known only from a copyleft implementation goes in Open questions
+  until independently verified.
+
+Hard rules for output:
+
+- No code excerpts, no code structure, and no identifier names taken
+  from copyrighted implementations may appear in spec documents.
+  Public API names required for interoperability (e.g. PawnIO
+  `ioctl_*` function names) are interface facts and are allowed.
+- Every fact or fact group carries a source note; pin section/page
+  where possible, otherwise add `TODO(provenance)`.
+- Uncertainty goes in the document's Open questions section, never in
+  the fact tables.
+- Start new documents from `docs/specs/sensors/spec-template.md`;
+  keep `Status: Draft — not implementation-ready` while any
+  `TODO(provenance)` remains; bump the revision number and history
+  table on every fact change.
+
+You write documentation only. Never write or edit Rust sensor
+implementation code in this role — that is the clean-room
+implementer's job, working from your documents.

--- a/.claude/agents/sensor-spec-author.md
+++ b/.claude/agents/sensor-spec-author.md
@@ -37,7 +37,9 @@ Hard rules for output:
 - Start new documents from `docs/specs/sensors/spec-template.md`;
   keep `Status: Draft — not implementation-ready` while any
   `TODO(provenance)` remains; bump the revision number and history
-  table on every fact change.
+  table on every fact change. The flip to
+  `Implementation-ready (rev N)` goes through the status-transition
+  checklist in the specs README and requires maintainer approval.
 
 You write documentation only. Never write or edit Rust sensor
 implementation code in this role — that is the clean-room

--- a/.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md
@@ -35,9 +35,10 @@ No other external sensor documentation was used.
 
 - [ ] This implementation references only `docs/specs/sensors/**` (at
       the revisions pinned above) and this repository.
-- [ ] Every spec document pinned above is implementation-ready (no
-      unresolved `TODO(provenance)` markers; status is not
-      `Draft — not implementation-ready`).
+- [ ] Every spec document pinned above carries
+      `Status: Implementation-ready (rev N)` at the pinned revision
+      and has no unresolved `TODO(provenance)` markers (see "Status
+      transition" in `docs/specs/sensors/README.md`).
 - [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
       Linux kernel, lm-sensors, or any decompiled monitoring tool
       while writing this implementation (full prohibited-source list:

--- a/.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md
@@ -1,0 +1,80 @@
+<!--
+Template for clean-room sensor implementation PRs (#1635).
+Rules: .github/instructions/clean-room-sensors.instructions.md
+Process: docs/specs/sensors/README.md
+-->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related Issues
+
+<!-- e.g., Relates to #1635 plus the phase child issue -->
+
+## Type of Change
+
+- [ ] Bug fix (`fix/` branch)
+- [x] New feature (`feat/` branch)
+- [ ] Refactoring (`refactor/` branch)
+- [ ] Documentation (`docs/` branch)
+- [ ] Dependencies update
+- [ ] Other (`chore/` branch)
+
+## Clean-room provenance
+
+<!-- Pin EVERY spec document consulted. One line per document. -->
+
+```text
+Implemented from docs/specs/sensors/<doc>.md revision <N> (commit <sha>).
+Implemented from docs/specs/sensors/<doc>.md revision <N> (commit <sha>).
+No other external sensor documentation was used.
+```
+
+### Implementer attestation
+
+- [ ] This implementation references only `docs/specs/sensors/**` (at
+      the revisions pinned above) and this repository.
+- [ ] Every spec document pinned above is implementation-ready (no
+      unresolved `TODO(provenance)` markers; status is not
+      `Draft — not implementation-ready`).
+- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
+      Linux kernel, lm-sensors, or any decompiled monitoring tool
+      while writing this implementation (full prohibited-source list:
+      `.github/instructions/clean-room-sensors.instructions.md`).
+- [ ] Register access added by this PR is read-only; the only writes
+      are those the pinned specs document as required for reads
+      (e.g. Super I/O config keys, bank select), and the ecosystem
+      mutex conventions are honored.
+
+### Reviewer attestation
+
+Reviewers: copy the checklist below into your approval review
+comment, with both boxes checked. Do not approve without it.
+
+```markdown
+- [ ] I reviewed this implementation only against
+      `docs/specs/sensors/**`, this repository, and the pinned spec
+      revision.
+- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
+      Linux kernel, lm-sensors, or decompiled monitoring tools while
+      reviewing this implementation.
+```
+
+## Screenshots / Videos
+
+<!-- If applicable, add screenshots or videos to demonstrate the changes -->
+
+## Test Plan
+
+<!-- Pure-function decoders with dump fixtures per the repo testing policy -->
+
+- [ ] Manual testing
+- [ ] Unit tests
+
+## Checklist
+
+- [ ] Self-reviewed the code
+- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
+- [ ] Tests pass (`npm test` / `cargo tauri-test`)
+- [ ] No new warnings or errors

--- a/.github/instructions/clean-room-sensors.instructions.md
+++ b/.github/instructions/clean-room-sensors.instructions.md
@@ -101,8 +101,11 @@ No PR may be opened or reviewed as clean-room implementation work
 unless all of the following hold (the "implementation gate" of
 `docs/specs/sensors/README.md`):
 
-1. Every consulted spec document is implementation-ready (no
-   unresolved `TODO(provenance)` markers).
+1. Every consulted spec document is implementation-ready: it carries
+   `Status: Implementation-ready (rev N)` at the pinned revision and
+   has no unresolved `TODO(provenance)` markers. The flip from draft
+   follows the status-transition checklist in
+   `docs/specs/sensors/README.md`.
 2. The PR uses the clean-room PR template
    (`.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md`,
    append `?template=clean-room-sensor-implementation.md&expand=1` to the

--- a/.github/instructions/clean-room-sensors.instructions.md
+++ b/.github/instructions/clean-room-sensors.instructions.md
@@ -1,0 +1,123 @@
+# Clean-room rules for PawnIO sensor work (HardwareVisualizer)
+
+These instructions enforce the clean-room (Chinese wall) process of
+issue #1635 for native CPU / Super I/O sensor monitoring via PawnIO.
+The canonical process description lives in
+[`docs/specs/sensors/README.md`](../../docs/specs/sensors/README.md);
+this file is the AI-facing enforcement summary and the committed
+**prohibited-source list**.
+
+Scope: any work on sensor specs under `docs/specs/sensors/**` and any
+Rust implementation of CPU / Super I/O sensor access (MSR, SMN,
+LPC/ISA port I/O, PawnIO client code).
+
+## Roles
+
+There are two strictly separated roles. A single session/agent must
+act in exactly one role. When writing or reviewing Rust sensor code,
+the **implementer** rules apply by default.
+
+| Role | Purpose |
+| --- | --- |
+| Spec author ("dirty room") | Produces fact-only spec documents under `docs/specs/sensors/**` from primary sources |
+| Implementer ("clean room") | Writes Rust strictly from those spec documents plus this repository |
+
+## Prohibited sources (implementer role)
+
+The implementer (and reviewers of implementation PRs) must NOT read,
+fetch, clone, search for, quote, or otherwise consult:
+
+- LibreHardwareMonitor / LibreHardwareMonitorLib (MPL-2.0)
+- OpenHardwareMonitor (MPL-2.0)
+- Linux kernel sources — in particular `drivers/hwmon/**`
+  (`k10temp`, `coretemp`, `nct6775`, `it87`, …) and `arch/x86`
+  MSR/SMN helpers (GPL-2.0)
+- lm-sensors / `sensors-detect` (GPL-2.0 / LGPL-2.1)
+- Any decompiled or disassembled monitoring tool (HWiNFO, AIDA64,
+  CAM, Open Hardware Monitor forks, …)
+- Forks, mirrors, vendored copies, patches, blog posts, gists, Q&A
+  answers, or AI summaries that reproduce code or code structure from
+  any of the above
+
+This applies to every channel: web search, web fetch, `git clone`,
+`curl`/`wget`, package contents, local checkouts, screenshots, and
+content pasted into the conversation by anyone other than the
+maintainer explicitly taking spec-author responsibility.
+
+## Allowed inputs (implementer role)
+
+- `docs/specs/sensors/**` at pinned revisions whose status is **not**
+  `Draft — not implementation-ready`
+- This repository (code, docs, issues, PRs)
+- General language/platform documentation that is not a sensor
+  monitoring implementation: Rust std/crate docs, Microsoft Windows
+  API documentation, `PawnIOLib.h` from an installed PawnIO release
+  (upstream-published API of the driver this project calls)
+
+If required information is missing from the specs, **stop and hand
+the question to the spec-author role** (file it as an Open question /
+spec revision request). Never fill spec gaps by consulting other
+sensor implementations.
+
+## Tool restrictions (implementer sessions)
+
+- Do not use web search / web fetch tools at all.
+- Do not use shell commands to fetch or clone anything from the
+  prohibited-source list (no `git clone`, `curl`, `wget` of those
+  projects). Dependency management (`cargo`/`npm` against their
+  default registries) is allowed.
+- Prefer running implementation work under the dedicated agent
+  definition `.claude/agents/sensor-clean-room-implementer.md`, whose
+  toolset omits web access.
+
+## Spec-author role (summary)
+
+Full rules: `docs/specs/sensors/README.md`. In short: vendor
+datasheets / public hardware specifications / independently collected
+dumps are the primary sources; MPL/GPL/LGPL implementations are
+**non-normative leads only** and may never be the sole basis of a
+normative fact; no code excerpts, structure, or identifiers from
+copyrighted implementations may enter the spec documents; every fact
+carries provenance. Use
+`.claude/agents/sensor-spec-author.md` for this role.
+
+## License policy
+
+- All new sensor code in this repository is MIT, produced clean-room
+  from the spec documents.
+- Translating or porting MPL/GPL/LGPL implementation code is
+  prohibited (carrying ported files under file-level MPL-2.0 was
+  considered and rejected in #1635).
+- PawnIO is GPL-2.0 with an exception for independent programs
+  communicating through its device IO control interface; the modules
+  are LGPL-2.1-or-later. Calling them via IOCTLs keeps this
+  repository MIT. Redistributing module blobs with an installer
+  requires third-party-notice compliance (see
+  `docs/specs/sensors/pawnio-interface.md`).
+
+## Implementation PR requirements
+
+No PR may be opened or reviewed as clean-room implementation work
+unless all of the following hold (the "implementation gate" of
+`docs/specs/sensors/README.md`):
+
+1. Every consulted spec document is implementation-ready (no
+   unresolved `TODO(provenance)` markers).
+2. The PR uses the clean-room PR template
+   (`.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md`,
+   append `?template=clean-room-sensor-implementation.md&expand=1` to the
+   compare URL) and completes:
+   - the spec **revision pinning** statement,
+   - the implementer **provenance attestation**,
+   - the reviewer **attestation** (reviewers copy the checklist into
+     their approval review comment).
+
+## Contamination handling
+
+If a prohibited source is viewed by accident in an implementer
+session (mis-click, search result, pasted content):
+
+1. Stop implementation work in that session immediately.
+2. Disclose the exposure in the PR or issue (what was seen, when).
+3. The contaminated session/contributor must not write or review the
+   affected implementation code; restart that work cleanly.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+<!--
+Clean-room sensor implementation PRs (#1635) must use the dedicated
+template instead: append
+?template=clean-room-sensor-implementation.md&expand=1 to the compare
+URL. See .github/instructions/clean-room-sensors.instructions.md
+-->
+
 ## Summary
 
 <!-- What does this PR do and why? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,4 @@ Read and follow these project-specific instruction files:
 - `.github/copilot-instructions.md` — Project overview, architecture, dev workflows, conventions
 - `.github/instructions/rust.instructions.md` — Rust coding rules (macro imports, platform-conditional code, testing)
 - `.github/instructions/documentation.instructions.md` — Documentation update rules
+- `.github/instructions/clean-room-sensors.instructions.md` — Clean-room rules for PawnIO sensor work (#1635): prohibited sources, roles, tool restrictions, PR requirements. MANDATORY before touching `docs/specs/sensors/**` or any CPU / Super I/O sensor implementation.

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -112,6 +112,37 @@ resolved and the Phase 0 guardrails are merged.
   approval review comment. The implementation PR template carries the
   checklist as a reminder of this requirement.
 
+## Status transition: Draft → Implementation-ready
+
+A document becomes a valid clean-room input only through this
+transition. The flip is proposed by the spec-author role and approved
+by a maintainer; the sign-off is the maintainer's approval of the PR
+that performs the flip.
+
+Checklist for the flipping PR (all items required):
+
+- [ ] Every `TODO(provenance)` marker is resolved: each affected fact
+      is pinned to a primary-source section/page, or independently
+      verified (e.g. against a hardware dump referenced by the
+      document).
+- [ ] Every entry under **Open questions** is either resolved (moved
+      into the fact tables with provenance) or explicitly marked
+      `non-blocking for <phase>` with a one-line justification kept in
+      the section.
+- [ ] No normative fact rests solely on a copyleft source (re-check
+      the notes column of the Sources table).
+- [ ] Scoped-enablement tables (e.g. the AMD per-family enablement
+      table) are consistent with the verification state of each row.
+- [ ] The revision number is bumped, the revision history records the
+      transition, and the Status field is set to
+      **`Implementation-ready (rev N)`** — this is the canonical
+      ready value that implementer and reviewer attestations check
+      for.
+
+Implementers and reviewers verify readiness by checking the Status
+field at the pinned revision; any remaining `TODO(provenance)` marker
+or unresolved blocking open question invalidates the flip.
+
 ## Current documents
 
 | Document | Covers | Issue phase |

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -126,13 +126,28 @@ Checklist for the flipping PR (all items required):
       verified (e.g. against a hardware dump referenced by the
       document).
 - [ ] Every entry under **Open questions** is either resolved (moved
-      into the fact tables with provenance) or explicitly marked
-      `non-blocking for <phase>` with a one-line justification kept in
-      the section.
+      into the fact tables with provenance) or explicitly annotated
+      in place, as the first line of the entry, using exactly this
+      form:
+
+      ```text
+      Non-blocking for <phase>: <one-line justification>.
+      ```
+
+      Example: `Non-blocking for Phase 1: package readout does not
+      depend on this; only per-core readings would.` The phase name
+      and justification stay in the Open questions section.
 - [ ] No normative fact rests solely on a copyleft source (re-check
       the notes column of the Sources table).
-- [ ] Scoped-enablement tables (e.g. the AMD per-family enablement
-      table) are consistent with the verification state of each row.
+- [ ] Scoped-enablement tables are consistent with the verification
+      state of each row. A *scoped-enablement table* is the pattern
+      for documents that are ready overall while specific hardware
+      scopes are not: a table in the **Detection** section with
+      columns `Scope` (e.g. CPU family or chip model), `Status` (what
+      verified the row, with source tag), and `Default enablement`
+      (enabled, or disabled until a named verification happens). The
+      per-family table in [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md)
+      is the reference example.
 - [ ] The revision number is bumped, the revision history records the
       transition, and the Status field is set to
       **`Implementation-ready (rev N)`** — this is the canonical

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -88,8 +88,8 @@ resolved and the Phase 0 guardrails are merged.
     attestation, and the reviewer attestation below — satisfied by
     [`clean-room-sensor-implementation.md`](../../../.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md)
   - dedicated role agents with tool restrictions exist — satisfied by
-    `.claude/agents/sensor-spec-author.md` and
-    `.claude/agents/sensor-clean-room-implementer.md` (the
+    [`.claude/agents/sensor-spec-author.md`](../../../.claude/agents/sensor-spec-author.md) and
+    [`.claude/agents/sensor-clean-room-implementer.md`](../../../.claude/agents/sensor-clean-room-implementer.md) (the
     implementer agent has no web tools)
 
   The artifacts above satisfy the gate's existence requirements;

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -78,11 +78,23 @@ resolved and the Phase 0 guardrails are merged.
   hardware dumps).
 - No implementation PR may be opened or reviewed as clean-room work
   until all of the following Phase 0 guardrails exist:
-  - `.github/instructions/` contains the prohibited-source list
-  - `CLAUDE.md` references the clean-room implementer restrictions
-  - the PR template requires spec revision pinning
-  - the PR template requires a provenance attestation
-  - the PR template requires the reviewer attestation below
+  - `.github/instructions/` contains the prohibited-source list —
+    satisfied by
+    [`clean-room-sensors.instructions.md`](../../../.github/instructions/clean-room-sensors.instructions.md)
+  - `CLAUDE.md` references the clean-room implementer restrictions —
+    satisfied by the instruction-file entry in
+    [`CLAUDE.md`](../../../CLAUDE.md)
+  - the PR template requires spec revision pinning, a provenance
+    attestation, and the reviewer attestation below — satisfied by
+    [`clean-room-sensor-implementation.md`](../../../.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md)
+  - dedicated role agents with tool restrictions exist — satisfied by
+    `.claude/agents/sensor-spec-author.md` and
+    `.claude/agents/sensor-clean-room-implementer.md` (the
+    implementer agent has no web tools)
+
+  The artifacts above satisfy the gate's existence requirements;
+  per-document readiness (`TODO(provenance)` resolution) still gates
+  each individual spec.
 - Reviewer contamination policy: reviewers can also breach the
   clean-room boundary. Implementation PR reviews must include this
   attestation:

--- a/docs/specs/sensors/spec-template.md
+++ b/docs/specs/sensors/spec-template.md
@@ -15,8 +15,10 @@ Rules: docs/specs/sensors/README.md
 
 <!--
 Status stays "Draft — not implementation-ready" while any
-TODO(provenance) marker is unresolved. See README.md "Document status
-and implementation gate".
+TODO(provenance) marker is unresolved. It flips to
+"Implementation-ready (rev N)" only via the status-transition
+checklist in README.md ("Status transition: Draft →
+Implementation-ready").
 -->
 
 ## Sources

--- a/docs/specs/sensors/spec-template.md
+++ b/docs/specs/sensors/spec-template.md
@@ -43,6 +43,10 @@ possible; otherwise add TODO(provenance).
 <!--
 How an implementation decides this document applies: CPUID checks,
 chip ID registers, presence probes. Each fact tagged with a source ID.
+If parts of the hardware scope are unverified while the rest of the
+document is ready, add a scoped-enablement table here (columns:
+Scope, Status, Default enablement) following the per-family example
+in cpu-amd-zen-smn.md.
 -->
 
 ## Register map (facts)
@@ -83,6 +87,10 @@ and what must never be written.
 <!--
 Anything not yet verified against a primary source, with what evidence
 exists so far. Implementers must treat these as unresolved.
+At status-flip time every entry must be resolved or annotated as its
+first line with exactly:
+  Non-blocking for <phase>: <one-line justification>.
+(see README.md "Status transition: Draft → Implementation-ready").
 -->
 
 ## Revision history


### PR DESCRIPTION
## Summary

Adds the **Phase 0 clean-room guardrail artifacts** required by the implementation gate in `docs/specs/sensors/README.md` (merged in #1636). With this PR, every gate requirement for starting clean-room PawnIO sensor implementation work (#1635) is satisfied — except per-document spec readiness (`TODO(provenance)` resolution), which remains a separate prerequisite per spec.

| Artifact | Purpose |
| --- | --- |
| `.github/instructions/clean-room-sensors.instructions.md` | AI-facing enforcement file: committed **prohibited-source list** (LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel hwmon, lm-sensors, decompiled tools, and any mirrors/excerpts), role separation (spec author vs implementer), allowed inputs, tool restrictions, license policy, implementation-PR requirements, and **contamination handling** procedure |
| `CLAUDE.md` | References the new instruction file as mandatory reading before touching `docs/specs/sensors/**` or sensor implementation code |
| `.github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md` | Dedicated implementation-PR template: spec **revision pinning** block, **implementer provenance attestation** (specs-only references, implementation-ready specs, read-only register access), and the **reviewer attestation** block reviewers copy into their approval comment |
| `.github/pull_request_template.md` | Pointer comment directing clean-room implementation PRs to the dedicated template (`?template=clean-room-sensor-implementation.md`) |
| `.claude/agents/sensor-spec-author.md` | "Dirty room" role agent: datasheet research, fact-only spec authoring; web tools allowed; never writes Rust sensor code |
| `.claude/agents/sensor-clean-room-implementer.md` | "Clean room" role agent: implements only from pinned, implementation-ready specs; **toolset omits WebFetch/WebSearch**; Bash fetching/cloning of prohibited sources forbidden; stops and routes spec gaps to the spec-author role |
| `docs/specs/sensors/README.md` | Implementation-gate bullets now link to the artifact satisfying each requirement, keeping the gate auditable |

### Notes

- Policy content mirrors what was reviewed and merged in #1636 (copyleft sources as non-normative leads only, draft-spec gating, reviewer contamination policy); this PR adds the enforcement artifacts the gate said must exist.
- The agent `tools:` allowlist removes web access from the implementer by construction; the instruction file additionally bans network fetching of prohibited sources via Bash (dependency registries excluded).
- This PR contains no implementation code. Implementation still cannot start until the Phase 1 specs drop their `Draft — not implementation-ready` status (provenance pinning).

## Related Issues

Refs #1635 (Phase 0 — Guardrails & process; spec template and safety policy were delivered in #1636)

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch) — process/guardrail artifacts (instructions, PR template, agent definitions)

## Screenshots / Videos

N/A (process artifacts only)

## Test Plan

- [x] Manual testing — verified rendered Markdown, relative links from `docs/specs/sensors/README.md` to the new artifacts, and that the template directory name (`.github/PULL_REQUEST_TEMPLATE/`) matches GitHub's multi-template convention
- [ ] Unit tests — N/A (no code changes)

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass — N/A (no `src/**` or Rust changes; Biome/cargo do not target these paths)
- [ ] Tests pass — N/A (no code changes)
- [x] No new warnings or errors

https://claude.ai/code/session_01R7Uxj8EFfCprg2pEqb6k6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7Uxj8EFfCprg2pEqb6k6y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added formal clean-room process for sensor work: separate spec-author and implementer roles, provenance rules, attestations, contamination handling, and explicit status-transition/implementation-readiness checklist.
  * Clarified spec template and README guidance on provenance markers, open‑question handling, scoped-enablement, and required artifacts for implementation readiness.
  * Added role-specific agent instruction documents to guide spec authors and implementers.

* **Chores**
  * Added/updated a dedicated clean-room PR template and project instructions enforcing prohibited sources, allowed inputs, attestations, and checklist requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->