### PR TITLE
fix: ignore Rust build artifacts in Vite watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,8 +108,8 @@ export default defineConfig(async ({ mode }) => ({
     port: 1520,
     strictPort: true,
     watch: {
-      // 3. tell vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+      // 3. tell vite to ignore Rust sources and build artifacts
+      ignored: ["**/src-tauri/**", "**/target/**"],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Ignore the Rust workspace target directory in Vite's dev-server watcher.
- Prevent Windows EBUSY failures when Tauri dev builds and locks hardware_monitor_lib.dll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vite development server configuration to exclude Rust source and build artifact directories from file watching, enhancing development performance by preventing unnecessary file monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->