### PR TITLE
docs(specs): flip Phase 1 sensor specs to Implementation-ready (rev 2) (#1635)

### DIFF
--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -66,9 +66,10 @@ in spec documents.
 
 ## Document status and implementation gate
 
-These documents are currently **draft specifications**. They are not
-implementation-ready clean-room inputs until all provenance TODOs are
-resolved and the Phase 0 guardrails are merged.
+Documents start as **draft specifications** and become valid
+clean-room inputs only through the status transition below (with the
+Phase 0 guardrails merged, as listed above). Per-document status is
+tracked in each document's header and in the Current documents table.
 
 - A document containing `TODO(provenance)` markers must carry
   `Status: Draft — not implementation-ready` and must not be used as
@@ -160,12 +161,12 @@ or unresolved blocking open question invalidates the flip.
 
 ## Current documents
 
-| Document | Covers | Issue phase |
-| --- | --- | --- |
-| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, licensing facts | Phase 1 |
-| [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 |
-| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 |
-| [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) |
+| Document | Covers | Issue phase | Status |
+| --- | --- | --- | --- |
+| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, licensing facts | Phase 1 | Implementation-ready (rev 2) |
+| [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
+| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 2) |
+| [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |
 
 Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) are
 **not yet written**; they are the Phase 3 / Phase 4 deliverables and

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -165,7 +165,7 @@ or unresolved blocking open question invalidates the flip.
 | --- | --- | --- | --- |
 | [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, licensing facts | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
-| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 2) |
+| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
 | [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |
 
 Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) are

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 1 |
-| Status | Draft — not implementation-ready |
+| Revision | 2 |
+| Status | Implementation-ready (rev 2) |
 | Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2) and Family 19h (Zen 3/Zen 4) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Family 1Ah (Zen 5) is recognized but disabled by default pending verification (see Detection). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -11,14 +11,14 @@
 
 | ID | Source | Notes |
 | --- | --- | --- |
-| S1 | AMD, *Processor Programming Reference (PPR) for AMD Family 17h Models 00h-0Fh Processors*, document no. 54945, register `SMU::THM::THM_TCON_CUR_TMP` | Primary |
-| S2 | AMD, *PPR for AMD Family 19h Model 01h, Revision B1 Processors*, document no. 55898 Vol 2 (same THM register) | Primary |
+| S1 | AMD, *PPR for AMD Family 19h Model 01h, Revision B1 Processors*, document no. **55898 Rev 0.50 (May 27, 2021), Vol 2, §10.3 Table 124** (p. 2-179): `SMU::THM::THM_TCON_CUR_TMP` at SMUTHM aperture `0005_9800h` | Primary; register, address, Tctl description |
+| S2 | AMD, *Open-Source Register Reference (OSRR) for AMD Family 17h*, **§4.2.1**: bits 31:21 current temperature; bit 19 clear → 0…225 °C, set → −49…206 °C. Verified via the verbatim citation carried in S8 | Primary (AMD document; quote carried by a non-copyleft source) |
 | S3 | AMD public statements on Tctl offsets: "AMD Ryzen™ Community Update #3" (R. Hallock, Apr 2017) and 2nd-gen Ryzen launch documentation | Primary for offsets |
 | S4 | Linux `k10temp` hwmon driver (GPL-2.0) | **Non-normative corroboration only.** No fact in this document relies solely on this source. No code, structure, identifiers, or tables were copied. |
-| S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls across the IOCTL boundary (allowed SMN windows, family gate, mutex). Not used as a source for any hardware register fact. No code was copied. |
-
-`TODO(provenance)`: pin PPR section/page numbers; the family 1Ah PPR
-reference still needs to be identified (see Open questions).
+| S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls across the IOCTL boundary (allowed SMN windows, family gate, caller-mutex `@warning` docs). Not used as a source for any hardware register fact. No code was copied. |
+| S6 | AMD, `asic_reg/thm/thm_9_0_sh_mask.h` (MIT, © 2017 AMD): `CUR_TEMP_MASK 0xFFE00000` (bits 31:21), `CUR_TEMP_RANGE_SEL_MASK 0x00080000` (bit 19), `CUR_TEMP_TJ_SEL` (bits 17:16), `CUR_TEMP_TJ_SLEW_SEL` (bit 18) | Primary; AMD-published, permissively licensed field masks |
+| S7 | PPR 55898 Vol 2 **§6.2.5–6.2.6 (SB-TSI)**: SB-TSI delivers Tctl encoded in 0.125 °C increments spanning 0–255.875 | Primary; scaling corroboration (11-bit × 0.125 °C = 255.875) |
+| S8 | FreeBSD `amdtemp(4)` driver, `sys/dev/amdtemp/amdtemp.c` (BSD-2-Clause) | Non-copyleft engineering source: carries the S2 OSRR quote, the `TJ_SEL` 49 °C note (attributed to an AMD-authored Linux patch), and CCD-register leads. Facts only; no code copied. |
 
 ## Detection
 
@@ -34,9 +34,9 @@ register facts are verified against a primary source:
 
 | Family | Status | Default enablement |
 | --- | --- | --- |
-| `0x17` | `THM_TCON_CUR_TMP` verified against AMD PPR (S1) | Enabled |
-| `0x19` | `THM_TCON_CUR_TMP` verified against AMD PPR (S2) | Enabled |
-| `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Disabled until PPR or hardware-dump verification |
+| `0x17` | Layout and ranges verified against AMD OSRR §4.2.1 (S2) and the AMD register header (S6) | Enabled |
+| `0x19` | Register, address, and Tctl description verified against PPR 55898 Vol 2 §10.3 (S1) | Enabled |
+| `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Disabled until PPR/OSRR or hardware-dump verification |
 
 ## Register map (facts)
 
@@ -47,19 +47,28 @@ register. See [`pawnio-interface.md`](pawnio-interface.md).
 
 | SMN address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 31:21 | `CUR_TEMP` — current reported temperature | 0.125 °C per LSB, unsigned 11-bit | S1, S2 |
-| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 19 | `CUR_TEMP_RANGE_SEL` — selects the reporting range | 0 → 0…225 °C; 1 → −49…206 °C | S1, S2 |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 31:21 | `CUR_TEMP` — "current control temperature (Tctl) after the slew-rate controls have been applied" | 0.125 °C per LSB, unsigned 11-bit | S1, S2, S6, S7 |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 19 | `CUR_TEMP_RANGE_SEL` — selects the reporting range | 0 → 0…225 °C; 1 → −49…206 °C | S2, S6 |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 17:16 | `CUR_TEMP_TJ_SEL` — `11b` marks `CUR_TEMP` as software-writable, and the 49 °C range adjustment then applies (see Quirks) | flag pair | S6 (bits); S8 (semantics) |
 
 Notes:
 
-- The same register address and layout are documented for Family 17h
-  (S1) and Family 19h (S2). Family 1Ah is not yet verified by this
-  spec and stays disabled by default — see Detection and Open
-  questions.
+- S1 defines the register at SMUTHM offset `0` with the SMUTHM
+  aperture at `0005_9800h`, i.e. absolute SMN address `0x00059800`,
+  and describes it as providing "the current control temperature
+  (Tctl) after the slew-rate controls have been applied".
+- The 0.125 °C/LSB scaling follows from S7: SB-TSI delivers the same
+  Tctl in 0.125 °C increments spanning 0–255.875, which is exactly
+  the unsigned 11-bit field range (2047 × 0.125 °C).
+- Layout verified for Family 17h via S2/S6 and for Family 19h via S1.
+  Family 1Ah is not yet verified by this spec and stays disabled by
+  default — see Detection and Open questions.
 - SMN is reached through an index/data register pair in the host
-  bridge PCI configuration space; the PawnIO module handles this and
-  serializes on the `Access_PCI` mutant. The client performs no raw
-  PCI configuration access. (S5)
+  bridge PCI configuration space; the PawnIO module performs that
+  access, and the **client must hold `Global\Access_PCI`** around
+  each call (caller-mutex requirement, S5; see
+  [`pawnio-interface.md`](pawnio-interface.md)). The client performs
+  no raw PCI configuration access.
 
 ## Read procedure and decode
 
@@ -69,7 +78,8 @@ Notes:
 3. Decoding rules (hardware semantics):
    - Extract `CUR_TEMP` from bits 31:21.
    - Tctl = `CUR_TEMP` × 0.125 °C.
-   - If `CUR_TEMP_RANGE_SEL` (bit 19) is 1, subtract 49 °C from Tctl.
+   - If `CUR_TEMP_RANGE_SEL` (bit 19) is 1, or `CUR_TEMP_TJ_SEL`
+     (bits 17:16) equals `11b`, subtract 49 °C from Tctl. (S2, S8)
    - Tdie = Tctl − the model's Tctl offset (table below); models not
      listed have offset 0, so Tdie equals Tctl.
 4. Publish Tdie as the CPU temperature. Plausibility gate (this
@@ -96,7 +106,12 @@ non-normative):
   numbers alone. (S3; corroborated by S4)
 - `CUR_TEMP_RANGE_SEL = 1` (the −49 °C range) is the normal case on
   many desktop parts; the decode in step 3 must always honor the bit
-  rather than assume either range. (S1)
+  rather than assume either range. (S2)
+- When `CUR_TEMP_TJ_SEL` (bits 17:16) reads `11b`, `CUR_TEMP` carries
+  a software-written value and the 49 °C adjustment applies even with
+  `RANGE_SEL` clear. S8 carries this as an engineering note
+  attributed to an AMD-authored Linux patch; Phase 2 dumps will
+  exercise it on real hardware.
 - A read returning all zeros indicates a failed SMN transaction rather
   than 0 °C (or −49 °C); treat as an invalid sample. (Project policy;
   consistent with the plausibility gate.)
@@ -106,30 +121,38 @@ non-normative):
 - Read-only: only `ioctl_read_smu_register` is used. The module's SMU
   write/command surfaces (`ioctl_write_smu_register`,
   `ioctl_send_smu_command`) are never invoked by this project.
-- PCI/SMN serialization relies on the module's `Access_PCI` mutant
-  handling; a single register read is one IOCTL, so no multi-call
-  client-side critical section is required for Tctl. (S5)
+- The module performs no locking itself; every SMU ioctl is
+  documented with a caller-must-hold warning for
+  `\BaseNamedObjects\Access_PCI`. The client therefore holds
+  `Global\Access_PCI` (bounded timeout; on timeout the sample is
+  skipped) around each `ioctl_read_smu_register` call. (S5)
 
 ## Future extensions (recorded, not yet specified)
 
-- Per-CCD temperature registers (`THM_DIE*_TEMP`) exist in the same
-  THM block; their addresses vary by model and need PPR verification
-  before a spec revision adds them.
+- Per-CCD temperature registers exist in the same THM block; their
+  addresses vary by model and need PPR/OSRR or dump verification
+  before a spec revision adds them. (S8 records
+  experimentally-derived bases `0x59954` (Zen 2) / `0x59b08` (Zen 4)
+  as non-normative leads.)
 - SMU PM-table reads (`ioctl_*_pm_table`) expose richer telemetry
   (per-core power, voltages) but are version-dependent; out of scope
   for Phase 1.
 
 ## Open questions
 
-- Family 1Ah (Zen 5): confirm `THM_TCON_CUR_TMP` address/layout from
-  an AMD PPR when available, or validate against a Phase 2 register
-  dump from real hardware before enabling by default.
-- Threadripper / EPYC multi-die parts: whether `0x59800` reports the
-  hottest die or a specific die needs verification on such hardware
-  (Phase 2 dumps).
+- Non-blocking for Phase 1: family 1Ah stays disabled by default via
+  the Detection enablement table. Confirm `THM_TCON_CUR_TMP`
+  address/layout from an AMD PPR/OSRR when available, or validate
+  against a Phase 2 register dump, before enabling it.
+- Non-blocking for Phase 1: the reported value is the package control
+  temperature that drives cooling policy regardless of die-selection
+  details, and Phase 1 targets single-die consumer parts. Whether
+  `0x59800` reports the hottest die or a specific die on
+  Threadripper / EPYC multi-die parts is verified via Phase 2 dumps.
 
 ## Revision history
 
 | Revision | Date | Change |
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
+| 2 | 2026-06-11 | Provenance pinned: PPR 55898 Vol 2 §10.3 (p. 2-179), AMD OSRR 17h §4.2.1, AMD MIT register header, SB-TSI scaling corroboration. Added `CUR_TEMP_TJ_SEL` field and decode rule. Corrected `Access_PCI` ownership to caller-held. Open questions resolved or annotated non-blocking. Status → Implementation-ready. |

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 2 |
-| Status | Implementation-ready (rev 2) |
+| Revision | 3 |
+| Status | Implementation-ready (rev 3) |
 | Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2) and Family 19h (Zen 3/Zen 4) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Family 1Ah (Zen 5) is recognized but disabled by default pending verification (see Detection). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -12,13 +12,13 @@
 | ID | Source | Notes |
 | --- | --- | --- |
 | S1 | AMD, *PPR for AMD Family 19h Model 01h, Revision B1 Processors*, document no. **55898 Rev 0.50 (May 27, 2021), Vol 2, §10.3 Table 124** (p. 2-179): `SMU::THM::THM_TCON_CUR_TMP` at SMUTHM aperture `0005_9800h` | Primary; register, address, Tctl description |
-| S2 | AMD, *Open-Source Register Reference (OSRR) for AMD Family 17h*, **§4.2.1**: bits 31:21 current temperature; bit 19 clear → 0…225 °C, set → −49…206 °C. Verified via the verbatim citation carried in S8 | Primary (AMD document; quote carried by a non-copyleft source) |
+| S2 | AMD, *Open-Source Register Reference (OSRR) for AMD Family 17h Processors, Models 00h–2Fh*, document no. **56255 Rev 3.03 (July 2018), §4.2.1 "Registers" (p. 243)**: `SMUTHMx00000000 (SMU::THM::THM_TCON_CUR_TMP)`, `SMUTHM=0005_9800h`; bits 31:21 `CUR_TEMP` "Provides current control temperature"; bit 19 `CUR_TEMP_RANGE_SEL` "0=Report on 0C to 225C scale range. 1=Report on -49C to 206C scale range."; bits 18:0 Reserved | Primary; the AMD PDF was fetched (GitHub mirror) and text-verified directly during authoring |
 | S3 | AMD public statements on Tctl offsets: "AMD Ryzen™ Community Update #3" (R. Hallock, Apr 2017) and 2nd-gen Ryzen launch documentation | Primary for offsets |
 | S4 | Linux `k10temp` hwmon driver (GPL-2.0) | **Non-normative corroboration only.** No fact in this document relies solely on this source. No code, structure, identifiers, or tables were copied. |
 | S5 | PawnIO `RyzenSMU.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls across the IOCTL boundary (allowed SMN windows, family gate, caller-mutex `@warning` docs). Not used as a source for any hardware register fact. No code was copied. |
-| S6 | AMD, `asic_reg/thm/thm_9_0_sh_mask.h` (MIT, © 2017 AMD): `CUR_TEMP_MASK 0xFFE00000` (bits 31:21), `CUR_TEMP_RANGE_SEL_MASK 0x00080000` (bit 19), `CUR_TEMP_TJ_SEL` (bits 17:16), `CUR_TEMP_TJ_SLEW_SEL` (bit 18) | Primary; AMD-published, permissively licensed field masks |
+| S6 | AMD, `asic_reg/thm/thm_9_0_sh_mask.h` (MIT, © 2017 AMD): `CUR_TEMP_MASK 0xFFE00000` (bits 31:21), `CUR_TEMP_RANGE_SEL_MASK 0x00080000` (bit 19) | Primary; AMD-published, permissively licensed field masks, consistent with S2. The header (a GPU THM IP description) additionally defines `CUR_TEMP_TJ_SEL`/`TJ_SLEW_SEL` in bits 18:16, which the CPU OSRR (S2) marks Reserved — see Open questions |
 | S7 | PPR 55898 Vol 2 **§6.2.5–6.2.6 (SB-TSI)**: SB-TSI delivers Tctl encoded in 0.125 °C increments spanning 0–255.875 | Primary; scaling corroboration (11-bit × 0.125 °C = 255.875) |
-| S8 | FreeBSD `amdtemp(4)` driver, `sys/dev/amdtemp/amdtemp.c` (BSD-2-Clause) | Non-copyleft engineering source: carries the S2 OSRR quote, the `TJ_SEL` 49 °C note (attributed to an AMD-authored Linux patch), and CCD-register leads. Facts only; no code copied. |
+| S8 | FreeBSD `amdtemp(4)` driver, `sys/dev/amdtemp/amdtemp.c` (BSD-2-Clause) | **Non-normative engineering corroboration only** (non-copyleft): carries an OSRR quote (superseded by the direct S2 pin), a `TJ_SEL` 49 °C note attributed to an AMD-authored Linux patch (not adopted — see Open questions), and CCD-register leads. Facts only; no code copied. |
 
 ## Detection
 
@@ -34,7 +34,7 @@ register facts are verified against a primary source:
 
 | Family | Status | Default enablement |
 | --- | --- | --- |
-| `0x17` | Layout and ranges verified against AMD OSRR §4.2.1 (S2) and the AMD register header (S6) | Enabled |
+| `0x17` | Layout and ranges verified against the directly pinned AMD OSRR 56255 Rev 3.03 §4.2.1, p. 243 (S2) and the AMD register header (S6) | Enabled |
 | `0x19` | Register, address, and Tctl description verified against PPR 55898 Vol 2 §10.3 (S1) | Enabled |
 | `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Disabled until PPR/OSRR or hardware-dump verification |
 
@@ -47,9 +47,8 @@ register. See [`pawnio-interface.md`](pawnio-interface.md).
 
 | SMN address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 31:21 | `CUR_TEMP` — "current control temperature (Tctl) after the slew-rate controls have been applied" | 0.125 °C per LSB, unsigned 11-bit | S1, S2, S6, S7 |
-| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 19 | `CUR_TEMP_RANGE_SEL` — selects the reporting range | 0 → 0…225 °C; 1 → −49…206 °C | S2, S6 |
-| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 17:16 | `CUR_TEMP_TJ_SEL` — `11b` marks `CUR_TEMP` as software-writable, and the 49 °C range adjustment then applies (see Quirks) | flag pair | S6 (bits); S8 (semantics) |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 31:21 | `CUR_TEMP` — "Provides current control temperature" (S2); "the current control temperature (Tctl) after the slew-rate controls have been applied" (S1) | 0.125 °C per LSB, unsigned 11-bit | S1, S2, S6, S7 |
+| `0x00059800` | `SMU::THM::THM_TCON_CUR_TMP` | 19 | `CUR_TEMP_RANGE_SEL` — "0=Report on 0C to 225C scale range. 1=Report on -49C to 206C scale range." | range select | S2, S6 |
 
 Notes:
 
@@ -60,7 +59,11 @@ Notes:
 - The 0.125 °C/LSB scaling follows from S7: SB-TSI delivers the same
   Tctl in 0.125 °C increments spanning 0–255.875, which is exactly
   the unsigned 11-bit field range (2047 × 0.125 °C).
-- Layout verified for Family 17h via S2/S6 and for Family 19h via S1.
+- Layout verified for Family 17h via the directly pinned OSRR (S2)
+  plus S6, and for Family 19h via S1. The OSRR marks bits 18:0 (other
+  than the fields above, i.e. including 18:16) as **Reserved** on the
+  CPU THM; the `TJ_SEL` fields named in the GPU-IP header (S6) are
+  therefore not part of this spec's decode — see Open questions.
   Family 1Ah is not yet verified by this spec and stays disabled by
   default — see Detection and Open questions.
 - SMN is reached through an index/data register pair in the host
@@ -78,8 +81,8 @@ Notes:
 3. Decoding rules (hardware semantics):
    - Extract `CUR_TEMP` from bits 31:21.
    - Tctl = `CUR_TEMP` × 0.125 °C.
-   - If `CUR_TEMP_RANGE_SEL` (bit 19) is 1, or `CUR_TEMP_TJ_SEL`
-     (bits 17:16) equals `11b`, subtract 49 °C from Tctl. (S2, S8)
+   - If `CUR_TEMP_RANGE_SEL` (bit 19) is 1, subtract 49 °C from Tctl.
+     (S2)
    - Tdie = Tctl − the model's Tctl offset (table below); models not
      listed have offset 0, so Tdie equals Tctl.
 4. Publish Tdie as the CPU temperature. Plausibility gate (this
@@ -100,18 +103,13 @@ non-normative):
 | Ryzen Threadripper 1900X / 1920X / 1950X | 27 °C |
 | Ryzen 7 2700X | 10 °C |
 | Ryzen Threadripper 2920X / 2950X / 2970WX / 2990WX | 27 °C |
-| Products without a primary-source documented positive Tctl offset (incl. Zen 2 and newer) | 0 °C, subject to per-family verification before this document reaches implementation-ready status |
+| Products without a primary-source documented positive Tctl offset (incl. Zen 2 and newer) | 0 °C — no positive offset is documented in the primary sources for these products; deviations discovered later (e.g. via Phase 2 dumps) require a spec revision before adoption |
 
 - Offset matching is by product name (OPN), not by family/model
   numbers alone. (S3; corroborated by S4)
 - `CUR_TEMP_RANGE_SEL = 1` (the −49 °C range) is the normal case on
   many desktop parts; the decode in step 3 must always honor the bit
   rather than assume either range. (S2)
-- When `CUR_TEMP_TJ_SEL` (bits 17:16) reads `11b`, `CUR_TEMP` carries
-  a software-written value and the 49 °C adjustment applies even with
-  `RANGE_SEL` clear. S8 carries this as an engineering note
-  attributed to an AMD-authored Linux patch; Phase 2 dumps will
-  exercise it on real hardware.
 - A read returning all zeros indicates a failed SMN transaction rather
   than 0 °C (or −49 °C); treat as an invalid sample. (Project policy;
   consistent with the plausibility gate.)
@@ -140,6 +138,14 @@ non-normative):
 
 ## Open questions
 
+- Non-blocking for Phase 1: the decode ignores bits 18:16. The CPU
+  OSRR (S2) marks bits 18:0 other than `RANGE_SEL` as Reserved, while
+  the GPU-IP header (S6) names `TJ_SEL`/`TJ_SLEW_SEL` there and an S8
+  engineering note claims a 49 °C adjustment when `TJ_SEL` reads
+  `11b`. Without AMD primary documentation for the CPU THM, this is
+  not part of the Ready decode path; revisit only if Phase 2 dumps
+  show readings explained by it (then a spec revision may adopt it as
+  a future extension).
 - Non-blocking for Phase 1: family 1Ah stays disabled by default via
   the Detection enablement table. Confirm `THM_TCON_CUR_TMP`
   address/layout from an AMD PPR/OSRR when available, or validate
@@ -156,3 +162,4 @@ non-normative):
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Provenance pinned: PPR 55898 Vol 2 §10.3 (p. 2-179), AMD OSRR 17h §4.2.1, AMD MIT register header, SB-TSI scaling corroboration. Added `CUR_TEMP_TJ_SEL` field and decode rule. Corrected `Access_PCI` ownership to caller-held. Open questions resolved or annotated non-blocking. Status → Implementation-ready. |
+| 3 | 2026-06-11 | OSRR 56255 Rev 3.03 §4.2.1 (p. 243) fetched and pinned directly (GitHub mirror of the AMD PDF), replacing the FreeBSD-carried quote as the Family 17h primary; S8 demoted to non-normative corroboration. `TJ_SEL` removed from the register map and decode path (the CPU OSRR marks bits 18:0 Reserved) and recorded as a non-blocking open question. Fixed the contradictory zero-offset wording in the Tctl-offset table. Status remains Implementation-ready. |

--- a/docs/specs/sensors/cpu-intel-dts-msr.md
+++ b/docs/specs/sensors/cpu-intel-dts-msr.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 1 |
-| Status | Draft — not implementation-ready |
+| Revision | 2 |
+| Status | Implementation-ready (rev 2) |
 | Scope | Package (and per-core) temperature on Intel x86-64 CPUs using the architectural digital thermal sensor (DTS) MSRs. Covers Nehalem-and-newer Core/Xeon/Atom parts that expose `MSR_TEMPERATURE_TARGET`. Excludes: pre-Nehalem TjMax estimation, thermal interrupt configuration, RAPL. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -11,13 +11,16 @@
 
 | ID | Source | Notes |
 | --- | --- | --- |
-| S1 | Intel, *Intel® 64 and IA-32 Architectures Software Developer's Manual*, Volume 3B, chapter "Thermal Monitoring and Protection" (section "Reading the Digital Sensor"). Combined-volume order no. 325462. | Primary; semantics |
-| S2 | Intel SDM Volume 4, *Model-Specific Registers*, Table 2-2 (architectural MSRs) and per-model tables for `MSR_TEMPERATURE_TARGET`. Order no. 335592. | Primary; register layouts |
-| S3 | Intel SDM Volume 2, `CPUID` instruction reference (leaf `06H`). | Primary; feature detection |
+| S1 | Intel SDM, Volume 3B, **§14.8.5.2 "Reading the Digital Sensor"** (Figure 14-31, `IA32_THERM_STATUS` layout) and **§14.9 "Package Level Thermal Management"** (Figure 14-33, `IA32_PACKAGE_THERM_STATUS` layout) | Primary; semantics and layouts |
+| S2 | Intel SDM, Volume 4, **Table 2-2** (IA-32 architectural MSRs): rows `19CH` and `1B1H` (the `1B1H` row at p. Vol. 4 2-17 carries the `CPUID.06H:EAX[6]` gate and the §14.9 cross-reference); **Table 2-26**: row `1A2H` `MSR_TEMPERATURE_TARGET` | Primary; register rows |
+| S3 | Intel SDM, Volume 2A, `CPUID` instruction, **leaf `06H` "Thermal and Power Management Leaf"** (p. 3-217): "Bit 00: Digital temperature sensor is supported if set" | Primary; feature detection |
+| S4 | Intel, *12th Generation Intel® Core™ Processors Datasheet, Volume 1* (doc no. 655258), section "Adaptive Thermal Monitor" | Primary; 6-bit TCC Activation Offset variant (bits 29:24) on newer products |
 
-`TODO(provenance)`: pin SDM revision number and page numbers at
-implementation review time (the SDM is revised quarterly; field
-layouts cited here are stable architectural definitions).
+All SDM section/figure/table identifiers above were verified against
+the combined-volume revision **325462-075US (June 2021)**; identifiers
+can shift between revisions (e.g. §14.7.5.2 in rev -070 corresponds
+to §14.8.5.2 in -075US). The cited field layouts are stable
+architectural definitions.
 
 ## Detection
 
@@ -41,7 +44,7 @@ its read allow-list).
 | `0x19C` | `IA32_THERM_STATUS` | 31 | Reading Valid (1 = digital readout is valid) | flag | S2 |
 | `0x1B1` | `IA32_PACKAGE_THERM_STATUS` | 22:16 | Package Digital Readout: package temperature below package TCC activation | °C, unsigned | S2 |
 | `0x1A2` | `MSR_TEMPERATURE_TARGET` | 23:16 | Temperature Target: TCC activation temperature (commonly called TjMax) | °C | S2 |
-| `0x1A2` | `MSR_TEMPERATURE_TARGET` | 27:24 or 29:24 (model-dependent width) | TCC Activation Offset: lowers the throttle activation point below the Temperature Target | °C | S2 |
+| `0x1A2` | `MSR_TEMPERATURE_TARGET` | 27:24 (29:24 on newer products) | TCC Activation Offset (R/W): "a temperature offset in degrees C from the temperature target (bits 23:16); PROCHOT# will assert at the offset target temperature" | °C | S2, S4 |
 
 Notes:
 
@@ -50,9 +53,10 @@ Notes:
 - `IA32_PACKAGE_THERM_STATUS` is **package-scope**: any logical CPU of
   the package reads the same value. It has **no** Reading Valid bit.
   (S2)
-- The `TCC Activation Offset` field width differs between models
-  (4-bit on many client models, 6-bit on some); consult the SDM Vol. 4
-  row for each supported model before using it. (S2)
+- The `TCC Activation Offset` field is 4 bits (27:24) in the SDM
+  rev -075US model tables (S2); newer product datasheets document a
+  6-bit field at 29:24 (S4). The decode in this document never
+  consumes the field, so the width difference does not affect Phase 1.
 
 ## Read procedure and decode
 
@@ -89,14 +93,20 @@ Notes:
   an otherwise idle system indicate a stuck or failed sensor read and
   are worth surfacing in logs, but this spec does not require dropping
   them. (S1)
-- Whether the digital readout is referenced to `Temperature Target`
-  alone or to `Temperature Target − TCC Activation Offset` is not
-  explicitly stated by the SDM; common practice is to use bits 23:16
-  without subtracting the offset. Recorded as an open question. (S1,
-  S2)
+- TCC Activation Offset does not enter the temperature calculation:
+  S2 defines the offset as "a temperature offset in degrees C **from
+  the temperature target (bits 23:16)**; PROCHOT# will assert at the
+  offset target temperature" — i.e. bits 23:16 stay the fixed
+  reference and a programmed offset moves the throttle-assertion
+  point below it. The decode therefore always uses `t_target` =
+  bits 23:16. (S1, S2; empirical confirmation on offset-programmed
+  machines tracked under Open questions)
 - Multi-package systems: `0x1B1` must be read once per package, with
   the reading thread affinity-pinned to a core of each package. Phase
-  1 targets single-package consumer machines (package 0). (S2)
+  1 targets single-package consumer machines (package 0). PawnIO
+  executes `RDMSR` on the calling thread's current processor, so the
+  client's thread affinity selects the package — see
+  [`pawnio-interface.md`](pawnio-interface.md). (S2)
 
 ## Safety notes
 
@@ -107,19 +117,18 @@ Notes:
 
 ## Open questions
 
-- TCC Activation Offset interaction with the readout reference (see
-  Quirks). Resolution requires checking the SDM "Setting Thermal
-  Targets" subsection wording against an offset-programmed machine.
-- Which logical CPU PawnIO executes `RDMSR` on (tracked in
-  [`pawnio-interface.md`](pawnio-interface.md)); package-scope reads
-  make this moot for Phase 1 on single-package machines.
-- Hybrid (P/E-core) parts: per-core readouts differ per core type;
-  package readout is defined identically. Verify no additional
-  enumeration is needed beyond CPUID leaf `06H` on a hybrid test
-  machine.
+- Non-blocking for Phase 1: the decode uses `t_target` = bits 23:16
+  per the resolved Quirks entry; empirical behavior on machines with
+  a nonzero programmed TCC Activation Offset is additionally
+  confirmed via Phase 2 dumps.
+- Non-blocking for Phase 1: only the package-scope readout (`0x1B1`)
+  is used, and it is architecturally identical on hybrid (P/E-core)
+  parts; per-core readings are out of scope. Verify per-core-type
+  behavior before any later per-core phase.
 
 ## Revision history
 
 | Revision | Date | Change |
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
+| 2 | 2026-06-11 | Provenance pinned to SDM 325462-075US (June 2021): §14.8.5.2/§14.9, Table 2-2 rows 19CH/1B1H, Table 2-26 row 1A2H, Vol 2A leaf 06H. TCC-offset readout-reference question resolved (offset moves PROCHOT only); RDMSR execution-context question resolved via PawnIO facts. Remaining open questions annotated non-blocking. Status → Implementation-ready. |

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 1 |
-| Status | Draft — not implementation-ready |
+| Revision | 2 |
+| Status | Implementation-ready (rev 2) |
 | Scope | Facts needed to integrate a Rust user-mode client with PawnIO: installation/detection, the PawnIOLib API, the module execution model, and the IOCTL contracts of the `IntelMSR`, `RyzenSMU`, and `LpcIO` modules. Excludes: writing new Pawn modules, driver internals. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -15,7 +15,9 @@
 | S2 | namazso, *PawnIO.Modules* repository, <https://github.com/namazso/PawnIO.Modules> | Primary; module list, license |
 | S3 | PawnIO.Modules wiki, "Using PawnIO Modules", <https://github.com/namazso/PawnIO.Modules/wiki/Using-PawnIO-Modules> | Primary; user-mode API |
 | S4 | PawnIO.Modules wiki, "Getting started with PawnIO", <https://github.com/namazso/PawnIO.Modules/wiki/Getting-started-with-PawnIO> | Primary; toolchain, signing |
-| S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Upstream-published interface definitions of the API this project calls across the IOCTL boundary (public `ioctl_*` contracts, allow-lists, mutex names); the PawnIO project is the authoritative source for its own interfaces. Not used as a source for any hardware register fact. No code was copied. |
+| S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Upstream-published interface definitions of the API this project calls across the IOCTL boundary (public `ioctl_*` contracts, allow-lists, caller-mutex `@warning` docs); the PawnIO project is the authoritative source for its own interfaces. Not used as a source for any hardware register fact. No code was copied. |
+| S6 | `PawnIOLib/include/PawnIOLib.h` in S1 (LGPL-2.1-or-later, © 2026 namazso) | Primary; exact user-mode API prototypes and doc comments |
+| S7 | PawnIO driver source in S1 (GPL-2.0 with IOCTL exception): `PawnIO/src/natives_impl_windows.cpp`, `PawnIO/include/pawnio_um.h` | Native semantics (execution context of `msr_read`, affinity natives) and device path. Interface facts only; no code was copied. |
 
 ## Licensing facts
 
@@ -24,6 +26,10 @@
   communicate "through the device IO control interface", and with
   LGPL code. A user-mode client that only talks to the driver via
   IOCTLs is such an independent module. (S1)
+- **PawnIOLib** (the user-mode library/DLL) is **LGPL-2.1-or-later**
+  (S6). The client loads the system-installed DLL dynamically and
+  ships none of its code, so MIT licensing of this repository is
+  unaffected.
 - The modules in PawnIO.Modules are **LGPL-2.1-or-later**. Our client
   invokes them through the driver's IOCTL interface and ships none of
   their code, so MIT licensing of this repository's code is unaffected.
@@ -47,38 +53,53 @@
   driver plus Windows test-signing mode. An end-user deployment
   therefore uses the signed driver with the signed module blobs
   released by the PawnIO project. (S4)
+- Compiled module blobs are named `<Module>.amx` (e.g. `IntelMSR.amx`,
+  `RyzenSMU.amx`); the PawnIO.Modules CI publishes `*.amx` artifacts
+  per release. The client bundles the blobs it needs and loads them
+  via `pawnio_load`. (S2)
 - Absence of PawnIO is a supported state: the client must detect the
   missing library/driver and report "unavailable" so the caller can
   fall back to the ACPI thermal-zone source (PR #1633).
 
 ## PawnIOLib user-mode API
 
-Facts from S3. The normative reference for exact prototypes is
-`PawnIOLib.h` shipped in the PawnIO installation directory
-(`TODO(provenance)`: pin exact signatures from the installed header
-during implementation).
+Prototypes and semantics verified against `PawnIOLib.h` (S6). Every
+function exists in three variants: HRESULT (`pawnio_*`), Win32 BOOL
+(`pawnio_*_win32`), and NTSTATUS (`pawnio_*_nt`); the HRESULT forms
+are listed here.
 
+```c
+HRESULT pawnio_version(PULONG version);
+  // version = (major << 16) | (minor << 8) | patch
+HRESULT pawnio_open(PHANDLE handle);      // open an executor
+HRESULT pawnio_load(HANDLE handle, const UCHAR* blob, SIZE_T size);
+HRESULT pawnio_execute(HANDLE handle, PCSTR name,
+                       const ULONG64* in,  SIZE_T in_size,
+                       PULONG64 out,       SIZE_T out_size,
+                       PSIZE_T return_size);
+HRESULT pawnio_close(HANDLE handle);
+```
+
+- `in_size` / `out_size` are documented as "Input/Output buffer
+  count" and `return_size` as "Entries written" — i.e. counts of
+  64-bit `ULONG64` cells, not bytes. (S6)
+- Asynchronous variants exist (`pawnio_execute_async`,
+  `pawnio_execute_async_nt`, OVERLAPPED mandatory); this project uses
+  only the synchronous form. (S6)
 - The library is loaded dynamically and functions are resolved by
-  name (e.g. via `GetProcAddress`).
-- Call sequence:
-  1. `pawnio_open(&handle)` — obtain a handle to the driver.
-  2. `pawnio_load(handle, blob, blob_size)` — load a compiled module
-     blob (`.amx`) into that handle's context.
-  3. `pawnio_execute(handle, "ioctl_<name>", in_buf, in_count,
-     out_buf, out_count, &return_size)` — invoke a module function by
-     its string name with input/output buffers.
+  name (e.g. via `GetProcAddress`). (S3)
+- The driver device object is `\Device\PawnIO`
+  (`pawnio_um.h` `k_device_path`); clients normally reach it through
+  PawnIOLib rather than opening the device directly. (S7)
 - Module functions are addressed by **string name** following the
-  `ioctl_*` convention. (S3)
+  `ioctl_*` convention. (S3, S5)
 - Buffers are arrays of **64-bit cells**: PawnIO only supports a
-  64-bit cell size (modules are compiled with `-C64`). Sizes are given
-  in cells, not bytes. (S3, S4)
+  64-bit cell size (modules are compiled with `-C64`). (S3, S4, S6)
 - Functions return NTSTATUS-style status codes; module-level denials
   observed in the module sources use `STATUS_ACCESS_DENIED` /
   `STATUS_NOT_SUPPORTED`. (S5)
-- One handle holds one loaded module; use one handle per module.
-  (`TODO(provenance)`: confirm against `PawnIOLib.h` whether a handle
-  may reload a different blob; also confirm the close/cleanup function
-  name, expected to be `pawnio_close`.)
+- One handle holds one loaded module; this project uses one executor
+  handle per module (see Open questions for reload semantics).
 
 ## Module IOCTL contracts
 
@@ -97,8 +118,17 @@ Target: Intel x86-64 CPUs only; other vendors get
 
 - The read allow-list includes the thermal MSRs this project needs:
   `0x19C` (IA32_THERM_STATUS), `0x1B1` (IA32_PACKAGE_THERM_STATUS),
-  `0x1A2` (MSR_TEMPERATURE_TARGET). Reads of MSRs outside the
-  allow-list fail with `STATUS_ACCESS_DENIED`. (S5)
+  `0x1A2` (MSR_TEMPERATURE_TARGET) — verified in
+  `is_allowed_msr_read`. Reads of MSRs outside the allow-list fail
+  with `STATUS_ACCESS_DENIED`. `ioctl_read_msr` is declared with
+  exactly 1 input and 1 output cell. (S5)
+- **Execution context:** the driver's `msr_read` native executes
+  `__readmsr` on the calling thread's current processor and sets no
+  affinity; the `IntelMSR` module does not use the
+  `cpu_set_affinity` / `cpu_restore_affinity` natives either. The
+  CPU a read targets is therefore controlled by the user-mode
+  caller's thread affinity. Package-scope MSRs (`0x1B1`, `0x1A2`)
+  read identically from any logical CPU of the package. (S5, S7)
 - The write allow-list is small (power-limit / mailbox registers) and
   is irrelevant here; this project performs no MSR writes.
 
@@ -120,11 +150,14 @@ Target: AMD x86-64 CPUs, families `0x17`, `0x19`, `0x1A` only.
   [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md)). (S5)
 - Internally the module performs SMN access through an index/data
   register pair in the host bridge PCI configuration space (bus 0,
-  device 0, function 0); the client never performs raw PCI access
-  itself. (S5; informative internal detail, not a contract this
-  project depends on)
-- The module synchronizes several operations on the named kernel
-  mutant `\BaseNamedObjects\Access_PCI`. (S5)
+  device 0, function 0; named constants `SMU_PCI_ADDR_REG`/`..DATA..`
+  = `0xC4`/`0xC8`); the client never performs raw PCI access itself.
+  (S5; informative internal detail, not a contract this project
+  depends on)
+- **The module does not acquire any mutex itself.** Each SMU ioctl is
+  documented with: "You should acquire the
+  `\BaseNamedObjects\Access_PCI` mutant before calling this" — i.e.
+  the **caller** must hold it. (S5)
 
 ### `LpcIO`
 
@@ -143,9 +176,10 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
 - Port access is restricted to the selected configuration register
   pair and BAR ranges discovered by `ioctl_find_bars` (clamped to
   8-byte-aligned windows). (S5)
-- The module takes the named kernel mutant
-  `\BaseNamedObjects\Access_ISABUS.HTP.Method` around its operations.
-  (S5)
+- **The module does not acquire any mutex itself.** Each port/config
+  ioctl is documented with: "You should acquire the
+  `\BaseNamedObjects\Access_ISABUS.HTP.Method` mutant before calling
+  this" — i.e. the **caller** must hold it. (S5)
 
 ## Mutex conventions
 
@@ -154,31 +188,32 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
   conventions are therefore:
   - **ISA / Super I/O:** `Global\Access_ISABUS.HTP.Method`
   - **PCI / SMN:** `Global\Access_PCI`
-- The modules acquire these mutants **per IOCTL call** (S5). A Super
-  I/O read transaction spans many IOCTLs (enter config mode, select
-  bank, read index/data, exit), so per-call locking alone cannot keep
-  the transaction atomic. The client must additionally hold the
-  corresponding `Global\…` mutex in user mode for the whole multi-step
-  transaction, matching the behavior of HWiNFO / LibreHardwareMonitor /
-  FanControl. (Convention; issue #1635)
+- The modules do **not** acquire these mutants; every relevant ioctl
+  documents that the caller must hold the mutant before calling (S5).
+  The user-mode client therefore holds `Global\Access_PCI` around
+  each `RyzenSMU` call, and `Global\Access_ISABUS.HTP.Method` across
+  each Super I/O transaction — which spans many IOCTLs (enter config
+  mode, select bank, read index/data, exit) and must be held for the
+  whole multi-step sequence, matching the behavior of HWiNFO /
+  LibreHardwareMonitor / FanControl. (S5; convention per issue #1635)
 - Mutex acquisition must use a bounded timeout and treat timeout as a
   failed (skipped) sample, never as permission to proceed unlocked.
 
 ## Open questions
 
-- On which logical CPU does `IntelMSR::ioctl_read_msr` execute the
-  read? Expected: the calling thread's current processor, making
-  per-core readings controllable via thread affinity. Phase 1 only
-  needs the package-scope MSR (any core of the package), but this must
-  be verified before adding per-core readings.
-- Exact `PawnIOLib.h` prototypes (including the close function and
-  version query) need to be pinned from an installed copy.
-- Module blob file names and installed locations of the signed module
-  releases (needed for installer integration) need to be confirmed
-  from a PawnIO release package.
+- Non-blocking for Phase 1: the client uses one executor handle per
+  module and never reloads a different blob on the same handle.
+  Whether `pawnio_load` may be called twice on one handle is not
+  documented upstream (S6); resolve only if a future phase needs it.
+- Non-blocking for Phase 1: the client ships and loads its own copies
+  of the required `.amx` blobs via `pawnio_load`, so the official
+  installer's module-directory layout does not affect Phase 1.
+  Confirm the layout if a future phase wants to reuse
+  installer-provided blobs.
 
 ## Revision history
 
 | Revision | Date | Change |
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
+| 2 | 2026-06-11 | Provenance resolved against upstream sources: exact `PawnIOLib.h` API (incl. `pawnio_close`, cell-count semantics), device path, `msr_read` execution context and affinity natives, blob naming. Corrected mutex ownership: modules document caller-held mutants and acquire none themselves. Status → Implementation-ready. |

--- a/docs/specs/sensors/superio-access.md
+++ b/docs/specs/sensors/superio-access.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 1 |
+| Revision | 2 |
 | Status | Draft — not implementation-ready |
 | Scope | The generic LPC/ISA access mechanism shared by PC Super I/O chips: configuration port pairs, vendor enter/exit key sequences, logical-device selection, chip identification, and locating the hardware-monitor I/O block. Applies to Nuvoton NCT67xx and ITE IT86xx/87xx families. Excludes: per-chip register maps (temperatures, fans, voltages) — those are the Phase 3/4 documents. |
 | Issue phase | Phases 2–4 (#1635) — mechanism shared by all of them |
@@ -100,9 +100,11 @@ For each slot (0, then 1):
   another monitor changes the selected index/bank between our write
   and read. (Issue #1635 convention; see
   [`pawnio-interface.md`](pawnio-interface.md))
-- The PawnIO `LpcIO` module additionally acquires the same named
-  mutant per IOCTL (S3); that does not make multi-IOCTL sequences
-  atomic, so the client-side mutex above is mandatory.
+- The PawnIO `LpcIO` module does not acquire the mutant itself: each
+  port/config ioctl is documented with a caller-must-hold warning for
+  `\BaseNamedObjects\Access_ISABUS.HTP.Method` (S3). The client-side
+  mutex above is therefore mandatory for single calls and multi-IOCTL
+  sequences alike.
 - Acquisition uses a bounded timeout; on timeout the sample is skipped
   (never proceed unlocked).
 
@@ -138,3 +140,4 @@ written in any phase of #1635.
 | Revision | Date | Change |
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
+| 2 | 2026-06-11 | Corrected `Access_ISABUS.HTP.Method` ownership: the LpcIO module documents caller-held acquisition and takes no mutex itself. Still Draft — Phase 3/4 datasheet pinning outstanding. |


### PR DESCRIPTION
## Summary

Flips the three **Phase 1 sensor specs to Implementation-ready** by resolving every `TODO(provenance)` marker against primary sources, per the status-transition checklist in `docs/specs/sensors/README.md`. Spec-author ("dirty room") role work; approving/merging this PR is the maintainer sign-off the transition requires.

| Document | New status | Key pins added |
| --- | --- | --- |
| `cpu-intel-dts-msr.md` | **Implementation-ready (rev 2)** | Intel SDM **325462-075US (June 2021)**: Vol 3B §14.8.5.2 / §14.9 (Fig. 14-31/14-33), Vol 4 Table 2-2 rows `19CH`/`1B1H` (p. Vol. 4 2-17), Table 2-26 row `1A2H`, Vol 2A CPUID leaf 06H (p. 3-217). TCC-offset question **resolved**: the offset is defined "from the temperature target (bits 23:16)" and moves PROCHOT# only — decode keeps bits 23:16 as reference (29:24 width variant cited to 12th-Gen datasheet 655258) |
| `cpu-amd-zen-smn.md` | **Implementation-ready (rev 3)** | AMD **PPR 55898 Rev 0.50 Vol 2 §10.3 Table 124 (p. 2-179)**: `SMUTHMx00000000`, aperture `0005_9800h`, CUR_TEMP[31:21], "control temperature (Tctl) after slew-rate controls"; AMD **OSRR 56255 Rev 3.03 (July 2018) §4.2.1 (p. 243) — fetched and text-verified directly** (GitHub mirror of the AMD PDF): CUR_TEMP[31:21], `CUR_TEMP_RANGE_SEL` bit 19 ("0=Report on 0C to 225C scale range. 1=Report on -49C to 206C scale range."), **bits 18:0 Reserved**; AMD **MIT register header** `thm_9_0_sh_mask.h` (masks `0xFFE00000`/`0x00080000`); **0.125 °C/LSB** pinned via PPR 55898 §6.2.5–6.2.6 (SB-TSI delivers Tctl in 0.125 °C steps, 0–255.875 = 11-bit range) |
| `pawnio-interface.md` | **Implementation-ready (rev 2)** | Exact `PawnIOLib.h` API verbatim (LGPL-2.1+; sizes are **ULONG64 cell counts**; `pawnio_close`/version/async confirmed), device path `\Device\PawnIO`, `msr_read` **executes on the calling thread's current CPU** (affinity natives exist; IntelMSR uses none), IntelMSR allowlist verified in source (0x19C/0x1B1/0x1A2), blob naming `*.amx` |

### AMD rev 3 — review corrections applied

- **OSRR pinned directly**: doc 56255 Rev 3.03 §4.2.1 (p. 243) was downloaded (GitHub mirror) and text-verified; the FreeBSD-carried quote is no longer the basis — FreeBSD `amdtemp(4)` is demoted to explicitly **non-normative corroboration**. Family 17h therefore remains in the Ready scope on a direct AMD pin.
- **`TJ_SEL` removed from the Ready decode path**: the CPU OSRR marks bits 18:0 (beyond `RANGE_SEL`) **Reserved**; the `TJ_SEL` 49 °C rule (GPU-IP header field + BSD engineering note) is recorded as a **non-blocking open question** pending AMD primary documentation or Phase 2 dumps. Decode subtracts 49 °C on `RANGE_SEL` only.
- Fixed the contradictory "before this document reaches implementation-ready status" wording in the zero-offset row of the Tctl-offset table.
- Family 1Ah stays **Disabled**; clean-room guardrails and the copyleft-non-normative policy unchanged; Intel / PawnIO / superio-access untouched by rev 3.

### Material correction found during verification (rev 2)

The rev 1 docs claimed PawnIO modules acquire the ecosystem mutants per IOCTL. Reading the module sources shows the opposite: **modules take no mutexes; every relevant ioctl is documented "You should acquire the `\BaseNamedObjects\Access_PCI` / `Access_ISABUS.HTP.Method` mutant before calling this"**. All four documents now state that the client holds `Global\Access_PCI` around each RyzenSMU call and `Global\Access_ISABUS.HTP.Method` across Super-I/O transactions (`superio-access.md` fixed too — it stays **Draft**, rev 2, pending Phase 3/4 datasheet pinning).

### Status-transition checklist (per `docs/specs/sensors/README.md`)

- [x] Every `TODO(provenance)` marker resolved in the three flipped documents (verified by grep; remaining markers exist only in the README/template convention text and the still-Draft `superio-access.md`)
- [x] Every Open-questions entry resolved (TCC offset, RDMSR execution context, PawnIOLib prototypes/close, blob names) or annotated `Non-blocking for Phase 1: …` in place (TJ_SEL — ignored by decode, OSRR marks bits Reserved; family 1Ah — disabled via enablement table; multi-die; hybrid; handle reload; installer module dir; offset empirics)
- [x] No normative fact rests solely on a copyleft source (k10temp and FreeBSD amdtemp are non-normative corroboration; normative sources are AMD official documents — PPR 55898, OSRR 56255 — an AMD MIT-licensed header, and Intel SDM)
- [x] Scoped-enablement table consistent: 17h (OSRR 56255 §4.2.1 direct pin + MIT header) Enabled, 19h (PPR 55898 §10.3) Enabled, 1Ah Disabled until verification
- [x] Revisions bumped with history entries; Status set to the canonical `Implementation-ready (rev N)`; README Current-documents table tracks per-document status

### Provenance method note

Primary PDFs were fetched and text-verified directly during authoring (SDM 325462-075US combined volume; PPR 55898 Vol 2 p. 2-179; **OSRR 56255 Rev 3.03 p. 243**; PawnIO/PawnIO.Modules sources incl. `PawnIOLib.h`, `natives_impl_windows.cpp`, `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p`; AMD `thm_9_0_sh_mask.h`; FreeBSD `amdtemp.c`). Intel/AMD vendor CDNs block non-browser fetches, so verified mirrors were used (contents quoted above are what was verified).

With this merged, the implementation gate is fully satisfied for the Phase 1 spec set.

## Related Issues

Refs #1635

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (documentation only)

## Test Plan

- [x] Manual testing — every pinned section/figure/table/bit-field was extracted from the named primary documents and compared against the spec text; checklist conformance verified by grep (no `TODO(provenance)` in flipped docs, canonical Status strings, `Non-blocking for Phase 1:` annotation format)
- [ ] Unit tests — N/A (no code changes)

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass — N/A (docs-only)
- [ ] Tests pass — N/A (no code changes)
- [x] No new warnings or errors

https://claude.ai/code/session_01R7Uxj8EFfCprg2pEqb6k6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Specs catalog wording updated: documents start as "Draft specifications" and become implementation-ready only after Phase 0 guardrails; status tracked in headers and the Current Documents table.
  * PawnIO, Intel DTS, and CPU (AMD Zen) specs advanced to implementation-ready revisions with clearer provenance and revised procedures.
  * CPU (AMD Zen) spec moved to Revision 3 with register/decode clarifications.
  * SuperIO access remains Draft — not implementation-ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->