### PR TITLE
fix: run render memory perf tests in e2e mode

### DIFF
--- a/playwright.memory.config.ts
+++ b/playwright.memory.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `vite dev --port ${RENDER_MEMORY_PORT} --strictPort`,
+    command: `vite dev --mode e2e --port ${RENDER_MEMORY_PORT} --strictPort`,
     url: `http://localhost:${RENDER_MEMORY_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
﻿## Summary
- Run the render memory Playwright web server with `--mode e2e`.
- Align `playwright.memory.config.ts` with the other web/mock E2E and render perf configs.

## Root cause
`test-render-memory-perf` expected the fixture CPU name from the E2E mock IPC harness, but the memory perf config started plain Vite without `--mode e2e`. That meant `src/main.e2e.tsx` was not used and the fixture never appeared.

## Validation
- `C:\Users\shoum\Develop\HardwareVisualizer\node_modules\.bin\biome.cmd check C:\Users\shoum\Develop\HardwareVisualizer-fix-render-memory-e2e-mode\playwright.memory.config.ts`
- `git diff --check`
- Short local memory perf run: `RENDER_MEMORY_WARMUP_MS=1000 RENDER_MEMORY_DURATION_MS=5000 RENDER_MEMORY_SAMPLE_INTERVAL_MS=1000 RENDER_MEMORY_TAIL_WINDOW_MS=2000 RENDER_MEMORY_STREAM_INTERVAL_MS=250 npm.cmd run test:perf:render-memory`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test server configuration for render-memory performance testing to ensure proper environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->