### PR TITLE
feat(core): native CPU package temperature via PawnIO (#1635 Phase 1)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ windows = { version = "0.62.2", features = [
     "Win32_System_IO",
     "Win32_System_Ioctl",
     "Win32_System_Performance",
+    "Win32_System_Registry",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -39,18 +39,40 @@ pub struct TemperatureSample {
 
 /// Read the latest CPU / sensor temperatures.
 ///
-/// Windows: ACPI thermal zones via the WMI sampler thread (started on the
-/// first call). The headline CPU value picks a CPU-named zone when one
-/// exists, otherwise the hottest zone — see
-/// [`crate::utils::thermal::select_cpu_temperature`].
+/// Windows: two cooperating sources, each on its own sampler thread
+/// (started on the first call):
+///
+/// 1. **PawnIO CPU package sensor** (preferred) — native Intel DTS /
+///    AMD Zen reading (#1635 Phase 1). When a fresh reading exists it
+///    becomes the headline `cpu_temperature` and is prepended to the
+///    sensor list as "CPU Package".
+/// 2. **ACPI thermal zones** via WMI (#1633) — always listed, and the
+///    headline fallback whenever PawnIO is unavailable (driver absent,
+///    unsupported CPU, stale reading): a CPU-named zone when one
+///    exists, otherwise the hottest zone — see
+///    [`crate::utils::thermal::select_cpu_temperature`].
 #[cfg(target_os = "windows")]
 pub fn sample_temperatures() -> TemperatureSample {
-  use crate::infrastructure::providers::thermal_zone;
+  use crate::infrastructure::providers::{pawnio_cpu_temp, thermal_zone};
 
   thermal_zone::init_thermal_zone_sampler();
-  let sensor_temperatures = thermal_zone::read_thermal_zones_cached();
-  let cpu_temperature =
-    crate::utils::thermal::select_cpu_temperature(&sensor_temperatures);
+  pawnio_cpu_temp::init_pawnio_cpu_temp_sampler();
+
+  let mut sensor_temperatures = thermal_zone::read_thermal_zones_cached();
+  let package_temperature = pawnio_cpu_temp::read_cpu_package_temperature_cached();
+
+  let cpu_temperature = package_temperature
+    .or_else(|| crate::utils::thermal::select_cpu_temperature(&sensor_temperatures));
+
+  if let Some(celsius) = package_temperature {
+    sensor_temperatures.insert(
+      0,
+      SensorTemperature {
+        name: pawnio_cpu_temp::CPU_PACKAGE_SENSOR_NAME.to_string(),
+        temperature: celsius,
+      },
+    );
+  }
 
   TemperatureSample {
     cpu_temperature,

--- a/core/src/infrastructure/providers/windows/mod.rs
+++ b/core/src/infrastructure/providers/windows/mod.rs
@@ -1,7 +1,10 @@
 pub mod adl_provider;
 pub mod device_io;
 pub mod directx;
+pub mod named_mutex;
 pub mod nvapi_provider;
+pub mod pawnio;
+pub mod pawnio_cpu_temp;
 pub mod pdh_provider;
 pub mod setupdi_provider;
 pub mod smart;

--- a/core/src/infrastructure/providers/windows/named_mutex.rs
+++ b/core/src/infrastructure/providers/windows/named_mutex.rs
@@ -1,0 +1,73 @@
+//! RAII wrapper around a Win32 named mutex (Windows).
+//!
+//! The PawnIO ecosystem coordinates hardware read transactions between
+//! concurrent monitoring tools through named mutexes (`Global\Access_PCI`
+//! for PCI/SMN, `Global\Access_ISABUS.HTP.Method` for ISA/Super I/O).
+//! The PawnIO modules acquire nothing themselves — every relevant ioctl
+//! documents that the **caller** must hold the mutex — so clients in
+//! this crate wrap each call in [`NamedMutex::acquire`]. See
+//! `docs/specs/sensors/pawnio-interface.md` (rev 2), "Mutex conventions".
+//!
+//! Acquisition always uses a bounded timeout, and a timeout means the
+//! caller skips its sample: proceeding unlocked is never an option.
+
+use std::time::Duration;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_ABANDONED, WAIT_OBJECT_0};
+use windows::Win32::System::Threading::{
+  CreateMutexW, ReleaseMutex, WaitForSingleObject,
+};
+use windows::core::PCWSTR;
+
+/// An open handle to a named Win32 mutex, created (or opened, when
+/// another process created it first) without initial ownership.
+pub struct NamedMutex {
+  handle: HANDLE,
+}
+
+impl NamedMutex {
+  /// Create or open the named mutex. Returns `None` when the object
+  /// cannot be created/opened (e.g. an incompatible ACL on the existing
+  /// object) — callers must then skip the protected operation.
+  pub fn create(name: &str) -> Option<Self> {
+    let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+    let handle = unsafe { CreateMutexW(None, false, PCWSTR(wide.as_ptr())) }.ok()?;
+    Some(Self { handle })
+  }
+
+  /// Acquire the mutex with a bounded timeout. Returns `None` on
+  /// timeout or wait failure; the caller must treat that as a skipped
+  /// sample and never proceed unlocked.
+  ///
+  /// `WAIT_ABANDONED` still grants ownership (the previous holder died
+  /// while owning the mutex). The transactions guarded here are
+  /// self-contained reads, so an abandoned mutex is safe to treat as
+  /// acquired.
+  pub fn acquire(&self, timeout: Duration) -> Option<NamedMutexGuard<'_>> {
+    let millis = timeout.as_millis().min(u32::MAX as u128) as u32;
+    let result = unsafe { WaitForSingleObject(self.handle, millis) };
+    (result == WAIT_OBJECT_0 || result == WAIT_ABANDONED)
+      .then_some(NamedMutexGuard { mutex: self })
+  }
+}
+
+impl Drop for NamedMutex {
+  fn drop(&mut self) {
+    unsafe {
+      let _ = CloseHandle(self.handle);
+    }
+  }
+}
+
+/// Ownership of an acquired [`NamedMutex`]; releases on drop.
+pub struct NamedMutexGuard<'a> {
+  mutex: &'a NamedMutex,
+}
+
+impl Drop for NamedMutexGuard<'_> {
+  fn drop(&mut self) {
+    unsafe {
+      let _ = ReleaseMutex(self.mutex.handle);
+    }
+  }
+}

--- a/core/src/infrastructure/providers/windows/pawnio.rs
+++ b/core/src/infrastructure/providers/windows/pawnio.rs
@@ -291,14 +291,17 @@ impl Drop for PawnIoModule<'_> {
 }
 
 /// Discover the PawnIO install directory: registry first, then the
-/// documented `%ProgramFiles%\PawnIO` fallback (only when the directory
-/// actually exists, so a clean miss reports as unavailable).
+/// documented `%ProgramFiles%\PawnIO` fallback (only when the candidate
+/// actually contains the library file, so a stale registry entry falls
+/// through to the fallback and a clean miss reports as unavailable).
 fn installed_location() -> Option<PathBuf> {
-  if let Some(dir) = registry_install_location() {
+  if let Some(dir) = registry_install_location()
+    && dir.join(PAWNIO_LIB_FILE).is_file()
+  {
     return Some(dir);
   }
   let fallback = PathBuf::from(std::env::var_os("ProgramFiles")?).join("PawnIO");
-  fallback.is_dir().then_some(fallback)
+  fallback.join(PAWNIO_LIB_FILE).is_file().then_some(fallback)
 }
 
 /// Read `InstallLocation` (REG_SZ) from the PawnIO uninstall key.

--- a/core/src/infrastructure/providers/windows/pawnio.rs
+++ b/core/src/infrastructure/providers/windows/pawnio.rs
@@ -1,0 +1,355 @@
+//! Minimal user-mode client for the PawnIO driver via PawnIOLib (Windows).
+//!
+//! Implemented clean-room from `docs/specs/sensors/pawnio-interface.md`
+//! (rev 2). Facts used here:
+//!
+//! - PawnIOLib's install location is discovered through the registry
+//!   value `InstallLocation` under
+//!   `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO`,
+//!   with `%ProgramFiles%\PawnIO` as the documented fallback. The
+//!   library is loaded dynamically and its functions are resolved by
+//!   name; this repository ships none of its (LGPL) code.
+//! - The HRESULT-form API: `pawnio_version`, `pawnio_open`,
+//!   `pawnio_load`, `pawnio_execute`, `pawnio_close`. Buffer sizes
+//!   passed to `pawnio_execute` are counts of 64-bit `ULONG64` cells,
+//!   not bytes, and `return_size` is the number of cells written.
+//! - One executor handle holds one loaded module; module functions are
+//!   addressed by string name (`ioctl_*`).
+//! - Absence of PawnIO is a supported state: every failure here surfaces
+//!   as an error the caller maps to "unavailable" (→ ACPI fallback).
+//!
+//! Compiled module blobs (`<Module>.amx`) are not bundled with this
+//! repository (LGPL artifacts; packaging happens later). They are read
+//! at runtime from a module directory: a process-wide override set via
+//! [`set_module_dir`], defaulting to `<exe dir>/pawnio`.
+
+use std::ffi::{CStr, c_char, c_void};
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use windows::Win32::Foundation::ERROR_SUCCESS;
+use windows::Win32::System::Registry::{HKEY_LOCAL_MACHINE, RRF_RT_REG_SZ, RegGetValueW};
+use windows::core::PCWSTR;
+
+use crate::log_debug;
+
+/// Registry key (under HKLM) holding the `InstallLocation` value.
+const UNINSTALL_KEY: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO";
+const INSTALL_LOCATION_VALUE: &str = "InstallLocation";
+
+/// File name of the user-mode library inside the install location.
+const PAWNIO_LIB_FILE: &str = "PawnIOLib.dll";
+
+/// Process-wide override for the module-blob directory. Read at session
+/// establishment, so setting it before sampling starts (or before the
+/// next establish attempt) takes effect.
+static MODULE_DIR_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Override the directory the PawnIO module blobs (`*.amx`) are read
+/// from. Intended for the app layer to call before sampling starts;
+/// without an override the default is `<directory of current exe>/pawnio`.
+pub fn set_module_dir(dir: PathBuf) {
+  if let Ok(mut guard) = MODULE_DIR_OVERRIDE.lock() {
+    *guard = Some(dir);
+  }
+}
+
+/// Resolve the module-blob directory: the override when set, otherwise
+/// `<exe dir>/pawnio`. `None` when neither can be resolved.
+pub fn module_dir() -> Option<PathBuf> {
+  if let Ok(guard) = MODULE_DIR_OVERRIDE.lock()
+    && let Some(dir) = guard.as_ref()
+  {
+    return Some(dir.clone());
+  }
+  std::env::current_exe()
+    .ok()
+    .and_then(|exe| exe.parent().map(|dir| dir.join("pawnio")))
+}
+
+/// Read a compiled module blob (`<module>.amx`) from the module
+/// directory.
+pub fn read_module_blob(module: &str) -> Result<Vec<u8>, PawnIoError> {
+  let Some(dir) = module_dir() else {
+    return Err(PawnIoError::BlobUnavailable(
+      "module directory unresolvable (no override, no executable directory)".to_string(),
+    ));
+  };
+  let path = dir.join(format!("{module}.amx"));
+  std::fs::read(&path)
+    .map_err(|e| PawnIoError::BlobUnavailable(format!("{}: {e}", path.display())))
+}
+
+/// Errors from PawnIO detection, loading, and execution. All of them
+/// mean "no native reading this round"; the provider decides between
+/// retrying later and tearing the session down.
+#[derive(Debug)]
+pub enum PawnIoError {
+  /// PawnIOLib could not be located or loaded — PawnIO is not installed
+  /// (or not where the documented discovery points).
+  LibraryUnavailable(String),
+  /// The installed PawnIOLib lacks a required export.
+  MissingExport(&'static str),
+  /// A PawnIOLib call returned a failure HRESULT.
+  Call { call: String, hresult: i32 },
+  /// `pawnio_execute` succeeded but wrote fewer output cells than the
+  /// ioctl contract promises.
+  ShortOutput {
+    call: String,
+    expected: usize,
+    written: usize,
+  },
+  /// The module blob could not be read.
+  BlobUnavailable(String),
+}
+
+impl fmt::Display for PawnIoError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::LibraryUnavailable(detail) => write!(f, "PawnIOLib unavailable: {detail}"),
+      Self::MissingExport(symbol) => write!(f, "PawnIOLib export missing: {symbol}"),
+      Self::Call { call, hresult } => {
+        write!(f, "{call} failed with HRESULT {hresult:#010X}")
+      }
+      Self::ShortOutput {
+        call,
+        expected,
+        written,
+      } => write!(f, "{call} wrote {written} of {expected} output cells"),
+      Self::BlobUnavailable(detail) => {
+        write!(f, "PawnIO module blob unavailable: {detail}")
+      }
+    }
+  }
+}
+
+// HRESULT-form prototypes from the interface spec, mapped to Rust:
+// HRESULT → i32 (failure codes have the high bit set, i.e. negative),
+// HANDLE → *mut c_void, PCSTR → *const c_char, SIZE_T/PSIZE_T → usize,
+// PULONG → *mut u32, ULONG64 → u64.
+type PawnioVersionFn = unsafe extern "system" fn(version: *mut u32) -> i32;
+type PawnioOpenFn = unsafe extern "system" fn(handle: *mut *mut c_void) -> i32;
+type PawnioLoadFn =
+  unsafe extern "system" fn(handle: *mut c_void, blob: *const u8, size: usize) -> i32;
+type PawnioExecuteFn = unsafe extern "system" fn(
+  handle: *mut c_void,
+  name: *const c_char,
+  input: *const u64,
+  in_size: usize,
+  output: *mut u64,
+  out_size: usize,
+  return_size: *mut usize,
+) -> i32;
+type PawnioCloseFn = unsafe extern "system" fn(handle: *mut c_void) -> i32;
+
+/// The dynamically loaded PawnIOLib with its exports resolved.
+pub struct PawnIo {
+  /// Keeps the DLL mapped so the resolved function pointers stay valid.
+  _lib: libloading::Library,
+  version: Option<PawnioVersionFn>,
+  open: PawnioOpenFn,
+  load: PawnioLoadFn,
+  execute: PawnioExecuteFn,
+  close: PawnioCloseFn,
+}
+
+impl PawnIo {
+  /// Locate and load the installed PawnIOLib (registry `InstallLocation`,
+  /// then `%ProgramFiles%\PawnIO`) and resolve the exports this project
+  /// uses. Failure means PawnIO is unavailable on this host.
+  pub fn load_installed() -> Result<Self, PawnIoError> {
+    let dir = installed_location().ok_or_else(|| {
+      PawnIoError::LibraryUnavailable(
+        "no InstallLocation registry value and no %ProgramFiles%\\PawnIO".to_string(),
+      )
+    })?;
+    let path = dir.join(PAWNIO_LIB_FILE);
+    let lib = unsafe { libloading::Library::new(&path) }
+      .map_err(|e| PawnIoError::LibraryUnavailable(format!("{}: {e}", path.display())))?;
+
+    // Mandatory exports; `pawnio_version` stays optional (diagnostics only).
+    let open = unsafe { lib.get::<PawnioOpenFn>(b"pawnio_open\0") }
+      .map(|symbol| *symbol)
+      .map_err(|_| PawnIoError::MissingExport("pawnio_open"))?;
+    let load = unsafe { lib.get::<PawnioLoadFn>(b"pawnio_load\0") }
+      .map(|symbol| *symbol)
+      .map_err(|_| PawnIoError::MissingExport("pawnio_load"))?;
+    let execute = unsafe { lib.get::<PawnioExecuteFn>(b"pawnio_execute\0") }
+      .map(|symbol| *symbol)
+      .map_err(|_| PawnIoError::MissingExport("pawnio_execute"))?;
+    let close = unsafe { lib.get::<PawnioCloseFn>(b"pawnio_close\0") }
+      .map(|symbol| *symbol)
+      .map_err(|_| PawnIoError::MissingExport("pawnio_close"))?;
+    let version = unsafe { lib.get::<PawnioVersionFn>(b"pawnio_version\0") }
+      .ok()
+      .map(|symbol| *symbol);
+
+    log_debug!(
+      "PawnIOLib loaded",
+      "pawnio::PawnIo::load_installed",
+      Some(path.display().to_string())
+    );
+
+    Ok(Self {
+      _lib: lib,
+      version,
+      open,
+      load,
+      execute,
+      close,
+    })
+  }
+
+  /// Driver/library version as `major.minor.patch`, decoded from
+  /// `version = (major << 16) | (minor << 8) | patch`.
+  pub fn version_string(&self) -> Option<String> {
+    let version_fn = self.version?;
+    let mut raw: u32 = 0;
+    let hresult = unsafe { version_fn(&mut raw) };
+    (hresult >= 0).then(|| format!("{}.{}.{}", raw >> 16, (raw >> 8) & 0xFF, raw & 0xFF))
+  }
+
+  /// Open an executor handle and load one compiled module blob into it
+  /// (one handle holds one loaded module).
+  pub fn open_module(&self, blob: &[u8]) -> Result<PawnIoModule<'_>, PawnIoError> {
+    let mut handle: *mut c_void = std::ptr::null_mut();
+    let hresult = unsafe { (self.open)(&mut handle) };
+    if hresult < 0 || handle.is_null() {
+      return Err(PawnIoError::Call {
+        call: "pawnio_open".to_string(),
+        hresult,
+      });
+    }
+    let hresult = unsafe { (self.load)(handle, blob.as_ptr(), blob.len()) };
+    if hresult < 0 {
+      unsafe {
+        let _ = (self.close)(handle);
+      }
+      return Err(PawnIoError::Call {
+        call: "pawnio_load".to_string(),
+        hresult,
+      });
+    }
+    Ok(PawnIoModule { lib: self, handle })
+  }
+}
+
+/// One executor handle with one loaded module. Closed on drop.
+pub struct PawnIoModule<'lib> {
+  lib: &'lib PawnIo,
+  handle: *mut c_void,
+}
+
+impl PawnIoModule<'_> {
+  /// Execute a module function (`ioctl_*`) by name. `input` and the
+  /// returned buffer are 64-bit cells; `output_cells` is the cell count
+  /// the ioctl contract promises, and a successful call that writes
+  /// fewer cells is reported as [`PawnIoError::ShortOutput`].
+  pub fn execute(
+    &self,
+    name: &CStr,
+    input: &[u64],
+    output_cells: usize,
+  ) -> Result<Vec<u64>, PawnIoError> {
+    let mut output = vec![0u64; output_cells];
+    let mut written: usize = 0;
+    let hresult = unsafe {
+      (self.lib.execute)(
+        self.handle,
+        name.as_ptr(),
+        input.as_ptr(),
+        input.len(),
+        output.as_mut_ptr(),
+        output.len(),
+        &mut written,
+      )
+    };
+    if hresult < 0 {
+      return Err(PawnIoError::Call {
+        call: format!("pawnio_execute({})", name.to_string_lossy()),
+        hresult,
+      });
+    }
+    if written < output_cells {
+      return Err(PawnIoError::ShortOutput {
+        call: name.to_string_lossy().into_owned(),
+        expected: output_cells,
+        written,
+      });
+    }
+    Ok(output)
+  }
+}
+
+impl Drop for PawnIoModule<'_> {
+  fn drop(&mut self) {
+    unsafe {
+      let _ = (self.lib.close)(self.handle);
+    }
+  }
+}
+
+/// Discover the PawnIO install directory: registry first, then the
+/// documented `%ProgramFiles%\PawnIO` fallback (only when the directory
+/// actually exists, so a clean miss reports as unavailable).
+fn installed_location() -> Option<PathBuf> {
+  if let Some(dir) = registry_install_location() {
+    return Some(dir);
+  }
+  let fallback = PathBuf::from(std::env::var_os("ProgramFiles")?).join("PawnIO");
+  fallback.is_dir().then_some(fallback)
+}
+
+/// Read `InstallLocation` (REG_SZ) from the PawnIO uninstall key.
+fn registry_install_location() -> Option<PathBuf> {
+  let subkey: Vec<u16> = UNINSTALL_KEY
+    .encode_utf16()
+    .chain(std::iter::once(0))
+    .collect();
+  let value: Vec<u16> = INSTALL_LOCATION_VALUE
+    .encode_utf16()
+    .chain(std::iter::once(0))
+    .collect();
+
+  // First call sizes the buffer (byte count incl. NUL), second fills it.
+  let mut byte_len: u32 = 0;
+  let status = unsafe {
+    RegGetValueW(
+      HKEY_LOCAL_MACHINE,
+      PCWSTR(subkey.as_ptr()),
+      PCWSTR(value.as_ptr()),
+      RRF_RT_REG_SZ,
+      None,
+      None,
+      Some(&mut byte_len),
+    )
+  };
+  if status != ERROR_SUCCESS || byte_len == 0 {
+    return None;
+  }
+
+  let mut buffer: Vec<u16> = vec![0; (byte_len as usize).div_ceil(2)];
+  let mut byte_size = byte_len;
+  let status = unsafe {
+    RegGetValueW(
+      HKEY_LOCAL_MACHINE,
+      PCWSTR(subkey.as_ptr()),
+      PCWSTR(value.as_ptr()),
+      RRF_RT_REG_SZ,
+      None,
+      Some(buffer.as_mut_ptr().cast::<c_void>()),
+      Some(&mut byte_size),
+    )
+  };
+  if status != ERROR_SUCCESS {
+    return None;
+  }
+
+  let chars = (byte_size as usize) / 2;
+  let location = String::from_utf16_lossy(&buffer[..chars.min(buffer.len())])
+    .trim_end_matches('\0')
+    .trim()
+    .to_string();
+  (!location.is_empty()).then(|| PathBuf::from(location))
+}

--- a/core/src/infrastructure/providers/windows/pawnio_cpu_temp.rs
+++ b/core/src/infrastructure/providers/windows/pawnio_cpu_temp.rs
@@ -1,0 +1,403 @@
+//! Native CPU package-temperature provider via PawnIO (Windows).
+//!
+//! Phase 1 of issue #1635. Reads the package temperature directly from
+//! the CPU instead of ACPI thermal zones:
+//!
+//! - **Intel**: digital thermal sensor MSRs through the PawnIO
+//!   `IntelMSR` module (`docs/specs/sensors/cpu-intel-dts-msr.md`, rev 2)
+//! - **AMD Zen**: `THM_TCON_CUR_TMP` over SMN through the PawnIO
+//!   `RyzenSMU` module (`docs/specs/sensors/cpu-amd-zen-smn.md`, rev 3)
+//! - PawnIO client contract: `docs/specs/sensors/pawnio-interface.md`
+//!   (rev 2)
+//!
+//! PawnIO IOCTLs are blocking, so all driver work is confined to one
+//! dedicated sampler thread (the `thermal_zone` pattern): the collector
+//! reads the latest value from a process-wide cache and never blocks.
+//! The cache enforces a freshness window so a stalled sampler stops
+//! feeding the headline value and the ACPI fallback takes over.
+//!
+//! Graceful degradation: when PawnIO is not installed (or the module
+//! blob is missing) the sampler logs once, reports unavailable, and
+//! re-probes at a slow idle cadence, leaving the ACPI thermal-zone
+//! source (#1633) in charge. A CPU that can never be supported (wrong
+//! vendor/family/feature bits, zero Temperature Target) ends the
+//! sampler outright.
+//!
+//! Register access is read-only: the only module functions ever invoked
+//! are `ioctl_read_msr` and `ioctl_read_smu_register`. Per the interface
+//! spec, Intel MSR reads need no ecosystem mutex, while every `RyzenSMU`
+//! call is wrapped in the caller-held `Global\Access_PCI` mutex with a
+//! bounded timeout — a timeout skips the sample, never reads unlocked.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use super::named_mutex::NamedMutex;
+use super::pawnio::{self, PawnIoError, PawnIoModule};
+use crate::utils::cpu_thermal::{self, CpuSensorPlan};
+use crate::{log_debug, log_error, log_info};
+
+/// Cadence of the sampler thread; matches the thermal-zone sampler so
+/// the two temperature sources age at the same rate.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// After this many consecutive failed reads the session is torn down
+/// (handles dropped) and detection restarts after [`IDLE_INTERVAL`].
+const FAILURES_BEFORE_TEARDOWN: u32 = 5;
+
+/// Re-probe cadence while PawnIO is unavailable. Keeps a PawnIO
+/// install during the session discoverable without polling noise.
+const IDLE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Readings older than this are not served from the cache; the caller
+/// then falls back to ACPI zones. Covers a few skipped samples without
+/// letting a dead sampler pin a stale headline value.
+const STALE_AFTER: Duration = Duration::from_secs(10);
+
+/// Bounded wait for `Global\Access_PCI` (spec: bounded timeout, and a
+/// timeout means a skipped sample). The exact bound is project policy.
+const PCI_MUTEX_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Ecosystem mutex the caller must hold around each `RyzenSMU` ioctl.
+const PCI_MUTEX_NAME: &str = r"Global\Access_PCI";
+
+/// Sensor-list display name of the PawnIO-derived package reading.
+pub const CPU_PACKAGE_SENSOR_NAME: &str = "CPU Package";
+
+/// Latest successful package reading with its timestamp.
+struct PackageReading {
+  celsius: f32,
+  read_at: Instant,
+}
+
+/// Latest reading (`None` while unavailable). Guarded by a `Mutex` for
+/// the non-blocking collector accessor.
+static LATEST_READING: OnceLock<Mutex<Option<PackageReading>>> = OnceLock::new();
+
+/// Indicates whether the sampler thread is running. Reset to `false`
+/// when the spawn fails so a later collector tick can retry instead of
+/// latching the sampler off for the rest of the process.
+static SAMPLER_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Start the background sampler thread. No-op if already running.
+pub fn init_pawnio_cpu_temp_sampler() {
+  let _ = LATEST_READING.get_or_init(|| Mutex::new(None));
+
+  // Only the caller that flips the flag spawns; concurrent callers bail.
+  if SAMPLER_STARTED
+    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+    .is_err()
+  {
+    return;
+  }
+
+  if let Err(e) = std::thread::Builder::new()
+    .name("pawnio-cpu-temp-sampler".to_string())
+    .spawn(sampler_loop)
+  {
+    SAMPLER_STARTED.store(false, Ordering::Release);
+    log_error!(
+      "failed to spawn pawnio-cpu-temp-sampler thread",
+      "pawnio_cpu_temp::init_pawnio_cpu_temp_sampler",
+      Some(e.to_string())
+    );
+  }
+}
+
+/// Latest CPU package temperature in raw °C, or `None` when no fresh
+/// PawnIO reading exists (driver absent, unsupported CPU, stalled
+/// sampler). Never blocks.
+pub fn read_cpu_package_temperature_cached() -> Option<f32> {
+  let reading = LATEST_READING.get()?.lock().ok()?;
+  reading
+    .as_ref()
+    .and_then(|r| (r.read_at.elapsed() <= STALE_AFTER).then_some(r.celsius))
+}
+
+fn store_reading(reading: Option<f32>) {
+  if let Some(latest) = LATEST_READING.get()
+    && let Ok(mut guard) = latest.lock()
+  {
+    *guard = reading.map(|celsius| PackageReading {
+      celsius,
+      read_at: Instant::now(),
+    });
+  }
+}
+
+/// How a session ended, deciding what the sampler does next.
+enum SessionEnd {
+  /// Recoverable (PawnIO missing, repeated read failures): drop all
+  /// handles, idle, then re-detect.
+  Retry,
+  /// The CPU can never produce a reading (e.g. zero Temperature
+  /// Target): the sampler thread ends for the process lifetime.
+  Unsupported,
+}
+
+/// Dedicated thread: classifies the CPU once, then owns the PawnIO
+/// handles and refreshes [`LATEST_READING`] until process exit.
+fn sampler_loop() {
+  let plan = detect_cpu();
+  match plan {
+    CpuSensorPlan::Unsupported => {
+      log_debug!(
+        "CPU is not a supported PawnIO temperature target; ACPI thermal zones remain the source",
+        "pawnio_cpu_temp::sampler_loop",
+        None::<&str>
+      );
+      return;
+    }
+    CpuSensorPlan::AmdFamilyDisabled { family } => {
+      // Recognized by the RyzenSMU module but not yet verified by the
+      // spec (scoped-enablement table) — disabled by default.
+      log_info!(
+        "AMD family recognized but disabled pending spec verification; using ACPI thermal zones",
+        "pawnio_cpu_temp::sampler_loop",
+        Some(format!("family {family:#x}"))
+      );
+      return;
+    }
+    CpuSensorPlan::IntelDts | CpuSensorPlan::AmdZenSmn { .. } => {}
+  }
+
+  let mut establish_failure_logged = false;
+  loop {
+    match run_session(plan, &mut establish_failure_logged) {
+      SessionEnd::Unsupported => {
+        store_reading(None);
+        return;
+      }
+      SessionEnd::Retry => {
+        store_reading(None);
+        std::thread::sleep(IDLE_INTERVAL);
+      }
+    }
+  }
+}
+
+/// Log the first establishment failure (then stay quiet until a session
+/// succeeds again) and signal a retry.
+fn note_establish_failure(detail: String, logged: &mut bool) -> SessionEnd {
+  if !*logged {
+    log_info!(
+      "PawnIO unavailable; CPU package temperature stays on ACPI thermal zones",
+      "pawnio_cpu_temp::run_session",
+      Some(detail)
+    );
+    *logged = true;
+  }
+  SessionEnd::Retry
+}
+
+/// Establish one PawnIO session (library + module blob + executor
+/// handle, all owned by this stack frame) and run its read loop.
+fn run_session(plan: CpuSensorPlan, establish_failure_logged: &mut bool) -> SessionEnd {
+  let (module_name, source_label) = match plan {
+    CpuSensorPlan::IntelDts => ("IntelMSR", "Intel DTS"),
+    CpuSensorPlan::AmdZenSmn { .. } => ("RyzenSMU", "AMD Zen SMN"),
+    // Guarded by sampler_loop; kept total for safety.
+    _ => return SessionEnd::Unsupported,
+  };
+
+  let lib = match pawnio::PawnIo::load_installed() {
+    Ok(lib) => lib,
+    Err(e) => return note_establish_failure(e.to_string(), establish_failure_logged),
+  };
+  let blob = match pawnio::read_module_blob(module_name) {
+    Ok(blob) => blob,
+    Err(e) => return note_establish_failure(e.to_string(), establish_failure_logged),
+  };
+  // One executor handle per module; lives until the session ends.
+  let module = match lib.open_module(&blob) {
+    Ok(module) => module,
+    Err(e) => return note_establish_failure(e.to_string(), establish_failure_logged),
+  };
+
+  log_info!(
+    &format!(
+      "PawnIO CPU package temperature sampler active ({source_label} via {module_name}, PawnIOLib {})",
+      lib
+        .version_string()
+        .unwrap_or_else(|| "unknown".to_string())
+    ),
+    "pawnio_cpu_temp::run_session",
+    None::<&str>
+  );
+  *establish_failure_logged = false;
+
+  match plan {
+    CpuSensorPlan::IntelDts => run_intel_session(&module),
+    CpuSensorPlan::AmdZenSmn { .. } => run_amd_session(&module),
+    _ => SessionEnd::Unsupported,
+  }
+}
+
+/// Intel DTS session: resolve the Temperature Target once, then decode
+/// `IA32_PACKAGE_THERM_STATUS` every tick.
+///
+/// `0x1B1` is package-scope (identical from any logical CPU of the
+/// package) and PawnIO executes `RDMSR` on the calling thread's current
+/// processor; Phase 1 targets single-package machines, so no thread
+/// affinity pinning is needed.
+fn run_intel_session(module: &PawnIoModule<'_>) -> SessionEnd {
+  // Spec read procedure step 2: read MSR_TEMPERATURE_TARGET once per
+  // session. A faulted read means "unsupported" for this session — the
+  // idle retry keeps a transient driver hiccup recoverable.
+  let msr_1a2 = match read_msr(module, cpu_thermal::MSR_TEMPERATURE_TARGET) {
+    Ok(value) => value,
+    Err(e) => {
+      log_debug!(
+        "MSR_TEMPERATURE_TARGET read faulted; treating Intel DTS as unsupported this session",
+        "pawnio_cpu_temp::run_intel_session",
+        Some(e.to_string())
+      );
+      return SessionEnd::Retry;
+    }
+  };
+  let Some(t_target) = cpu_thermal::intel_temperature_target(msr_1a2) else {
+    log_info!(
+      "Temperature Target field is zero; Intel DTS unsupported on this part",
+      "pawnio_cpu_temp::run_intel_session",
+      None::<&str>
+    );
+    return SessionEnd::Unsupported;
+  };
+  if !cpu_thermal::intel_t_target_plausible(t_target) {
+    log_info!(
+      "Temperature Target outside the 50-120 °C plausibility bounds; Intel DTS unsupported",
+      "pawnio_cpu_temp::run_intel_session",
+      Some(format!("t_target = {t_target} °C"))
+    );
+    return SessionEnd::Unsupported;
+  }
+
+  run_read_loop(|| {
+    read_msr(module, cpu_thermal::MSR_IA32_PACKAGE_THERM_STATUS)
+      .ok()
+      .and_then(|value| cpu_thermal::intel_package_temperature(t_target, value))
+  })
+}
+
+/// AMD Zen session: read `THM_TCON_CUR_TMP` over SMN every tick, under
+/// the caller-held `Global\Access_PCI` mutex, and publish Tdie.
+fn run_amd_session(module: &PawnIoModule<'_>) -> SessionEnd {
+  // The Tctl − Tdie offset is keyed by product name (OPN) and constant
+  // for the session; unlisted products use the documented default of 0.
+  let tctl_offset = cpu_thermal::amd_tctl_offset(&read_brand_string());
+
+  let Some(pci_mutex) = NamedMutex::create(PCI_MUTEX_NAME) else {
+    log_debug!(
+      "failed to create/open the Access_PCI mutex; skipping this session",
+      "pawnio_cpu_temp::run_amd_session",
+      None::<&str>
+    );
+    return SessionEnd::Retry;
+  };
+
+  run_read_loop(|| {
+    // Hold the mutex for exactly one self-contained register read; a
+    // wait timeout skips the sample (never proceed unlocked).
+    let raw = {
+      let _guard = pci_mutex.acquire(PCI_MUTEX_TIMEOUT)?;
+      module
+        .execute(
+          c"ioctl_read_smu_register",
+          &[cpu_thermal::AMD_SMN_THM_TCON_CUR_TMP],
+          1,
+        )
+        .ok()?[0]
+    };
+    // out[0] carries the 32-bit register value in a 64-bit cell.
+    cpu_thermal::amd_tdie_celsius(raw as u32, tctl_offset)
+  })
+}
+
+/// Shared per-sample loop: publish successes, count failures, and tear
+/// the session down after [`FAILURES_BEFORE_TEARDOWN`] misses in a row.
+/// Single failures keep the last good value — the cache freshness
+/// window ages it out if the gap persists.
+fn run_read_loop(mut read_once: impl FnMut() -> Option<f32>) -> SessionEnd {
+  let mut consecutive_failures: u32 = 0;
+  loop {
+    match read_once() {
+      Some(celsius) => {
+        consecutive_failures = 0;
+        store_reading(Some(celsius));
+      }
+      None => {
+        consecutive_failures = consecutive_failures.saturating_add(1);
+        if consecutive_failures >= FAILURES_BEFORE_TEARDOWN {
+          log_debug!(
+            "repeated PawnIO read failures; tearing the session down for idle re-detection",
+            "pawnio_cpu_temp::run_read_loop",
+            None::<&str>
+          );
+          return SessionEnd::Retry;
+        }
+      }
+    }
+    std::thread::sleep(SAMPLE_INTERVAL);
+  }
+}
+
+/// Read one allow-listed MSR through the `IntelMSR` module
+/// (`ioctl_read_msr`: 1 input cell = MSR index, 1 output cell = value).
+fn read_msr(module: &PawnIoModule<'_>, msr: u64) -> Result<u64, PawnIoError> {
+  let output = module.execute(c"ioctl_read_msr", &[msr], 1)?;
+  Ok(output[0])
+}
+
+/// Classify the host CPU from CPUID (vendor, family, thermal feature
+/// bits). Leaves beyond the maximum supported leaf are passed as 0,
+/// which the pure classifier treats as "feature absent".
+#[cfg(target_arch = "x86_64")]
+fn detect_cpu() -> CpuSensorPlan {
+  use std::arch::x86_64::__cpuid;
+  let leaf0 = __cpuid(0);
+  let vendor = cpu_thermal::cpuid_vendor_string(leaf0.ebx, leaf0.ecx, leaf0.edx);
+  let max_standard_leaf = leaf0.eax;
+  let leaf1_eax = if max_standard_leaf >= 1 {
+    __cpuid(1).eax
+  } else {
+    0
+  };
+  let leaf06_eax = if max_standard_leaf >= 6 {
+    __cpuid(6).eax
+  } else {
+    0
+  };
+  cpu_thermal::plan_cpu_sensor(&vendor, leaf1_eax, leaf06_eax)
+}
+
+/// PawnIO targets x86-64 CPUs; other architectures report unsupported.
+#[cfg(not(target_arch = "x86_64"))]
+fn detect_cpu() -> CpuSensorPlan {
+  CpuSensorPlan::Unsupported
+}
+
+/// CPU brand string from CPUID leaves `0x80000002..=0x80000004`; empty
+/// when the extended leaves are unavailable (then the Tctl offset
+/// lookup falls through to the default of 0).
+#[cfg(target_arch = "x86_64")]
+fn read_brand_string() -> String {
+  use std::arch::x86_64::__cpuid;
+  if __cpuid(0x8000_0000).eax < 0x8000_0004 {
+    return String::new();
+  }
+  let mut regs = [0u32; 12];
+  for (i, leaf) in (0x8000_0002u32..=0x8000_0004).enumerate() {
+    let result = __cpuid(leaf);
+    regs[i * 4] = result.eax;
+    regs[i * 4 + 1] = result.ebx;
+    regs[i * 4 + 2] = result.ecx;
+    regs[i * 4 + 3] = result.edx;
+  }
+  cpu_thermal::cpuid_brand_string(&regs)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn read_brand_string() -> String {
+  String::new()
+}

--- a/core/src/utils/cpu_thermal.rs
+++ b/core/src/utils/cpu_thermal.rs
@@ -1,0 +1,703 @@
+//! Pure decode / detection helpers for native CPU package-temperature
+//! sensors read through PawnIO (issue #1635, Phase 1).
+//!
+//! Implemented clean-room from these spec documents only:
+//!
+//! - `docs/specs/sensors/cpu-intel-dts-msr.md` (rev 2) — Intel digital
+//!   thermal sensor MSR layout, decode, and plausibility gates
+//! - `docs/specs/sensors/cpu-amd-zen-smn.md` (rev 3) — AMD Zen THM
+//!   register layout, decode, Tctl offsets, per-family enablement
+//! - `docs/specs/sensors/pawnio-interface.md` (rev 2) — module names
+//!   referenced in doc comments
+//!
+//! Everything here is a platform-neutral pure function so the decode
+//! logic stays unit-testable on every OS. The Windows-only provider
+//! (`infrastructure::providers::windows::pawnio_cpu_temp`) feeds it raw
+//! CPUID / MSR / SMN values and publishes the result.
+
+/// CPUID leaf 0 vendor string of Intel CPUs.
+pub const INTEL_VENDOR: &str = "GenuineIntel";
+/// CPUID leaf 0 vendor string of AMD CPUs.
+pub const AMD_VENDOR: &str = "AuthenticAMD";
+
+/// `MSR_TEMPERATURE_TARGET` — TCC activation temperature ("TjMax").
+/// Read once per session; bits 23:16 carry the Temperature Target.
+pub const MSR_TEMPERATURE_TARGET: u64 = 0x1A2;
+
+/// `IA32_PACKAGE_THERM_STATUS` — package-scope digital readout.
+/// Reads identically from any logical CPU of the package and has no
+/// Reading Valid bit.
+pub const MSR_IA32_PACKAGE_THERM_STATUS: u64 = 0x1B1;
+
+/// SMN address of `SMU::THM::THM_TCON_CUR_TMP` (SMUTHM aperture
+/// `0x0005_9800`, register offset 0). Inside the PawnIO `RyzenSMU`
+/// module's allowed window `0x56000`–`0x5AFFF`.
+pub const AMD_SMN_THM_TCON_CUR_TMP: u64 = 0x0005_9800;
+
+/// Intel plausibility bounds for the Temperature Target in °C
+/// (project policy from the spec: "t_target within 50–120 °C").
+const INTEL_T_TARGET_MIN: u32 = 50;
+const INTEL_T_TARGET_MAX: u32 = 120;
+
+/// AMD plausibility bounds for Tdie in °C (project policy from the
+/// spec: "accept only −40 ≤ Tdie ≤ 120 °C").
+const AMD_TDIE_MIN: f32 = -40.0;
+const AMD_TDIE_MAX: f32 = 120.0;
+
+// ── CPUID register decoding ──
+
+/// Assemble the CPU vendor string from CPUID leaf 0.
+///
+/// The 12 ASCII bytes are carried in EBX, EDX, ECX — in that register
+/// order — as little-endian byte groups (standard x86 CPUID convention).
+pub fn cpuid_vendor_string(ebx: u32, ecx: u32, edx: u32) -> String {
+  let mut bytes = Vec::with_capacity(12);
+  bytes.extend_from_slice(&ebx.to_le_bytes());
+  bytes.extend_from_slice(&edx.to_le_bytes());
+  bytes.extend_from_slice(&ecx.to_le_bytes());
+  String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Assemble the CPU brand string from CPUID leaves
+/// `0x80000002..=0x80000004` (standard x86 convention): each leaf
+/// contributes EAX, EBX, ECX, EDX as little-endian byte groups, 48
+/// bytes total, NUL-padded. Trailing NULs and surrounding whitespace
+/// are stripped.
+pub fn cpuid_brand_string(regs: &[u32; 12]) -> String {
+  let mut bytes = Vec::with_capacity(48);
+  for reg in regs {
+    bytes.extend_from_slice(&reg.to_le_bytes());
+  }
+  let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+  String::from_utf8_lossy(&bytes[..end]).trim().to_string()
+}
+
+// ── Intel DTS (cpu-intel-dts-msr.md) ──
+
+/// `CPUID.06H:EAX[0]` — digital thermal sensor (DTS) supported.
+pub fn intel_dts_supported(leaf06_eax: u32) -> bool {
+  leaf06_eax & 0x1 != 0
+}
+
+/// `CPUID.06H:EAX[6]` — package thermal management (PTM) supported;
+/// `IA32_PACKAGE_THERM_STATUS` exists only when this is set.
+pub fn intel_ptm_supported(leaf06_eax: u32) -> bool {
+  leaf06_eax & (1 << 6) != 0
+}
+
+/// Extract the Temperature Target (TCC activation temperature, °C)
+/// from `MSR_TEMPERATURE_TARGET` (`0x1A2`) bits 23:16.
+///
+/// Returns `None` when the field is 0 — the spec's "not supported"
+/// marker (pre-Nehalem parts without a usable target). A faulted MSR
+/// read is the other "unsupported" condition and is handled by the
+/// caller. The TCC Activation Offset (bits 27:24, 29:24 on newer
+/// products) never enters the decode: bits 23:16 stay the fixed
+/// reference.
+pub fn intel_temperature_target(msr_1a2: u64) -> Option<u32> {
+  let t_target = ((msr_1a2 >> 16) & 0xFF) as u32;
+  (t_target != 0).then_some(t_target)
+}
+
+/// Publishing bound on the Temperature Target: 50–120 °C inclusive.
+pub fn intel_t_target_plausible(t_target: u32) -> bool {
+  (INTEL_T_TARGET_MIN..=INTEL_T_TARGET_MAX).contains(&t_target)
+}
+
+/// Decode the package temperature from `IA32_PACKAGE_THERM_STATUS`
+/// (`0x1B1`).
+///
+/// Hardware semantics: bits 22:16 carry the Package Digital Readout —
+/// degrees **below** the package TCC activation temperature — so
+/// `temperature = t_target − readout` in °C. All other status bits of
+/// the register are ignored (the package register has no Reading Valid
+/// bit).
+///
+/// Plausibility gate before publishing (project policy from the spec):
+/// accept only `0 < temperature ≤ t_target` — inclusive, so a readout
+/// of 0 decodes to `temperature == t_target` ("at TjMax") and passes —
+/// and `t_target` within 50–120 °C. Returns `None` for dropped samples.
+pub fn intel_package_temperature(t_target: u32, msr_1b1: u64) -> Option<f32> {
+  if !intel_t_target_plausible(t_target) {
+    return None;
+  }
+  let readout = ((msr_1b1 >> 16) & 0x7F) as i64;
+  let temperature = t_target as i64 - readout;
+  (temperature > 0 && temperature <= t_target as i64).then_some(temperature as f32)
+}
+
+// ── AMD Zen THM over SMN (cpu-amd-zen-smn.md) ──
+
+/// Effective AMD family from CPUID leaf 1 EAX: base family (bits 11:8)
+/// plus extended family (bits 27:20), the latter added only when the
+/// base family is `0xF` (AMD CPUID convention per the spec).
+pub fn amd_effective_family(leaf1_eax: u32) -> u32 {
+  let base = (leaf1_eax >> 8) & 0xF;
+  if base == 0xF {
+    base + ((leaf1_eax >> 20) & 0xFF)
+  } else {
+    base
+  }
+}
+
+/// Per-family enablement (the spec's scoped-enablement table).
+///
+/// "Recognized by the PawnIO module" and "enabled by this project" are
+/// separate decisions: a family is enabled only once its THM register
+/// facts are verified against a primary source in the spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AmdFamilySupport {
+  /// THM register facts verified by the spec — enabled (`0x17`, `0x19`).
+  Enabled,
+  /// Recognized by the PawnIO `RyzenSMU` module but not yet verified by
+  /// the spec — disabled by default (`0x1A`, Zen 5).
+  RecognizedDisabled,
+  /// Not a supported Zen SMN target.
+  Unsupported,
+}
+
+/// Look up a family in the spec's enablement table.
+pub fn amd_family_support(family: u32) -> AmdFamilySupport {
+  match family {
+    0x17 | 0x19 => AmdFamilySupport::Enabled,
+    0x1A => AmdFamilySupport::RecognizedDisabled,
+    _ => AmdFamilySupport::Unsupported,
+  }
+}
+
+/// Decode Tctl from the 32-bit `THM_TCON_CUR_TMP` register value.
+///
+/// Hardware semantics:
+/// - An all-zero register read indicates a failed SMN transaction
+///   rather than 0 °C → `None` (invalid sample).
+/// - `CUR_TEMP` (bits 31:21, unsigned 11-bit) scales at 0.125 °C/LSB.
+/// - `CUR_TEMP_RANGE_SEL` (bit 19) = 1 selects the −49…206 °C range:
+///   subtract 49 °C. The bit must always be honored — the −49 °C range
+///   is the normal case on many desktop parts.
+/// - Bits 18:0 other than `RANGE_SEL` are Reserved on the CPU THM and
+///   are ignored.
+pub fn amd_tctl_celsius(thm_tcon_cur_tmp: u32) -> Option<f32> {
+  if thm_tcon_cur_tmp == 0 {
+    return None;
+  }
+  let cur_temp = (thm_tcon_cur_tmp >> 21) & 0x7FF;
+  let mut tctl = cur_temp as f32 * 0.125;
+  if thm_tcon_cur_tmp & (1 << 19) != 0 {
+    tctl -= 49.0;
+  }
+  Some(tctl)
+}
+
+/// AMD-published Tctl − Tdie offsets, keyed by product name (OPN).
+/// Products not listed have offset 0 (no positive offset is documented
+/// in the primary sources for them, including Zen 2 and newer).
+const AMD_TCTL_OFFSETS: &[(&str, f32)] = &[
+  ("Ryzen 7 1700X", 20.0),
+  ("Ryzen 7 1800X", 20.0),
+  ("Ryzen Threadripper 1900X", 27.0),
+  ("Ryzen Threadripper 1920X", 27.0),
+  ("Ryzen Threadripper 1950X", 27.0),
+  ("Ryzen 7 2700X", 10.0),
+  ("Ryzen Threadripper 2920X", 27.0),
+  ("Ryzen Threadripper 2950X", 27.0),
+  ("Ryzen Threadripper 2970WX", 27.0),
+  ("Ryzen Threadripper 2990WX", 27.0),
+];
+
+/// Tctl − Tdie offset in °C for a CPU brand string.
+///
+/// Matching is by product name (OPN), not family/model numbers: the
+/// brand string is whitespace-normalized and matched case-insensitively
+/// against the documented product names. Unlisted products — including
+/// otherwise similar SKUs like the Ryzen 5 1600X — get the default 0.
+pub fn amd_tctl_offset(brand: &str) -> f32 {
+  let normalized = brand
+    .split_whitespace()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .to_ascii_uppercase();
+  for (product, offset) in AMD_TCTL_OFFSETS {
+    if normalized.contains(&product.to_ascii_uppercase()) {
+      return *offset;
+    }
+  }
+  0.0
+}
+
+/// Decode Tdie (the published CPU temperature) from a
+/// `THM_TCON_CUR_TMP` register value and the model's Tctl offset.
+///
+/// `Tdie = Tctl − offset`. Plausibility gate before publishing (project
+/// policy from the spec): accept only −40 ≤ Tdie ≤ 120 °C; all-zero
+/// register reads are already rejected by [`amd_tctl_celsius`].
+pub fn amd_tdie_celsius(thm_tcon_cur_tmp: u32, tctl_offset: f32) -> Option<f32> {
+  let tdie = amd_tctl_celsius(thm_tcon_cur_tmp)? - tctl_offset;
+  (AMD_TDIE_MIN..=AMD_TDIE_MAX)
+    .contains(&tdie)
+    .then_some(tdie)
+}
+
+// ── Detection plan ──
+
+/// Which native CPU package-temperature source the host CPU supports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuSensorPlan {
+  /// `GenuineIntel` with DTS and PTM: read the package DTS MSRs through
+  /// the PawnIO `IntelMSR` module.
+  IntelDts,
+  /// `AuthenticAMD` on a spec-enabled Zen family: read `THM_TCON_CUR_TMP`
+  /// through the PawnIO `RyzenSMU` module.
+  AmdZenSmn { family: u32 },
+  /// `AuthenticAMD` on a family the PawnIO module recognizes but the
+  /// spec has not verified yet (`0x1A`) — disabled by default.
+  AmdFamilyDisabled { family: u32 },
+  /// Everything else: vendor, family, or feature bits rule it out.
+  Unsupported,
+}
+
+/// Classify the host CPU from raw CPUID values.
+///
+/// - `vendor` — CPUID leaf 0 vendor string.
+/// - `leaf1_eax` — CPUID leaf 1 EAX (family fields); pass 0 when the
+///   leaf is unavailable.
+/// - `leaf06_eax` — CPUID leaf 6 EAX (thermal feature bits); pass 0
+///   when the leaf is unavailable (treated as "no DTS/PTM").
+///
+/// Intel requires every detection fact of the spec's table: the vendor
+/// string plus both `EAX[0]` (DTS) and `EAX[6]` (PTM — the package
+/// register Phase 1 reads exists only with this bit). The remaining
+/// Intel condition (a usable Temperature Target) needs an MSR read and
+/// is checked by the provider at session establishment.
+pub fn plan_cpu_sensor(vendor: &str, leaf1_eax: u32, leaf06_eax: u32) -> CpuSensorPlan {
+  if vendor == INTEL_VENDOR {
+    if intel_dts_supported(leaf06_eax) && intel_ptm_supported(leaf06_eax) {
+      return CpuSensorPlan::IntelDts;
+    }
+    return CpuSensorPlan::Unsupported;
+  }
+  if vendor == AMD_VENDOR {
+    let family = amd_effective_family(leaf1_eax);
+    return match amd_family_support(family) {
+      AmdFamilySupport::Enabled => CpuSensorPlan::AmdZenSmn { family },
+      AmdFamilySupport::RecognizedDisabled => CpuSensorPlan::AmdFamilyDisabled { family },
+      AmdFamilySupport::Unsupported => CpuSensorPlan::Unsupported,
+    };
+  }
+  CpuSensorPlan::Unsupported
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── cpuid_vendor_string ──
+
+  #[test]
+  fn vendor_string_genuine_intel() {
+    // CPUID leaf 0 fixture: EBX="Genu", EDX="ineI", ECX="ntel".
+    assert_eq!(
+      cpuid_vendor_string(0x756E_6547, 0x6C65_746E, 0x4965_6E69),
+      "GenuineIntel"
+    );
+  }
+
+  #[test]
+  fn vendor_string_authentic_amd() {
+    // CPUID leaf 0 fixture: EBX="Auth", EDX="enti", ECX="cAMD".
+    assert_eq!(
+      cpuid_vendor_string(0x6874_7541, 0x444D_4163, 0x6974_6E65),
+      "AuthenticAMD"
+    );
+  }
+
+  // ── cpuid_brand_string ──
+
+  fn brand_regs(brand: &str) -> [u32; 12] {
+    let mut bytes = [0u8; 48];
+    bytes[..brand.len()].copy_from_slice(brand.as_bytes());
+    let mut regs = [0u32; 12];
+    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+      regs[i] = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+    regs
+  }
+
+  #[test]
+  fn brand_string_assembles_and_trims_nul_padding() {
+    let regs = brand_regs("AMD Ryzen 7 1800X Eight-Core Processor");
+    assert_eq!(
+      cpuid_brand_string(&regs),
+      "AMD Ryzen 7 1800X Eight-Core Processor"
+    );
+  }
+
+  #[test]
+  fn brand_string_trims_surrounding_whitespace() {
+    let regs = brand_regs("  Intel(R) Core(TM) i7 CPU   ");
+    assert_eq!(cpuid_brand_string(&regs), "Intel(R) Core(TM) i7 CPU");
+  }
+
+  #[test]
+  fn brand_string_all_zero_regs_is_empty() {
+    assert_eq!(cpuid_brand_string(&[0u32; 12]), "");
+  }
+
+  // ── intel leaf 6 feature bits ──
+
+  #[test]
+  fn intel_leaf06_bits_decode_independently() {
+    assert!(!intel_dts_supported(0));
+    assert!(!intel_ptm_supported(0));
+    assert!(intel_dts_supported(0x1));
+    assert!(!intel_ptm_supported(0x1));
+    assert!(!intel_dts_supported(1 << 6));
+    assert!(intel_ptm_supported(1 << 6));
+    assert!(intel_dts_supported(0x41));
+    assert!(intel_ptm_supported(0x41));
+  }
+
+  // ── intel_temperature_target ──
+
+  #[test]
+  fn t_target_extracted_from_bits_23_16() {
+    // Fixture: Temperature Target 100 °C, all other bits clear.
+    assert_eq!(intel_temperature_target(0x0064_0000), Some(100));
+  }
+
+  #[test]
+  fn t_target_zero_field_means_unsupported() {
+    assert_eq!(intel_temperature_target(0), None);
+    // Bits outside 23:16 set, field itself 0 → still unsupported.
+    assert_eq!(intel_temperature_target(0xFF00_FFFF), None);
+  }
+
+  #[test]
+  fn t_target_ignores_tcc_activation_offset_bits() {
+    // Fixture: target 100 °C with a 6-bit TCC Activation Offset of 10
+    // programmed at bits 29:24 — the offset never enters the decode.
+    let msr = (10u64 << 24) | (100u64 << 16);
+    assert_eq!(intel_temperature_target(msr), Some(100));
+  }
+
+  #[test]
+  fn t_target_ignores_unrelated_low_and_high_bits() {
+    let msr = 0xFFFF_FFFF_0064_FFFF;
+    assert_eq!(intel_temperature_target(msr), Some(0x64));
+  }
+
+  // ── intel_t_target_plausible ──
+
+  #[test]
+  fn t_target_bounds_are_inclusive() {
+    assert!(intel_t_target_plausible(50));
+    assert!(intel_t_target_plausible(100));
+    assert!(intel_t_target_plausible(120));
+    assert!(!intel_t_target_plausible(49));
+    assert!(!intel_t_target_plausible(121));
+    assert!(!intel_t_target_plausible(0));
+    assert!(!intel_t_target_plausible(255));
+  }
+
+  // ── intel_package_temperature ──
+
+  #[test]
+  fn package_temperature_subtracts_readout_from_t_target() {
+    // Fixture: readout 38 °C below target, plus unrelated status flag
+    // bits the decode must ignore.
+    let msr_1b1 = (38u64 << 16) | 0x0000_0001;
+    assert_eq!(intel_package_temperature(100, msr_1b1), Some(62.0));
+  }
+
+  #[test]
+  fn package_readout_masks_bits_22_16_only() {
+    // Neighbor bits 15 and 23 set; readout field carries 30.
+    let msr_1b1 = (30u64 << 16) | (1u64 << 15) | (1u64 << 23);
+    assert_eq!(intel_package_temperature(100, msr_1b1), Some(70.0));
+  }
+
+  #[test]
+  fn package_readout_zero_decodes_to_t_target_and_passes() {
+    // Saturated readout: 0 below target = "at TjMax" — the gate's
+    // inclusive upper bound accepts it.
+    assert_eq!(intel_package_temperature(100, 0), Some(100.0));
+  }
+
+  #[test]
+  fn package_temperature_zero_or_below_is_dropped() {
+    // readout == t_target → temperature 0 → fails the strict lower bound.
+    assert_eq!(intel_package_temperature(100, 100u64 << 16), None);
+    // readout > t_target → negative temperature → dropped.
+    assert_eq!(intel_package_temperature(100, 110u64 << 16), None);
+  }
+
+  #[test]
+  fn package_temperature_gates_t_target_bounds() {
+    let msr_1b1 = 30u64 << 16;
+    // Boundary targets pass…
+    assert_eq!(intel_package_temperature(50, msr_1b1), Some(20.0));
+    assert_eq!(intel_package_temperature(120, msr_1b1), Some(90.0));
+    // …out-of-bounds targets drop the sample regardless of readout.
+    assert_eq!(intel_package_temperature(49, msr_1b1), None);
+    assert_eq!(intel_package_temperature(121, msr_1b1), None);
+  }
+
+  // ── amd_effective_family ──
+
+  #[test]
+  fn effective_family_adds_extended_family_when_base_is_0xf() {
+    // Fixture: family 17h (Zen) leaf 1 EAX — base 0xF, extended 0x8.
+    assert_eq!(amd_effective_family(0x0080_0F11), 0x17);
+    // Fixture: family 19h (Zen 3) — base 0xF, extended 0xA.
+    assert_eq!(amd_effective_family(0x00A2_0F10), 0x19);
+    // Fixture: family 1Ah (Zen 5) — base 0xF, extended 0xB.
+    assert_eq!(amd_effective_family(0x00B4_0F00), 0x1A);
+  }
+
+  #[test]
+  fn effective_family_ignores_extended_family_when_base_is_not_0xf() {
+    // Base family 6 with a nonzero extended-family field: not added.
+    assert_eq!(amd_effective_family(0x0090_06EA), 0x6);
+    assert_eq!(amd_effective_family(0x0000_0F00), 0xF);
+  }
+
+  // ── amd_family_support ──
+
+  #[test]
+  fn family_0x17_and_0x19_are_enabled() {
+    assert_eq!(amd_family_support(0x17), AmdFamilySupport::Enabled);
+    assert_eq!(amd_family_support(0x19), AmdFamilySupport::Enabled);
+  }
+
+  #[test]
+  fn family_0x1a_is_recognized_but_disabled() {
+    assert_eq!(
+      amd_family_support(0x1A),
+      AmdFamilySupport::RecognizedDisabled
+    );
+  }
+
+  #[test]
+  fn other_families_are_unsupported() {
+    assert_eq!(amd_family_support(0x15), AmdFamilySupport::Unsupported);
+    assert_eq!(amd_family_support(0x16), AmdFamilySupport::Unsupported);
+    assert_eq!(amd_family_support(0x6), AmdFamilySupport::Unsupported);
+    assert_eq!(amd_family_support(0x1B), AmdFamilySupport::Unsupported);
+  }
+
+  // ── amd_tctl_celsius ──
+
+  #[test]
+  fn tctl_scales_cur_temp_at_one_eighth_degree() {
+    // Fixture: CUR_TEMP = 760 → 95.0 °C, RANGE_SEL clear.
+    assert_eq!(amd_tctl_celsius(760 << 21), Some(95.0));
+    // Fixture: CUR_TEMP = 1 → smallest nonzero step.
+    assert_eq!(amd_tctl_celsius(1 << 21), Some(0.125));
+  }
+
+  #[test]
+  fn tctl_range_sel_subtracts_49() {
+    // Fixture: CUR_TEMP = 1152 (144.0 °C raw) with RANGE_SEL set →
+    // −49 °C rebase → 95.0 °C.
+    let reg = (1152u32 << 21) | (1 << 19);
+    assert_eq!(amd_tctl_celsius(reg), Some(95.0));
+  }
+
+  #[test]
+  fn tctl_all_zero_read_is_rejected() {
+    // All-zero register = failed SMN transaction, not 0 °C.
+    assert_eq!(amd_tctl_celsius(0), None);
+  }
+
+  #[test]
+  fn tctl_ignores_reserved_bits_18_0() {
+    // All reserved bits 18:0 set (bit 19 is RANGE_SEL = 0x0008_0000 and
+    // stays clear here; 18:16 are named TJ_SEL only in the GPU-IP
+    // header) — they must not affect the decode.
+    let reg = (760u32 << 21) | 0x0007_FFFF;
+    assert_eq!(amd_tctl_celsius(reg), Some(95.0));
+  }
+
+  #[test]
+  fn tctl_max_field_value_decodes() {
+    // CUR_TEMP = 2047 → 255.875 °C (the SB-TSI-corroborated full range);
+    // the publishing gate, not this decode, rejects it later.
+    assert_eq!(amd_tctl_celsius(0x7FFu32 << 21), Some(255.875));
+  }
+
+  // ── amd_tctl_offset ──
+
+  #[test]
+  fn tctl_offset_ryzen_7_1700x_and_1800x_is_20() {
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen 7 1700X Eight-Core Processor"),
+      20.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen 7 1800X Eight-Core Processor"),
+      20.0
+    );
+  }
+
+  #[test]
+  fn tctl_offset_first_gen_threadripper_is_27() {
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 1900X 8-Core Processor"),
+      27.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 1920X 12-Core Processor"),
+      27.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 1950X 16-Core Processor"),
+      27.0
+    );
+  }
+
+  #[test]
+  fn tctl_offset_ryzen_7_2700x_is_10() {
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen 7 2700X Eight-Core Processor"),
+      10.0
+    );
+  }
+
+  #[test]
+  fn tctl_offset_second_gen_threadripper_is_27() {
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 2920X 12-Core Processor"),
+      27.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 2950X 16-Core Processor"),
+      27.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 2970WX 24-Core Processor"),
+      27.0
+    );
+    assert_eq!(
+      amd_tctl_offset("AMD Ryzen Threadripper 2990WX 32-Core Processor"),
+      27.0
+    );
+  }
+
+  #[test]
+  fn tctl_offset_defaults_to_zero_for_unlisted_products() {
+    // Zen 2 and newer have no documented positive offset…
+    assert_eq!(amd_tctl_offset("AMD Ryzen 7 3700X 8-Core Processor"), 0.0);
+    assert_eq!(amd_tctl_offset("AMD Ryzen 9 7950X 16-Core Processor"), 0.0);
+    // …and neither do similar-but-unlisted first-gen SKUs or other lines.
+    assert_eq!(amd_tctl_offset("AMD Ryzen 5 1600X Six-Core Processor"), 0.0);
+    assert_eq!(amd_tctl_offset("AMD EPYC 7551P 32-Core Processor"), 0.0);
+    assert_eq!(amd_tctl_offset(""), 0.0);
+  }
+
+  #[test]
+  fn tctl_offset_matching_normalizes_whitespace_and_case() {
+    assert_eq!(amd_tctl_offset("AMD  Ryzen  7  1800X Eight-Core"), 20.0);
+    assert_eq!(amd_tctl_offset("amd ryzen threadripper 2990wx"), 27.0);
+  }
+
+  // ── amd_tdie_celsius ──
+
+  #[test]
+  fn tdie_subtracts_model_offset() {
+    // Fixture: Tctl 95.0 °C (RANGE_SEL path) on a 27 °C-offset part.
+    let reg = (1152u32 << 21) | (1 << 19);
+    assert_eq!(amd_tdie_celsius(reg, 27.0), Some(68.0));
+    // Zero offset publishes Tctl as-is.
+    assert_eq!(amd_tdie_celsius(760 << 21, 0.0), Some(95.0));
+  }
+
+  #[test]
+  fn tdie_gate_bounds_are_inclusive() {
+    // CUR_TEMP = 72 → 9.0 °C raw − 49 → exactly −40.0 °C: passes.
+    let reg_low = (72u32 << 21) | (1 << 19);
+    assert_eq!(amd_tdie_celsius(reg_low, 0.0), Some(-40.0));
+    // One LSB lower → −40.125 °C: dropped.
+    let reg_below = (71u32 << 21) | (1 << 19);
+    assert_eq!(amd_tdie_celsius(reg_below, 0.0), None);
+    // CUR_TEMP = 960 → exactly 120.0 °C: passes.
+    assert_eq!(amd_tdie_celsius(960 << 21, 0.0), Some(120.0));
+    // One LSB higher → 120.125 °C: dropped.
+    assert_eq!(amd_tdie_celsius(961 << 21, 0.0), None);
+  }
+
+  #[test]
+  fn tdie_rejects_all_zero_register() {
+    assert_eq!(amd_tdie_celsius(0, 0.0), None);
+    assert_eq!(amd_tdie_celsius(0, 20.0), None);
+  }
+
+  // ── plan_cpu_sensor ──
+
+  #[test]
+  fn plan_intel_requires_dts_and_ptm_bits() {
+    assert_eq!(
+      plan_cpu_sensor(INTEL_VENDOR, 0, 0x41),
+      CpuSensorPlan::IntelDts
+    );
+    // Missing PTM (no package register) → unsupported.
+    assert_eq!(
+      plan_cpu_sensor(INTEL_VENDOR, 0, 0x1),
+      CpuSensorPlan::Unsupported
+    );
+    // Missing DTS → unsupported.
+    assert_eq!(
+      plan_cpu_sensor(INTEL_VENDOR, 0, 1 << 6),
+      CpuSensorPlan::Unsupported
+    );
+    // Leaf unavailable (passed as 0) → unsupported.
+    assert_eq!(
+      plan_cpu_sensor(INTEL_VENDOR, 0, 0),
+      CpuSensorPlan::Unsupported
+    );
+  }
+
+  #[test]
+  fn plan_amd_enabled_families_use_smn() {
+    assert_eq!(
+      plan_cpu_sensor(AMD_VENDOR, 0x0080_0F11, 0),
+      CpuSensorPlan::AmdZenSmn { family: 0x17 }
+    );
+    assert_eq!(
+      plan_cpu_sensor(AMD_VENDOR, 0x00A2_0F10, 0),
+      CpuSensorPlan::AmdZenSmn { family: 0x19 }
+    );
+  }
+
+  #[test]
+  fn plan_amd_family_0x1a_is_recognized_but_disabled() {
+    assert_eq!(
+      plan_cpu_sensor(AMD_VENDOR, 0x00B4_0F00, 0),
+      CpuSensorPlan::AmdFamilyDisabled { family: 0x1A }
+    );
+  }
+
+  #[test]
+  fn plan_amd_pre_zen_family_is_unsupported() {
+    // Family 15h fixture: base 0xF, extended 0x6.
+    assert_eq!(
+      plan_cpu_sensor(AMD_VENDOR, 0x0060_0F12, 0),
+      CpuSensorPlan::Unsupported
+    );
+  }
+
+  #[test]
+  fn plan_unknown_vendor_is_unsupported() {
+    assert_eq!(
+      plan_cpu_sensor("CentaurHauls", 0, 0x41),
+      CpuSensorPlan::Unsupported
+    );
+    assert_eq!(
+      plan_cpu_sensor("", 0x0080_0F11, 0x41),
+      CpuSensorPlan::Unsupported
+    );
+    // Vendor comparison is exact — no partial matches.
+    assert_eq!(
+      plan_cpu_sensor("GenuineIntel ", 0, 0x41),
+      CpuSensorPlan::Unsupported
+    );
+  }
+}

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod cpu_thermal;
 pub mod formatter;
 pub mod ip;
 pub mod logger;


### PR DESCRIPTION
<!--
Template: .github/PULL_REQUEST_TEMPLATE/clean-room-sensor-implementation.md
Rules: .github/instructions/clean-room-sensors.instructions.md
Process: docs/specs/sensors/README.md
-->

## Summary

Phase 1 of #1635: native CPU package temperature on Windows via [PawnIO](https://github.com/namazso/PawnIO), implemented clean-room from `docs/specs/sensors/**` only.

- **`core/src/infrastructure/providers/windows/pawnio.rs`** — PawnIOLib client: install discovery (registry `InstallLocation` → `%ProgramFiles%\PawnIO` fallback), dynamic DLL loading via `libloading`, HRESULT-form bindings (`pawnio_open/load/execute/close/version`) with 64-bit-cell buffer semantics, one executor handle per module, runtime module-blob directory resolution (`set_module_dir` override, default `<exe dir>/pawnio`).
- **`core/src/utils/cpu_thermal.rs`** — platform-neutral pure decoders/detection (unit-tested on every OS, 40 tests): Intel DTS (`MSR_TEMPERATURE_TARGET` bits 23:16, package readout bits 22:16 of `IA32_PACKAGE_THERM_STATUS`, plausibility gates), AMD Zen THM (`CUR_TEMP` bits 31:21 × 0.125 °C, `RANGE_SEL` −49 °C rebase, OPN-keyed Tctl offsets, −40…120 °C gate, all-zero-read rejection), CPUID vendor/brand/effective-family parsing, and the per-family enablement table (`0x17`/`0x19` enabled, `0x1A` recognized-but-disabled).
- **`core/src/infrastructure/providers/windows/pawnio_cpu_temp.rs`** — provider on the `thermal_zone.rs` house pattern: dedicated sampler thread (2 s cadence), non-blocking cached accessor with a 10 s freshness window, failure backoff (5 misses → session teardown → 60 s idle re-probe), one-shot "unavailable" logging, permanent shutdown for CPUs that can never be supported.
- **`core/src/infrastructure/providers/windows/named_mutex.rs`** — RAII Win32 named-mutex wrapper with bounded-timeout acquire (reusable for the Phase 2+ ISA mutex).
- **`core/src/collector/sampling.rs`** — `sample_temperatures()` (Windows) prefers a fresh PawnIO package reading for the headline `cpu_temperature` and prepends it to the sensor list as **"CPU Package"**; when PawnIO yields nothing the behavior is exactly the previous ACPI thermal-zone path (#1633) — no regression on machines without PawnIO.

Safety: register access is **read-only** — the only module functions bound anywhere are `ioctl_read_msr` and `ioctl_read_smu_register`. Every `RyzenSMU` call is wrapped in caller-held `Global\Access_PCI` (500 ms bounded wait; timeout ⇒ skipped sample, never an unlocked read); Intel MSR reads take no mutex per the interface spec.

Deliberately **not** in this PR (follow-ups): bundling the LGPL `*.amx` module blobs / installer integration (packaging task; until then the provider reports unavailable and ACPI stays in charge), app-layer `set_module_dir` wiring, README user-facing docs (behavior only changes once the driver + blobs ship).

### Open questions for the spec-author role

1. `pawnio-interface.md` documents how to find the install *location* but not the DLL *file name* inside it; the client uses `PawnIOLib.dll`. Failure mode if wrong is graceful unavailability (ACPI fallback), never incorrect hardware access. Please confirm and pin in the spec.
2. Project-policy choices where the specs leave latitude (recorded in code comments): t_target 50–120 °C bound implemented as inclusive; `Access_PCI` wait bound 500 ms; `WAIT_ABANDONED` treated as acquired (transactions are self-contained reads).

## Related Issues

Relates to #1635 (Phase 1 — CPU package temperature)

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Clean-room provenance

```text
Implemented from docs/specs/sensors/pawnio-interface.md revision 2 (commit fe39c3f19ca7195a67746a8c3af6ed2149b73838).
Implemented from docs/specs/sensors/cpu-intel-dts-msr.md revision 2 (commit fe39c3f19ca7195a67746a8c3af6ed2149b73838).
Implemented from docs/specs/sensors/cpu-amd-zen-smn.md revision 3 (commit fe39c3f19ca7195a67746a8c3af6ed2149b73838).
No other external sensor documentation was used.
```

### Implementer attestation

- [x] This implementation references only `docs/specs/sensors/**` (at
      the revisions pinned above) and this repository.
- [x] Every spec document pinned above carries
      `Status: Implementation-ready (rev N)` at the pinned revision
      and has no unresolved `TODO(provenance)` markers (see "Status
      transition" in `docs/specs/sensors/README.md`).
- [x] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or any decompiled monitoring tool
      while writing this implementation (full prohibited-source list:
      `.github/instructions/clean-room-sensors.instructions.md`).
- [x] Register access added by this PR is read-only; the only writes
      are those the pinned specs document as required for reads
      (e.g. Super I/O config keys, bank select), and the ecosystem
      mutex conventions are honored.

Implementation was produced by the dedicated `sensor-clean-room-implementer` agent (no web tools). Beyond the pinned specs and this repository it consulted only locally vendored crate sources (`windows-0.62.2`, `libloading-0.9.0` in `~/.cargo/registry`) for exact Rust API signatures, and standard x86 CPUID conventions as general platform documentation. `superio-access.md` (Draft) was not consulted.

### Reviewer attestation

Reviewers: copy the checklist below into your approval review
comment, with both boxes checked. Do not approve without it.

```markdown
- [ ] I reviewed this implementation only against
      `docs/specs/sensors/**`, this repository, and the pinned spec
      revision.
- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or decompiled monitoring tools while
      reviewing this implementation.
```

## Screenshots / Videos

N/A — without PawnIO + module blobs installed the UI is unchanged (ACPI path). With them installed, the dashboard's CPU temperature comes from the native package sensor and the sensor list gains a "CPU Package" entry.

## Test Plan

- [ ] Manual testing — pending a Windows machine with PawnIO installed and `IntelMSR.amx` / `RyzenSMU.amx` blobs placed in `<exe dir>/pawnio` (no behavior change without them; fixtures-based decoder coverage stands in per the repo testing policy)
- [x] Unit tests — 40 new pure-decoder/detection tests in `utils::cpu_thermal` (register-value fixtures for every decode rule, gate boundary, offset-table row, and family gate); `cargo test -p hardviz-core --lib`: 277 passed

Verification run on this branch:

- `cargo test -p hardviz-core --lib` — 277 passed, 0 failed
- `cargo clippy -p hardviz-core --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo check` / `clippy --target x86_64-pc-windows-msvc` for the new Windows-gated code — clean via a temporary out-of-tree harness on the pinned 1.96.0 toolchain (the full-crate cross-check is blocked in the Linux dev container by a pre-existing `ring v0.17.14` build-script failure, confirmed identical on the unmodified baseline; the Windows CI job is the authoritative check)

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

https://claude.ai/code/session_01Wci7MrKzeZgHN96gecEtA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wci7MrKzeZgHN96gecEtA3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native CPU Package temperature support on Windows for Intel and AMD processors.
  * Background sampler publishes fresh package-temperature readings for use in the UI.
  * Sampling now combines package readings with existing thermal-zone sources, preferring package values when available.
  * Improved robustness and fallback handling when native package readings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->