### PR TITLE
feat: add render memory performance check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
               - 'vite.config.ts'
               - 'playwright.config.ts'
               - 'playwright.perf.config.ts'
+              - 'playwright.memory.config.ts'
               - 'tsconfig*.json'
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -556,6 +557,43 @@ jobs:
         with:
           name: render-perf-results
           path: test-results/render-perf/
+          if-no-files-found: warn
+
+  #
+  # Frontend memory growth checks (Playwright web/mock IPC harness)
+  #
+  test-render-memory-perf:
+    needs: change-detection
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.frontend-changed == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    env:
+      RENDER_MEMORY_WARMUP_MS: "10000"
+      RENDER_MEMORY_DURATION_MS: "30000"
+      RENDER_MEMORY_SAMPLE_INTERVAL_MS: "5000"
+      RENDER_MEMORY_TAIL_WINDOW_MS: "15000"
+      RENDER_MEMORY_STREAM_INTERVAL_MS: "1000"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run render memory performance tests
+        run: npm run test:perf:render-memory
+
+      - name: Upload render memory performance results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: render-memory-perf-results
+          path: test-results/render-memory/
           if-no-files-found: warn
 
   #

--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -123,6 +123,35 @@ even while it starts as an observation signal. In CI the `test-render-perf` job
 runs only for frontend pull requests, uploads artifacts, and stays outside the
 merge gate.
 
+## Render memory smoke
+
+Frontend memory-growth checks also reuse the web/mock harness, but they measure
+Dashboard behavior while mocked Tauri IPC events continue to arrive over time:
+
+```bash
+npm run test:perf:render-memory
+```
+
+This suite starts a deterministic `hardware-monitor-update` stream through the
+mocked Tauri event path, then samples Chromium through CDP:
+
+- `Runtime.getHeapUsage`
+- `Performance.getMetrics`
+- `Memory.getDOMCounters`
+
+The report is written under:
+
+```text
+test-results/render-memory/
+```
+
+The check watches JS heap growth, DOM document/node counters, and JavaScript
+listener growth from a warmup baseline plus the later-window heap slope. This is
+a frontend memory-growth signal, not a Windows WebView2 process-memory check;
+the existing full performance workflow remains responsible for real Tauri
+process-level CPU/RSS monitoring. In CI the `test-render-memory-perf` job runs
+only for frontend pull requests, uploads artifacts, and stays non-blocking.
+
 ## CI
 
 The `test-e2e-web` job in `.github/workflows/ci.yml` runs the suite on

--- a/e2e/perf/render-memory.spec.ts
+++ b/e2e/perf/render-memory.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+import { gotoApp } from "../helpers";
+import {
+  analyzeMemoryGrowth,
+  collectMemorySamples,
+  createMemorySession,
+  type MemorySample,
+  type MemoryThresholds,
+  writeMemoryReport,
+} from "./renderMemory";
+
+const PERF_BOOTSTRAP_TIMEOUT = 60_000;
+const CONFIG = {
+  warmupMs: Number(process.env.RENDER_MEMORY_WARMUP_MS ?? 10_000),
+  durationMs: Number(process.env.RENDER_MEMORY_DURATION_MS ?? 45_000),
+  sampleIntervalMs: Number(
+    process.env.RENDER_MEMORY_SAMPLE_INTERVAL_MS ?? 5_000,
+  ),
+  tailWindowMs: Number(process.env.RENDER_MEMORY_TAIL_WINDOW_MS ?? 20_000),
+  streamIntervalMs: Number(
+    process.env.RENDER_MEMORY_STREAM_INTERVAL_MS ?? 1_000,
+  ),
+};
+const THRESHOLDS: MemoryThresholds = {
+  jsHeapGrowthBytes: 20 * 1024 * 1024,
+  jsHeapSlopeBytesPerMinute: 8 * 1024 * 1024,
+  domNodeGrowth: 300,
+  listenerGrowth: 50,
+};
+
+test.describe("frontend memory growth", () => {
+  test("dashboard mock IPC stream memory stays observable", async ({
+    page,
+    context,
+  }) => {
+    await gotoApp(page, { timeout: PERF_BOOTSTRAP_TIMEOUT });
+
+    const cdp = await context.newCDPSession(page);
+    await createMemorySession(cdp);
+
+    await page.evaluate(async (streamIntervalMs) => {
+      if (!window.__E2E__) {
+        throw new Error(
+          "window.__E2E__ is not installed (VITE_E2E_MOCK unset?)",
+        );
+      }
+      await window.__E2E__.startHardwareUpdateStream({
+        intervalMs: streamIntervalMs,
+      });
+    }, CONFIG.streamIntervalMs);
+
+    let emittedCount = 0;
+    let samples: MemorySample[] = [];
+    try {
+      samples = await collectMemorySamples(cdp, CONFIG);
+    } finally {
+      const result = await page.evaluate(async () =>
+        window.__E2E__?.stopHardwareUpdateStream(),
+      );
+      emittedCount = result?.emittedCount ?? 0;
+      await cdp.detach();
+    }
+
+    const analysis = analyzeMemoryGrowth(
+      samples,
+      THRESHOLDS,
+      CONFIG.tailWindowMs,
+    );
+    await writeMemoryReport({
+      generatedAt: new Date().toISOString(),
+      scenario: "dashboard-mock-ipc-stream",
+      config: {
+        ...CONFIG,
+        emittedCount,
+      },
+      thresholds: THRESHOLDS,
+      analysis,
+      samples,
+    });
+
+    if (analysis.status === "warn") {
+      console.warn(
+        `Frontend memory growth warning: ${analysis.reasons.join("; ")}`,
+      );
+    }
+
+    expect(samples.length).toBeGreaterThanOrEqual(3);
+    expect(analysis.baselineElapsedMs).toBeGreaterThanOrEqual(CONFIG.warmupMs);
+  });
+});

--- a/e2e/perf/render-memory.spec.ts
+++ b/e2e/perf/render-memory.spec.ts
@@ -22,10 +22,10 @@ const CONFIG = {
   ),
 };
 const THRESHOLDS: MemoryThresholds = {
-  jsHeapGrowthBytes: 20 * 1024 * 1024,
-  jsHeapSlopeBytesPerMinute: 8 * 1024 * 1024,
-  domNodeGrowth: 300,
-  listenerGrowth: 50,
+  jsHeapGrowthBytes: 8 * 1024 * 1024,
+  jsHeapSlopeBytesPerMinute: 3 * 1024 * 1024,
+  domNodeGrowth: 100,
+  listenerGrowth: 20,
 };
 
 test.describe("frontend memory growth", () => {

--- a/e2e/perf/renderMemory.ts
+++ b/e2e/perf/renderMemory.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { CDPSession } from "@playwright/test";
+
+export type MemorySample = {
+  phase: "warmup" | "measure";
+  elapsedMs: number;
+  jsHeapUsedBytes: number;
+  jsHeapTotalBytes: number;
+  runtimeHeapUsedBytes: number;
+  runtimeHeapTotalBytes: number;
+  documents: number;
+  nodes: number;
+  jsEventListeners: number;
+};
+
+export type MemoryThresholds = {
+  jsHeapGrowthBytes: number;
+  jsHeapSlopeBytesPerMinute: number;
+  domNodeGrowth: number;
+  listenerGrowth: number;
+};
+
+export type MemoryGrowthAnalysis = {
+  status: "ok" | "warn";
+  baselineElapsedMs: number;
+  finalElapsedMs: number;
+  jsHeapGrowthBytes: number;
+  runtimeHeapGrowthBytes: number;
+  domNodeGrowth: number;
+  documentGrowth: number;
+  listenerGrowth: number;
+  tailSlopeBytesPerMinute: number;
+  reasons: string[];
+};
+
+export type MemoryReport = {
+  generatedAt: string;
+  scenario: string;
+  config: {
+    warmupMs: number;
+    durationMs: number;
+    sampleIntervalMs: number;
+    tailWindowMs: number;
+    streamIntervalMs: number;
+    emittedCount?: number;
+  };
+  thresholds: MemoryThresholds;
+  analysis: MemoryGrowthAnalysis;
+  samples: MemorySample[];
+};
+
+type RuntimeHeapUsage = {
+  usedSize: number;
+  totalSize: number;
+};
+
+type PerformanceMetricsResult = {
+  metrics: Array<{ name: string; value: number }>;
+};
+
+type DomCounters = {
+  documents: number;
+  nodes: number;
+  jsEventListeners: number;
+};
+
+const REPORT_DIR = path.join("test-results", "render-memory");
+const REPORT_PATH = path.join(REPORT_DIR, "render-memory-results.json");
+
+export const createMemorySession = async (cdp: CDPSession) => {
+  await cdp.send("Performance.enable");
+};
+
+export const collectMemorySample = async (
+  cdp: CDPSession,
+  phase: MemorySample["phase"],
+  elapsedMs: number,
+): Promise<MemorySample> => {
+  await collectGarbage(cdp);
+  const [runtimeHeap, performance, domCounters] = await Promise.all([
+    cdp.send("Runtime.getHeapUsage") as Promise<RuntimeHeapUsage>,
+    cdp.send("Performance.getMetrics") as Promise<PerformanceMetricsResult>,
+    cdp.send("Memory.getDOMCounters") as Promise<DomCounters>,
+  ]);
+  const metrics = new Map(
+    performance.metrics.map((metric) => [metric.name, metric.value]),
+  );
+
+  return {
+    phase,
+    elapsedMs,
+    jsHeapUsedBytes: Math.round(metrics.get("JSHeapUsedSize") ?? 0),
+    jsHeapTotalBytes: Math.round(metrics.get("JSHeapTotalSize") ?? 0),
+    runtimeHeapUsedBytes: Math.round(runtimeHeap.usedSize),
+    runtimeHeapTotalBytes: Math.round(runtimeHeap.totalSize),
+    documents: domCounters.documents,
+    nodes: domCounters.nodes,
+    jsEventListeners: domCounters.jsEventListeners,
+  };
+};
+
+export const collectMemorySamples = async (
+  cdp: CDPSession,
+  config: Pick<
+    MemoryReport["config"],
+    "warmupMs" | "durationMs" | "sampleIntervalMs"
+  >,
+): Promise<MemorySample[]> => {
+  const samples: MemorySample[] = [];
+  const startedAt = Date.now();
+  let nextElapsedMs = 0;
+
+  while (nextElapsedMs <= config.durationMs) {
+    const elapsedMs = Date.now() - startedAt;
+    samples.push(
+      await collectMemorySample(
+        cdp,
+        elapsedMs < config.warmupMs ? "warmup" : "measure",
+        elapsedMs,
+      ),
+    );
+
+    nextElapsedMs += config.sampleIntervalMs;
+    const waitMs = Math.min(
+      config.sampleIntervalMs,
+      Math.max(0, config.durationMs - (Date.now() - startedAt)),
+    );
+    if (waitMs === 0) break;
+    await sleep(waitMs);
+  }
+
+  const lastSample = samples.at(-1);
+  const elapsedMs = Date.now() - startedAt;
+  if (!lastSample || lastSample.elapsedMs < config.durationMs) {
+    samples.push(
+      await collectMemorySample(
+        cdp,
+        "measure",
+        Math.max(elapsedMs, config.warmupMs),
+      ),
+    );
+  }
+
+  return samples;
+};
+
+export const analyzeMemoryGrowth = (
+  samples: MemorySample[],
+  thresholds: MemoryThresholds,
+  tailWindowMs: number,
+): MemoryGrowthAnalysis => {
+  if (samples.length < 2) {
+    throw new Error("At least two memory samples are required for analysis.");
+  }
+
+  const baseline = samples.find((sample) => sample.phase === "measure");
+  if (!baseline) {
+    throw new Error("At least one post-warmup memory sample is required.");
+  }
+
+  const finalSample = samples[samples.length - 1];
+  const tailStartMs = finalSample.elapsedMs - tailWindowMs;
+  const tailSamples = samples.filter(
+    (sample) => sample.phase === "measure" && sample.elapsedMs >= tailStartMs,
+  );
+  const tailSlopeBytesPerMinute =
+    tailSamples.length >= 2 ? slopeBytesPerMinute(tailSamples) : 0;
+
+  const analysis = {
+    status: "ok" as const,
+    baselineElapsedMs: baseline.elapsedMs,
+    finalElapsedMs: finalSample.elapsedMs,
+    jsHeapGrowthBytes: finalSample.jsHeapUsedBytes - baseline.jsHeapUsedBytes,
+    runtimeHeapGrowthBytes:
+      finalSample.runtimeHeapUsedBytes - baseline.runtimeHeapUsedBytes,
+    domNodeGrowth: finalSample.nodes - baseline.nodes,
+    documentGrowth: finalSample.documents - baseline.documents,
+    listenerGrowth: finalSample.jsEventListeners - baseline.jsEventListeners,
+    tailSlopeBytesPerMinute,
+    reasons: [] as string[],
+  };
+
+  if (
+    analysis.jsHeapGrowthBytes > thresholds.jsHeapGrowthBytes &&
+    analysis.tailSlopeBytesPerMinute > thresholds.jsHeapSlopeBytesPerMinute
+  ) {
+    analysis.reasons.push(
+      "JS heap grew past the threshold and kept rising in the tail window.",
+    );
+  }
+
+  if (analysis.domNodeGrowth > thresholds.domNodeGrowth) {
+    analysis.reasons.push("DOM node count grew past the threshold.");
+  }
+
+  if (analysis.listenerGrowth > thresholds.listenerGrowth) {
+    analysis.reasons.push(
+      "JavaScript event listener count grew past the threshold.",
+    );
+  }
+
+  return {
+    ...analysis,
+    status: analysis.reasons.length > 0 ? "warn" : "ok",
+  };
+};
+
+export const writeMemoryReport = async (report: MemoryReport) => {
+  await fs.mkdir(REPORT_DIR, { recursive: true });
+  await fs.writeFile(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+};
+
+const slopeBytesPerMinute = (samples: MemorySample[]) => {
+  const firstElapsedMs = samples[0].elapsedMs;
+  const points = samples.map((sample) => ({
+    x: (sample.elapsedMs - firstElapsedMs) / 60_000,
+    y: sample.jsHeapUsedBytes,
+  }));
+  const meanX = average(points.map((point) => point.x));
+  const meanY = average(points.map((point) => point.y));
+  const numerator = points.reduce(
+    (sum, point) => sum + (point.x - meanX) * (point.y - meanY),
+    0,
+  );
+  const denominator = points.reduce(
+    (sum, point) => sum + (point.x - meanX) ** 2,
+    0,
+  );
+
+  return denominator === 0 ? 0 : Math.round(numerator / denominator);
+};
+
+const average = (values: number[]) =>
+  values.reduce((sum, value) => sum + value, 0) / values.length;
+
+const collectGarbage = async (cdp: CDPSession) => {
+  try {
+    await cdp.send("HeapProfiler.collectGarbage");
+  } catch {
+    // Best-effort only; metrics are still useful when GC collection is unavailable.
+  }
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -6,6 +6,7 @@
   "include": [
     "./**/*.ts",
     "../playwright.config.ts",
-    "../playwright.perf.config.ts"
+    "../playwright.perf.config.ts",
+    "../playwright.memory.config.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:perf:render": "playwright test --config playwright.perf.config.ts",
+    "test:perf:render-memory": "playwright test --config playwright.memory.config.ts",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",
     "lint": "biome lint && biome check && biome format --write",

--- a/playwright.memory.config.ts
+++ b/playwright.memory.config.ts
@@ -1,18 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
-/**
- * Lightweight frontend render performance checks.
- *
- * This reuses the web/mock E2E mode, but keeps results separate from the
- * evidence capture suite so it can start as a non-blocking PR signal.
- */
-const RENDER_PERF_PORT = 1522;
+const RENDER_MEMORY_PORT = 1523;
 
 export default defineConfig({
   testDir: "./e2e/perf",
-  testMatch: ["**/render-perf.spec.ts"],
-  outputDir: "./test-results/render-perf/output",
-  timeout: 90_000,
+  testMatch: ["**/render-memory.spec.ts"],
+  outputDir: "./test-results/render-memory/output",
+  timeout: 150_000,
   fullyParallel: false,
   workers: 1,
   forbidOnly: !!process.env.CI,
@@ -22,12 +16,12 @@ export default defineConfig({
         ["list"],
         [
           "html",
-          { outputFolder: "test-results/render-perf/report", open: "never" },
+          { outputFolder: "test-results/render-memory/report", open: "never" },
         ],
       ]
     : [["list"]],
   use: {
-    baseURL: `http://localhost:${RENDER_PERF_PORT}`,
+    baseURL: `http://localhost:${RENDER_MEMORY_PORT}`,
     colorScheme: "dark",
     locale: "en-US",
     timezoneId: "UTC",
@@ -46,8 +40,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `vite dev --port ${RENDER_PERF_PORT} --strictPort`,
-    url: `http://localhost:${RENDER_PERF_PORT}`,
+    command: `vite dev --port ${RENDER_MEMORY_PORT} --strictPort`,
+    url: `http://localhost:${RENDER_MEMORY_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: { VITE_E2E_MOCK: "true" },

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -1,4 +1,3 @@
-import { emit } from "@tauri-apps/api/event";
 import { mockIPC, mockWindows } from "@tauri-apps/api/mocks";
 import type { HardwareMonitorUpdate } from "@/rspc/bindings";
 import { buildArchiveRecords, buildProcessStats } from "../fixtures/archive";
@@ -19,11 +18,27 @@ declare global {
       emitHardwareUpdate: (payload?: HardwareMonitorUpdate) => Promise<void>;
       /** Emit a deterministic series of updates so charts build up history. */
       emitHardwareUpdateSeries: (count?: number) => Promise<void>;
+      /**
+       * Start a deterministic event stream through the mocked Tauri event IPC.
+       * Used by long-running frontend memory tests.
+       */
+      startHardwareUpdateStream: (options?: {
+        intervalMs?: number;
+      }) => Promise<void>;
+      stopHardwareUpdateStream: () => Promise<{ emittedCount: number }>;
     };
   }
 }
 
 type InvokeHandler = (args?: unknown) => unknown;
+type EventListenArgs = { event: string; handler: number };
+type EventEmitArgs = { event: string; payload?: unknown };
+type EventUnlistenArgs = { event: string; eventId?: number; id?: number };
+type TauriInternalsWindow = Window & {
+  __TAURI_INTERNALS__?: {
+    runCallback?: (id: number, data: unknown) => void;
+  };
+};
 
 const STORE_RID = 1;
 
@@ -36,7 +51,27 @@ const storeKey = (args?: unknown) => (args as { key: string }).key;
  */
 const buildInvokeHandlers = (
   store: Map<string, unknown>,
+  eventListeners: Map<string, Set<number>>,
 ): Record<string, InvokeHandler> => ({
+  // --- @tauri-apps/plugin-event ---
+  "plugin:event|listen": (args) => {
+    const a = args as EventListenArgs;
+    if (!eventListeners.has(a.event)) {
+      eventListeners.set(a.event, new Set());
+    }
+    eventListeners.get(a.event)?.add(a.handler);
+    return a.handler;
+  },
+  "plugin:event|emit": (args) => {
+    dispatchTauriEvent(eventListeners, args as EventEmitArgs);
+    return null;
+  },
+  "plugin:event|unlisten": (args) => {
+    const a = args as EventUnlistenArgs;
+    eventListeners.get(a.event)?.delete(a.eventId ?? a.id ?? -1);
+    return null;
+  },
+
   // --- @tauri-apps/plugin-store (rid-based key-value store) ---
   "plugin:store|load": () => STORE_RID,
   "plugin:store|has": (args) => store.has(storeKey(args)),
@@ -114,6 +149,25 @@ const buildInvokeHandlers = (
     buildProcessStats((args as { end: string }).end),
 });
 
+const dispatchTauriEvent = (
+  eventListeners: Map<string, Set<number>>,
+  args: EventEmitArgs,
+) => {
+  const runCallback = (window as TauriInternalsWindow).__TAURI_INTERNALS__
+    ?.runCallback;
+  if (!runCallback) {
+    return;
+  }
+
+  for (const handler of eventListeners.get(args.event) ?? []) {
+    runCallback(handler, {
+      event: args.event,
+      id: handler,
+      payload: args.payload,
+    });
+  }
+};
+
 /**
  * Install Tauri IPC/event/window mocks so the React app runs in a plain
  * browser with deterministic fixture data. Loaded from `src/main.tsx` only
@@ -142,35 +196,75 @@ export const installTauriMocks = () => {
   };
 
   const store = new Map<string, unknown>(Object.entries(storeFixture));
-  const handlers = buildInvokeHandlers(store);
+  const eventListeners = new Map<string, Set<number>>();
+  const handlers = buildInvokeHandlers(store, eventListeners);
+  let streamTimer: number | undefined;
+  let streamIndex = 0;
+  let streamRunning = false;
 
-  mockIPC(
-    (cmd: string, args?: unknown) => {
-      if (Object.hasOwn(handlers, cmd)) {
-        return handlers[cmd](args);
-      }
+  const emitHardwareUpdateAt = async (index: number) => {
+    const series = buildHardwareUpdateSeries(index + 1);
+    dispatchTauriEvent(eventListeners, {
+      event: "hardware-monitor-update",
+      payload: series[index],
+    });
+  };
 
-      // Settings mutators (`set_theme`, `set_language`, ...) succeed silently
-      // so settings-screen scenarios can interact without enumerating them.
-      if (cmd.startsWith("set_")) {
-        return null;
-      }
+  const stopHardwareUpdateStream = () => {
+    streamRunning = false;
+    if (streamTimer !== undefined) {
+      window.clearTimeout(streamTimer);
+      streamTimer = undefined;
+    }
+    return { emittedCount: streamIndex };
+  };
 
-      throw new Error(`[e2e-mock] Unhandled invoke: ${cmd}`);
-    },
-    { shouldMockEvents: true },
-  );
+  mockIPC((cmd: string, args?: unknown) => {
+    if (Object.hasOwn(handlers, cmd)) {
+      return handlers[cmd](args);
+    }
+
+    // Settings mutators (`set_theme`, `set_language`, ...) succeed silently
+    // so settings-screen scenarios can interact without enumerating them.
+    if (cmd.startsWith("set_")) {
+      return null;
+    }
+
+    throw new Error(`[e2e-mock] Unhandled invoke: ${cmd}`);
+  });
 
   window.__E2E__ = {
-    emitHardwareUpdate: (payload) =>
-      emit(
-        "hardware-monitor-update",
-        payload ?? buildHardwareUpdateSeries(1)[0],
-      ),
+    emitHardwareUpdate: async (payload) =>
+      dispatchTauriEvent(eventListeners, {
+        event: "hardware-monitor-update",
+        payload: payload ?? buildHardwareUpdateSeries(1)[0],
+      }),
     emitHardwareUpdateSeries: async (count = 30) => {
       for (const payload of buildHardwareUpdateSeries(count)) {
-        await emit("hardware-monitor-update", payload);
+        dispatchTauriEvent(eventListeners, {
+          event: "hardware-monitor-update",
+          payload,
+        });
       }
     },
+    startHardwareUpdateStream: async ({ intervalMs = 1_000 } = {}) => {
+      stopHardwareUpdateStream();
+      streamIndex = 0;
+      streamRunning = true;
+
+      const tick = async () => {
+        if (!streamRunning) return;
+
+        await emitHardwareUpdateAt(streamIndex);
+        streamIndex += 1;
+
+        if (streamRunning) {
+          streamTimer = window.setTimeout(tick, intervalMs);
+        }
+      };
+
+      await tick();
+    },
+    stopHardwareUpdateStream: async () => stopHardwareUpdateStream(),
   };
 };


### PR DESCRIPTION
## Summary

- Adds `test:perf:render-memory`, a Playwright/CDP smoke for Dashboard frontend memory growth while mocked Tauri IPC events keep flowing.
- Extends the web/mock Tauri harness with `listen`/`emit`/`unlisten` event delivery plus a deterministic `hardware-monitor-update` stream.
- Adds a non-blocking PR CI job that uploads `test-results/render-memory/` artifacts.
- Replaces the closed PR #1645 direction: this does not sample `msedgewebview2.exe` or WebView2 OS process memory.

## Related Issues

Closes #1644

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A. This adds a performance test and JSON/report artifacts.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Validated with:

- `npx tsc -p e2e/tsconfig.json --noEmit`
- `npx biome check playwright.perf.config.ts playwright.memory.config.ts e2e/perf/render-memory.spec.ts e2e/perf/renderMemory.ts src/e2e/mocks/installTauriMocks.ts e2e/tsconfig.json docs/development/e2e-captures.md .github/workflows/ci.yml package.json`
- `actionlint .github/workflows/ci.yml`
- `npm run test:perf:render-memory`
- `npm run test:perf:render`
- `npm run test:e2e`

Latest local render-memory artifact reported `status: ok`, `emittedCount: 45`, `domNodeGrowth: 0`, `listenerGrowth: 0`, and heap growth below threshold. Existing Recharts responsive container size warnings still appear in Playwright logs.

## Checklist

- [x] Self-reviewed the code
- [x] Targeted linting and formatting pass
- [x] Tests pass for the touched E2E/perf paths
- [x] No new Tauri mock callback warning flood during the memory stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a render-memory E2E/perf test and an npm script to run it locally.
  * Exposed a deterministic in-browser hardware-update stream API for testing.

* **CI**
  * Frontend CI now runs a non-blocking render-memory perf job on PRs and uploads artifacts for review.

* **Documentation**
  * Added doc section describing the render-memory test, metrics collected, and reporting artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->