### PR TITLE
feat: add Windows PawnIO CPU temperature sampling

### DIFF
--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -35,26 +35,71 @@ pub struct SystemSample {
 pub struct TemperatureSample {
   pub cpu_temperature: Option<f32>,
   pub sensor_temperatures: Vec<SensorTemperature>,
+  pub unavailable_reason: Option<String>,
 }
 
 /// Read the latest CPU / sensor temperatures.
 ///
-/// Windows: ACPI thermal zones via the WMI sampler thread (started on the
-/// first call). The headline CPU value picks a CPU-named zone when one
+/// Windows: prefer CPU package temperature from a supported PawnIO source,
+/// then fall back to ACPI thermal zones via the WMI sampler thread. When only
+/// ACPI is available, the headline CPU value picks a CPU-named zone when one
 /// exists, otherwise the hottest zone — see
 /// [`crate::utils::thermal::select_cpu_temperature`].
 #[cfg(target_os = "windows")]
 pub fn sample_temperatures() -> TemperatureSample {
-  use crate::infrastructure::providers::thermal_zone;
+  use crate::infrastructure::providers::{cpu_temperature, thermal_zone};
 
   thermal_zone::init_thermal_zone_sampler();
   let sensor_temperatures = thermal_zone::read_thermal_zones_cached();
-  let cpu_temperature =
-    crate::utils::thermal::select_cpu_temperature(&sensor_temperatures);
-
-  TemperatureSample {
-    cpu_temperature,
+  build_temperature_sample(
+    cpu_temperature::sample_cpu_package_temperature(),
     sensor_temperatures,
+  )
+}
+
+#[cfg(target_os = "windows")]
+fn build_temperature_sample(
+  pawnio_cpu_temperature: Result<
+    crate::infrastructure::providers::cpu_temperature::CpuPackageTemperature,
+    String,
+  >,
+  mut sensor_temperatures: Vec<SensorTemperature>,
+) -> TemperatureSample {
+  match pawnio_cpu_temperature {
+    Ok(sample) => {
+      sensor_temperatures.insert(
+        0,
+        SensorTemperature {
+          name: match sample.source {
+            crate::infrastructure::providers::cpu_temperature::CpuTemperatureSource::IntelDtsPackageMsr => {
+              "CPU Package (PawnIO Intel DTS)"
+            }
+            crate::infrastructure::providers::cpu_temperature::CpuTemperatureSource::AmdZenSmnTctl => {
+              "CPU Package (PawnIO AMD SMN)"
+            }
+          }
+          .to_string(),
+          temperature: sample.temperature_celsius,
+        },
+      );
+      TemperatureSample {
+        cpu_temperature: Some(sample.temperature_celsius),
+        sensor_temperatures,
+        unavailable_reason: None,
+      }
+    }
+    Err(pawnio_reason) => {
+      let cpu_temperature =
+        crate::utils::thermal::select_cpu_temperature(&sensor_temperatures);
+      let unavailable_reason = cpu_temperature.is_none().then(|| {
+        format!("PawnIO unavailable ({pawnio_reason}); ACPI thermal zones unavailable")
+      });
+      TemperatureSample {
+        cpu_temperature,
+        sensor_temperatures,
+        unavailable_reason,
+      }
+    }
   }
 }
 
@@ -646,6 +691,7 @@ mod tests {
           temperature: 40.2,
         },
       ],
+      unavailable_reason: None,
     };
     let snap = build_metrics_snapshot(&sys, &[], &temps);
     assert_eq!(snap.cpu_temperature, Some(50.0));
@@ -661,6 +707,65 @@ mod tests {
           temperature: 40.0,
         },
       ]
+    );
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_prefers_pawnio_cpu_package() {
+    let sample = build_temperature_sample(
+      Ok(
+        crate::infrastructure::providers::cpu_temperature::CpuPackageTemperature {
+          temperature_celsius: 61.25,
+          source: crate::infrastructure::providers::cpu_temperature::CpuTemperatureSource::IntelDtsPackageMsr,
+        },
+      ),
+      vec![SensorTemperature {
+        name: "TZ00".into(),
+        temperature: 45.0,
+      }],
+    );
+
+    assert_eq!(sample.cpu_temperature, Some(61.25));
+    assert_eq!(
+      sample.sensor_temperatures[0].name,
+      "CPU Package (PawnIO Intel DTS)"
+    );
+    assert_eq!(sample.sensor_temperatures[0].temperature, 61.25);
+    assert!(sample.unavailable_reason.is_none());
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_falls_back_to_acpi_cpu_zone() {
+    let sample = build_temperature_sample(
+      Err("PawnIOLib.dll not found".to_string()),
+      vec![
+        SensorTemperature {
+          name: "TZ00".into(),
+          temperature: 70.0,
+        },
+        SensorTemperature {
+          name: "CPUZ".into(),
+          temperature: 51.0,
+        },
+      ],
+    );
+
+    assert_eq!(sample.cpu_temperature, Some(51.0));
+    assert!(sample.unavailable_reason.is_none());
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_returns_unavailable_reason_when_all_sources_fail() {
+    let sample =
+      build_temperature_sample(Err("pawnio_open failed".to_string()), Vec::new());
+
+    assert_eq!(sample.cpu_temperature, None);
+    assert_eq!(
+      sample.unavailable_reason.as_deref(),
+      Some("PawnIO unavailable (pawnio_open failed); ACPI thermal zones unavailable")
     );
   }
 

--- a/core/src/infrastructure/providers/windows/cpu_temperature.rs
+++ b/core/src/infrastructure/providers/windows/cpu_temperature.rs
@@ -1,0 +1,710 @@
+use std::fmt;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use super::cpu_temperature_decode::{
+  CpuTemperatureDecodeError, decode_amd_zen_package_temperature,
+  decode_intel_package_temperature, decode_intel_temperature_target,
+};
+use super::pawn_io::{
+  ACCESS_PCI_MUTEX, NamedMutex, PawnIoClient, PawnIoDiscovery, PawnIoInitError,
+  PawnIoModule,
+};
+use crate::{log_debug, log_warn};
+
+const PAWNIO_MUTEX_TIMEOUT: Duration = Duration::from_millis(50);
+const MSR_TEMPERATURE_TARGET: u64 = 0x1a2;
+const IA32_PACKAGE_THERM_STATUS: u64 = 0x1b1;
+const AMD_THM_TCON_CUR_TMP: u64 = 0x0005_9800;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuVendor {
+  Intel,
+  Amd,
+  Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpuIdentity {
+  pub vendor: CpuVendor,
+  pub vendor_id: String,
+  pub brand: String,
+  pub family: u32,
+  pub model: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntelThermalCapabilities {
+  pub digital_temperature_sensor: bool,
+  pub package_thermal_management: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AmdFamilyEnablement {
+  pub recognized_by_pawnio_module: bool,
+  pub enabled_by_spec: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpuTemperatureSource {
+  IntelDtsPackageMsr,
+  AmdZenSmnTctl,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpuTemperatureFallbackReason {
+  UnsupportedCpuVendor(String),
+  IntelDtsUnavailable,
+  IntelPackageThermalUnavailable,
+  AmdFamilyDisabled(u32),
+  AmdFamilyUnsupported(u32),
+}
+
+impl fmt::Display for CpuTemperatureFallbackReason {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::UnsupportedCpuVendor(vendor) => {
+        write!(f, "unsupported CPU vendor {vendor}")
+      }
+      Self::IntelDtsUnavailable => write!(f, "Intel digital thermal sensor unavailable"),
+      Self::IntelPackageThermalUnavailable => {
+        write!(f, "Intel package thermal management unavailable")
+      }
+      Self::AmdFamilyDisabled(family) => {
+        write!(f, "AMD family 0x{family:x} is disabled by the ready spec")
+      }
+      Self::AmdFamilyUnsupported(family) => {
+        write!(
+          f,
+          "AMD family 0x{family:x} is unsupported by the ready spec"
+        )
+      }
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CpuTemperatureCandidate {
+  pub(crate) source: CpuTemperatureSource,
+  pub(crate) module: PawnIoModule,
+}
+
+pub fn amd_family_enablement(family: u32) -> AmdFamilyEnablement {
+  match family {
+    0x17 | 0x19 => AmdFamilyEnablement {
+      recognized_by_pawnio_module: true,
+      enabled_by_spec: true,
+    },
+    0x1a => AmdFamilyEnablement {
+      recognized_by_pawnio_module: true,
+      enabled_by_spec: false,
+    },
+    _ => AmdFamilyEnablement {
+      recognized_by_pawnio_module: false,
+      enabled_by_spec: false,
+    },
+  }
+}
+
+pub(crate) fn select_cpu_temperature_candidate(
+  cpu: &CpuIdentity,
+  intel: Option<IntelThermalCapabilities>,
+) -> Result<CpuTemperatureCandidate, CpuTemperatureFallbackReason> {
+  match cpu.vendor {
+    CpuVendor::Intel => {
+      let capabilities = intel.unwrap_or(IntelThermalCapabilities {
+        digital_temperature_sensor: false,
+        package_thermal_management: false,
+      });
+      if !capabilities.digital_temperature_sensor {
+        return Err(CpuTemperatureFallbackReason::IntelDtsUnavailable);
+      }
+      if !capabilities.package_thermal_management {
+        return Err(CpuTemperatureFallbackReason::IntelPackageThermalUnavailable);
+      }
+      Ok(CpuTemperatureCandidate {
+        source: CpuTemperatureSource::IntelDtsPackageMsr,
+        module: PawnIoModule::IntelMsr,
+      })
+    }
+    CpuVendor::Amd => {
+      let enablement = amd_family_enablement(cpu.family);
+      if enablement.enabled_by_spec {
+        Ok(CpuTemperatureCandidate {
+          source: CpuTemperatureSource::AmdZenSmnTctl,
+          module: PawnIoModule::RyzenSmu,
+        })
+      } else if enablement.recognized_by_pawnio_module {
+        Err(CpuTemperatureFallbackReason::AmdFamilyDisabled(cpu.family))
+      } else {
+        Err(CpuTemperatureFallbackReason::AmdFamilyUnsupported(
+          cpu.family,
+        ))
+      }
+    }
+    CpuVendor::Other => Err(CpuTemperatureFallbackReason::UnsupportedCpuVendor(
+      cpu.vendor_id.clone(),
+    )),
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpuTemperatureDiagnostics {
+  pub cpu: CpuIdentity,
+  pub intel_capabilities: Option<IntelThermalCapabilities>,
+  pub amd_enablement: Option<AmdFamilyEnablement>,
+  pub pawnio: PawnIoDiscovery,
+  pub selected_source: Option<CpuTemperatureSource>,
+  pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CpuPackageTemperature {
+  pub temperature_celsius: f32,
+  pub source: CpuTemperatureSource,
+}
+
+enum ActiveCpuTemperatureSource {
+  Intel {
+    client: PawnIoClient,
+    target_celsius: u32,
+  },
+  Amd {
+    client: PawnIoClient,
+    tctl_offset_celsius: f32,
+  },
+}
+
+struct CpuTemperatureSampler {
+  diagnostics: CpuTemperatureDiagnostics,
+  active: Option<ActiveCpuTemperatureSource>,
+  sample_failure_logged: bool,
+}
+
+static CPU_TEMPERATURE_SAMPLER: OnceLock<Mutex<CpuTemperatureSampler>> = OnceLock::new();
+
+pub fn sample_cpu_package_temperature() -> Result<CpuPackageTemperature, String> {
+  let sampler = CPU_TEMPERATURE_SAMPLER.get_or_init(|| {
+    let sampler = CpuTemperatureSampler::new();
+    log_debug!(
+      "cpu_temperature_diagnostics",
+      "windows::cpu_temperature::sample_cpu_package_temperature",
+      Some(format!("{:?}", sampler.diagnostics))
+    );
+    Mutex::new(sampler)
+  });
+
+  sampler
+    .lock()
+    .map_err(|_| "CPU temperature sampler lock poisoned".to_string())?
+    .sample()
+}
+
+pub fn cpu_temperature_diagnostics() -> CpuTemperatureDiagnostics {
+  let sampler = CPU_TEMPERATURE_SAMPLER.get_or_init(|| {
+    let sampler = CpuTemperatureSampler::new();
+    log_debug!(
+      "cpu_temperature_diagnostics",
+      "windows::cpu_temperature::cpu_temperature_diagnostics",
+      Some(format!("{:?}", sampler.diagnostics))
+    );
+    Mutex::new(sampler)
+  });
+
+  sampler
+    .lock()
+    .map(|sampler| sampler.diagnostics.clone())
+    .unwrap_or_else(|_| CpuTemperatureDiagnostics::unavailable("sampler lock poisoned"))
+}
+
+impl CpuTemperatureDiagnostics {
+  fn unavailable(reason: impl Into<String>) -> Self {
+    Self {
+      cpu: CpuIdentity::unknown(),
+      intel_capabilities: None,
+      amd_enablement: None,
+      pawnio: PawnIoDiscovery::unavailable("sampler unavailable"),
+      selected_source: None,
+      fallback_reason: Some(reason.into()),
+    }
+  }
+}
+
+impl CpuTemperatureSampler {
+  fn new() -> Self {
+    let cpu = detect_cpu_identity();
+    let intel_capabilities = (cpu.vendor == CpuVendor::Intel)
+      .then(detect_intel_thermal_capabilities)
+      .flatten();
+    let amd_enablement =
+      (cpu.vendor == CpuVendor::Amd).then(|| amd_family_enablement(cpu.family));
+
+    let candidate = match select_cpu_temperature_candidate(&cpu, intel_capabilities) {
+      Ok(candidate) => candidate,
+      Err(reason) => {
+        let reason = reason.to_string();
+        let mut pawnio = PawnIoDiscovery::probe_install();
+        if pawnio.fallback_reason.is_none() {
+          pawnio.fallback_reason =
+            Some("PawnIO module not selected for unsupported CPU".to_string());
+        }
+        return Self {
+          diagnostics: CpuTemperatureDiagnostics {
+            cpu,
+            intel_capabilities,
+            amd_enablement,
+            pawnio,
+            selected_source: None,
+            fallback_reason: Some(reason),
+          },
+          active: None,
+          sample_failure_logged: false,
+        };
+      }
+    };
+
+    match ActiveCpuTemperatureSource::open(&cpu, &candidate) {
+      Ok((active, pawnio)) => Self {
+        diagnostics: CpuTemperatureDiagnostics {
+          cpu,
+          intel_capabilities,
+          amd_enablement,
+          pawnio,
+          selected_source: Some(candidate.source),
+          fallback_reason: None,
+        },
+        active: Some(active),
+        sample_failure_logged: false,
+      },
+      Err(error) => Self {
+        diagnostics: CpuTemperatureDiagnostics {
+          cpu,
+          intel_capabilities,
+          amd_enablement,
+          pawnio: *error.discovery,
+          selected_source: None,
+          fallback_reason: Some(error.reason),
+        },
+        active: None,
+        sample_failure_logged: false,
+      },
+    }
+  }
+
+  fn sample(&mut self) -> Result<CpuPackageTemperature, String> {
+    let result = match self.active.as_mut() {
+      Some(ActiveCpuTemperatureSource::Intel {
+        client,
+        target_celsius,
+      }) => client
+        .read_msr(IA32_PACKAGE_THERM_STATUS)
+        .and_then(|status| {
+          decode_intel_package_temperature(*target_celsius, status)
+            .map_err(format_decode_error)
+        })
+        .map(|temperature| CpuPackageTemperature {
+          temperature_celsius: temperature,
+          source: CpuTemperatureSource::IntelDtsPackageMsr,
+        }),
+      Some(ActiveCpuTemperatureSource::Amd {
+        client,
+        tctl_offset_celsius,
+      }) => match NamedMutex::acquire(ACCESS_PCI_MUTEX, PAWNIO_MUTEX_TIMEOUT) {
+        Ok(_mutex) => client
+          .read_smu_register(AMD_THM_TCON_CUR_TMP)
+          .and_then(|value| {
+            decode_amd_zen_package_temperature(value as u32, *tctl_offset_celsius)
+              .map_err(format_decode_error)
+          })
+          .map(|temperature| CpuPackageTemperature {
+            temperature_celsius: temperature,
+            source: CpuTemperatureSource::AmdZenSmnTctl,
+          }),
+        Err(reason) => Err(reason),
+      },
+      None => Err(
+        self
+          .diagnostics
+          .fallback_reason
+          .clone()
+          .unwrap_or_else(|| "CPU package temperature unavailable".to_string()),
+      ),
+    };
+
+    if let Err(reason) = &result
+      && !self.sample_failure_logged
+    {
+      self.sample_failure_logged = true;
+      log_warn!(
+        "cpu_temperature_sample_failed",
+        "windows::cpu_temperature::CpuTemperatureSampler::sample",
+        Some(reason.clone())
+      );
+    }
+
+    result
+  }
+}
+
+impl ActiveCpuTemperatureSource {
+  fn open(
+    cpu: &CpuIdentity,
+    candidate: &CpuTemperatureCandidate,
+  ) -> Result<(Self, PawnIoDiscovery), PawnIoInitError> {
+    let (client, mut discovery) = PawnIoClient::open(candidate.module.clone())?;
+    let active = match candidate.source {
+      CpuTemperatureSource::IntelDtsPackageMsr => {
+        let target_msr = match client.read_msr(MSR_TEMPERATURE_TARGET) {
+          Ok(value) => value,
+          Err(reason) => {
+            discovery.fallback_reason = Some(reason.clone());
+            return Err(PawnIoInitError {
+              discovery: Box::new(discovery),
+              reason,
+            });
+          }
+        };
+        let target_celsius = match decode_intel_temperature_target(target_msr) {
+          Ok(value) => value,
+          Err(error) => {
+            let reason = format_decode_error(error);
+            discovery.fallback_reason = Some(reason.clone());
+            return Err(PawnIoInitError {
+              discovery: Box::new(discovery),
+              reason,
+            });
+          }
+        };
+        Self::Intel {
+          client,
+          target_celsius,
+        }
+      }
+      CpuTemperatureSource::AmdZenSmnTctl => Self::Amd {
+        client,
+        tctl_offset_celsius: amd_tctl_offset_celsius(&cpu.brand),
+      },
+    };
+
+    Ok((active, discovery))
+  }
+}
+
+fn format_decode_error(error: CpuTemperatureDecodeError) -> String {
+  format!("CPU temperature decode failed: {error:?}")
+}
+
+fn detect_cpu_identity() -> CpuIdentity {
+  detect_cpu_identity_x86().unwrap_or_else(CpuIdentity::unknown)
+}
+
+impl CpuIdentity {
+  fn unknown() -> Self {
+    Self {
+      vendor: CpuVendor::Other,
+      vendor_id: "unknown".to_string(),
+      brand: String::new(),
+      family: 0,
+      model: 0,
+    }
+  }
+}
+
+fn detect_intel_thermal_capabilities() -> Option<IntelThermalCapabilities> {
+  cpuid_leaf(6).map(|leaf| IntelThermalCapabilities {
+    digital_temperature_sensor: (leaf.eax & 0x1) != 0,
+    package_thermal_management: (leaf.eax & (1 << 6)) != 0,
+  })
+}
+
+fn amd_tctl_offset_celsius(brand: &str) -> f32 {
+  let brand = brand.to_ascii_uppercase();
+  if brand.contains("RYZEN 7 1700X") || brand.contains("RYZEN 7 1800X") {
+    20.0
+  } else if brand.contains("RYZEN 7 2700X") {
+    10.0
+  } else {
+    0.0
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CpuidLeaf {
+  eax: u32,
+  ebx: u32,
+  ecx: u32,
+  edx: u32,
+}
+
+#[cfg(target_arch = "x86_64")]
+fn cpuid_leaf(leaf: u32) -> Option<CpuidLeaf> {
+  use core::arch::x86_64::__cpuid;
+  let max_leaf = if leaf >= 0x8000_0000 {
+    __cpuid(0x8000_0000).eax
+  } else {
+    __cpuid(0).eax
+  };
+  (leaf <= max_leaf).then(|| {
+    let result = __cpuid(leaf);
+    CpuidLeaf {
+      eax: result.eax,
+      ebx: result.ebx,
+      ecx: result.ecx,
+      edx: result.edx,
+    }
+  })
+}
+
+#[cfg(target_arch = "x86")]
+fn cpuid_leaf(leaf: u32) -> Option<CpuidLeaf> {
+  use core::arch::x86::__cpuid;
+  let max_leaf = if leaf >= 0x8000_0000 {
+    __cpuid(0x8000_0000).eax
+  } else {
+    __cpuid(0).eax
+  };
+  (leaf <= max_leaf).then(|| {
+    let result = __cpuid(leaf);
+    CpuidLeaf {
+      eax: result.eax,
+      ebx: result.ebx,
+      ecx: result.ecx,
+      edx: result.edx,
+    }
+  })
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn cpuid_leaf(_leaf: u32) -> Option<CpuidLeaf> {
+  None
+}
+
+#[cfg(target_arch = "x86_64")]
+fn cpuid_leaf_unchecked(leaf: u32) -> CpuidLeaf {
+  use core::arch::x86_64::__cpuid;
+  let result = __cpuid(leaf);
+  CpuidLeaf {
+    eax: result.eax,
+    ebx: result.ebx,
+    ecx: result.ecx,
+    edx: result.edx,
+  }
+}
+
+#[cfg(target_arch = "x86")]
+fn cpuid_leaf_unchecked(leaf: u32) -> CpuidLeaf {
+  use core::arch::x86::__cpuid;
+  let result = __cpuid(leaf);
+  CpuidLeaf {
+    eax: result.eax,
+    ebx: result.ebx,
+    ecx: result.ecx,
+    edx: result.edx,
+  }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn cpuid_leaf_unchecked(_leaf: u32) -> CpuidLeaf {
+  CpuidLeaf {
+    eax: 0,
+    ebx: 0,
+    ecx: 0,
+    edx: 0,
+  }
+}
+
+fn detect_cpu_identity_x86() -> Option<CpuIdentity> {
+  let leaf0 = cpuid_leaf(0)?;
+  let vendor_id = vendor_id_from_leaf0(leaf0);
+  let leaf1 = cpuid_leaf(1)?;
+  let (family, model) = effective_family_model(leaf1.eax);
+  let brand = cpu_brand_string();
+  let vendor = match vendor_id.as_str() {
+    "GenuineIntel" => CpuVendor::Intel,
+    "AuthenticAMD" => CpuVendor::Amd,
+    _ => CpuVendor::Other,
+  };
+
+  Some(CpuIdentity {
+    vendor,
+    vendor_id,
+    brand,
+    family,
+    model,
+  })
+}
+
+fn vendor_id_from_leaf0(leaf: CpuidLeaf) -> String {
+  let mut bytes = Vec::with_capacity(12);
+  bytes.extend_from_slice(&leaf.ebx.to_le_bytes());
+  bytes.extend_from_slice(&leaf.edx.to_le_bytes());
+  bytes.extend_from_slice(&leaf.ecx.to_le_bytes());
+  String::from_utf8_lossy(&bytes).trim().to_string()
+}
+
+fn cpu_brand_string() -> String {
+  let Some(extended) = cpuid_leaf(0x8000_0000) else {
+    return String::new();
+  };
+  if extended.eax < 0x8000_0004 {
+    return String::new();
+  }
+
+  let mut bytes = Vec::with_capacity(48);
+  for leaf in 0x8000_0002..=0x8000_0004 {
+    let result = cpuid_leaf_unchecked(leaf);
+    bytes.extend_from_slice(&result.eax.to_le_bytes());
+    bytes.extend_from_slice(&result.ebx.to_le_bytes());
+    bytes.extend_from_slice(&result.ecx.to_le_bytes());
+    bytes.extend_from_slice(&result.edx.to_le_bytes());
+  }
+
+  String::from_utf8_lossy(&bytes)
+    .trim_matches(char::from(0))
+    .trim()
+    .to_string()
+}
+
+fn effective_family_model(eax: u32) -> (u32, u32) {
+  let base_family = (eax >> 8) & 0x0f;
+  let base_model = (eax >> 4) & 0x0f;
+  let extended_family = (eax >> 20) & 0xff;
+  let extended_model = (eax >> 16) & 0x0f;
+
+  let family = if base_family == 0x0f {
+    base_family + extended_family
+  } else {
+    base_family
+  };
+  let model = if base_family == 0x06 || base_family == 0x0f {
+    base_model + (extended_model << 4)
+  } else {
+    base_model
+  };
+
+  (family, model)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn cpu(vendor: CpuVendor, vendor_id: &str, family: u32) -> CpuIdentity {
+    CpuIdentity {
+      vendor,
+      vendor_id: vendor_id.to_string(),
+      brand: String::new(),
+      family,
+      model: 0,
+    }
+  }
+
+  #[test]
+  fn amd_family_17h_and_19h_are_enabled() {
+    assert_eq!(
+      amd_family_enablement(0x17),
+      AmdFamilyEnablement {
+        recognized_by_pawnio_module: true,
+        enabled_by_spec: true
+      }
+    );
+    assert_eq!(
+      amd_family_enablement(0x19),
+      AmdFamilyEnablement {
+        recognized_by_pawnio_module: true,
+        enabled_by_spec: true
+      }
+    );
+  }
+
+  #[test]
+  fn amd_family_1ah_is_recognized_but_disabled() {
+    assert_eq!(
+      amd_family_enablement(0x1a),
+      AmdFamilyEnablement {
+        recognized_by_pawnio_module: true,
+        enabled_by_spec: false
+      }
+    );
+  }
+
+  #[test]
+  fn intel_candidate_requires_dts_and_package_thermal_management() {
+    let cpu = cpu(CpuVendor::Intel, "GenuineIntel", 6);
+    assert_eq!(
+      select_cpu_temperature_candidate(
+        &cpu,
+        Some(IntelThermalCapabilities {
+          digital_temperature_sensor: true,
+          package_thermal_management: true,
+        }),
+      ),
+      Ok(CpuTemperatureCandidate {
+        source: CpuTemperatureSource::IntelDtsPackageMsr,
+        module: PawnIoModule::IntelMsr,
+      })
+    );
+
+    assert_eq!(
+      select_cpu_temperature_candidate(
+        &cpu,
+        Some(IntelThermalCapabilities {
+          digital_temperature_sensor: true,
+          package_thermal_management: false,
+        }),
+      ),
+      Err(CpuTemperatureFallbackReason::IntelPackageThermalUnavailable)
+    );
+  }
+
+  #[test]
+  fn amd_candidate_accepts_only_enabled_families() {
+    assert_eq!(
+      select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x19), None),
+      Ok(CpuTemperatureCandidate {
+        source: CpuTemperatureSource::AmdZenSmnTctl,
+        module: PawnIoModule::RyzenSmu,
+      })
+    );
+
+    assert_eq!(
+      select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x1a), None),
+      Err(CpuTemperatureFallbackReason::AmdFamilyDisabled(0x1a))
+    );
+    assert_eq!(
+      select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x16), None),
+      Err(CpuTemperatureFallbackReason::AmdFamilyUnsupported(0x16))
+    );
+  }
+
+  #[test]
+  fn effective_family_model_adds_extended_family_for_amd_zen() {
+    let eax = (0x8 << 20) | (0x1 << 16) | (0xf << 8) | (0x1 << 4);
+
+    assert_eq!(effective_family_model(eax), (0x17, 0x11));
+  }
+
+  #[test]
+  fn effective_family_model_adds_extended_model_for_intel_family_6() {
+    let eax = (0xa << 16) | (0x6 << 8) | (0x5 << 4);
+
+    assert_eq!(effective_family_model(eax), (0x6, 0xa5));
+  }
+
+  #[test]
+  fn amd_tctl_offset_is_limited_to_ready_phase1_models() {
+    assert_eq!(
+      amd_tctl_offset_celsius("AMD Ryzen 7 1700X Eight-Core"),
+      20.0
+    );
+    assert_eq!(
+      amd_tctl_offset_celsius("AMD Ryzen 7 1800X Eight-Core"),
+      20.0
+    );
+    assert_eq!(
+      amd_tctl_offset_celsius("AMD Ryzen 7 2700X Eight-Core"),
+      10.0
+    );
+    assert_eq!(amd_tctl_offset_celsius("AMD Ryzen 9 3900X"), 0.0);
+  }
+}

--- a/core/src/infrastructure/providers/windows/cpu_temperature_decode.rs
+++ b/core/src/infrastructure/providers/windows/cpu_temperature_decode.rs
@@ -1,0 +1,175 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CpuTemperatureDecodeError {
+  ZeroIntelTemperatureTarget,
+  ImplausibleIntelTemperatureTarget(u32),
+  ImplausibleIntelPackageTemperature { temperature: i32, target: u32 },
+  ZeroAmdTemperatureRegister,
+  ImplausibleAmdTemperature,
+}
+
+pub(crate) fn decode_intel_temperature_target(
+  msr_temperature_target: u64,
+) -> Result<u32, CpuTemperatureDecodeError> {
+  let target = ((msr_temperature_target >> 16) & 0xff) as u32;
+  if target == 0 {
+    return Err(CpuTemperatureDecodeError::ZeroIntelTemperatureTarget);
+  }
+  if !(50..=120).contains(&target) {
+    return Err(CpuTemperatureDecodeError::ImplausibleIntelTemperatureTarget(target));
+  }
+  Ok(target)
+}
+
+pub(crate) fn decode_intel_package_temperature(
+  temperature_target_celsius: u32,
+  package_therm_status: u64,
+) -> Result<f32, CpuTemperatureDecodeError> {
+  if !(50..=120).contains(&temperature_target_celsius) {
+    return Err(
+      CpuTemperatureDecodeError::ImplausibleIntelTemperatureTarget(
+        temperature_target_celsius,
+      ),
+    );
+  }
+
+  let readout_below_target = ((package_therm_status >> 16) & 0x7f) as i32;
+  let temperature = temperature_target_celsius as i32 - readout_below_target;
+  if temperature <= 0 || temperature > temperature_target_celsius as i32 {
+    return Err(
+      CpuTemperatureDecodeError::ImplausibleIntelPackageTemperature {
+        temperature,
+        target: temperature_target_celsius,
+      },
+    );
+  }
+
+  Ok(temperature as f32)
+}
+
+pub(crate) fn decode_amd_zen_package_temperature(
+  thm_tcon_cur_tmp: u32,
+  tctl_offset_celsius: f32,
+) -> Result<f32, CpuTemperatureDecodeError> {
+  if thm_tcon_cur_tmp == 0 {
+    return Err(CpuTemperatureDecodeError::ZeroAmdTemperatureRegister);
+  }
+
+  let cur_temp = ((thm_tcon_cur_tmp >> 21) & 0x7ff) as f32;
+  let mut temperature = cur_temp * 0.125;
+  if ((thm_tcon_cur_tmp >> 19) & 0x1) == 1 {
+    temperature -= 49.0;
+  }
+  temperature -= tctl_offset_celsius;
+
+  if !(-40.0..=120.0).contains(&temperature) {
+    return Err(CpuTemperatureDecodeError::ImplausibleAmdTemperature);
+  }
+
+  Ok(temperature)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn intel_target_msr(target: u64) -> u64 {
+    target << 16
+  }
+
+  fn intel_package_status(readout_below_target: u64) -> u64 {
+    readout_below_target << 16
+  }
+
+  fn amd_temperature_register(cur_temp: u32, range_sel: bool, reserved_bits: u32) -> u32 {
+    (cur_temp << 21) | ((range_sel as u32) << 19) | ((reserved_bits & 0x7) << 16)
+  }
+
+  #[test]
+  fn intel_temperature_target_decodes_bits_23_to_16() {
+    assert_eq!(
+      decode_intel_temperature_target(intel_target_msr(100)),
+      Ok(100)
+    );
+  }
+
+  #[test]
+  fn intel_temperature_target_rejects_zero() {
+    assert_eq!(
+      decode_intel_temperature_target(intel_target_msr(0)),
+      Err(CpuTemperatureDecodeError::ZeroIntelTemperatureTarget)
+    );
+  }
+
+  #[test]
+  fn intel_temperature_target_rejects_implausible_values() {
+    assert_eq!(
+      decode_intel_temperature_target(intel_target_msr(125)),
+      Err(CpuTemperatureDecodeError::ImplausibleIntelTemperatureTarget(125))
+    );
+  }
+
+  #[test]
+  fn intel_package_temperature_subtracts_readout_from_target() {
+    assert_eq!(
+      decode_intel_package_temperature(100, intel_package_status(42)),
+      Ok(58.0)
+    );
+  }
+
+  #[test]
+  fn intel_package_temperature_accepts_zero_readout_as_target_temperature() {
+    assert_eq!(
+      decode_intel_package_temperature(100, intel_package_status(0)),
+      Ok(100.0)
+    );
+  }
+
+  #[test]
+  fn intel_package_temperature_rejects_negative_result() {
+    assert_eq!(
+      decode_intel_package_temperature(90, intel_package_status(100)),
+      Err(
+        CpuTemperatureDecodeError::ImplausibleIntelPackageTemperature {
+          temperature: -10,
+          target: 90
+        }
+      )
+    );
+  }
+
+  #[test]
+  fn amd_zen_temperature_decodes_cur_temp_in_one_eighth_degrees() {
+    let register = amd_temperature_register(512, false, 0);
+
+    assert_eq!(decode_amd_zen_package_temperature(register, 0.0), Ok(64.0));
+  }
+
+  #[test]
+  fn amd_zen_temperature_honors_range_select_subtracting_49_degrees() {
+    let register = amd_temperature_register(800, true, 0);
+
+    assert_eq!(decode_amd_zen_package_temperature(register, 0.0), Ok(51.0));
+  }
+
+  #[test]
+  fn amd_zen_temperature_applies_tctl_offset() {
+    let register = amd_temperature_register(800, false, 0);
+
+    assert_eq!(decode_amd_zen_package_temperature(register, 20.0), Ok(80.0));
+  }
+
+  #[test]
+  fn amd_zen_temperature_ignores_reserved_tj_sel_bits() {
+    let register = amd_temperature_register(800, false, 0b011);
+
+    assert_eq!(decode_amd_zen_package_temperature(register, 0.0), Ok(100.0));
+  }
+
+  #[test]
+  fn amd_zen_temperature_rejects_all_zero_register() {
+    assert_eq!(
+      decode_amd_zen_package_temperature(0, 0.0),
+      Err(CpuTemperatureDecodeError::ZeroAmdTemperatureRegister)
+    );
+  }
+}

--- a/core/src/infrastructure/providers/windows/mod.rs
+++ b/core/src/infrastructure/providers/windows/mod.rs
@@ -1,7 +1,10 @@
 pub mod adl_provider;
+pub mod cpu_temperature;
+mod cpu_temperature_decode;
 pub mod device_io;
 pub mod directx;
 pub mod nvapi_provider;
+mod pawn_io;
 pub mod pdh_provider;
 pub mod setupdi_provider;
 pub mod smart;

--- a/core/src/infrastructure/providers/windows/pawn_io.rs
+++ b/core/src/infrastructure/providers/windows/pawn_io.rs
@@ -9,13 +9,16 @@ use windows::Win32::Foundation::{
   CloseHandle, HANDLE, WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::System::Threading::{
-  CreateMutexW, ReleaseMutex, WaitForSingleObject,
+  CreateMutexW, MUTEX_MODIFY_STATE, OpenMutexW, ReleaseMutex,
+  SYNCHRONIZATION_SYNCHRONIZE, WaitForSingleObject,
 };
 use windows::core::PCWSTR;
 
 const PAWNIO_DLL_NAME: &str = "PawnIOLib.dll";
 const INTEL_MSR_MODULE_FILE: &str = "IntelMSR.amx";
+const INTEL_MSR_LEGACY_MODULE_FILE: &str = "IntelMSR.bin";
 const RYZEN_SMU_MODULE_FILE: &str = "RyzenSMU.amx";
+const RYZEN_SMU_LEGACY_MODULE_FILE: &str = "RyzenSMU.bin";
 
 pub(crate) const ACCESS_PCI_MUTEX: &str = "Global\\Access_PCI";
 
@@ -26,11 +29,15 @@ pub(crate) enum PawnIoModule {
 }
 
 impl PawnIoModule {
-  fn file_name(&self) -> &'static str {
+  fn file_names(&self) -> &'static [&'static str] {
     match self {
-      Self::IntelMsr => INTEL_MSR_MODULE_FILE,
-      Self::RyzenSmu => RYZEN_SMU_MODULE_FILE,
+      Self::IntelMsr => &[INTEL_MSR_MODULE_FILE, INTEL_MSR_LEGACY_MODULE_FILE],
+      Self::RyzenSmu => &[RYZEN_SMU_MODULE_FILE, RYZEN_SMU_LEGACY_MODULE_FILE],
     }
+  }
+
+  fn not_found_reason(&self) -> String {
+    format!("{} not found", self.file_names().join(" or "))
   }
 }
 
@@ -117,7 +124,7 @@ impl PawnIoClient {
     let module_path = match discovery.module_path.clone() {
       Some(path) => path,
       None => {
-        let reason = format!("{} not found", module.file_name());
+        let reason = module.not_found_reason();
         discovery.fallback_reason = Some(reason.clone());
         return Err(PawnIoInitError {
           discovery: Box::new(discovery),
@@ -298,8 +305,7 @@ pub(crate) struct NamedMutex {
 impl NamedMutex {
   pub(crate) fn acquire(name: &str, timeout: Duration) -> Result<Self, String> {
     let wide_name = wide_null(name);
-    let handle = unsafe { CreateMutexW(None, false, PCWSTR(wide_name.as_ptr())) }
-      .map_err(|e| format!("failed to create/open mutex {name}: {e:?}"))?;
+    let handle = open_or_create_mutex(name, PCWSTR(wide_name.as_ptr()))?;
     let wait = unsafe { WaitForSingleObject(handle, timeout.as_millis() as u32) };
     if wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED {
       Ok(Self {
@@ -326,16 +332,26 @@ impl Drop for NamedMutex {
   }
 }
 
+fn open_or_create_mutex(name: &str, wide_name: PCWSTR) -> Result<HANDLE, String> {
+  let access = MUTEX_MODIFY_STATE | SYNCHRONIZATION_SYNCHRONIZE;
+  match unsafe { OpenMutexW(access, false, wide_name) } {
+    Ok(handle) => Ok(handle),
+    Err(open_error) => unsafe { CreateMutexW(None, false, wide_name) }.map_err(|create_error| {
+      format!(
+        "failed to open/create mutex {name}: open={open_error:?}; create={create_error:?}"
+      )
+    }),
+  }
+}
+
 fn discover_pawnio_files(module: &PawnIoModule) -> PawnIoDiscovery {
   let mut discovery = PawnIoDiscovery::probe_install();
   let candidates = pawnio_install_candidates();
-  let module_path = candidates
-    .iter()
-    .find_map(|path| find_named_file(path, module.file_name(), 4));
+  let module_path = find_first_module_file(&candidates, module.file_names(), 4);
 
   discovery.module_path = module_path;
   if discovery.pawnio_available && discovery.module_path.is_none() {
-    discovery.fallback_reason = Some(format!("{} not found", module.file_name()));
+    discovery.fallback_reason = Some(module.not_found_reason());
   }
   discovery
 }
@@ -377,6 +393,18 @@ fn pawnio_install_location_from_registry() -> Option<PathBuf> {
       let value = line[index + "REG_SZ".len()..].trim();
       (!value.is_empty()).then(|| PathBuf::from(value))
     })
+}
+
+fn find_first_module_file(
+  roots: &[PathBuf],
+  file_names: &[&str],
+  max_depth: usize,
+) -> Option<PathBuf> {
+  file_names.iter().find_map(|file_name| {
+    roots
+      .iter()
+      .find_map(|root| find_named_file(root, file_name, max_depth))
+  })
 }
 
 fn find_named_file(root: &Path, file_name: &str, max_depth: usize) -> Option<PathBuf> {

--- a/core/src/infrastructure/providers/windows/pawn_io.rs
+++ b/core/src/infrastructure/providers/windows/pawn_io.rs
@@ -1,0 +1,428 @@
+use std::ffi::{CString, c_char};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use libloading::Library;
+use windows::Win32::Foundation::{
+  CloseHandle, HANDLE, WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows::Win32::System::Threading::{
+  CreateMutexW, ReleaseMutex, WaitForSingleObject,
+};
+use windows::core::PCWSTR;
+
+const PAWNIO_DLL_NAME: &str = "PawnIOLib.dll";
+const INTEL_MSR_MODULE_FILE: &str = "IntelMSR.amx";
+const RYZEN_SMU_MODULE_FILE: &str = "RyzenSMU.amx";
+
+pub(crate) const ACCESS_PCI_MUTEX: &str = "Global\\Access_PCI";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PawnIoModule {
+  IntelMsr,
+  RyzenSmu,
+}
+
+impl PawnIoModule {
+  fn file_name(&self) -> &'static str {
+    match self {
+      Self::IntelMsr => INTEL_MSR_MODULE_FILE,
+      Self::RyzenSmu => RYZEN_SMU_MODULE_FILE,
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PawnIoDiscovery {
+  pub install_location: Option<PathBuf>,
+  pub dll_path: Option<PathBuf>,
+  pub module_path: Option<PathBuf>,
+  pub pawnio_available: bool,
+  pub library_loadable: bool,
+  pub driver_openable: bool,
+  pub module_loadable: bool,
+  pub version: Option<u32>,
+  pub fallback_reason: Option<String>,
+}
+
+impl PawnIoDiscovery {
+  pub(crate) fn unavailable(reason: impl Into<String>) -> Self {
+    Self {
+      install_location: None,
+      dll_path: None,
+      module_path: None,
+      pawnio_available: false,
+      library_loadable: false,
+      driver_openable: false,
+      module_loadable: false,
+      version: None,
+      fallback_reason: Some(reason.into()),
+    }
+  }
+
+  pub(crate) fn probe_install() -> Self {
+    let candidates = pawnio_install_candidates();
+    let install_location = candidates.iter().find(|path| path.exists()).cloned();
+    let dll_path = candidates
+      .iter()
+      .find_map(|path| find_named_file(path, PAWNIO_DLL_NAME, 4));
+    let pawnio_available = dll_path.is_some();
+    let fallback_reason =
+      (!pawnio_available).then(|| format!("{PAWNIO_DLL_NAME} not found"));
+
+    Self {
+      install_location,
+      dll_path,
+      module_path: None,
+      pawnio_available,
+      library_loadable: false,
+      driver_openable: false,
+      module_loadable: false,
+      version: None,
+      fallback_reason,
+    }
+  }
+}
+
+pub(crate) struct PawnIoClient {
+  library: PawnIoLibrary,
+  handle: HANDLE,
+}
+
+pub(crate) struct PawnIoInitError {
+  pub(crate) discovery: Box<PawnIoDiscovery>,
+  pub(crate) reason: String,
+}
+
+impl PawnIoClient {
+  pub(crate) fn open(
+    module: PawnIoModule,
+  ) -> Result<(Self, PawnIoDiscovery), PawnIoInitError> {
+    let mut discovery = discover_pawnio_files(&module);
+
+    let dll_path = match discovery.dll_path.clone() {
+      Some(path) => path,
+      None => {
+        let reason = format!("{PAWNIO_DLL_NAME} not found");
+        discovery.fallback_reason = Some(reason.clone());
+        return Err(PawnIoInitError {
+          discovery: Box::new(discovery),
+          reason,
+        });
+      }
+    };
+
+    let module_path = match discovery.module_path.clone() {
+      Some(path) => path,
+      None => {
+        let reason = format!("{} not found", module.file_name());
+        discovery.fallback_reason = Some(reason.clone());
+        return Err(PawnIoInitError {
+          discovery: Box::new(discovery),
+          reason,
+        });
+      }
+    };
+
+    let library = match PawnIoLibrary::load(&dll_path) {
+      Ok(library) => {
+        discovery.library_loadable = true;
+        library
+      }
+      Err(reason) => {
+        discovery.fallback_reason = Some(reason.clone());
+        return Err(PawnIoInitError {
+          discovery: Box::new(discovery),
+          reason,
+        });
+      }
+    };
+
+    let mut version = 0_u32;
+    let hr = unsafe { (library.version)(&mut version) };
+    if hresult_succeeded(hr) {
+      discovery.version = Some(version);
+    }
+
+    let mut handle = HANDLE::default();
+    let hr = unsafe { (library.open)(&mut handle) };
+    if hresult_failed(hr) || handle.is_invalid() {
+      let reason = format!("pawnio_open failed: {}", format_hresult(hr));
+      discovery.fallback_reason = Some(reason.clone());
+      return Err(PawnIoInitError {
+        discovery: Box::new(discovery),
+        reason,
+      });
+    }
+    discovery.driver_openable = true;
+
+    let blob = match fs::read(&module_path) {
+      Ok(blob) => blob,
+      Err(e) => {
+        let _ = unsafe { (library.close)(handle) };
+        let reason = format!("failed to read {}: {e}", module_path.display());
+        discovery.fallback_reason = Some(reason.clone());
+        return Err(PawnIoInitError {
+          discovery: Box::new(discovery),
+          reason,
+        });
+      }
+    };
+
+    let hr = unsafe { (library.load)(handle, blob.as_ptr(), blob.len()) };
+    if hresult_failed(hr) {
+      let _ = unsafe { (library.close)(handle) };
+      let reason = format!("pawnio_load failed: {}", format_hresult(hr));
+      discovery.fallback_reason = Some(reason.clone());
+      return Err(PawnIoInitError {
+        discovery: Box::new(discovery),
+        reason,
+      });
+    }
+    discovery.module_loadable = true;
+
+    Ok((Self { library, handle }, discovery))
+  }
+
+  pub(crate) fn read_msr(&self, msr: u64) -> Result<u64, String> {
+    self.execute("ioctl_read_msr", &[msr]).map(|out| out[0])
+  }
+
+  pub(crate) fn read_smu_register(&self, address: u64) -> Result<u64, String> {
+    self
+      .execute("ioctl_read_smu_register", &[address])
+      .map(|out| out[0])
+  }
+
+  fn execute(&self, name: &str, input: &[u64]) -> Result<Vec<u64>, String> {
+    let name =
+      CString::new(name).map_err(|e| format!("invalid PawnIO function name: {e}"))?;
+    let mut output = [0_u64; 1];
+    let mut return_size = 0_usize;
+    let hr = unsafe {
+      (self.library.execute)(
+        self.handle,
+        name.as_ptr(),
+        input.as_ptr(),
+        input.len(),
+        output.as_mut_ptr(),
+        output.len(),
+        &mut return_size,
+      )
+    };
+    if hresult_failed(hr) {
+      return Err(format!(
+        "pawnio_execute {} failed: {}",
+        name.to_string_lossy(),
+        format_hresult(hr)
+      ));
+    }
+    if return_size == 0 {
+      return Err(format!(
+        "pawnio_execute {} returned no output cells",
+        name.to_string_lossy()
+      ));
+    }
+
+    Ok(output[..return_size.min(output.len())].to_vec())
+  }
+}
+
+impl Drop for PawnIoClient {
+  fn drop(&mut self) {
+    let _ = unsafe { (self.library.close)(self.handle) };
+  }
+}
+
+// SAFETY: the PawnIO handle is only used behind the process-wide CPU
+// temperature sampler mutex, and the DLL remains loaded for the full handle
+// lifetime through `PawnIoLibrary`.
+unsafe impl Send for PawnIoClient {}
+
+type PawnIoVersion = unsafe extern "system" fn(*mut u32) -> i32;
+type PawnIoOpen = unsafe extern "system" fn(*mut HANDLE) -> i32;
+type PawnIoLoad = unsafe extern "system" fn(HANDLE, *const u8, usize) -> i32;
+type PawnIoExecute = unsafe extern "system" fn(
+  HANDLE,
+  *const c_char,
+  *const u64,
+  usize,
+  *mut u64,
+  usize,
+  *mut usize,
+) -> i32;
+type PawnIoClose = unsafe extern "system" fn(HANDLE) -> i32;
+
+struct PawnIoLibrary {
+  _library: Library,
+  version: PawnIoVersion,
+  open: PawnIoOpen,
+  load: PawnIoLoad,
+  execute: PawnIoExecute,
+  close: PawnIoClose,
+}
+
+impl PawnIoLibrary {
+  fn load(path: &Path) -> Result<Self, String> {
+    let library = unsafe { Library::new(path) }
+      .map_err(|e| format!("failed to load {}: {e}", path.display()))?;
+    let version = *unsafe { library.get::<PawnIoVersion>(b"pawnio_version") }
+      .map_err(|e| format!("missing pawnio_version: {e}"))?;
+    let open = *unsafe { library.get::<PawnIoOpen>(b"pawnio_open") }
+      .map_err(|e| format!("missing pawnio_open: {e}"))?;
+    let load = *unsafe { library.get::<PawnIoLoad>(b"pawnio_load") }
+      .map_err(|e| format!("missing pawnio_load: {e}"))?;
+    let execute = *unsafe { library.get::<PawnIoExecute>(b"pawnio_execute") }
+      .map_err(|e| format!("missing pawnio_execute: {e}"))?;
+    let close = *unsafe { library.get::<PawnIoClose>(b"pawnio_close") }
+      .map_err(|e| format!("missing pawnio_close: {e}"))?;
+
+    Ok(Self {
+      _library: library,
+      version,
+      open,
+      load,
+      execute,
+      close,
+    })
+  }
+}
+
+pub(crate) struct NamedMutex {
+  handle: HANDLE,
+  acquired: bool,
+}
+
+impl NamedMutex {
+  pub(crate) fn acquire(name: &str, timeout: Duration) -> Result<Self, String> {
+    let wide_name = wide_null(name);
+    let handle = unsafe { CreateMutexW(None, false, PCWSTR(wide_name.as_ptr())) }
+      .map_err(|e| format!("failed to create/open mutex {name}: {e:?}"))?;
+    let wait = unsafe { WaitForSingleObject(handle, timeout.as_millis() as u32) };
+    if wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED {
+      Ok(Self {
+        handle,
+        acquired: true,
+      })
+    } else {
+      let _ = unsafe { CloseHandle(handle) };
+      if wait == WAIT_TIMEOUT {
+        Err(format!("timed out waiting for mutex {name}"))
+      } else {
+        Err(format!("failed waiting for mutex {name}: {wait:?}"))
+      }
+    }
+  }
+}
+
+impl Drop for NamedMutex {
+  fn drop(&mut self) {
+    if self.acquired {
+      let _ = unsafe { ReleaseMutex(self.handle) };
+    }
+    let _ = unsafe { CloseHandle(self.handle) };
+  }
+}
+
+fn discover_pawnio_files(module: &PawnIoModule) -> PawnIoDiscovery {
+  let mut discovery = PawnIoDiscovery::probe_install();
+  let candidates = pawnio_install_candidates();
+  let module_path = candidates
+    .iter()
+    .find_map(|path| find_named_file(path, module.file_name(), 4));
+
+  discovery.module_path = module_path;
+  if discovery.pawnio_available && discovery.module_path.is_none() {
+    discovery.fallback_reason = Some(format!("{} not found", module.file_name()));
+  }
+  discovery
+}
+
+fn pawnio_install_candidates() -> Vec<PathBuf> {
+  let mut candidates = Vec::new();
+  if let Some(registry_path) = pawnio_install_location_from_registry() {
+    candidates.push(registry_path);
+  }
+  for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
+    if let Some(value) = std::env::var_os(var) {
+      let path = PathBuf::from(value).join("PawnIO");
+      if !candidates.iter().any(|candidate| candidate == &path) {
+        candidates.push(path);
+      }
+    }
+  }
+  candidates
+}
+
+fn pawnio_install_location_from_registry() -> Option<PathBuf> {
+  let output = Command::new("reg.exe")
+    .args([
+      "query",
+      r"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO",
+      "/v",
+      "InstallLocation",
+    ])
+    .output()
+    .ok()?;
+  if !output.status.success() {
+    return None;
+  }
+
+  String::from_utf8_lossy(&output.stdout)
+    .lines()
+    .find_map(|line| {
+      let index = line.find("REG_SZ")?;
+      let value = line[index + "REG_SZ".len()..].trim();
+      (!value.is_empty()).then(|| PathBuf::from(value))
+    })
+}
+
+fn find_named_file(root: &Path, file_name: &str, max_depth: usize) -> Option<PathBuf> {
+  if max_depth == 0 || !root.exists() {
+    return None;
+  }
+
+  let direct = root.join(file_name);
+  if direct.is_file() {
+    return Some(direct);
+  }
+
+  let entries = fs::read_dir(root).ok()?;
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_file()
+      && path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case(file_name))
+        .unwrap_or(false)
+    {
+      return Some(path);
+    }
+    if path.is_dir()
+      && let Some(found) = find_named_file(&path, file_name, max_depth - 1)
+    {
+      return Some(found);
+    }
+  }
+
+  None
+}
+
+fn hresult_succeeded(hr: i32) -> bool {
+  hr >= 0
+}
+
+fn hresult_failed(hr: i32) -> bool {
+  !hresult_succeeded(hr)
+}
+
+fn format_hresult(hr: i32) -> String {
+  format!("0x{:08X}", hr as u32)
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+  value.encode_utf16().chain(std::iter::once(0)).collect()
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ documentation.
 ## Main Entry Points
 
 - [Backend architecture](architecture/backend.md)
+- [Windows sensor external components](architecture/windows-sensor-external-components.md)
 - [Architecture decision records](adr/)
 - [Sensor hardware specs (clean-room)](specs/sensors/)
 - [Frontend architecture](../src/README.md)

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -182,6 +182,10 @@ Core infrastructure contains lower-level external access used by Core:
 - `providers/`: OS, vendor, and system data providers. See
   [`core/README.md`](../../core/README.md) for Core-specific provider details.
 
+Windows sensor providers that depend on external runtime components, such as
+PawnIO and its CPU-specific module blobs, are documented in
+[`windows-sensor-external-components.md`](windows-sensor-external-components.md).
+
 ### Persistence (`core/src/persistence/`, `src-tauri/src/infrastructure/`)
 
 Persistence is split:

--- a/docs/architecture/windows-sensor-external-components.md
+++ b/docs/architecture/windows-sensor-external-components.md
@@ -16,8 +16,22 @@ Required components:
 - A working PawnIO driver installation that `pawnio_open` can open.
 - `PawnIOLib.dll`, loaded dynamically from the existing installation.
 - One CPU-specific PawnIO module blob:
-  - Intel package temperature path: `IntelMSR.amx`.
-  - AMD Family 17h / 19h package temperature path: `RyzenSMU.amx`.
+  - Intel package temperature path: `IntelMSR.amx` or `IntelMSR.bin`.
+  - AMD Family 17h / 19h package temperature path: `RyzenSMU.amx` or
+    `RyzenSMU.bin`.
+
+The collector prefers the implementation-ready spec names (`*.amx`) and then
+falls back to the installed module names observed during local validation
+(`*.bin`). The module extension is an operational compatibility detail only; it
+does not change the CPU register decode path.
+
+The process that opens PawnIO must have enough Windows privileges to access the
+driver. On the local Phase 1 validation machine, the `PawnIO` kernel driver
+service was installed and running, but a non-elevated process still failed at
+`pawnio_open` with `0x80070005`. Running the same probe elevated allowed the
+driver open, module load, and CPU package temperature sample to succeed. Until
+HardwareVisualizer has an elevated helper or service, users should expect to run
+the app as administrator for PawnIO-backed CPU package temperature collection.
 
 The current collector searches these locations:
 
@@ -38,8 +52,8 @@ unavailable reason instead of publishing a CPU temperature. Example reasons
 include:
 
 - `PawnIOLib.dll not found`.
-- `IntelMSR.amx not found`.
-- `RyzenSMU.amx not found`.
+- `IntelMSR.amx or IntelMSR.bin not found`.
+- `RyzenSMU.amx or RyzenSMU.bin not found`.
 - `pawnio_open failed: ...`.
 - `pawnio_load failed: ...`.
 
@@ -48,15 +62,15 @@ include:
 The Phase 1 implementation only uses read-only CPU package temperature paths:
 
 - Intel: `MSR_TEMPERATURE_TARGET` and `IA32_PACKAGE_THERM_STATUS` through
-  `IntelMSR.amx`.
-- AMD: SMN `0x00059800` through `RyzenSMU.amx`, enabled only for Family 17h and
+  `IntelMSR`.
+- AMD: SMN `0x00059800` through `RyzenSMU`, enabled only for Family 17h and
   Family 19h.
 
 The following are not covered by this runtime checklist or by the Phase 1
 implementation:
 
 - Installing PawnIO.
-- Bundling `PawnIOLib.dll` or `*.amx` module blobs.
+- Bundling `PawnIOLib.dll` or module blobs.
 - Driver installer integration or bootstrapper work.
 - AMD Family 1Ah / Zen 5 enablement.
 - AMD per-CCD temperatures or SMU PM-table metrics.

--- a/docs/architecture/windows-sensor-external-components.md
+++ b/docs/architecture/windows-sensor-external-components.md
@@ -1,0 +1,67 @@
+# Windows Sensor External Components
+
+This document lists the external runtime components required by Windows native
+sensor collection. It is an operational checklist, not a hardware fact source.
+The clean-room implementation remains derived from the pinned
+`docs/specs/sensors/**` implementation-ready specs and this repository.
+
+## Phase 1 CPU Package Temperature
+
+Windows CPU package temperature collection through PawnIO requires an existing
+local PawnIO installation. HardwareVisualizer does not install, bundle, or
+bootstrap PawnIO in Phase 1.
+
+Required components:
+
+- A working PawnIO driver installation that `pawnio_open` can open.
+- `PawnIOLib.dll`, loaded dynamically from the existing installation.
+- One CPU-specific PawnIO module blob:
+  - Intel package temperature path: `IntelMSR.amx`.
+  - AMD Family 17h / 19h package temperature path: `RyzenSMU.amx`.
+
+The current collector searches these locations:
+
+- `InstallLocation` under
+  `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO`.
+- `%ProgramFiles%\PawnIO`.
+- `%ProgramW6432%\PawnIO`.
+- `%ProgramFiles(x86)%\PawnIO`.
+
+Within each candidate root, the collector searches recursively for
+`PawnIOLib.dll` and the selected module file. If the DLL or module is missing,
+if the DLL cannot be loaded, if the driver cannot be opened, or if the module
+cannot be loaded, CPU package temperature falls back to the existing ACPI
+thermal-zone path.
+
+If both PawnIO and ACPI thermal zones are unavailable, the collector reports an
+unavailable reason instead of publishing a CPU temperature. Example reasons
+include:
+
+- `PawnIOLib.dll not found`.
+- `IntelMSR.amx not found`.
+- `RyzenSMU.amx not found`.
+- `pawnio_open failed: ...`.
+- `pawnio_load failed: ...`.
+
+## Scope Boundaries
+
+The Phase 1 implementation only uses read-only CPU package temperature paths:
+
+- Intel: `MSR_TEMPERATURE_TARGET` and `IA32_PACKAGE_THERM_STATUS` through
+  `IntelMSR.amx`.
+- AMD: SMN `0x00059800` through `RyzenSMU.amx`, enabled only for Family 17h and
+  Family 19h.
+
+The following are not covered by this runtime checklist or by the Phase 1
+implementation:
+
+- Installing PawnIO.
+- Bundling `PawnIOLib.dll` or `*.amx` module blobs.
+- Driver installer integration or bootstrapper work.
+- AMD Family 1Ah / Zen 5 enablement.
+- AMD per-CCD temperatures or SMU PM-table metrics.
+- Threadripper / EPYC multi-die-specific behavior.
+- Super I/O, fan RPM, voltage, and motherboard sensors.
+
+If a future release bundles PawnIO components, update the Windows third-party
+notices and release packaging documentation before shipping those artifacts.


### PR DESCRIPTION
﻿## Summary

Adds Phase 1 Windows CPU package temperature collection through existing PawnIO installations.

- Detects CPU vendor/family/model, Intel DTS/PTM capability, AMD Family 17h/19h enablement, PawnIO library/module availability, selected source, and fallback reason.
- Adds read-only Intel package DTS MSR and AMD Zen SMN Tctl/Tdie sampling with ACPI thermal-zone fallback.
- Keeps PawnIO install/bootstrap/bundling out of scope; only detects and uses an existing installation.
- Adds pure decode functions and focused unit tests for Intel `MSR_TEMPERATURE_TARGET` / `IA32_PACKAGE_THERM_STATUS` and AMD SMN `0x00059800` `CUR_TEMP` / `CUR_TEMP_RANGE_SEL`.

## Related Issues

Relates to #1635.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Clean-room provenance

```text
Implemented from docs/specs/sensors/pawnio-interface.md revision 2 (commit 7acf127d740df9d5e217f9013e78648f860bbe52).
Implemented from docs/specs/sensors/cpu-intel-dts-msr.md revision 2 (commit 7acf127d740df9d5e217f9013e78648f860bbe52).
Implemented from docs/specs/sensors/cpu-amd-zen-smn.md revision 3 (commit 7acf127d740df9d5e217f9013e78648f860bbe52).
No other external sensor documentation was used.
```

### Implementer attestation

- [x] This implementation references only `docs/specs/sensors/**` (at
      the revisions pinned above) and this repository.
- [x] Every spec document pinned above carries
      `Status: Implementation-ready (rev N)` at the pinned revision
      and has no unresolved `TODO(provenance)` markers (see "Status
      transition" in `docs/specs/sensors/README.md`).
- [x] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or any decompiled monitoring tool
      while writing this implementation (full prohibited-source list:
      `.github/instructions/clean-room-sensors.instructions.md`).
- [x] Register access added by this PR is read-only; the only writes
      are those the pinned specs document as required for reads
      (e.g. Super I/O config keys, bank select), and the ecosystem
      mutex conventions are honored.

### Reviewer attestation

Reviewers: copy the checklist below into your approval review
comment, with both boxes checked. Do not approve without it.

```markdown
- [ ] I reviewed this implementation only against
      `docs/specs/sensors/**`, this repository, and the pinned spec
      revision.
- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or decompiled monitoring tools while
      reviewing this implementation.
```

## Screenshots / Videos

Not applicable; backend sensor collection change.

## Test Plan

- [x] Manual testing
- [x] Unit tests

Validation run locally:

```text
cargo fmt -p hardviz-core --check
cargo test -p hardviz-core
cargo clippy -p hardviz-core -- -D warnings
cargo check
git diff --check
git diff --cached --check
```

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo fmt -p hardviz-core --check`; `cargo clippy -p hardviz-core -- -D warnings`)
- [x] Tests pass (`cargo test -p hardviz-core`; `cargo check`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows: Integrated support for native CPU package temperature sampling using external runtime components for Intel and AMD, with prioritized sources and fallbacks.
* **Bug Fixes**
  * Improved handling when all temperature sources fail; samples now include a clear unavailable-reason.
* **Documentation**
  * Added docs describing required Windows external components and operational fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->