### PR TITLE
fix: isolate E2E mock entry from production

### DIFF
--- a/docs/development/e2e-captures.md
+++ b/docs/development/e2e-captures.md
@@ -22,7 +22,7 @@ npm run test:e2e
 ```
 
 Playwright starts its own Vite dev server on port `1521` with
-`VITE_E2E_MOCK=true` (a regular `npm run dev` server on `1520` is never
+`vite dev --mode e2e` (a regular `npm run dev` server on `1520` is never
 reused). Captures are written to:
 
 ```text
@@ -35,9 +35,9 @@ timeout for the initial render assertion.
 
 ## How the mocks work
 
-- `src/main.tsx` installs the mocks before importing the app, only when
-  `VITE_E2E_MOCK=true`. The branch is statically false in production builds,
-  so the mock code is dead-code eliminated from release bundles.
+- `vite --mode e2e` rewrites `index.html` to use `src/main.e2e.tsx`.
+  The regular `src/main.tsx` keeps the production/Tauri app entry static,
+  while the E2E entry installs mocks before dynamically importing the app.
 - `src/e2e/mocks/installTauriMocks.ts` is the single mock entry point:
   - `mockIPC(..., { shouldMockEvents: true })` from `@tauri-apps/api/mocks`
     intercepts every `invoke()` (generated tauri-specta commands and

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,9 +4,8 @@ import { defineConfig, devices } from "@playwright/test";
  * Playwright web/mock E2E harness (issue #1609).
  *
  * Runs the Vite/React frontend in a plain browser with Tauri IPC and event
- * mocks (see `src/e2e/mocks/installTauriMocks.ts`, enabled via
- * `VITE_E2E_MOCK=true`). Captures PNG evidence screenshots under
- * `test-results/captures/`.
+ * mocks (see `src/main.e2e.tsx`, enabled via `vite --mode e2e`). Captures PNG
+ * evidence screenshots under `test-results/captures/`.
  *
  * A dedicated port (1521) is used so a regular `npm run dev` server
  * (1520, without mocks) is never reused by accident.
@@ -47,7 +46,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `vite dev --port ${E2E_PORT} --strictPort`,
+    command: `vite dev --mode e2e --port ${E2E_PORT} --strictPort`,
     url: `http://localhost:${E2E_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `vite dev --port ${RENDER_PERF_PORT} --strictPort`,
+    command: `vite dev --mode e2e --port ${RENDER_PERF_PORT} --strictPort`,
     url: `http://localhost:${RENDER_PERF_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -116,8 +116,8 @@ const buildInvokeHandlers = (
 
 /**
  * Install Tauri IPC/event/window mocks so the React app runs in a plain
- * browser with deterministic fixture data. Loaded from `src/main.tsx` only
- * when `VITE_E2E_MOCK=true` (the branch is dead-code eliminated otherwise).
+ * browser with deterministic fixture data. Loaded from `src/main.e2e.tsx`,
+ * which Vite serves only in `--mode e2e`.
  *
  * Mock layers:
  * - `mockWindows("main")` fakes the current window label.

--- a/src/main.e2e.tsx
+++ b/src/main.e2e.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { installTauriMocks } from "./e2e/mocks/installTauriMocks";
+
+const bootstrap = async () => {
+  installTauriMocks();
+
+  const { App } = await import("./App");
+
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+};
+
+bootstrap().catch((error) => {
+  console.error("Failed to bootstrap the E2E app:", error);
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,24 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { App } from "./App";
 
-const bootstrap = async () => {
-  // E2E-only: install Tauri IPC/event mocks before any app module runs.
-  // The condition is statically false in production builds, so the mock
-  // chunk is dead-code eliminated and never shipped.
-  if (import.meta.env.VITE_E2E_MOCK === "true") {
-    const { installTauriMocks } = await import("./e2e/mocks/installTauriMocks");
-    installTauriMocks();
-  }
-
-  const { App } = await import("./App");
-
-  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-};
-
-bootstrap().catch((error) => {
-  console.error("Failed to bootstrap the app:", error);
-});
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,16 @@ const reactDevTools = (): PluginOption => {
   };
 };
 
+const e2eEntry = (): PluginOption => {
+  return {
+    name: "hardware-visualizer-e2e-entry",
+    apply: "serve",
+    transformIndexHtml(html) {
+      return html.replace("/src/main.tsx", "/src/main.e2e.tsx");
+    },
+  };
+};
+
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => ({
   plugins: [
@@ -43,6 +53,7 @@ export default defineConfig(async ({ mode }) => ({
     babel({ presets: [reactCompilerPreset()] }),
     tailwindcss(),
     mode === "react-devtools" && reactDevTools(),
+    mode === "e2e" && e2eEntry(),
   ],
 
   build: {
@@ -107,8 +118,8 @@ export default defineConfig(async ({ mode }) => ({
     },
   },
   optimizeDeps: {
-    // Pre-bundle the Tauri mock module so the E2E harness (VITE_E2E_MOCK)
-    // doesn't trigger a mid-session dependency re-optimization.
-    include: ["@tauri-apps/api/mocks"],
+    // Pre-bundle the Tauri mock module only in E2E mode so the regular app
+    // entry path stays independent from the web/mock harness.
+    include: mode === "e2e" ? ["@tauri-apps/api/mocks"] : [],
   },
 }));


### PR DESCRIPTION
## Summary

- Restore `src/main.tsx` to the normal static React/Tauri app entrypoint.
- Add `src/main.e2e.tsx` for the web/mock Playwright harness so mocks are still installed before the app module loads.
- Make Vite serve the E2E entry only in `--mode e2e`, and point the E2E/render-perf Playwright configs at that mode.

## Root cause

The Performance Test artifacts show the regression as WebView-backed process-tree memory growth rather than a steady app-process RSS increase:

- 2026-06-07 baseline (`e548058d`): WebView growth `-4.2 MB`, process-tree growth `-3.3 MB`, passed.
- 2026-06-08 first failing run (`fe66ece2`): WebView growth `+167.8 MB`, process-tree growth `+193.2 MB`, failed.
- 2026-06-10 latest failing run (`70190312`): WebView growth `+286.0 MB`, process-tree growth `+316.4 MB`, failed.

The failure starts immediately after the PR range that added the E2E mock harness. That PR changed the normal `src/main.tsx` to always async-import `./App` so mocks could be installed before the app in E2E. This PR keeps that ordering only for E2E and removes the production/Tauri entrypoint coupling.

## Validation

- `npm.cmd run build`
- Production `dist/assets` scan for `main.e2e`, `installTauriMocks`, `e2e-mock`, `VITE_E2E_MOCK`, `__E2E__`, and `mockIPC`: no matches
- `npm.cmd run lint:ci`
- `npm.cmd run test:e2e` (`7 passed`)
- `npm.cmd run test:perf:render` (`2 passed`)
- `git diff --check`
- `git diff --cached --check`
- Manual GitHub Actions `Performance Test` on this branch: success, https://github.com/shm11C3/HardwareVisualizer/actions/runs/27366419936
  - App memory avg `72.1 MB`, growth `-0.8 MB` (threshold avg `80 MB`, growth `50 MB`)
  - Process-tree memory avg `504.8 MB`, growth `6.7 MB` (threshold avg `600 MB`, growth `50 MB`)
  - WebView memory avg `432.7 MB`, growth `7.6 MB`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored E2E testing infrastructure and configuration to streamline the development environment setup and test harness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->