### PR TITLE
feat: add render performance CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
               - 'package*.json'
               - 'vite.config.ts'
               - 'playwright.config.ts'
+              - 'playwright.perf.config.ts'
               - 'tsconfig*.json'
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -525,6 +526,35 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/comment-e2e-captures.sh
+
+  #
+  # Frontend render performance checks (Playwright web/mock harness)
+  #
+  test-render-perf:
+    needs: change-detection
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.frontend-changed == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run render performance tests
+        run: npm run test:perf:render
+
+      - name: Upload render performance results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: render-perf-results
+          path: test-results/render-perf/
+          if-no-files-found: warn
 
   #
   # Frontend Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node

--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -100,6 +100,29 @@ Determinism rules:
   `en-US` locale, UTC timezone, reduced motion (see `playwright.config.ts`).
 - Use fixture data only — never live hardware values.
 
+## Render performance smoke
+
+Lightweight render performance checks reuse the same web/mock harness, but run
+as a separate suite:
+
+```bash
+npm run test:perf:render
+```
+
+The suite writes a JSON report and Playwright artifacts under:
+
+```text
+test-results/render-perf/
+```
+
+These checks target coarse, CI-stable signals such as DOM element count,
+Long Task count, and generous interaction timing. They intentionally avoid
+strict FPS, CPU, and memory gates. Thresholds are moderate rather than
+extremely loose because this suite is meant to catch obvious render regressions
+even while it starts as an observation signal. In CI the `test-render-perf` job
+runs only for frontend pull requests, uploads artifacts, and stays outside the
+merge gate.
+
 ## CI
 
 The `test-e2e-web` job in `.github/workflows/ci.yml` runs the suite on

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -26,15 +26,18 @@ export const saveCapture = (page: Page, name: string) =>
 export const BOOTSTRAP_TIMEOUT = 30_000;
 
 const CPU_NAME = sysInfoFixture.cpu?.name ?? "";
+type GotoAppOptions = {
+  timeout?: number;
+};
 
 /**
  * Load the app and wait until the dashboard rendered fixture data,
  * i.e. settings/mock bootstrap completed.
  */
-export const gotoApp = async (page: Page) => {
+export const gotoApp = async (page: Page, options: GotoAppOptions = {}) => {
   await page.goto("/");
   await expect(page.getByText(CPU_NAME).first()).toBeVisible({
-    timeout: BOOTSTRAP_TIMEOUT,
+    timeout: options.timeout ?? BOOTSTRAP_TIMEOUT,
   });
 };
 

--- a/e2e/perf/render-perf.spec.ts
+++ b/e2e/perf/render-perf.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+import { gotoApp, navigateTo, seedHardwareHistory } from "../helpers";
+import {
+  collectRenderPerfResult,
+  installRenderPerfObserver,
+  type RenderPerfResult,
+  resetRenderPerf,
+  writeRenderPerfReport,
+} from "./renderPerf";
+
+const results: RenderPerfResult[] = [];
+const PERF_BOOTSTRAP_TIMEOUT = 60_000;
+const THRESHOLDS = {
+  dashboardUpdates: {
+    interactionMs: 2_000,
+    domElementCount: 1_500,
+    longTaskCount: 10,
+    maxLongTaskMs: 500,
+    totalLongTaskMs: 1_500,
+  },
+  usageChart: {
+    interactionMs: 3_000,
+    domElementCount: 1_000,
+    longTaskCount: 10,
+    maxLongTaskMs: 500,
+    totalLongTaskMs: 1_000,
+  },
+};
+
+const measureMs = async (action: () => Promise<void>) => {
+  const start = Date.now();
+  await action();
+  return Date.now() - start;
+};
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("frontend render performance", () => {
+  test.beforeEach(async ({ page }) => {
+    await installRenderPerfObserver(page);
+  });
+
+  test.afterAll(async () => {
+    await writeRenderPerfReport(results);
+  });
+
+  test("dashboard repeated metric updates stay bounded", async ({ page }) => {
+    const readyMs = await measureMs(async () => {
+      await gotoApp(page, { timeout: PERF_BOOTSTRAP_TIMEOUT });
+    });
+
+    await resetRenderPerf(page);
+    const interactionMs = await measureMs(async () => {
+      await page.evaluate(async () => {
+        if (!window.__E2E__) {
+          throw new Error(
+            "window.__E2E__ is not installed (VITE_E2E_MOCK unset?)",
+          );
+        }
+        await window.__E2E__.emitHardwareUpdateSeries(60);
+      });
+      await page.waitForTimeout(600);
+    });
+
+    const result = await collectRenderPerfResult(page, {
+      screen: "dashboard-updates",
+      readyMs,
+      interactionMs,
+    });
+    results.push(result);
+
+    expect.soft(result.readyMs).toBeLessThanOrEqual(PERF_BOOTSTRAP_TIMEOUT);
+    expect
+      .soft(result.interactionMs)
+      .toBeLessThanOrEqual(THRESHOLDS.dashboardUpdates.interactionMs);
+    expect
+      .soft(result.domElementCount)
+      .toBeLessThanOrEqual(THRESHOLDS.dashboardUpdates.domElementCount);
+    expect
+      .soft(result.longTaskCount)
+      .toBeLessThanOrEqual(THRESHOLDS.dashboardUpdates.longTaskCount);
+    expect
+      .soft(result.maxLongTaskMs)
+      .toBeLessThanOrEqual(THRESHOLDS.dashboardUpdates.maxLongTaskMs);
+    expect
+      .soft(result.totalLongTaskMs)
+      .toBeLessThanOrEqual(THRESHOLDS.dashboardUpdates.totalLongTaskMs);
+  });
+
+  test("usage chart render stays bounded", async ({ page }) => {
+    await gotoApp(page, { timeout: PERF_BOOTSTRAP_TIMEOUT });
+    await seedHardwareHistory(page);
+    await resetRenderPerf(page);
+
+    const interactionMs = await measureMs(async () => {
+      await navigateTo(page, "usage");
+      await expect(page.getByText("RAM", { exact: true })).toBeVisible({
+        timeout: PERF_BOOTSTRAP_TIMEOUT,
+      });
+      await expect(page.getByText("GPU", { exact: true })).toBeVisible();
+      await page.waitForTimeout(600);
+    });
+
+    const result = await collectRenderPerfResult(page, {
+      screen: "usage-chart",
+      interactionMs,
+    });
+    results.push(result);
+
+    expect
+      .soft(result.interactionMs)
+      .toBeLessThanOrEqual(THRESHOLDS.usageChart.interactionMs);
+    expect
+      .soft(result.domElementCount)
+      .toBeLessThanOrEqual(THRESHOLDS.usageChart.domElementCount);
+    expect
+      .soft(result.longTaskCount)
+      .toBeLessThanOrEqual(THRESHOLDS.usageChart.longTaskCount);
+    expect
+      .soft(result.maxLongTaskMs)
+      .toBeLessThanOrEqual(THRESHOLDS.usageChart.maxLongTaskMs);
+    expect
+      .soft(result.totalLongTaskMs)
+      .toBeLessThanOrEqual(THRESHOLDS.usageChart.totalLongTaskMs);
+  });
+});

--- a/e2e/perf/render-perf.spec.ts
+++ b/e2e/perf/render-perf.spec.ts
@@ -9,6 +9,8 @@ import {
 } from "./renderPerf";
 
 const results: RenderPerfResult[] = [];
+// The perf suite runs extra browser instrumentation, so cold-start bootstrap
+// gets more room than BOOTSTRAP_TIMEOUT in the regular capture suite.
 const PERF_BOOTSTRAP_TIMEOUT = 60_000;
 const THRESHOLDS = {
   dashboardUpdates: {

--- a/e2e/perf/renderPerf.ts
+++ b/e2e/perf/renderPerf.ts
@@ -62,10 +62,14 @@ export const collectRenderPerfResult = async (
 ): Promise<RenderPerfResult> => {
   const browserMetrics = await page.evaluate(() => {
     const longTaskDurations = window.__RENDER_PERF__?.longTaskDurations ?? [];
+    const maxLongTaskDuration = longTaskDurations.reduce(
+      (max, duration) => Math.max(max, duration),
+      0,
+    );
     return {
       domElementCount: document.getElementsByTagName("*").length,
       longTaskCount: longTaskDurations.length,
-      maxLongTaskMs: Math.round(Math.max(0, ...longTaskDurations)),
+      maxLongTaskMs: Math.round(maxLongTaskDuration),
       totalLongTaskMs: Math.round(
         longTaskDurations.reduce((sum, duration) => sum + duration, 0),
       ),

--- a/e2e/perf/renderPerf.ts
+++ b/e2e/perf/renderPerf.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "@playwright/test";
+
+declare global {
+  interface Window {
+    __RENDER_PERF__?: {
+      longTaskDurations: number[];
+      reset: () => void;
+    };
+  }
+}
+
+export type RenderPerfResult = {
+  screen: string;
+  domElementCount: number;
+  longTaskCount: number;
+  maxLongTaskMs: number;
+  totalLongTaskMs: number;
+  readyMs?: number;
+  interactionMs?: number;
+};
+
+const REPORT_DIR = path.join("test-results", "render-perf");
+const REPORT_PATH = path.join(REPORT_DIR, "render-perf-results.json");
+
+export const installRenderPerfObserver = async (page: Page) => {
+  await page.addInitScript(() => {
+    const state = {
+      longTaskDurations: [] as number[],
+      reset() {
+        this.longTaskDurations = [];
+      },
+    };
+
+    window.__RENDER_PERF__ = state;
+
+    if (!("PerformanceObserver" in window)) {
+      return;
+    }
+
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          state.longTaskDurations.push(entry.duration);
+        }
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+    } catch {
+      // The Long Task API is Chromium-only; leave the metric empty elsewhere.
+    }
+  });
+};
+
+export const resetRenderPerf = async (page: Page) => {
+  await page.evaluate(() => window.__RENDER_PERF__?.reset());
+};
+
+export const collectRenderPerfResult = async (
+  page: Page,
+  timing: Pick<RenderPerfResult, "screen" | "readyMs" | "interactionMs">,
+): Promise<RenderPerfResult> => {
+  const browserMetrics = await page.evaluate(() => {
+    const longTaskDurations = window.__RENDER_PERF__?.longTaskDurations ?? [];
+    return {
+      domElementCount: document.getElementsByTagName("*").length,
+      longTaskCount: longTaskDurations.length,
+      maxLongTaskMs: Math.round(Math.max(0, ...longTaskDurations)),
+      totalLongTaskMs: Math.round(
+        longTaskDurations.reduce((sum, duration) => sum + duration, 0),
+      ),
+    };
+  });
+
+  return {
+    ...timing,
+    ...browserMetrics,
+  };
+};
+
+export const writeRenderPerfReport = async (results: RenderPerfResult[]) => {
+  await fs.mkdir(REPORT_DIR, { recursive: true });
+  await fs.writeFile(
+    REPORT_PATH,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        results,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+};

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["./**/*.ts", "../playwright.config.ts"]
+  "include": [
+    "./**/*.ts",
+    "../playwright.config.ts",
+    "../playwright.perf.config.ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "test": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:perf:render": "playwright test --config playwright.perf.config.ts",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "lint": "biome lint && biome check && biome format --write",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,7 @@ const E2E_PORT = 1521;
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: ["**/perf/**"],
   outputDir: "./test-results/output",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Lightweight frontend render performance checks.
+ *
+ * This reuses the web/mock E2E mode, but keeps results separate from the
+ * evidence capture suite so it can start as a non-blocking PR signal.
+ */
+const RENDER_PERF_PORT = 1522;
+
+export default defineConfig({
+  testDir: "./e2e/perf",
+  outputDir: "./test-results/render-perf/output",
+  timeout: 90_000,
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [
+        ["list"],
+        [
+          "html",
+          { outputFolder: "test-results/render-perf/report", open: "never" },
+        ],
+      ]
+    : [["list"]],
+  use: {
+    baseURL: `http://localhost:${RENDER_PERF_PORT}`,
+    colorScheme: "dark",
+    locale: "en-US",
+    timezoneId: "UTC",
+    contextOptions: { reducedMotion: "reduce" },
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 800 },
+        deviceScaleFactor: 1,
+      },
+    },
+  ],
+  webServer: {
+    command: `vite dev --port ${RENDER_PERF_PORT} --strictPort`,
+    url: `http://localhost:${RENDER_PERF_PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: { VITE_E2E_MOCK: "true" },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a lightweight Playwright render performance suite for frontend PRs.

- Reuses the existing web/mock E2E harness with a dedicated Playwright config on port 1522.
- Measures Dashboard repeated metric updates and Usage chart rendering with DOM, Long Task, and interaction timing metrics.
- Uses moderate thresholds rather than very loose limits, while keeping the CI job non-blocking and outside the merge gate for the first observation phase.
- Uploads JSON/report artifacts under test-results/render-perf/.

This does not prove Windows WebView2 or native Tauri runtime performance, but it gives PRs an earlier signal for render regressions that are visible in the mock frontend path.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (fix/ branch)
- [x] New feature (feat/ branch)
- [ ] Refactoring (refactor/ branch)
- [ ] Documentation (docs/ branch)
- [ ] Dependencies update
- [ ] Other (chore/ branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Validated with:

- npx biome check playwright.config.ts playwright.perf.config.ts e2e/helpers.ts e2e/perf/renderPerf.ts e2e/perf/render-perf.spec.ts e2e/tsconfig.json docs/development/e2e-captures.md .github/workflows/ci.yml package.json
- npx tsc -p e2e/tsconfig.json --noEmit
- actionlint .github/workflows/ci.yml
- npm run test:perf:render
- npm run test:e2e

Observed render perf sample after tightening thresholds:

- dashboard-updates: interactionMs 614, DOM 750, longTaskCount 1, maxLongTaskMs 71
- usage-chart: interactionMs 975, DOM 148, longTaskCount 0

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [ ] No new warnings or errors

Note: Playwright runs still print existing web/mock console warnings from Recharts/Tauri mock callbacks; they are not introduced as failing conditions by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced lightweight render performance monitoring and reporting for dashboard and chart interactions.

* **Documentation**
  * Added docs for the render performance smoke test suite, outputs, and stability thresholds.

* **Tests**
  * Added Playwright-based render performance tests that run on frontend PRs and upload results (non-blocking).

* **Chores**
  * CI and Playwright setups updated to support dedicated render-perf runs and a new test command.

* **Bug Fixes**
  * E2E helper accepts an optional timeout override for more reliable waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->