### PR TITLE
perf-monitor: extend measurement window to stabilize Growth

### DIFF
--- a/perf-monitor/src/config.rs
+++ b/perf-monitor/src/config.rs
@@ -60,8 +60,8 @@ impl std::error::Error for ValidationError {}
 impl Default for Timing {
   fn default() -> Self {
     Self {
-      warmup_seconds: 10,
-      measurement_seconds: 30,
+      warmup_seconds: 15,
+      measurement_seconds: 60,
       sample_interval_ms: 1000,
     }
   }

--- a/perf-thresholds.toml
+++ b/perf-thresholds.toml
@@ -9,8 +9,8 @@ max_p95_memory_mb = 500.0
 max_memory_growth_mb = 50.0
 
 [timing]
-warmup_seconds = 10
-measurement_seconds = 30
+warmup_seconds = 15
+measurement_seconds = 60
 sample_interval_ms = 1000
 
 [platforms.windows]


### PR DESCRIPTION
## Summary
- Extend perf-monitor measurement window to reduce variance in the Growth metric (`last_sample - first_sample`)
- `warmup_seconds` 10 → 15s (more headroom for Tauri + WebView stabilization on CI runners)
- `measurement_seconds` 30 → 60s (doubles sample count from 30 to 60, halving endpoint noise impact)
- Update `Timing::default()` in `perf-monitor/src/config.rs` to match the TOML values

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — all 21 tests pass
- [ ] Verify Growth variance improvement in the next daily perf-test run (perf-test.yml)

https://claude.ai/code/session_019xZbUrvuY6jPbow4QK4nTN