### PR TITLE
docs(specs): PawnIO module blob distribution + Phase 1 implementer field validation (rev 4) (#1635)

### DIFF
--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -163,7 +163,7 @@ or unresolved blocking open question invalidates the flip.
 
 | Document | Covers | Issue phase | Status |
 | --- | --- | --- | --- |
-| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, blob distribution, licensing facts | Phase 1 | Implementation-ready (rev 3) |
+| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, blob distribution (signed `.bin`), elevation requirement, licensing facts | Phase 1 | Implementation-ready (rev 4) |
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
 | [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -163,7 +163,7 @@ or unresolved blocking open question invalidates the flip.
 
 | Document | Covers | Issue phase | Status |
 | --- | --- | --- | --- |
-| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, licensing facts | Phase 1 | Implementation-ready (rev 2) |
+| [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, blob distribution, licensing facts | Phase 1 | Implementation-ready (rev 3) |
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
 | [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 2 |
-| Status | Implementation-ready (rev 2) |
+| Revision | 3 |
+| Status | Implementation-ready (rev 3) |
 | Scope | Facts needed to integrate a Rust user-mode client with PawnIO: installation/detection, the PawnIOLib API, the module execution model, and the IOCTL contracts of the `IntelMSR`, `RyzenSMU`, and `LpcIO` modules. Excludes: writing new Pawn modules, driver internals. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -18,6 +18,7 @@
 | S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Upstream-published interface definitions of the API this project calls across the IOCTL boundary (public `ioctl_*` contracts, allow-lists, caller-mutex `@warning` docs); the PawnIO project is the authoritative source for its own interfaces. Not used as a source for any hardware register fact. No code was copied. |
 | S6 | `PawnIOLib/include/PawnIOLib.h` in S1 (LGPL-2.1-or-later, © 2026 namazso) | Primary; exact user-mode API prototypes and doc comments |
 | S7 | PawnIO driver source in S1 (GPL-2.0 with IOCTL exception): `PawnIO/src/natives_impl_windows.cpp`, `PawnIO/include/pawnio_um.h` | Native semantics (execution context of `msr_read`, affinity natives) and device path. Interface facts only; no code was copied. |
+| S8 | PawnIO.Modules `README.md` and GitHub Releases, <https://github.com/namazso/PawnIO.Modules/releases>; CI workflow `.github/workflows/ci.yml` in S2 | Primary; module-blob distribution channels and signing status |
 
 ## Licensing facts
 
@@ -53,10 +54,30 @@
   driver plus Windows test-signing mode. An end-user deployment
   therefore uses the signed driver with the signed module blobs
   released by the PawnIO project. (S4)
+- The driver and PawnIOLib runtime are distributed from
+  <https://pawnio.eu> (signed installer). (S1, S4)
+
+## Module blob distribution
+
+- **Signed module blobs are distributed via the PawnIO.Modules
+  GitHub Releases** — the repository README states "Signed builds can
+  be found in Releases." This is the channel an end-user deployment
+  must use, because the production driver loads signed modules only.
+  Latest release at authoring: **0.2.8 (2024-06-12)**. (S8)
+- The PawnIO.Modules CI (`build` workflow) compiles every `*.p` with
+  `pawncc` (`-C64 -iinclude`) and uploads the resulting `*.amx` as a
+  per-commit build artifact. **CI artifacts and self-built blobs are
+  unsigned** (the workflow has no signing step) and therefore load
+  only under the unrestricted driver + test-signing. (S8)
+- Consequence for this project: bundle the **signed** blobs from a
+  pinned PawnIO.Modules release (e.g. `RyzenSMU` and `IntelMSR` for
+  Phase 1), not self-built copies. Redistribution must comply with
+  the modules' LGPL-2.1 terms (see Licensing facts).
 - Compiled module blobs are named `<Module>.amx` (e.g. `IntelMSR.amx`,
-  `RyzenSMU.amx`); the PawnIO.Modules CI publishes `*.amx` artifacts
-  per release. The client bundles the blobs it needs and loads them
-  via `pawnio_load`. (S2)
+  `RyzenSMU.amx`). The client bundles the signed blobs it needs and
+  loads them via `pawnio_load`; for where the blobs come from and the
+  signed-vs-unsigned distinction, see "Module blob distribution"
+  above. (S2, S8)
 - Absence of PawnIO is a supported state: the client must detect the
   missing library/driver and report "unavailable" so the caller can
   fall back to the ACPI thermal-zone source (PR #1633).
@@ -205,11 +226,12 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
   module and never reloads a different blob on the same handle.
   Whether `pawnio_load` may be called twice on one handle is not
   documented upstream (S6); resolve only if a future phase needs it.
-- Non-blocking for Phase 1: the client ships and loads its own copies
-  of the required `.amx` blobs via `pawnio_load`, so the official
-  installer's module-directory layout does not affect Phase 1.
-  Confirm the layout if a future phase wants to reuse
-  installer-provided blobs.
+- Non-blocking for Phase 1: signed blobs come from the PawnIO.Modules
+  GitHub Releases (resolved — see "Module blob distribution"). The
+  exact per-release asset packaging (individual `.amx` files vs. a
+  single archive) was not confirmable verbatim at authoring time
+  because the Releases asset list failed to render; confirm the asset
+  names against the pinned release when wiring up bundling.
 
 ## Revision history
 
@@ -217,3 +239,4 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Provenance resolved against upstream sources: exact `PawnIOLib.h` API (incl. `pawnio_close`, cell-count semantics), device path, `msr_read` execution context and affinity natives, blob naming. Corrected mutex ownership: modules document caller-held mutants and acquire none themselves. Status → Implementation-ready. |
+| 3 | 2026-06-13 | Added "Module blob distribution" section: signed blobs ship via the PawnIO.Modules GitHub Releases (README-stated; latest 0.2.8, 2024-06-12), CI artifacts/self-builds are unsigned, driver/PawnIOLib from pawnio.eu. Resolved the blob-source open question (asset packaging left as a narrow non-blocking confirmation). Added source S8. Status remains Implementation-ready. |

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 3 |
-| Status | Implementation-ready (rev 3) |
+| Revision | 4 |
+| Status | Implementation-ready (rev 4) |
 | Scope | Facts needed to integrate a Rust user-mode client with PawnIO: installation/detection, the PawnIOLib API, the module execution model, and the IOCTL contracts of the `IntelMSR`, `RyzenSMU`, and `LpcIO` modules. Excludes: writing new Pawn modules, driver internals. |
 | Issue phase | Phase 1 (#1635) |
 
@@ -18,7 +18,9 @@
 | S5 | Module sources `IntelMSR.p`, `RyzenSMU.p`, `LpcIO.p` in S2 (LGPL-2.1-or-later) | Upstream-published interface definitions of the API this project calls across the IOCTL boundary (public `ioctl_*` contracts, allow-lists, caller-mutex `@warning` docs); the PawnIO project is the authoritative source for its own interfaces. Not used as a source for any hardware register fact. No code was copied. |
 | S6 | `PawnIOLib/include/PawnIOLib.h` in S1 (LGPL-2.1-or-later, © 2026 namazso) | Primary; exact user-mode API prototypes and doc comments |
 | S7 | PawnIO driver source in S1 (GPL-2.0 with IOCTL exception): `PawnIO/src/natives_impl_windows.cpp`, `PawnIO/include/pawnio_um.h` | Native semantics (execution context of `msr_read`, affinity natives) and device path. Interface facts only; no code was copied. |
-| S8 | PawnIO.Modules `README.md` and GitHub Releases, <https://github.com/namazso/PawnIO.Modules/releases>; CI workflow `.github/workflows/ci.yml` in S2 | Primary; module-blob distribution channels and signing status |
+| S8 | PawnIO.Modules `README.md` and GitHub Releases, <https://github.com/namazso/PawnIO.Modules/releases>; CI workflow `.github/workflows/ci.yml` in S2 | Primary; module-blob distribution channels and signing status. Release 0.2.8 assets (via the release `expanded_assets` fragment): `release_0_2_8.zip` + source archives |
+| S9 | PawnIO repo in S1: `PawnIOUtil/PawnIOUtil.cpp` (the `sign` command and signed-blob layout), `PawnIO/PawnIO.inf.in` (device security descriptor), `PawnIO/src/driver.cpp` (`IoCreateDevice`) | Primary; signed-module format and device access control. Interface facts only; no code was copied |
+| S10 | Implementer field validation on AMD Ryzen 7 7800X3D (Windows), reported 2026-06-13: installed module file names, `pawnio_open` access-denied without elevation, `Global\Access_PCI` open-vs-create behavior | Independent runtime observation (clean-room: the implementer ran the actual hardware and PawnIO; no prohibited source consulted). Corroborates the primary-source facts above |
 
 ## Licensing facts
 
@@ -56,6 +58,30 @@
   released by the PawnIO project. (S4)
 - The driver and PawnIOLib runtime are distributed from
   <https://pawnio.eu> (signed installer). (S1, S4)
+- **The core PawnIO installer does not bundle the sensor modules.** A
+  core install contains the runtime and tooling only — `PawnIOLib.dll`,
+  `PawnIOLib.h`, `PawnIOUtil.exe`, the uninstaller — reflecting the
+  PawnIO (runtime) vs PawnIO.Modules (modules) repository split. The
+  `IntelMSR` / `RyzenSMU` module files come separately from the
+  PawnIO.Modules release and must be supplied by this application; do
+  not assume they exist under the PawnIO install directory. (S1, S2;
+  observed by S10)
+
+### Privilege requirement (Windows)
+
+- **`pawnio_open` requires Administrator / elevation.** The driver's
+  device object DACL is set by the INF to
+  `D:P(A;;GA;;;SY)(A;;GA;;;BA)` (S9), i.e. `GENERIC_ALL` for Local
+  System (`SY`) and Built-in Administrators (`BA`) only, with no ACE
+  for normal users. A non-elevated caller therefore fails `pawnio_open`
+  with `0x80070005` (`E_ACCESSDENIED`), even though `PawnIOLib.dll`
+  loads and `pawnio_version` succeeds, and even when the `PawnIO`
+  kernel service is installed and running. (S9; observed by S10)
+- Detection must distinguish three states so the caller can react
+  correctly: library/driver **absent** → fall back to ACPI zones
+  (#1633); present but **access-denied** (`0x80070005`) → report that
+  elevation is required rather than "unsupported"; present and
+  **openable** → proceed.
 
 ## Module blob distribution
 
@@ -65,20 +91,32 @@
   must use, because the production driver loads signed modules only.
   Latest release at authoring: **0.2.8 (2026-06-12)**, verified
   against the upstream git tag `0.2.8` (commit `754635b`). (S8)
-- The PawnIO.Modules CI (`build` workflow) compiles every `*.p` with
-  `pawncc` (`-C64 -iinclude`) and uploads the resulting `*.amx` as a
-  per-commit build artifact. **CI artifacts and self-built blobs are
-  unsigned** (the workflow has no signing step) and therefore load
-  only under the unrestricted driver + test-signing. (S8)
-- Consequence for this project: bundle the **signed** blobs from a
-  pinned PawnIO.Modules release (e.g. `RyzenSMU` and `IntelMSR` for
-  Phase 1), not self-built copies. Redistribution must comply with
-  the modules' LGPL-2.1 terms (see Licensing facts).
-- Compiled module blobs are named `<Module>.amx` (e.g. `IntelMSR.amx`,
-  `RyzenSMU.amx`). The client bundles the signed blobs it needs and
-  loads them via `pawnio_load`; for where the blobs come from and the
-  signed-vs-unsigned distinction, see "Module blob distribution"
-  above. (S2, S8)
+- The release ships as a **single archive** (0.2.8: `release_0_2_8.zip`,
+  alongside the auto-generated source archives), not as individual
+  per-module assets. The signed module files live inside that archive.
+  (S8)
+- **Two distinct artifact forms, distinguished by extension:**
+  - `*.amx` — the raw `pawncc` output (`-C64 -iinclude`), **unsigned**.
+    This is what the PawnIO.Modules CI `build` workflow uploads as a
+    per-commit artifact and what a local `pawncc` build produces. The
+    production (signed) driver will **not** load these; they require
+    the unrestricted driver + Windows test-signing. (S8)
+  - `*.bin` — the **signed** module: `PawnIOUtil sign` wraps an `.amx`
+    as `[u32 little-endian signature length][signature][amx bytes]`
+    and writes it to a separate file (S9). These are the files shipped
+    inside the release archive and installed on disk as, e.g.,
+    `RyzenSMU.bin` / `IntelMSR.bin`; they are what the production
+    driver loads. (S9; observed by S10)
+- `pawnio_load` takes an **in-memory blob and is extension-agnostic**
+  (S6) — it does not require any particular file name. The client must
+  therefore not hard-require `.amx`: load the signed `.bin` that the
+  release/install provides, treating the module file name/extension as
+  configuration (default `.bin`).
+- Consequence for this project: bundle the **signed `.bin`** modules
+  from a pinned PawnIO.Modules release (`RyzenSMU.bin` and
+  `IntelMSR.bin` for Phase 1), not self-built `.amx` copies.
+  Redistribution must comply with the modules' LGPL-2.1 terms (see
+  Licensing facts).
 - Absence of PawnIO is a supported state: the client must detect the
   missing library/driver and report "unavailable" so the caller can
   fall back to the ACPI thermal-zone source (PR #1633).
@@ -220,6 +258,17 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
   LibreHardwareMonitor / FanControl. (S5; convention per issue #1635)
 - Mutex acquisition must use a bounded timeout and treat timeout as a
   failed (skipped) sample, never as permission to proceed unlocked.
+- **Open an existing mutant before creating one.** These mutants are
+  shared with other monitors (HWiNFO / LibreHardwareMonitor /
+  FanControl), and whichever process creates one first sets its ACL.
+  Calling `CreateMutexW` against an already-existing, restrictively
+  ACL'd object can fail with access-denied. Acquire with
+  `OpenMutexW(MUTEX_MODIFY_STATE | SYNCHRONIZE, FALSE, name)` first and
+  fall back to `CreateMutexW` only when the object does not yet exist;
+  request only the minimal rights needed to `WaitForSingleObject` /
+  `ReleaseMutex`. (Win32 semantics; observed by S10 — `CreateMutexW`
+  on an existing `Global\Access_PCI` returned access-denied, while
+  open-then-create succeeded.)
 
 ## Open questions
 
@@ -227,12 +276,23 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
   module and never reloads a different blob on the same handle.
   Whether `pawnio_load` may be called twice on one handle is not
   documented upstream (S6); resolve only if a future phase needs it.
-- Non-blocking for Phase 1: signed blobs come from the PawnIO.Modules
-  GitHub Releases (resolved — see "Module blob distribution"). The
-  exact per-release asset packaging (individual `.amx` files vs. a
-  single archive) was not confirmable verbatim at authoring time
-  because the Releases asset list failed to render; confirm the asset
-  names against the pinned release when wiring up bundling.
+- Resolved (rev 4): signed blobs come from the PawnIO.Modules GitHub
+  Releases as a single archive (`release_<version>.zip`) containing
+  signed `*.bin` modules; see "Module blob distribution". When pinning
+  a release, confirm the exact in-archive module file names against
+  that release.
+
+## Follow-up scope (out of Phase 1)
+
+A user-friendly deployment needs more than this document; an
+installer/setup helper is expected to handle, and to surface
+diagnostics for, each of: installing and starting the PawnIO kernel
+driver; ensuring `PawnIOLib.dll` is present; placing the signed
+`IntelMSR` / `RyzenSMU` `.bin` modules where the app loads them;
+obtaining elevation for `pawnio_open`; and reporting the distinct
+failure modes (missing DLL, missing module, driver access-denied,
+module load failure). Captured here from S10; tracked as a later
+phase of #1635, not part of the Phase 1 read path.
 
 ## Revision history
 
@@ -241,3 +301,4 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Provenance resolved against upstream sources: exact `PawnIOLib.h` API (incl. `pawnio_close`, cell-count semantics), device path, `msr_read` execution context and affinity natives, blob naming. Corrected mutex ownership: modules document caller-held mutants and acquire none themselves. Status → Implementation-ready. |
 | 3 | 2026-06-13 | Added "Module blob distribution" section: signed blobs ship via the PawnIO.Modules GitHub Releases (README-stated; latest 0.2.8, 2026-06-12, verified against the upstream git tag), CI artifacts/self-builds are unsigned, driver/PawnIOLib from pawnio.eu. Resolved the blob-source open question (asset packaging left as a narrow non-blocking confirmation). Added source S8. Status remains Implementation-ready. |
+| 4 | 2026-06-13 | Implementer field-validation corrections (Ryzen 7 7800X3D, S10), all cross-checked against PawnIO primary sources (S9): signed modules are `*.bin` (`PawnIOUtil sign` blob layout) shipped inside the release archive `release_0_2_8.zip`, vs unsigned `*.amx` build output — `pawnio_load` is extension-agnostic, so dropped the `.amx`-only naming claim; `pawnio_open` requires elevation (device DACL `D:P(A;;GA;;;SY)(A;;GA;;;BA)`; non-elevated → `0x80070005`), added three-state detection; core installer excludes modules; mutex acquisition must open-before-create to avoid ACL failures on shared mutants; added a follow-up-scope note for installer UX. Resolved the asset-packaging open question. Status remains Implementation-ready. |

--- a/docs/specs/sensors/pawnio-interface.md
+++ b/docs/specs/sensors/pawnio-interface.md
@@ -63,7 +63,8 @@
   GitHub Releases** — the repository README states "Signed builds can
   be found in Releases." This is the channel an end-user deployment
   must use, because the production driver loads signed modules only.
-  Latest release at authoring: **0.2.8 (2024-06-12)**. (S8)
+  Latest release at authoring: **0.2.8 (2026-06-12)**, verified
+  against the upstream git tag `0.2.8` (commit `754635b`). (S8)
 - The PawnIO.Modules CI (`build` workflow) compiles every `*.p` with
   `pawncc` (`-C64 -iinclude`) and uploads the resulting `*.amx` as a
   per-commit build artifact. **CI artifacts and self-built blobs are
@@ -239,4 +240,4 @@ Target: x86-64 systems; provides port I/O for Super I/O chips.
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Provenance resolved against upstream sources: exact `PawnIOLib.h` API (incl. `pawnio_close`, cell-count semantics), device path, `msr_read` execution context and affinity natives, blob naming. Corrected mutex ownership: modules document caller-held mutants and acquire none themselves. Status → Implementation-ready. |
-| 3 | 2026-06-13 | Added "Module blob distribution" section: signed blobs ship via the PawnIO.Modules GitHub Releases (README-stated; latest 0.2.8, 2024-06-12), CI artifacts/self-builds are unsigned, driver/PawnIOLib from pawnio.eu. Resolved the blob-source open question (asset packaging left as a narrow non-blocking confirmation). Added source S8. Status remains Implementation-ready. |
+| 3 | 2026-06-13 | Added "Module blob distribution" section: signed blobs ship via the PawnIO.Modules GitHub Releases (README-stated; latest 0.2.8, 2026-06-12, verified against the upstream git tag), CI artifacts/self-builds are unsigned, driver/PawnIOLib from pawnio.eu. Resolved the blob-source open question (asset packaging left as a narrow non-blocking confirmation). Added source S8. Status remains Implementation-ready. |


### PR DESCRIPTION
## Summary

Updates `docs/specs/sensors/pawnio-interface.md` with **where the PawnIO module blobs come from** (rev 3) and then folds in **implementer field-validation corrections** from running the Phase 1 path on real hardware (rev 4). Spec-author ("dirty room") role; every runtime observation is cross-checked against PawnIO's own source before adoption — no prohibited monitoring source consulted.

### rev 3 — Module blob distribution
- Signed blobs ship via the **PawnIO.Modules GitHub Releases** (README: "Signed builds can be found in Releases"). Latest **0.2.8 (2026-06-12)**, verified against the upstream git tag `0.2.8` (commit `754635b`); the earlier `2024-06-12` was a web-extraction misread, corrected.
- CI artifacts / self-built blobs are **unsigned**; driver + PawnIOLib come from pawnio.eu.

### rev 4 — Implementer field validation (AMD Ryzen 7 7800X3D), each pinned to a PawnIO primary source

| Feedback | Resolution + primary-source pin |
|---|---|
| **Blob is `.bin`, not `.amx`** (`RyzenSMU.amx` absent; `RyzenSMU.bin` loaded, ~68.75–69.875 °C, `AmdZenSmnTctl`) | `PawnIOUtil sign` (S9) wraps an `.amx` as `[u32 sig_len][signature][amx]` → separate file; the release ships a **single archive `release_0_2_8.zip`** (S8, via `expanded_assets`) of signed `*.bin` modules. `*.amx` is the unsigned `pawncc`/CI output the production driver won't load. `pawnio_load` is **extension-agnostic** (S6) → dropped the "named `.amx`" claim; the client bundles signed `.bin`. |
| **Core installer excludes modules** | PawnIO (runtime) vs PawnIO.Modules (modules) repo split (S1/S2); made explicit that the app must supply the modules. |
| **`pawnio_open` needs elevation** (`0x80070005` as user, OK elevated; `pawnio_version`=131072 either way) | Driver INF `PawnIO.inf.in` sets device DACL **`D:P(A;;GA;;;SY)(A;;GA;;;BA)`** = System + Administrators only (S9) → non-elevated gets `E_ACCESSDENIED`. Added a **three-state detection rule** (absent → ACPI fallback; access-denied → "elevation required"; openable → proceed). |
| **Mutex `CreateMutexW` access-denied on existing `Global\Access_PCI`** | Added open-before-create guidance: `OpenMutexW(MUTEX_MODIFY_STATE\|SYNCHRONIZE)` first, fall back to `CreateMutexW`; minimal rights only (Win32 semantics + S10). |
| **Installer/setup UX** | Captured as a non-normative **Follow-up scope (out of Phase 1)** note. |

Sources added: **S9** (PawnIOUtil `sign`, `PawnIO.inf.in` DACL, driver `IoCreateDevice`), **S10** (implementer field validation). Resolved the asset-packaging open question. `pawnio-interface.md` → **rev 4**; README status table updated. Intel / AMD / superio-access untouched.

## Related Issues

Refs #1635

## Type of Change

- [x] Documentation (`docs/` branch)

## Test Plan

- [x] Manual — facts cross-checked against PawnIO sources (`PawnIOUtil.cpp` `sign`/blob layout, `PawnIO.inf.in` security descriptor, `driver.cpp` `IoCreateDevice`, `PawnIOLib.h`), the release `expanded_assets` fragment (`release_0_2_8.zip`), and the upstream `0.2.8` git tag date; reconciled with the implementer's Ryzen 7 7800X3D runtime report.
- [ ] Unit tests — N/A (no code changes)

## Checklist

- [x] Self-reviewed
- [ ] Lint/format — N/A (docs-only)
- [ ] Tests — N/A (no code changes)
- [x] No new warnings or errors

https://claude.ai/code/session_01R7Uxj8EFfCprg2pEqb6k6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PawnIO interface specification to revision 4 with clarifications on signed module distribution from PawnIO.Modules GitHub Releases.
  * Enhanced mutex conventions guidance for managing named mutex access.
  * Refined open questions and revision history documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->