### PR TITLE
feat: add external component guidance

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,3 +117,9 @@ _Avoid_: Storage Health Record, storage health snapshot, realtime SMART
 **Storage Device Refresh**:
 The user-initiated action that re-detects connected storage devices, collects current health signals, updates today's Storage Health Record, and reflects added or removed devices in displays.
 _Avoid_: Rescan, reload, auto-detection, live polling
+
+### Sensor Availability
+
+**External Component Guidance**:
+A user-facing notice shown after hardware collection tries and cannot use an optional external runtime component, and fallback collection still leaves user-visible hardware data unavailable.
+_Avoid_: Startup dependency check, install prompt, dependency error, missing component alert

--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -8,7 +8,10 @@
 //! Tauri `HardwareMonitorUpdate` event.
 
 use crate::collector::HistoryStore;
-use crate::models::{GpuMetric, MetricsSnapshot, ProcessSample, SensorTemperature};
+use crate::models::{
+  ExternalComponentGuidanceCandidate, GpuMetric, MetricsSnapshot, ProcessSample,
+  SensorTemperature,
+};
 
 /// One GPU sample collected per physical GPU. `None` means the metric is
 /// unavailable for this GPU vendor / platform.
@@ -36,6 +39,7 @@ pub struct TemperatureSample {
   pub cpu_temperature: Option<f32>,
   pub sensor_temperatures: Vec<SensorTemperature>,
   pub unavailable_reason: Option<String>,
+  pub guidance_candidates: Vec<ExternalComponentGuidanceCandidate>,
 }
 
 /// Read the latest CPU / sensor temperatures.
@@ -86,6 +90,7 @@ fn build_temperature_sample(
         cpu_temperature: Some(sample.temperature_celsius),
         sensor_temperatures,
         unavailable_reason: None,
+        guidance_candidates: Vec::new(),
       }
     }
     Err(pawnio_reason) => {
@@ -94,10 +99,21 @@ fn build_temperature_sample(
       let unavailable_reason = cpu_temperature.is_none().then(|| {
         format!("PawnIO unavailable ({pawnio_reason}); ACPI thermal zones unavailable")
       });
+      let guidance_candidates = unavailable_reason
+        .as_ref()
+        .map(|reason| {
+          vec![
+            ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+              reason.clone(),
+            ),
+          ]
+        })
+        .unwrap_or_default();
       TemperatureSample {
         cpu_temperature,
         sensor_temperatures,
         unavailable_reason,
+        guidance_candidates,
       }
     }
   }
@@ -527,6 +543,9 @@ pub fn build_metrics_snapshot(
         temperature: s.temperature.round(),
       })
       .collect(),
+    external_component_guidance_candidates: temperature_sample
+      .guidance_candidates
+      .clone(),
   }
 }
 
@@ -692,6 +711,7 @@ mod tests {
         },
       ],
       unavailable_reason: None,
+      guidance_candidates: Vec::new(),
     };
     let snap = build_metrics_snapshot(&sys, &[], &temps);
     assert_eq!(snap.cpu_temperature, Some(50.0));
@@ -708,6 +728,31 @@ mod tests {
         },
       ]
     );
+  }
+
+  #[test]
+  fn snapshot_carries_external_component_guidance_candidates() {
+    let sys = SystemSample {
+      cpu_usage: 0.0,
+      memory_usage: 0.0,
+      processors_usage: vec![],
+      processes: vec![],
+    };
+    let candidate = ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+      "PawnIOLib.dll not found".to_string(),
+    );
+    let temps = TemperatureSample {
+      cpu_temperature: None,
+      sensor_temperatures: vec![],
+      unavailable_reason: Some(
+        "PawnIO unavailable; ACPI thermal zones unavailable".to_string(),
+      ),
+      guidance_candidates: vec![candidate.clone()],
+    };
+
+    let snap = build_metrics_snapshot(&sys, &[], &temps);
+
+    assert_eq!(snap.external_component_guidance_candidates, vec![candidate]);
   }
 
   #[cfg(target_os = "windows")]
@@ -767,6 +812,39 @@ mod tests {
       sample.unavailable_reason.as_deref(),
       Some("PawnIO unavailable (pawnio_open failed); ACPI thermal zones unavailable")
     );
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_returns_guidance_when_pawnio_and_acpi_fail() {
+    let sample =
+      build_temperature_sample(Err("PawnIOLib.dll not found".to_string()), Vec::new());
+
+    assert_eq!(sample.cpu_temperature, None);
+    assert_eq!(sample.guidance_candidates.len(), 1);
+    assert_eq!(
+      sample.guidance_candidates[0].key,
+      "pawnio:cpu-package-temperature:v1"
+    );
+    assert_eq!(
+      sample.guidance_candidates[0].missing_signals,
+      vec!["cpu-temperature".to_string()]
+    );
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_does_not_return_guidance_when_acpi_fallback_succeeds() {
+    let sample = build_temperature_sample(
+      Err("PawnIOLib.dll not found".to_string()),
+      vec![SensorTemperature {
+        name: "CPUZ".into(),
+        temperature: 51.0,
+      }],
+    );
+
+    assert_eq!(sample.cpu_temperature, Some(51.0));
+    assert!(sample.guidance_candidates.is_empty());
   }
 
   // ── resolve_gpu_name_from_map ──

--- a/core/src/event_bus.rs
+++ b/core/src/event_bus.rs
@@ -79,6 +79,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     }
   }
 
@@ -153,6 +154,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
 
     let received = rx.recv().await.expect("receive snapshot");

--- a/core/src/infrastructure/providers/linux/smart.rs
+++ b/core/src/infrastructure/providers/linux/smart.rs
@@ -1,21 +1,55 @@
 use crate::infrastructure::providers::smartctl::{self, SmartctlDevice};
+use crate::models::external_component_guidance::all_storage_health_signal_names;
 use crate::models::hardware::SmartDiskInfo;
+use crate::models::{ExternalComponentGuidanceCandidate, SmartInfoCollectionOutcome};
 use std::fs;
 
 pub fn get_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
+  get_smart_info_with_guidance().disks
+}
+
+pub fn get_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
   match smartctl::collect_smart_info_from_scan() {
-    Ok(disks) => Ok(disks),
+    Ok(disks) => SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates: Vec::new(),
+    },
     Err(scan_error) => {
       let devices = linux_device_candidates();
       if devices.is_empty() {
-        return Err(scan_error);
+        return SmartInfoCollectionOutcome {
+          disks: Err(scan_error.clone()),
+          guidance_candidates: vec![
+            ExternalComponentGuidanceCandidate::smartctl_storage_health(
+              all_storage_health_signal_names(),
+              None,
+              scan_error,
+            ),
+          ],
+        };
       }
 
-      smartctl::collect_smart_info_from_devices(&devices).map_err(|fallback_error| {
-        format!(
-          "Failed to collect SMART info from smartctl scan ({scan_error}) and Linux device candidates ({fallback_error})"
-        )
-      })
+      match smartctl::collect_smart_info_from_devices(&devices) {
+        Ok(disks) => SmartInfoCollectionOutcome {
+          disks: Ok(disks),
+          guidance_candidates: Vec::new(),
+        },
+        Err(fallback_error) => {
+          let detail = format!(
+            "Failed to collect SMART info from smartctl scan ({scan_error}) and Linux device candidates ({fallback_error})"
+          );
+          SmartInfoCollectionOutcome {
+            disks: Err(detail.clone()),
+            guidance_candidates: vec![
+              ExternalComponentGuidanceCandidate::smartctl_storage_health(
+                all_storage_health_signal_names(),
+                None,
+                detail,
+              ),
+            ],
+          }
+        }
+      }
     }
   }
 }

--- a/core/src/infrastructure/providers/macos/smart.rs
+++ b/core/src/infrastructure/providers/macos/smart.rs
@@ -1,21 +1,55 @@
 use crate::infrastructure::providers::smartctl::{self, SmartctlDevice};
+use crate::models::external_component_guidance::all_storage_health_signal_names;
 use crate::models::hardware::SmartDiskInfo;
+use crate::models::{ExternalComponentGuidanceCandidate, SmartInfoCollectionOutcome};
 use std::process::Command;
 
 pub fn get_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
+  get_smart_info_with_guidance().disks
+}
+
+pub fn get_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
   match smartctl::collect_smart_info_from_scan() {
-    Ok(disks) => Ok(disks),
+    Ok(disks) => SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates: Vec::new(),
+    },
     Err(scan_error) => {
       let devices = diskutil_device_candidates();
       if devices.is_empty() {
-        return Err(scan_error);
+        return SmartInfoCollectionOutcome {
+          disks: Err(scan_error.clone()),
+          guidance_candidates: vec![
+            ExternalComponentGuidanceCandidate::smartctl_storage_health(
+              all_storage_health_signal_names(),
+              None,
+              scan_error,
+            ),
+          ],
+        };
       }
 
-      smartctl::collect_smart_info_from_devices(&devices).map_err(|fallback_error| {
-        format!(
-          "Failed to collect SMART info from smartctl scan ({scan_error}) and macOS diskutil candidates ({fallback_error})"
-        )
-      })
+      match smartctl::collect_smart_info_from_devices(&devices) {
+        Ok(disks) => SmartInfoCollectionOutcome {
+          disks: Ok(disks),
+          guidance_candidates: Vec::new(),
+        },
+        Err(fallback_error) => {
+          let detail = format!(
+            "Failed to collect SMART info from smartctl scan ({scan_error}) and macOS diskutil candidates ({fallback_error})"
+          );
+          SmartInfoCollectionOutcome {
+            disks: Err(detail.clone()),
+            guidance_candidates: vec![
+              ExternalComponentGuidanceCandidate::smartctl_storage_health(
+                all_storage_health_signal_names(),
+                None,
+                detail,
+              ),
+            ],
+          }
+        }
+      }
     }
   }
 }

--- a/core/src/infrastructure/providers/windows/smart.rs
+++ b/core/src/infrastructure/providers/windows/smart.rs
@@ -1,6 +1,13 @@
 use crate::infrastructure::providers::smartctl;
 use crate::log_warn;
+use crate::models::external_component_guidance::{
+  SIGNAL_AVAILABLE_SPARE, SIGNAL_CURRENT_PENDING_SECTORS, SIGNAL_MEDIA_ERRORS,
+  SIGNAL_OFFLINE_UNCORRECTABLE_SECTORS, SIGNAL_PERCENTAGE_USED,
+  SIGNAL_REALLOCATED_SECTORS, SIGNAL_SMART_OVERALL_HEALTH, SIGNAL_TEMPERATURE,
+  all_storage_health_signal_names,
+};
 use crate::models::hardware::{SmartAttribute, SmartDiskInfo, SmartHealthStatus};
+use crate::models::{ExternalComponentGuidanceCandidate, SmartInfoCollectionOutcome};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
@@ -66,7 +73,11 @@ struct MsftStorageReliabilityCounter {
 }
 
 pub fn get_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
-  collect_with_fallbacks(
+  get_smart_info_with_guidance().disks
+}
+
+pub fn get_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
+  collect_with_fallbacks_with_guidance(
     super::device_io::get_smart_info,
     query_wmi_smart_info,
     smartctl::collect_smart_info_from_scan,
@@ -74,6 +85,7 @@ pub fn get_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
   )
 }
 
+#[cfg(test)]
 fn collect_with_fallbacks<D, W, S, C>(
   mut device_io: D,
   mut wmi: W,
@@ -86,29 +98,81 @@ where
   S: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
   C: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
 {
+  collect_with_fallbacks_with_guidance(&mut device_io, &mut wmi, &mut smartctl, &mut cim)
+    .disks
+}
+
+fn collect_with_fallbacks_with_guidance<D, W, S, C>(
+  mut device_io: D,
+  mut wmi: W,
+  mut smartctl: S,
+  mut cim: C,
+) -> SmartInfoCollectionOutcome
+where
+  D: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
+  W: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
+  S: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
+  C: FnMut() -> Result<Vec<SmartDiskInfo>, String>,
+{
   let mut failures = Vec::new();
 
   if let Some(disks) =
     collect_from_source("DeviceIoControl", &mut device_io, &mut failures)
   {
-    return Ok(disks);
+    return SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates: Vec::new(),
+    };
   }
   if let Some(disks) = collect_from_source("Windows WMI", &mut wmi, &mut failures) {
-    return Ok(disks);
+    return SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates: Vec::new(),
+    };
   }
+
+  let smartctl_failure_index = failures.len();
   if let Some(disks) = collect_from_source("smartctl", &mut smartctl, &mut failures) {
-    return Ok(disks);
+    return SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates: Vec::new(),
+    };
   }
+  let smartctl_failure = failures.get(smartctl_failure_index).cloned();
+
   if let Some(disks) =
     collect_from_source("Storage Management CIM", &mut cim, &mut failures)
   {
-    return Ok(disks);
+    let guidance_candidates = smartctl_failure
+      .as_deref()
+      .and_then(|detail| smartctl_guidance_for_disks(&disks, detail))
+      .into_iter()
+      .collect();
+    return SmartInfoCollectionOutcome {
+      disks: Ok(disks),
+      guidance_candidates,
+    };
   }
 
-  Err(format!(
-    "Failed to collect Windows storage health info: {}",
-    failures.join("; ")
-  ))
+  let guidance_candidates = smartctl_failure
+    .as_deref()
+    .map(|detail| {
+      ExternalComponentGuidanceCandidate::smartctl_storage_health(
+        all_storage_health_signal_names(),
+        None,
+        detail.to_string(),
+      )
+    })
+    .into_iter()
+    .collect();
+
+  SmartInfoCollectionOutcome {
+    disks: Err(format!(
+      "Failed to collect Windows storage health info: {}",
+      failures.join("; ")
+    )),
+    guidance_candidates,
+  }
 }
 
 fn collect_from_source<F>(
@@ -142,6 +206,142 @@ where
       None
     }
   }
+}
+
+fn smartctl_guidance_for_disks(
+  disks: &[SmartDiskInfo],
+  diagnostic_detail: &str,
+) -> Option<ExternalComponentGuidanceCandidate> {
+  let mut missing_signals = Vec::new();
+  let mut affected_device_count = 0_u32;
+
+  for disk in disks {
+    let disk_missing = missing_storage_health_signals(disk);
+    if !disk_missing.is_empty() {
+      affected_device_count += 1;
+    }
+    for signal in disk_missing {
+      if !missing_signals.contains(&signal) {
+        missing_signals.push(signal);
+      }
+    }
+  }
+
+  (!missing_signals.is_empty()).then(|| {
+    ExternalComponentGuidanceCandidate::smartctl_storage_health(
+      missing_signals,
+      Some(affected_device_count),
+      diagnostic_detail.to_string(),
+    )
+  })
+}
+
+fn missing_storage_health_signals(disk: &SmartDiskInfo) -> Vec<String> {
+  let mut missing = Vec::new();
+
+  if matches!(disk.health_status, SmartHealthStatus::Unknown) {
+    missing.push(SIGNAL_SMART_OVERALL_HEALTH.to_string());
+  }
+  if disk.temperature_celsius.is_none() {
+    missing.push(SIGNAL_TEMPERATURE.to_string());
+  }
+
+  match storage_protocol_kind(disk) {
+    StorageProtocolKind::Nvme => {
+      push_if_attr_missing(
+        disk,
+        None,
+        "Percentage Used",
+        SIGNAL_PERCENTAGE_USED,
+        &mut missing,
+      );
+      push_if_attr_missing(
+        disk,
+        None,
+        "Available Spare",
+        SIGNAL_AVAILABLE_SPARE,
+        &mut missing,
+      );
+      push_if_attr_missing(
+        disk,
+        None,
+        "Media Errors",
+        SIGNAL_MEDIA_ERRORS,
+        &mut missing,
+      );
+    }
+    StorageProtocolKind::Ata => {
+      push_if_attr_missing(
+        disk,
+        Some(5),
+        "Reallocated Sector Count",
+        SIGNAL_REALLOCATED_SECTORS,
+        &mut missing,
+      );
+      push_if_attr_missing(
+        disk,
+        Some(197),
+        "Current Pending Sector Count",
+        SIGNAL_CURRENT_PENDING_SECTORS,
+        &mut missing,
+      );
+      push_if_attr_missing(
+        disk,
+        Some(198),
+        "Offline Uncorrectable Sector Count",
+        SIGNAL_OFFLINE_UNCORRECTABLE_SECTORS,
+        &mut missing,
+      );
+    }
+    StorageProtocolKind::Unknown => {}
+  }
+
+  missing
+}
+
+enum StorageProtocolKind {
+  Ata,
+  Nvme,
+  Unknown,
+}
+
+fn storage_protocol_kind(disk: &SmartDiskInfo) -> StorageProtocolKind {
+  let value = disk
+    .protocol
+    .as_deref()
+    .or(disk.device_type.as_deref())
+    .unwrap_or_default()
+    .to_ascii_lowercase();
+
+  if value.contains("nvme") {
+    StorageProtocolKind::Nvme
+  } else if value.contains("ata") || value.contains("sata") || value.contains("sat") {
+    StorageProtocolKind::Ata
+  } else {
+    StorageProtocolKind::Unknown
+  }
+}
+
+fn push_if_attr_missing(
+  disk: &SmartDiskInfo,
+  id: Option<u32>,
+  name: &str,
+  signal: &str,
+  missing: &mut Vec<String>,
+) {
+  if !has_attr_value(disk, id, name) {
+    missing.push(signal.to_string());
+  }
+}
+
+fn has_attr_value(disk: &SmartDiskInfo, id: Option<u32>, name: &str) -> bool {
+  disk.attributes.iter().any(|attr| {
+    let matches = match id {
+      Some(id) => attr.id == Some(id),
+      None => attr.name.eq_ignore_ascii_case(name),
+    };
+    matches && (attr.raw_value.is_some() || attr.current.is_some())
+  })
 }
 
 fn query_wmi_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
@@ -584,6 +784,56 @@ mod tests {
       vec!["device_io", "wmi", "smartctl", "cim"]
     );
     assert_eq!(disks[0].device_name, "cim");
+  }
+
+  #[test]
+  fn guidance_candidate_is_returned_when_smartctl_fails_and_cim_lacks_health_signals() {
+    let outcome = collect_with_fallbacks_with_guidance(
+      || Err("unsupported".to_string()),
+      || Ok(Vec::new()),
+      || Err("smartctl is not installed".to_string()),
+      || Ok(vec![smart_disk("cim")]),
+    );
+
+    let disks = outcome.disks.expect("CIM should still be used as fallback");
+
+    assert_eq!(disks[0].device_name, "cim");
+    assert_eq!(outcome.guidance_candidates.len(), 1);
+    assert_eq!(
+      outcome.guidance_candidates[0].key,
+      "smartctl:storage-health:v1"
+    );
+    assert_eq!(
+      outcome.guidance_candidates[0].affected_device_count,
+      Some(1)
+    );
+    assert!(
+      outcome.guidance_candidates[0]
+        .missing_signals
+        .contains(&"temperature".to_string())
+    );
+  }
+
+  #[test]
+  fn guidance_candidate_is_not_returned_when_cim_covers_health_signals() {
+    let mut disk = smart_disk("cim");
+    disk.protocol = Some("NVMe".to_string());
+    disk.temperature_celsius = Some(40);
+    disk.attributes = vec![
+      cim_attr("Percentage Used", 3),
+      cim_attr("Available Spare", 98),
+      cim_attr("Media Errors", 0),
+    ];
+
+    let outcome = collect_with_fallbacks_with_guidance(
+      || Err("unsupported".to_string()),
+      || Ok(Vec::new()),
+      || Err("Failed to execute smartctl: not found".to_string()),
+      || Ok(vec![disk.clone()]),
+    );
+
+    assert!(outcome.disks.is_ok());
+    assert!(outcome.guidance_candidates.is_empty());
   }
 
   #[test]

--- a/core/src/models/external_component_guidance.rs
+++ b/core/src/models/external_component_guidance.rs
@@ -101,6 +101,7 @@ pub fn classify_external_component_reason(detail: &str) -> ExternalComponentReas
     || normalized.contains("no such file")
     || normalized.contains("cannot find")
     || normalized.contains("failed to execute")
+    || normalized.contains("not installed")
   {
     return ExternalComponentReasonKind::Missing;
   }
@@ -129,4 +130,17 @@ pub fn all_storage_health_signal_names() -> Vec<String> {
   .into_iter()
   .map(ToOwned::to_owned)
   .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn classify_external_component_reason_treats_not_installed_as_missing() {
+    assert_eq!(
+      classify_external_component_reason("smartctl is not installed"),
+      ExternalComponentReasonKind::Missing
+    );
+  }
 }

--- a/core/src/models/external_component_guidance.rs
+++ b/core/src/models/external_component_guidance.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+
+use super::hardware::SmartDiskInfo;
+
+pub const PAWNIO_CPU_PACKAGE_TEMPERATURE_KEY: &str = "pawnio:cpu-package-temperature:v1";
+pub const SMARTCTL_STORAGE_HEALTH_KEY: &str = "smartctl:storage-health:v1";
+
+pub const SIGNAL_CPU_TEMPERATURE: &str = "cpu-temperature";
+pub const SIGNAL_SMART_OVERALL_HEALTH: &str = "smart-overall-health";
+pub const SIGNAL_TEMPERATURE: &str = "temperature";
+pub const SIGNAL_PERCENTAGE_USED: &str = "percentage-used";
+pub const SIGNAL_AVAILABLE_SPARE: &str = "available-spare";
+pub const SIGNAL_REALLOCATED_SECTORS: &str = "reallocated-sectors";
+pub const SIGNAL_CURRENT_PENDING_SECTORS: &str = "current-pending-sectors";
+pub const SIGNAL_OFFLINE_UNCORRECTABLE_SECTORS: &str = "offline-uncorrectable-sectors";
+pub const SIGNAL_MEDIA_ERRORS: &str = "media-errors";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalComponentGuidanceCandidate {
+  pub key: String,
+  pub component: ExternalComponent,
+  pub usage: ExternalComponentUsage,
+  pub reason_kind: ExternalComponentReasonKind,
+  pub missing_signals: Vec<String>,
+  pub affected_device_count: Option<u32>,
+  pub diagnostic_detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SmartInfoCollectionOutcome {
+  pub disks: Result<Vec<SmartDiskInfo>, String>,
+  pub guidance_candidates: Vec<ExternalComponentGuidanceCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponent {
+  Pawnio,
+  Smartctl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponentUsage {
+  CpuPackageTemperature,
+  StorageHealth,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponentReasonKind {
+  Missing,
+  Permission,
+  Misconfigured,
+  Failed,
+}
+
+impl ExternalComponentGuidanceCandidate {
+  pub fn pawnio_cpu_package_temperature(diagnostic_detail: String) -> Self {
+    Self {
+      key: PAWNIO_CPU_PACKAGE_TEMPERATURE_KEY.to_string(),
+      component: ExternalComponent::Pawnio,
+      usage: ExternalComponentUsage::CpuPackageTemperature,
+      reason_kind: classify_external_component_reason(&diagnostic_detail),
+      missing_signals: vec![SIGNAL_CPU_TEMPERATURE.to_string()],
+      affected_device_count: None,
+      diagnostic_detail: Some(diagnostic_detail),
+    }
+  }
+
+  pub fn smartctl_storage_health(
+    missing_signals: Vec<String>,
+    affected_device_count: Option<u32>,
+    diagnostic_detail: String,
+  ) -> Self {
+    Self {
+      key: SMARTCTL_STORAGE_HEALTH_KEY.to_string(),
+      component: ExternalComponent::Smartctl,
+      usage: ExternalComponentUsage::StorageHealth,
+      reason_kind: classify_external_component_reason(&diagnostic_detail),
+      missing_signals,
+      affected_device_count,
+      diagnostic_detail: Some(diagnostic_detail),
+    }
+  }
+}
+
+pub fn classify_external_component_reason(detail: &str) -> ExternalComponentReasonKind {
+  let normalized = detail.to_ascii_lowercase();
+
+  if normalized.contains("permission denied")
+    || normalized.contains("access is denied")
+    || normalized.contains("operation not permitted")
+    || normalized.contains("administrator")
+  {
+    return ExternalComponentReasonKind::Permission;
+  }
+
+  if normalized.contains("not found")
+    || normalized.contains("no such file")
+    || normalized.contains("cannot find")
+    || normalized.contains("failed to execute")
+  {
+    return ExternalComponentReasonKind::Missing;
+  }
+
+  if normalized.contains("invalid")
+    || normalized.contains("misconfigured")
+    || normalized.contains("unsupported")
+  {
+    return ExternalComponentReasonKind::Misconfigured;
+  }
+
+  ExternalComponentReasonKind::Failed
+}
+
+pub fn all_storage_health_signal_names() -> Vec<String> {
+  [
+    SIGNAL_SMART_OVERALL_HEALTH,
+    SIGNAL_TEMPERATURE,
+    SIGNAL_PERCENTAGE_USED,
+    SIGNAL_AVAILABLE_SPARE,
+    SIGNAL_REALLOCATED_SECTORS,
+    SIGNAL_CURRENT_PENDING_SECTORS,
+    SIGNAL_OFFLINE_UNCORRECTABLE_SECTORS,
+    SIGNAL_MEDIA_ERRORS,
+  ]
+  .into_iter()
+  .map(ToOwned::to_owned)
+  .collect()
+}

--- a/core/src/models/metrics.rs
+++ b/core/src/models/metrics.rs
@@ -1,3 +1,5 @@
+use super::ExternalComponentGuidanceCandidate;
+
 /// One sample of per-GPU metrics, normalized across vendors and platforms.
 ///
 /// `None` indicates the metric is unavailable for this vendor/platform.
@@ -57,4 +59,7 @@ pub struct MetricsSnapshot {
   /// All named temperature sensors in raw °C (ACPI thermal zones on
   /// Windows). Empty when unsupported.
   pub sensor_temperatures: Vec<SensorTemperature>,
+  /// Diagnostic side data for optional runtime components that were
+  /// attempted but unavailable while user-visible data remains missing.
+  pub external_component_guidance_candidates: Vec<ExternalComponentGuidanceCandidate>,
 }

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -1,6 +1,11 @@
 //! Tauri-independent data models shared across the core crate.
 
+pub mod external_component_guidance;
 pub mod hardware;
 mod metrics;
 
+pub use external_component_guidance::{
+  ExternalComponent, ExternalComponentGuidanceCandidate, ExternalComponentReasonKind,
+  ExternalComponentUsage, SmartInfoCollectionOutcome,
+};
 pub use metrics::{GpuMetric, MetricsSnapshot, ProcessSample, SensorTemperature};

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -75,7 +75,7 @@ impl ArchiveController {
         // (e.g. when the collector temporarily out-paces us, or after
         // a `Lagged` recovery) cannot starve the 60-second write;
         // `rx.recv()` is last and may shed a snapshot in favor of an
-        // overdue write — which is fine because the tracker only ever
+        // overdue write - which is fine because the tracker only ever
         // computes aggregates over its 60-sample rings.
         tokio::select! {
           biased;
@@ -118,7 +118,7 @@ impl ArchiveController {
       // Phase 5 (#1408): write a final summary on shutdown so samples
       // accumulated since the last 60s tick are not lost when the user
       // explicitly quits. `is_dirty()` skips the flush when nothing has
-      // been ingested since the previous write — common when shutdown
+      // been ingested since the previous write - common when shutdown
       // lands within a fraction of a second after a scheduled tick.
       if tracker.is_dirty() {
         tracker.write_archive().await;
@@ -141,7 +141,7 @@ impl ArchiveController {
 /// This is a **one-shot** operation: it deletes everything older than
 /// the cutoff at the moment of the call and then returns. App calls it
 /// once at startup when `hardware_archive.scheduled_data_deletion` is
-/// enabled — that matches the pre-Phase-4 behavior of the previous
+/// enabled - that matches the pre-Phase-4 behavior of the previous
 /// `batch_delete_old_data` wrapper. The cleanup trigger is still
 /// "next process boot", not a recurring schedule.
 pub async fn cleanup_old_data(retention_days: u32) {
@@ -276,7 +276,7 @@ impl ArchiveTracker {
 
     // Age out accumulators that haven't been refreshed within the
     // grace window. Evicting on every snapshot (the previous behavior)
-    // dropped processes that exited just before the archive tick — a
+    // dropped processes that exited just before the archive tick - a
     // short-lived offender that burned CPU for most of the minute and
     // then exited would never appear in the archive row. Keeping
     // entries for [`PROCESS_GRACE_TICKS`] solves that without letting
@@ -297,7 +297,7 @@ impl ArchiveTracker {
       // Trade-off: a recycled PID running the same binary name is
       // indistinguishable from the original here and will continue
       // accumulating into the existing rings. That's a rare and
-      // benign case — the values stay representative of a process
+      // benign case - the values stay representative of a process
       // with that name on that PID slot.
       let pid_reused =
         entry.last_seen_tick != 0 && !entry.name.is_empty() && entry.name != sample.name;
@@ -356,7 +356,7 @@ impl ArchiveTracker {
     // Walk the union of every GPU history map so adapters that report
     // only temperature or only dedicated memory (e.g. Linux DRM, ADL
     // without VRAM, Apple IOKit without thermals) still produce a row
-    // — iterating `gpu_usage_histories` alone would silently drop them.
+    // - iterating `gpu_usage_histories` alone would silently drop them.
     let gpu_ids: HashSet<&String> = self
       .gpu_usage_histories
       .keys()
@@ -540,7 +540,7 @@ impl StatsCalculator {
       return (None, None, None);
     }
     // Sum in i64: dedicated GPU memory is reported in KB, so 60 samples
-    // from a high-VRAM card (e.g. 80 GB ≈ 8.4×10⁷ KB) easily exceed
+    // from a high-VRAM card (e.g. 80 GB is about 84,000,000 KB) easily exceed
     // i32::MAX. An i32 accumulator panics in debug and silently wraps
     // in release.
     let sum: i64 = values.iter().map(|&v| v as i64).sum();
@@ -565,6 +565,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     }
   }
 
@@ -689,6 +690,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
     assert_eq!(t.gpu_name_map.get("gpu:0").unwrap(), "RTX");
     assert_eq!(t.gpu_usage_histories.get("gpu:0").unwrap().len(), 1);
@@ -714,6 +716,7 @@ mod tests {
       }],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     }
   }
 
@@ -748,7 +751,7 @@ mod tests {
   fn ingest_resets_rings_on_pid_reuse_with_different_name() {
     let mut t = ArchiveTracker::new();
     t.ingest(snap_with_pid(42, "victim"));
-    // Drive several ticks without PID 42 — it stays in the map (still
+    // Drive several ticks without PID 42 - it stays in the map (still
     // within grace) but we don't push to its rings.
     for _ in 0..3 {
       t.ingest(snap_with_pid(99, "filler"));
@@ -781,7 +784,7 @@ mod tests {
     t.ingest(snap_with_pid(42, "victim"));
 
     let acc = t.processes.get(&42).unwrap();
-    // The brief gap must not wipe the rolling history — only the new
+    // The brief gap must not wipe the rolling history - only the new
     // sample is appended.
     assert_eq!(acc.cpu_history.len(), len_before + 1);
     assert_eq!(acc.memory_kb_history.len(), len_before + 1);
@@ -826,6 +829,7 @@ mod tests {
       }],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
     assert!(t.collect_process_stats().is_empty());
   }
@@ -847,6 +851,7 @@ mod tests {
       }],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
     let stats = t.collect_process_stats();
     assert_eq!(stats.len(), 1);
@@ -871,6 +876,7 @@ mod tests {
       }],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
     assert!(t.collect_process_stats().is_empty());
   }
@@ -896,6 +902,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     });
     let gpus = t.collect_gpu_data();
     assert_eq!(gpus.len(), 1);

--- a/core/src/persistence/mod.rs
+++ b/core/src/persistence/mod.rs
@@ -17,4 +17,4 @@ pub mod storage_health;
 pub use archive::{
   ArchiveController, HARDWARE_ARCHIVE_INTERVAL_SECONDS, cleanup_old_data,
 };
-pub use storage_health::StorageHealthController;
+pub use storage_health::{ExternalComponentGuidanceSink, StorageHealthController};

--- a/core/src/persistence/storage_health.rs
+++ b/core/src/persistence/storage_health.rs
@@ -2,6 +2,7 @@
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -12,6 +13,7 @@ use crate::models::hardware::{
   SmartAttribute, SmartDiskInfo, SmartHealthStatus, StorageDeviceRecord,
   StorageHealthRecordDraft, StorageHealthStatus, StorageWarningLevel,
 };
+use crate::models::{ExternalComponentGuidanceCandidate, SmartInfoCollectionOutcome};
 use crate::settings::STORAGE_HEALTH_IDENTITY_HASH_KEY_BYTES;
 use crate::{log_error, log_info, log_warn};
 
@@ -22,6 +24,9 @@ const PERCENTAGE_USED_WARNING: f32 = 80.0;
 const PERCENTAGE_USED_CRITICAL: f32 = 100.0;
 const AVAILABLE_SPARE_WARNING_PERCENT: f32 = 20.0;
 const AVAILABLE_SPARE_CRITICAL_PERCENT: f32 = 10.0;
+
+pub type ExternalComponentGuidanceSink =
+  Arc<dyn Fn(Vec<ExternalComponentGuidanceCandidate>) + Send + Sync + 'static>;
 
 pub struct StorageHealthController {
   handle: JoinHandle<()>,
@@ -34,11 +39,26 @@ impl StorageHealthController {
     retention_days: u32,
     identity_hash_key: [u8; STORAGE_HEALTH_IDENTITY_HASH_KEY_BYTES],
   ) -> Self {
+    Self::setup_with_guidance_sink(runtime, retention_days, identity_hash_key, None)
+  }
+
+  pub fn setup_with_guidance_sink(
+    runtime: Handle,
+    retention_days: u32,
+    identity_hash_key: [u8; STORAGE_HEALTH_IDENTITY_HASH_KEY_BYTES],
+    guidance_sink: Option<ExternalComponentGuidanceSink>,
+  ) -> Self {
     let (stop_tx, mut stop_rx) = watch::channel(false);
 
     let handle = runtime.spawn(async move {
       let today = local_date_string();
-      run_daily_record_for_date(retention_days, &today, &identity_hash_key).await;
+      run_daily_record_for_date(
+        retention_days,
+        &today,
+        &identity_hash_key,
+        guidance_sink.as_ref(),
+      )
+      .await;
       let mut last_checked_date = Some(today);
 
       let mut ticker =
@@ -62,7 +82,12 @@ impl StorageHealthController {
           _ = ticker.tick() => {
             let today = local_date_string();
             if last_checked_date.as_deref() != Some(today.as_str()) {
-              run_daily_record_for_date(retention_days, &today, &identity_hash_key).await;
+              run_daily_record_for_date(
+                retention_days,
+                &today,
+                &identity_hash_key,
+                guidance_sink.as_ref(),
+              ).await;
               last_checked_date = Some(today);
             }
           }
@@ -83,23 +108,35 @@ async fn run_daily_record_for_date(
   retention_days: u32,
   date: &str,
   identity_hash_key: &[u8; STORAGE_HEALTH_IDENTITY_HASH_KEY_BYTES],
+  guidance_sink: Option<&ExternalComponentGuidanceSink>,
 ) {
   let collected_at = chrono::Utc::now().to_rfc3339();
-  let disks = match tokio::task::spawn_blocking(collect_platform_smart_info).await {
-    Ok(Ok(disks)) => disks,
-    Ok(Err(e)) => {
+  let outcome =
+    match tokio::task::spawn_blocking(collect_platform_smart_info_with_guidance).await {
+      Ok(outcome) => outcome,
+      Err(e) => {
+        log_error!(
+          "Failed to join storage health collection task",
+          "persistence::storage_health::run_daily_record_for_date",
+          Some(e.to_string())
+        );
+        return;
+      }
+    };
+
+  if !outcome.guidance_candidates.is_empty()
+    && let Some(sink) = guidance_sink
+  {
+    sink(outcome.guidance_candidates.clone());
+  }
+
+  let disks = match outcome.disks {
+    Ok(disks) => disks,
+    Err(e) => {
       log_error!(
         "Failed to collect storage health info",
         "persistence::storage_health::run_daily_record_for_date",
         Some(e)
-      );
-      return;
-    }
-    Err(e) => {
-      log_error!(
-        "Failed to join storage health collection task",
-        "persistence::storage_health::run_daily_record_for_date",
-        Some(e.to_string())
       );
       return;
     }
@@ -423,18 +460,18 @@ fn local_date_string() -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn collect_platform_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
-  crate::infrastructure::providers::linux::smart::get_smart_info()
+fn collect_platform_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
+  crate::infrastructure::providers::linux::smart::get_smart_info_with_guidance()
 }
 
 #[cfg(target_os = "macos")]
-fn collect_platform_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
-  crate::infrastructure::providers::macos::smart::get_smart_info()
+fn collect_platform_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
+  crate::infrastructure::providers::macos::smart::get_smart_info_with_guidance()
 }
 
 #[cfg(target_os = "windows")]
-fn collect_platform_smart_info() -> Result<Vec<SmartDiskInfo>, String> {
-  crate::infrastructure::providers::windows::smart::get_smart_info()
+fn collect_platform_smart_info_with_guidance() -> SmartInfoCollectionOutcome {
+  crate::infrastructure::providers::windows::smart::get_smart_info_with_guidance()
 }
 
 #[cfg(test)]

--- a/core/tests/persistence_decoupling.rs
+++ b/core/tests/persistence_decoupling.rs
@@ -22,6 +22,7 @@ fn snapshot(value: f32) -> MetricsSnapshot {
     processes: vec![],
     cpu_temperature: None,
     sensor_temperatures: vec![],
+    external_component_guidance_candidates: vec![],
   }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ documentation.
 ## Main Entry Points
 
 - [Backend architecture](architecture/backend.md)
+- [External components](user/external-components.md)
 - [Windows sensor external components](architecture/windows-sensor-external-components.md)
 - [Architecture decision records](adr/)
 - [Sensor hardware specs (clean-room)](specs/sensors/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ documentation.
 ## Main Entry Points
 
 - [Backend architecture](architecture/backend.md)
-- [External components](user/external-components.md)
+- [External components](user/external-components.md) /
+  [Japanese](user/external-components.ja.md)
 - [Windows sensor external components](architecture/windows-sensor-external-components.md)
 - [Architecture decision records](adr/)
 - [Sensor hardware specs (clean-room)](specs/sensors/)
@@ -33,6 +34,9 @@ docs/
 ├── specs/                          # Clean-room hardware specification documents
 │   └── sensors/                    # Sensor specs for PawnIO-based monitoring
 ├── third-party-notices/            # Generated and manual third-party notices
+├── user/                           # User-facing guides published by the website
+│   ├── external-components.md      # External component setup guide
+│   └── external-components.ja.md   # Japanese external component setup guide
 ├── download-verification.md        # Download verification guide
 ├── download-verification.ja.md     # Japanese download verification guide
 └── internal/                       # Maintainer/internal operations docs

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -292,6 +292,60 @@ when it helps explain partial support, and avoid converting a partially
 available device into an all-or-nothing failure unless the caller cannot
 produce a useful result without that data.
 
+External Component Guidance follows the same best-effort rule. Core may produce
+structured guidance candidates when an optional runtime component such as
+PawnIO or `smartctl` was actually attempted, could not be used, and fallback
+collection still leaves user-visible hardware data unavailable. Those
+candidates are diagnostic side data only: they must not change collection
+results, fallback order, or aggregate success/failure behavior.
+
+Core candidates should describe stable facts such as component, usage,
+reason-kind, missing important signals, and optional diagnostic detail. App owns
+the user-facing policy: it checks `externalComponentGuidance.acknowledgedKeys`
+in `settings.json`, holds unshown candidates only in session memory, maps
+guidance keys to detail URLs, returns candidates only while a relevant view can
+show them, and persists acknowledgements through typed settings commands.
+
+The initial candidate shape should stay minimal: a stable guidance key,
+component, usage, reason kind, missing signal names, optional affected device
+count, and optional diagnostic detail. Raw provider errors can be carried as
+diagnostic detail for logs or expandable UI, but translated user-facing copy
+should be driven by component, usage, and reason kind.
+
+The initial implementation scope is limited to PawnIO for Windows CPU package
+temperature and `smartctl` for Storage Health. Other vendor libraries, drivers,
+or OS APIs should not be folded into this guidance path until their component,
+usage, fallback behavior, and user action are explicit.
+The first implementation slice should wire both initial guidance keys through
+the shared candidate, settings, command, and dialog path rather than shipping
+only one component first.
+
+The minimum validation should cover both included components. PawnIO guidance
+appears only when PawnIO cannot provide CPU package temperature and no ACPI CPU
+temperature fallback is available. `smartctl` guidance appears only when
+`smartctl` cannot be used and fallback Storage Health collection still lacks an
+important health signal for at least one device. In both cases, tests should
+also cover the inverse path where the optional component is unavailable but
+fallback collection provides the user-visible data, so no guidance candidate is
+produced.
+
+App should aggregate unacknowledged guidance candidates by stable key. Repeated
+detections of the same key replace the session-held candidate instead of
+growing a queue, and already acknowledged keys are discarded before display.
+If more than one unacknowledged key is relevant to the current view, the
+frontend should show them one at a time.
+
+Relevant frontend views should request pending guidance through a typed command
+when they mount or become visible, rather than relying on a backend push event.
+That command should filter candidates by view and return only guidance that can
+be shown in the current UI context. Acknowledgement is a separate typed command
+that records the guidance key in App-owned settings.
+
+The frontend's "later" action should suppress the same guidance key only for
+the current app session. It must not write an acknowledgement to settings, so a
+future app session can show the guidance again if the same collection gap still
+exists.
+
 ### Add or Change Persisted Data
 
 1. Keep Tauri SQL plugin migration definitions in

--- a/docs/architecture/windows-sensor-external-components.md
+++ b/docs/architecture/windows-sensor-external-components.md
@@ -20,6 +20,11 @@ Required components:
   - AMD Family 17h / 19h package temperature path: `RyzenSMU.amx` or
     `RyzenSMU.bin`.
 
+The CPU-specific module blob is not installed by the PawnIO runtime itself.
+Users must download a release asset from
+<https://github.com/namazso/PawnIO.Modules/releases>, extract the module blob,
+and place the required file under `C:\Program Files\PawnIO`.
+
 The collector prefers the implementation-ready spec names (`*.amx`) and then
 falls back to the installed module names observed during local validation
 (`*.bin`). The module extension is an operational compatibility detail only; it

--- a/docs/documentation-guide.md
+++ b/docs/documentation-guide.md
@@ -17,6 +17,7 @@ Use the closest stable owner:
   - `src-tauri/README.md` for the Tauri app crate.
   - `core/README.md` for `hardviz-core`.
 - Task guides that cross code owners live under `docs/development/`.
+- User-facing guides that are published by the website live under `docs/user/`.
 - Architecture docs live under `docs/architecture/`.
 - Release, verification, signing, and distribution docs should live under
   `docs/release/` or `docs/security/` when those directories are introduced.

--- a/docs/user/external-components.ja.md
+++ b/docs/user/external-components.ja.md
@@ -1,0 +1,119 @@
+# 外部コンポーネント
+
+[English](external-components.md) | [日本語](external-components.ja.md)
+
+このページは External Component Guidance の日本語版の元コンテンツです。現時点では、アプリは GitHub 上で表示されるこのドキュメントを直接開きます。将来的には HardwareVisualizer の website がこのページを元にした内容を公開し、website URL が用意できた時点でアプリ側のリンク先を切り替えます。
+
+暫定的なアプリ内詳細リンク:
+
+- PawnIO:
+  `https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.ja.md#pawnio`
+- smartctl:
+  `https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.ja.md#smartctl`
+
+HardwareVisualizer は、多くのハードウェア情報を任意の外部コンポーネントなしで取得できます。一部のより深いセンサー経路では、ユーザーが別途インストールする必要があるツールやドライバーに依存します。HardwareVisualizer は、それらのコンポーネントを自動でダウンロード、インストール、同梱、有効化しません。
+
+External Component Guidance は、HardwareVisualizer が任意コンポーネントを使おうとして使えず、さらにフォールバック取得でもユーザーに表示するハードウェア情報が不足する場合にだけ表示されます。フォールバック取得で必要な情報を取得できた場合、アプリはこの案内を表示しません。
+
+## ダイアログの意味
+
+ダイアログでは次の内容を案内します。
+
+- 使えなかった任意コンポーネント
+- 取得できず表示できないハードウェア情報
+- その情報を表示できるようにするための対応
+
+このダイアログは情報提供のためのものです。ハードウェア監視は、利用できる最善のフォールバックデータで継続します。
+
+## PawnIO
+
+PawnIO は、対応している CPU で PawnIO 経由の取得経路が利用できる場合に、Windows の CPU パッケージ温度を取得するために使われます。
+
+ダッシュボードで CPU 温度を表示できない場合、PawnIO が関係していることがあります。HardwareVisualizer が ACPI thermal zone 経由で CPU 温度を表示できている場合、PawnIO の案内は表示しません。
+
+### PawnIO で表示できる項目
+
+PawnIO は、CPU ごとのセンサー経路から Windows の CPU パッケージ温度を取得できます。
+
+- Intel MSR モジュール経由の Intel パッケージ温度
+- Ryzen SMU モジュール経由の AMD Family 17h / Family 19h パッケージ温度
+
+### ユーザー側で必要な準備
+
+PawnIO 経由で CPU パッケージ温度を取得するには、対象の PC に次のものが必要です。
+
+- 正しく動作する PawnIO driver/runtime
+- PawnIO runtime に含まれる `PawnIOLib.dll`
+- PawnIO.Modules のリリースアセットに含まれる CPU 別モジュール
+  - 対応 Intel CPU では `IntelMSR.amx` または `IntelMSR.bin`
+  - 対応 AMD CPU では `RyzenSMU.amx` または `RyzenSMU.bin`
+- HardwareVisualizer のプロセスが PawnIO driver を開ける Windows 権限
+
+モジュールを配置する手順:
+
+1. PawnIO runtime をインストールします。
+2. [namazso/PawnIO.Modules](https://github.com/namazso/PawnIO.Modules/releases) からリリースアセットをダウンロードします。
+3. アーカイブを展開し、必要な CPU モジュールファイルを `C:\Program Files\PawnIO` にコピーします。
+   - Intel パッケージ温度を取得する場合は、`IntelMSR.amx` または `IntelMSR.bin` をコピーします。
+   - 対応 AMD パッケージ温度を取得する場合は、`RyzenSMU.amx` または `RyzenSMU.bin` をコピーします。
+   - どちらの CPU 経路が必要かわからない場合は、両方のモジュールファイルをコピーしても問題ありません。
+4. HardwareVisualizer を再起動します。
+
+`C:\Program Files\PawnIO` への書き込みには、通常は管理者権限が必要です。
+
+PawnIO をインストール済みでも HardwareVisualizer が権限不足を報告する場合は、HardwareVisualizer を管理者として実行してから再度確認してください。
+
+### 公式の入手先
+
+- PawnIO runtime: <https://github.com/namazso/PawnIO>
+- PawnIO modules: <https://github.com/namazso/PawnIO.Modules/releases>
+
+実装上の詳細は [`../architecture/windows-sensor-external-components.md`](../architecture/windows-sensor-external-components.md) に記録しています。
+
+## smartctl
+
+`smartctl` は smartmontools に含まれるツールです。HardwareVisualizer は、OS 標準の経路だけでは十分なデバイス健康状態を取得できない場合に、Storage Health の取得元の 1 つとして `smartctl` を使用できます。
+
+Storage Health が少なくとも 1 つのストレージデバイスで重要な健康状態シグナルを取得できない場合、`smartctl` の案内が表示されることがあります。OS 標準またはフォールバックの取得元で重要な健康状態シグナルを取得できている場合、この案内は表示しません。
+
+`smartctl:storage-health:v1` の案内キーはクロスプラットフォームです。Windows、Linux、macOS のいずれでも、HardwareVisualizer が実際に `smartctl` を使おうとして、利用可能な取得元では重要な Storage Health シグナルを取得できなかった場合に表示されます。
+
+Live Storage Health は、利用できる場合は軽量な OS 標準の読み取り経路を使用します。ライブポーリングの周期では `smartctl` を使用しません。
+
+### smartctl で改善できる項目
+
+Storage Health では、HardwareVisualizer は次の情報を重要な健康状態シグナルとして扱います。
+
+- SMART 全体健康状態
+- 温度
+- NVMe 使用率
+- NVMe 予備領域
+- 代替処理済みセクター数
+- 現在保留中のセクター数
+- オフライン訂正不能セクター数
+- NVMe メディアエラー
+
+電源投入時間、電源投入回数、異常シャットダウン回数、エラーログエントリ数などの値も UI 上では有用な場合があります。ただし、それらだけが不足している場合は外部コンポーネント案内を表示しません。
+
+### ユーザー側で必要な準備
+
+`smartctl` を使うには、利用している OS 向けの smartmontools をインストールし、`smartctl` 実行ファイルを `PATH` から利用できるようにしてください。
+
+一部のストレージデバイスや OS では、SMART データの読み取りに昇格権限が必要な場合があります。`smartctl` をインストール済みでも HardwareVisualizer が Storage Health シグナルを取得できない場合は、利用している OS とデバイスで必要な権限で HardwareVisualizer を実行してください。
+
+`smartctl` のインストールまたは設定修正後、Storage Device Refresh が利用できる場合は実行してください。そうでない場合は HardwareVisualizer を再起動してください。日次の Storage Health 収集も、次回のスケジュール実行時に再試行します。
+
+### 公式の入手先
+
+- smartmontools: <https://www.smartmontools.org/>
+
+## 案内理由
+
+アプリは、利用できないコンポーネントを次のように分類することがあります。
+
+- `missing`: 実行ファイル、DLL、またはモジュールファイルが見つからない
+- `permission`: コンポーネントは存在するが、現在の権限では開けない
+- `misconfigured`: runtime は存在するが、必要な driver、service、module が不足している
+- `failed`: コンポーネントは実行されたが、対象デバイスまたはセンサーの有効なデータを返さなかった
+
+website では、これらの分類を使って、raw error string を主なユーザー向けメッセージとして表示するのではなく、具体的な次の対応を表示します。

--- a/docs/user/external-components.md
+++ b/docs/user/external-components.md
@@ -1,5 +1,7 @@
 # External Components
 
+[English](external-components.md) | [Japanese](external-components.ja.md)
+
 This page is the source content for External Component Guidance. For now, the
 app should open the GitHub-rendered version of this document directly. The
 HardwareVisualizer website should later publish content derived from this page,

--- a/docs/user/external-components.md
+++ b/docs/user/external-components.md
@@ -1,0 +1,142 @@
+# External Components
+
+This page is the source content for External Component Guidance. For now, the
+app should open the GitHub-rendered version of this document directly. The
+HardwareVisualizer website should later publish content derived from this page,
+and the app can switch to that website URL when it exists.
+
+Temporary in-app detail links:
+
+- PawnIO:
+  `https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.md#pawnio`
+- smartctl:
+  `https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.md#smartctl`
+
+HardwareVisualizer can collect many hardware signals without optional external
+components. Some deeper sensor paths depend on tools or drivers that users must
+install separately. HardwareVisualizer does not download, install, bundle, or
+enable those components automatically.
+
+External Component Guidance appears only after HardwareVisualizer tries to use
+an optional component, cannot use it, and fallback collection still leaves
+user-visible hardware data unavailable. If fallback collection obtains the
+needed information, the app should not show guidance.
+
+## What The Dialog Means
+
+The dialog tells you:
+
+- which optional component could not be used;
+- which hardware information remains unavailable;
+- what action may make that information available.
+
+The dialog is informational. Hardware monitoring continues with the best
+available fallback data.
+
+## PawnIO
+
+PawnIO is used on Windows for CPU package temperature collection when the CPU
+supports the implemented PawnIO-backed path.
+
+PawnIO may be relevant when the CPU temperature is unavailable in the dashboard.
+If HardwareVisualizer can still show a CPU temperature through ACPI thermal
+zones, it should not show PawnIO guidance.
+
+### What PawnIO Enables
+
+PawnIO can provide Windows CPU package temperature from CPU-specific sensor
+paths:
+
+- Intel package temperature through the Intel MSR module.
+- AMD Family 17h and Family 19h package temperature through the Ryzen SMU
+  module.
+
+### Required User Setup
+
+For PawnIO-backed CPU package temperature collection, the machine needs:
+
+- a working PawnIO driver/runtime installation;
+- `PawnIOLib.dll`;
+- one CPU-specific module blob:
+  - `IntelMSR.amx` or `IntelMSR.bin` for supported Intel CPUs;
+  - `RyzenSMU.amx` or `RyzenSMU.bin` for supported AMD CPUs;
+- enough Windows privileges for the app process to open the PawnIO driver.
+
+If PawnIO is installed but HardwareVisualizer reports a permission issue, run
+HardwareVisualizer as administrator and try again.
+
+### Official Sources
+
+- PawnIO runtime: <https://github.com/namazso/PawnIO>
+- PawnIO modules: <https://github.com/namazso/PawnIO.Modules/releases>
+
+More implementation detail is recorded in
+[`../architecture/windows-sensor-external-components.md`](../architecture/windows-sensor-external-components.md).
+
+## smartctl
+
+`smartctl` is part of smartmontools. HardwareVisualizer can use it as one
+Storage Health collection source when native OS paths cannot provide enough
+device-health signals.
+
+`smartctl` guidance may be relevant when Storage Health cannot collect important
+health signals for at least one storage device. It should not appear if native
+or fallback sources already collect the important health signals.
+
+The `smartctl:storage-health:v1` guidance key is cross-platform. Windows,
+Linux, and macOS can all surface it when HardwareVisualizer actually attempts
+to use `smartctl` and still cannot collect the important Storage Health
+signals through the available sources.
+
+Live Storage Health uses the cheap native read path where available and does
+not use `smartctl` on its live polling cadence.
+
+### What smartctl Can Improve
+
+For Storage Health, HardwareVisualizer treats these as important health signals:
+
+- SMART overall health;
+- temperature;
+- NVMe percentage used;
+- NVMe available spare;
+- reallocated sector count;
+- current pending sector count;
+- offline uncorrectable sector count;
+- NVMe media errors.
+
+Other values, such as power-on hours, power cycle count, unsafe shutdown count,
+or error-log entry count, may still be useful in the UI. Missing only those
+values should not trigger external component guidance.
+
+### Required User Setup
+
+To use `smartctl`, install smartmontools for your operating system and make
+sure the `smartctl` executable is available on `PATH`.
+
+Some storage devices or operating systems may also require elevated privileges
+to read SMART data. If `smartctl` is installed but HardwareVisualizer still
+cannot collect Storage Health signals, try running HardwareVisualizer with the
+permissions required by your operating system and device.
+
+After installing or fixing `smartctl`, run Storage Device Refresh when
+available, or restart HardwareVisualizer. Daily Storage Health collection will
+also retry on its next scheduled collection.
+
+### Official Source
+
+- smartmontools: <https://www.smartmontools.org/>
+
+## Guidance Reasons
+
+The app may classify an unavailable component as:
+
+- `missing`: the executable, DLL, or module file was not found;
+- `permission`: the component exists but cannot be opened with current
+  privileges;
+- `misconfigured`: the runtime exists but a required driver, service, or module
+  is missing;
+- `failed`: the component ran but did not return usable data for the target
+  device or sensor.
+
+The website should use those classifications to show specific next steps rather
+than displaying raw error strings as the main user-facing message.

--- a/docs/user/external-components.md
+++ b/docs/user/external-components.md
@@ -56,11 +56,28 @@ paths:
 For PawnIO-backed CPU package temperature collection, the machine needs:
 
 - a working PawnIO driver/runtime installation;
-- `PawnIOLib.dll`;
-- one CPU-specific module blob:
+- `PawnIOLib.dll`, which is provided by the PawnIO runtime installation;
+- one CPU-specific module blob from the PawnIO.Modules release assets:
   - `IntelMSR.amx` or `IntelMSR.bin` for supported Intel CPUs;
   - `RyzenSMU.amx` or `RyzenSMU.bin` for supported AMD CPUs;
 - enough Windows privileges for the app process to open the PawnIO driver.
+
+To set up the module blob:
+
+1. Install the PawnIO runtime.
+2. Download a release asset from
+   [namazso/PawnIO.Modules](https://github.com/namazso/PawnIO.Modules/releases).
+3. Extract the archive and copy the CPU module file you need into
+   `C:\Program Files\PawnIO`.
+   - For Intel package temperature, copy `IntelMSR.amx` or `IntelMSR.bin`.
+   - For supported AMD package temperature, copy `RyzenSMU.amx` or
+     `RyzenSMU.bin`.
+   - If you are not sure which CPU path applies, copying both module files is
+     acceptable.
+4. Restart HardwareVisualizer.
+
+Writing to `C:\Program Files\PawnIO` usually requires administrator
+permission.
 
 If PawnIO is installed but HardwareVisualizer reports a permission issue, run
 HardwareVisualizer as administrator and try again.

--- a/src-tauri/src/_tests/commands/settings_test.rs
+++ b/src-tauri/src/_tests/commands/settings_test.rs
@@ -46,6 +46,8 @@ mod tests {
       text_selectable: false,
       close_to_tray: false,
       close_to_tray_choice_made: false,
+      external_component_guidance:
+        models::settings::ExternalComponentGuidanceSettings::default(),
       tray_widget: crate::tray::widget::TrayWidgetSettings::default(),
     };
 

--- a/src-tauri/src/_tests/commands/settings_test.rs
+++ b/src-tauri/src/_tests/commands/settings_test.rs
@@ -90,6 +90,10 @@ mod tests {
     assert_eq!(settings.window_opacity, expected.window_opacity);
     assert_eq!(settings.glass_blur, expected.glass_blur);
     assert_eq!(settings.temperature_unit, expected.temperature_unit);
+    assert_eq!(
+      settings.external_component_guidance,
+      expected.external_component_guidance
+    );
   }
 
   #[test]

--- a/src-tauri/src/adapters/window.rs
+++ b/src-tauri/src/adapters/window.rs
@@ -15,7 +15,7 @@ use tauri_specta::Event as _;
 /// forwards each [`MetricsSnapshot`] to the main window as the existing
 /// [`HardwareMonitorUpdate`] Tauri event. This is the only place that
 /// translates Core events into a Tauri emit. It also applies the user's
-/// preferred temperature unit (`Celsius` / `Fahrenheit`) — the Core
+/// preferred temperature unit (`Celsius` / `Fahrenheit`) - the Core
 /// collector always publishes raw °C, and presentation conversion lives
 /// here at the App-side boundary.
 pub struct WindowAdapter {
@@ -85,6 +85,16 @@ impl WindowAdapter {
     if let Some(snapshot) = self.latest_snapshot.load() {
       emit_snapshot(app_handle, snapshot);
     }
+  }
+
+  pub fn latest_external_component_guidance_candidates(
+    &self,
+  ) -> Vec<hardviz_core::models::ExternalComponentGuidanceCandidate> {
+    self
+      .latest_snapshot
+      .load()
+      .map(|snapshot| snapshot.external_component_guidance_candidates)
+      .unwrap_or_default()
   }
 
   pub async fn terminate(self) {
@@ -228,6 +238,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     }
   }
 
@@ -241,6 +252,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Celsius);
     assert_eq!(update.cpu_usage, 12.5);
@@ -264,6 +276,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Celsius);
     assert_eq!(update.gpus.len(), 2);
@@ -295,6 +308,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Fahrenheit);
     assert_eq!(update.gpus[0].gpu_temperature, Some(212.0));
@@ -318,6 +332,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Celsius);
     assert_eq!(update.gpus[0].gpu_temperature, Some(66.0));
@@ -341,6 +356,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Fahrenheit);
     assert!(update.gpus[0].gpu_usage.is_none());
@@ -368,6 +384,7 @@ mod tests {
           temperature: 40.0,
         },
       ],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Fahrenheit);
     assert_eq!(update.cpu_temperature, Some(122.0));
@@ -391,6 +408,7 @@ mod tests {
         name: "TZ00".into(),
         temperature: 49.6,
       }],
+      external_component_guidance_candidates: vec![],
     };
     let update = to_hardware_monitor_update(snap, &TemperatureUnit::Celsius);
     assert_eq!(update.cpu_temperature, Some(50.0));
@@ -448,6 +466,10 @@ mod tests {
   #[test]
   fn window_snapshot_omits_process_samples() {
     let mut snapshot = make_snapshot(1.0);
+    let candidate =
+      hardviz_core::models::ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+        "PawnIOLib.dll not found".to_string(),
+      );
     snapshot
       .processes
       .push(hardviz_core::models::ProcessSample {
@@ -457,9 +479,16 @@ mod tests {
         memory_kb: 1024.0,
         run_time_secs: 60,
       });
+    snapshot
+      .external_component_guidance_candidates
+      .push(candidate.clone());
 
     let snapshot = to_window_snapshot(snapshot);
 
     assert!(snapshot.processes.is_empty());
+    assert_eq!(
+      snapshot.external_component_guidance_candidates,
+      vec![candidate]
+    );
   }
 }

--- a/src-tauri/src/commands/external_component_guidance.rs
+++ b/src-tauri/src/commands/external_component_guidance.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use crate::commands::settings;
+use crate::models;
+use crate::services::external_component_guidance_service::{
+  ExternalComponentGuidanceState, ExternalComponentGuidanceView,
+};
+use tauri::command;
+
+#[command]
+#[specta::specta]
+pub async fn get_external_component_guidance_candidates(
+  view: ExternalComponentGuidanceView,
+  state: tauri::State<'_, settings::AppState>,
+  guidance_state: tauri::State<'_, Arc<ExternalComponentGuidanceState>>,
+  workers: tauri::State<'_, crate::workers::WorkersState>,
+) -> Result<
+  Vec<models::external_component_guidance::ExternalComponentGuidanceCandidate>,
+  String,
+> {
+  let latest_snapshot_candidates = workers
+    .window_adapter
+    .lock()
+    .map_err(|_| "window adapter state lock poisoned".to_string())?
+    .as_ref()
+    .map(|adapter| adapter.latest_external_component_guidance_candidates())
+    .unwrap_or_default();
+  guidance_state.record_candidates(latest_snapshot_candidates);
+
+  let acknowledged_keys = state
+    .settings
+    .lock()
+    .map_err(|_| "settings state lock poisoned".to_string())?
+    .external_component_guidance
+    .acknowledged_keys
+    .clone();
+
+  Ok(
+    guidance_state
+      .pending_candidates(view, &acknowledged_keys)
+      .into_iter()
+      .map(Into::into)
+      .collect(),
+  )
+}
+
+#[command]
+#[specta::specta]
+pub async fn defer_external_component_guidance_for_session(
+  key: String,
+  guidance_state: tauri::State<'_, Arc<ExternalComponentGuidanceState>>,
+) -> Result<(), String> {
+  guidance_state.defer_for_session(&key);
+  Ok(())
+}

--- a/src-tauri/src/commands/external_component_guidance.rs
+++ b/src-tauri/src/commands/external_component_guidance.rs
@@ -4,6 +4,7 @@ use crate::commands::settings;
 use crate::models;
 use crate::services::external_component_guidance_service::{
   ExternalComponentGuidanceState, ExternalComponentGuidanceView,
+  normalize_external_component_guidance_key,
 };
 use tauri::command;
 
@@ -50,6 +51,7 @@ pub async fn defer_external_component_guidance_for_session(
   key: String,
   guidance_state: tauri::State<'_, Arc<ExternalComponentGuidanceState>>,
 ) -> Result<(), String> {
+  let key = normalize_external_component_guidance_key(&key)?;
   guidance_state.defer_for_session(&key);
   Ok(())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod background_image;
+pub mod external_component_guidance;
 pub mod hardware;
 pub mod settings;
 pub mod system;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -59,8 +59,10 @@ impl AppState {
 pub mod commands {
 
   use super::*;
+  use crate::services::external_component_guidance_service::ExternalComponentGuidanceState;
   use crate::tray::widget::TrayWidgetSettings;
   use serde_json::json;
+  use std::sync::Arc;
   use tauri::{Emitter, EventTarget, Manager, Window};
 
   const ERROR_TITLE: &str = "Failed to update settings file";
@@ -155,6 +157,7 @@ pub mod commands {
       text_selectable: settings.text_selectable,
       close_to_tray: settings.close_to_tray,
       close_to_tray_choice_made: settings.close_to_tray_choice_made,
+      external_component_guidance: settings.external_component_guidance,
       tray_widget: settings.tray_widget.normalized(),
     };
 
@@ -678,6 +681,26 @@ pub mod commands {
       emit_error(&window)?;
       return Err(e);
     }
+
+    Ok(())
+  }
+
+  #[tauri::command]
+  #[specta::specta]
+  pub async fn acknowledge_external_component_guidance_key(
+    window: Window,
+    state: tauri::State<'_, AppState>,
+    guidance_state: tauri::State<'_, Arc<ExternalComponentGuidanceState>>,
+    key: String,
+  ) -> Result<(), String> {
+    let mut settings = state.settings.lock().unwrap();
+
+    if let Err(e) = settings.acknowledge_external_component_guidance_key(key.clone()) {
+      emit_error(&window)?;
+      return Err(e);
+    }
+
+    guidance_state.remove_key(&key);
 
     Ok(())
   }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -59,7 +59,9 @@ impl AppState {
 pub mod commands {
 
   use super::*;
-  use crate::services::external_component_guidance_service::ExternalComponentGuidanceState;
+  use crate::services::external_component_guidance_service::{
+    ExternalComponentGuidanceState, normalize_external_component_guidance_key,
+  };
   use crate::tray::widget::TrayWidgetSettings;
   use serde_json::json;
   use std::sync::Arc;
@@ -693,6 +695,7 @@ pub mod commands {
     guidance_state: tauri::State<'_, Arc<ExternalComponentGuidanceState>>,
     key: String,
   ) -> Result<(), String> {
+    let key = normalize_external_component_guidance_key(&key)?;
     let mut settings = state.settings.lock().unwrap();
 
     if let Err(e) = settings.acknowledge_external_component_guidance_key(key.clone()) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,12 +23,14 @@ mod workers;
 mod _tests;
 
 use commands::background_image;
+use commands::external_component_guidance;
 use commands::hardware;
 use commands::settings;
 use commands::system;
 use commands::ui;
 use commands::updater::app_updates;
 use hardviz_core::collector::HistoryStore;
+use services::external_component_guidance_service::ExternalComponentGuidanceState;
 use std::sync::{Arc, Mutex};
 use tauri::Manager;
 use tauri::Wry;
@@ -57,6 +59,8 @@ pub fn run() {
   // loop read/write through this store. Persistence no longer shares it —
   // the archive worker subscribes to the EventBus instead (#1407).
   let history_store = Arc::new(HistoryStore::new());
+  let external_component_guidance_state =
+    Arc::new(ExternalComponentGuidanceState::default());
 
   let core_settings = app_state.core_settings.lock().unwrap().clone();
 
@@ -98,6 +102,8 @@ pub fn run() {
       hardware::get_gpu_memory_usage,
       hardware::get_storage_health_latest_records,
       hardware::get_live_storage_health,
+      external_component_guidance::get_external_component_guidance_candidates,
+      external_component_guidance::defer_external_component_guidance_for_session,
       hardware::get_data_archive_records,
       hardware::get_gpu_archive_records,
       hardware::get_process_stats,
@@ -134,6 +140,7 @@ pub fn run() {
       settings::commands::set_text_selectable,
       settings::commands::set_tray_widget_settings,
       settings::commands::set_close_to_tray_preference,
+      settings::commands::acknowledge_external_component_guidance_key,
       settings::commands::read_license_file,
       settings::commands::read_third_party_notices_file,
       settings::commands::open_license_file_path,
@@ -158,6 +165,7 @@ pub fn run() {
     .expect("Failed to export typescript bindings");
 
   let store_for_setup = Arc::clone(&history_store);
+  let guidance_for_setup = Arc::clone(&external_component_guidance_state);
 
   let mut tauri_builder = tauri::Builder::<Wry>::default()
     .invoke_handler(builder.invoke_handler())
@@ -236,11 +244,18 @@ pub fn run() {
         if core_settings.storage_health.enabled {
           match core_settings.storage_health_identity.hash_key_bytes() {
             Ok(identity_hash_key) => {
+              let storage_guidance_state = Arc::clone(&guidance_for_setup);
+              let storage_guidance_sink:
+                hardviz_core::persistence::ExternalComponentGuidanceSink =
+                Arc::new(move |candidates| {
+                  storage_guidance_state.record_candidates(candidates);
+                });
               let storage_health =
-                hardviz_core::persistence::StorageHealthController::setup(
+                hardviz_core::persistence::StorageHealthController::setup_with_guidance_sink(
                   runtime_handle.clone(),
                   core_settings.storage_health.retention_days,
                   identity_hash_key,
+                  Some(storage_guidance_sink),
                 );
               // Live Storage Health (ADR 0006): enumerate devices once at
               // startup so on-demand reads never enumerate. The WMI query
@@ -349,6 +364,7 @@ pub fn run() {
     .plugin(tauri_plugin_opener::init())
     .manage(history_store)
     .manage(app_state)
+    .manage(external_component_guidance_state)
     .manage(lifecycle::CloseToTrayRuntimeState::default())
     .manage(workers::WorkersState::default())
     .manage(app_updates::PendingUpdate(Mutex::new(None)));

--- a/src-tauri/src/models/external_component_guidance.rs
+++ b/src-tauri/src/models/external_component_guidance.rs
@@ -1,0 +1,106 @@
+use hardviz_core::models as core_models;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalComponentGuidanceCandidate {
+  pub key: String,
+  pub component: ExternalComponent,
+  pub usage: ExternalComponentUsage,
+  pub reason_kind: ExternalComponentReasonKind,
+  pub missing_signals: Vec<String>,
+  pub affected_device_count: Option<u32>,
+  pub diagnostic_detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponent {
+  Pawnio,
+  Smartctl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponentUsage {
+  CpuPackageTemperature,
+  StorageHealth,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponentReasonKind {
+  Missing,
+  Permission,
+  Misconfigured,
+  Failed,
+}
+
+impl From<core_models::ExternalComponentGuidanceCandidate>
+  for ExternalComponentGuidanceCandidate
+{
+  fn from(src: core_models::ExternalComponentGuidanceCandidate) -> Self {
+    Self {
+      key: src.key,
+      component: src.component.into(),
+      usage: src.usage.into(),
+      reason_kind: src.reason_kind.into(),
+      missing_signals: src.missing_signals,
+      affected_device_count: src.affected_device_count,
+      diagnostic_detail: src.diagnostic_detail,
+    }
+  }
+}
+
+impl From<core_models::ExternalComponent> for ExternalComponent {
+  fn from(value: core_models::ExternalComponent) -> Self {
+    match value {
+      core_models::ExternalComponent::Pawnio => Self::Pawnio,
+      core_models::ExternalComponent::Smartctl => Self::Smartctl,
+    }
+  }
+}
+
+impl From<core_models::ExternalComponentUsage> for ExternalComponentUsage {
+  fn from(value: core_models::ExternalComponentUsage) -> Self {
+    match value {
+      core_models::ExternalComponentUsage::CpuPackageTemperature => {
+        Self::CpuPackageTemperature
+      }
+      core_models::ExternalComponentUsage::StorageHealth => Self::StorageHealth,
+    }
+  }
+}
+
+impl From<core_models::ExternalComponentReasonKind> for ExternalComponentReasonKind {
+  fn from(value: core_models::ExternalComponentReasonKind) -> Self {
+    match value {
+      core_models::ExternalComponentReasonKind::Missing => Self::Missing,
+      core_models::ExternalComponentReasonKind::Permission => Self::Permission,
+      core_models::ExternalComponentReasonKind::Misconfigured => Self::Misconfigured,
+      core_models::ExternalComponentReasonKind::Failed => Self::Failed,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn converts_core_guidance_candidate_to_wire_shape() {
+    let candidate =
+      core_models::ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+        "PawnIOLib.dll not found".to_string(),
+      );
+
+    let wire = ExternalComponentGuidanceCandidate::from(candidate);
+
+    assert_eq!(wire.key, "pawnio:cpu-package-temperature:v1");
+    assert_eq!(wire.component, ExternalComponent::Pawnio);
+    assert_eq!(wire.usage, ExternalComponentUsage::CpuPackageTemperature);
+    assert_eq!(wire.reason_kind, ExternalComponentReasonKind::Missing);
+    assert_eq!(wire.missing_signals, vec!["cpu-temperature"]);
+  }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive_history;
 pub mod background_image;
+pub mod external_component_guidance;
 pub mod hardware;
 pub mod hardware_archive;
 pub mod settings;

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -23,6 +23,12 @@ impl Default for LineGraphColorSettings {
   }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ExternalComponentGuidanceSettings {
+  pub acknowledged_keys: Vec<String>,
+}
+
 ///
 /// ## App-owned settings persisted in `settings.json`.
 ///
@@ -61,6 +67,7 @@ pub struct Settings {
   pub text_selectable: bool,
   pub close_to_tray: bool,
   pub close_to_tray_choice_made: bool,
+  pub external_component_guidance: ExternalComponentGuidanceSettings,
   pub tray_widget: crate::tray::widget::TrayWidgetSettings,
 }
 
@@ -107,6 +114,7 @@ pub struct ClientSettings {
   pub text_selectable: bool,
   pub close_to_tray: bool,
   pub close_to_tray_choice_made: bool,
+  pub external_component_guidance: ExternalComponentGuidanceSettings,
   pub tray_widget: crate::tray::widget::TrayWidgetSettings,
 }
 
@@ -148,6 +156,7 @@ impl Default for Settings {
       text_selectable: false,
       close_to_tray: false,
       close_to_tray_choice_made: false,
+      external_component_guidance: ExternalComponentGuidanceSettings::default(),
       tray_widget: crate::tray::widget::TrayWidgetSettings::default(),
     }
   }
@@ -293,6 +302,7 @@ mod tests {
       text_selectable: false,
       close_to_tray: false,
       close_to_tray_choice_made: false,
+      external_component_guidance: ExternalComponentGuidanceSettings::default(),
       tray_widget: crate::tray::widget::TrayWidgetSettings::default(),
     };
 
@@ -424,6 +434,34 @@ mod tests {
     assert_eq!(settings.transparent_ui, defaults.transparent_ui);
     assert_eq!(settings.window_opacity, defaults.window_opacity);
     assert_eq!(settings.glass_blur, defaults.glass_blur);
+  }
+
+  #[test]
+  fn external_component_guidance_settings_default_to_no_acknowledged_keys() {
+    let settings = Settings::default();
+
+    assert!(
+      settings
+        .external_component_guidance
+        .acknowledged_keys
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn merge_from_json_str_recovers_external_component_guidance_keys() {
+    let mut settings = Settings::default();
+
+    settings
+      .merge_from_json_str(
+        r#"{"externalComponentGuidance":{"acknowledgedKeys":["smartctl:storage-health:v1"]}}"#,
+      )
+      .unwrap();
+
+    assert_eq!(
+      settings.external_component_guidance.acknowledged_keys,
+      vec!["smartctl:storage-health:v1".to_string()]
+    );
   }
 
   #[test]

--- a/src-tauri/src/services/external_component_guidance_service.rs
+++ b/src-tauri/src/services/external_component_guidance_service.rs
@@ -15,6 +15,17 @@ pub enum ExternalComponentGuidanceView {
   StorageHealth,
 }
 
+pub(crate) fn normalize_external_component_guidance_key(
+  key: &str,
+) -> Result<String, String> {
+  let key = key.trim();
+  if key.is_empty() {
+    return Err("external component guidance key must not be empty".to_string());
+  }
+
+  Ok(key.to_string())
+}
+
 #[derive(Default)]
 pub struct ExternalComponentGuidanceState {
   pending: Mutex<BTreeMap<String, ExternalComponentGuidanceCandidate>>,
@@ -160,5 +171,19 @@ mod tests {
 
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].key, "smartctl:storage-health:v1");
+  }
+
+  #[test]
+  fn normalize_external_component_guidance_key_trims_valid_keys() {
+    assert_eq!(
+      normalize_external_component_guidance_key(" pawnio:cpu-package-temperature:v1 ")
+        .unwrap(),
+      "pawnio:cpu-package-temperature:v1"
+    );
+  }
+
+  #[test]
+  fn normalize_external_component_guidance_key_rejects_empty_keys() {
+    assert!(normalize_external_component_guidance_key(" \t").is_err());
   }
 }

--- a/src-tauri/src/services/external_component_guidance_service.rs
+++ b/src-tauri/src/services/external_component_guidance_service.rs
@@ -1,0 +1,164 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
+
+use hardviz_core::models::{
+  ExternalComponent, ExternalComponentGuidanceCandidate, ExternalComponentUsage,
+};
+use serde::Deserialize;
+use specta::Type;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ExternalComponentGuidanceView {
+  Dashboard,
+  CpuDetail,
+  StorageHealth,
+}
+
+#[derive(Default)]
+pub struct ExternalComponentGuidanceState {
+  pending: Mutex<BTreeMap<String, ExternalComponentGuidanceCandidate>>,
+  deferred_for_session: Mutex<BTreeSet<String>>,
+}
+
+impl ExternalComponentGuidanceState {
+  pub fn record_candidates(
+    &self,
+    candidates: impl IntoIterator<Item = ExternalComponentGuidanceCandidate>,
+  ) {
+    let Ok(mut pending) = self.pending.lock() else {
+      return;
+    };
+
+    for candidate in candidates {
+      if candidate.key.trim().is_empty() {
+        continue;
+      }
+      pending.insert(candidate.key.clone(), candidate);
+    }
+  }
+
+  pub fn pending_candidates(
+    &self,
+    view: ExternalComponentGuidanceView,
+    acknowledged_keys: &[String],
+  ) -> Vec<ExternalComponentGuidanceCandidate> {
+    let acknowledged: BTreeSet<&str> =
+      acknowledged_keys.iter().map(String::as_str).collect();
+    let deferred = self
+      .deferred_for_session
+      .lock()
+      .map(|keys| keys.clone())
+      .unwrap_or_default();
+    let Ok(pending) = self.pending.lock() else {
+      return Vec::new();
+    };
+
+    pending
+      .values()
+      .filter(|candidate| !acknowledged.contains(candidate.key.as_str()))
+      .filter(|candidate| !deferred.contains(candidate.key.as_str()))
+      .filter(|candidate| is_relevant_to_view(candidate, view))
+      .cloned()
+      .collect()
+  }
+
+  pub fn defer_for_session(&self, key: &str) {
+    if let Ok(mut deferred) = self.deferred_for_session.lock() {
+      deferred.insert(key.to_string());
+    }
+  }
+
+  pub fn remove_key(&self, key: &str) {
+    if let Ok(mut pending) = self.pending.lock() {
+      pending.remove(key);
+    }
+    if let Ok(mut deferred) = self.deferred_for_session.lock() {
+      deferred.remove(key);
+    }
+  }
+}
+
+fn is_relevant_to_view(
+  candidate: &ExternalComponentGuidanceCandidate,
+  view: ExternalComponentGuidanceView,
+) -> bool {
+  match view {
+    ExternalComponentGuidanceView::Dashboard => true,
+    ExternalComponentGuidanceView::CpuDetail => {
+      candidate.component == ExternalComponent::Pawnio
+        && candidate.usage == ExternalComponentUsage::CpuPackageTemperature
+    }
+    ExternalComponentGuidanceView::StorageHealth => {
+      candidate.component == ExternalComponent::Smartctl
+        && candidate.usage == ExternalComponentUsage::StorageHealth
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn pawnio_candidate() -> hardviz_core::models::ExternalComponentGuidanceCandidate {
+    hardviz_core::models::ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+      "PawnIOLib.dll not found".to_string(),
+    )
+  }
+
+  fn smartctl_candidate() -> hardviz_core::models::ExternalComponentGuidanceCandidate {
+    hardviz_core::models::ExternalComponentGuidanceCandidate::smartctl_storage_health(
+      vec!["temperature".to_string()],
+      Some(1),
+      "smartctl is not installed".to_string(),
+    )
+  }
+
+  #[test]
+  fn pending_candidates_filter_acknowledged_keys() {
+    let state = ExternalComponentGuidanceState::default();
+    state.record_candidates(vec![pawnio_candidate(), smartctl_candidate()]);
+
+    let pending = state.pending_candidates(
+      ExternalComponentGuidanceView::Dashboard,
+      &["pawnio:cpu-package-temperature:v1".to_string()],
+    );
+
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].key, "smartctl:storage-health:v1");
+  }
+
+  #[test]
+  fn defer_for_session_hides_key_until_process_restart() {
+    let state = ExternalComponentGuidanceState::default();
+    state.record_candidates(vec![pawnio_candidate()]);
+
+    state.defer_for_session("pawnio:cpu-package-temperature:v1");
+
+    let pending = state.pending_candidates(ExternalComponentGuidanceView::Dashboard, &[]);
+    assert!(pending.is_empty());
+  }
+
+  #[test]
+  fn pending_candidates_are_filtered_by_view() {
+    let state = ExternalComponentGuidanceState::default();
+    state.record_candidates(vec![pawnio_candidate(), smartctl_candidate()]);
+
+    let pending = state.pending_candidates(ExternalComponentGuidanceView::CpuDetail, &[]);
+
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].key, "pawnio:cpu-package-temperature:v1");
+  }
+
+  #[test]
+  fn pending_candidates_filter_storage_health_view() {
+    let state = ExternalComponentGuidanceState::default();
+    state.record_candidates(vec![pawnio_candidate(), smartctl_candidate()]);
+
+    let pending =
+      state.pending_candidates(ExternalComponentGuidanceView::StorageHealth, &[]);
+
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].key, "smartctl:storage-health:v1");
+  }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive_history_service;
 pub mod background_image_service;
+pub mod external_component_guidance_service;
 pub mod gpu_service;
 pub mod hardware_service;
 pub mod language_service;

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -231,6 +231,7 @@ impl models::settings::Settings {
     try_field!(text_selectable, "textSelectable");
     try_field!(close_to_tray, "closeToTray");
     try_field!(close_to_tray_choice_made, "closeToTrayChoiceMade");
+    try_field!(external_component_guidance, "externalComponentGuidance");
     try_field!(tray_widget, "trayWidget");
 
     Ok(())
@@ -480,6 +481,22 @@ impl models::settings::Settings {
   pub fn set_close_to_tray_preference(&mut self, new_value: bool) -> Result<(), String> {
     self.close_to_tray = new_value;
     self.close_to_tray_choice_made = true;
+    self.write_file()
+  }
+
+  pub fn acknowledge_external_component_guidance_key(
+    &mut self,
+    key: String,
+  ) -> Result<(), String> {
+    let key = key.trim().to_string();
+    if !key.is_empty()
+      && !self
+        .external_component_guidance
+        .acknowledged_keys
+        .contains(&key)
+    {
+      self.external_component_guidance.acknowledged_keys.push(key);
+    }
     self.write_file()
   }
 }

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -1,5 +1,6 @@
 use crate::enums;
 use crate::models;
+use crate::services::external_component_guidance_service::normalize_external_component_guidance_key;
 use crate::utils;
 use crate::{log_error, log_info};
 use std::io::Write;
@@ -488,16 +489,21 @@ impl models::settings::Settings {
     &mut self,
     key: String,
   ) -> Result<(), String> {
-    let key = key.trim().to_string();
-    if !key.is_empty()
-      && !self
-        .external_component_guidance
-        .acknowledged_keys
-        .contains(&key)
+    let key = normalize_external_component_guidance_key(&key)?;
+    if self
+      .external_component_guidance
+      .acknowledged_keys
+      .contains(&key)
     {
-      self.external_component_guidance.acknowledged_keys.push(key);
+      return self.write_file();
     }
-    self.write_file()
+
+    let mut next = self.clone();
+    next.external_component_guidance.acknowledged_keys.push(key);
+    next.write_file()?;
+    *self = next;
+
+    Ok(())
   }
 }
 

--- a/src-tauri/src/tray/widget.rs
+++ b/src-tauri/src/tray/widget.rs
@@ -393,6 +393,7 @@ mod tests {
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],
+      external_component_guidance_candidates: vec![],
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/ErrorFallback";
 import { RootErrorFallback } from "@/components/RootErrorFallback";
 import { CloseToTrayFirstRunDialog } from "@/components/shared/CloseToTrayFirstRunDialog";
+import { ExternalComponentGuidanceDialog } from "@/components/shared/ExternalComponentGuidanceDialog";
 import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
 import { useSelectedGpuPersistence } from "@/features/hardware/hooks/useSelectedGpuPersistence";
 import { useErrorModalListener } from "@/hooks/useTauriEventListener";
@@ -308,6 +309,10 @@ const AppContent = () => {
           <AppUpdate />
           <CloseToTrayFirstRunDialog
             closeToTrayChoiceMade={settings.closeToTrayChoiceMade}
+            settingsLoaded={settingsLoaded}
+          />
+          <ExternalComponentGuidanceDialog
+            displayTarget={displayTarget}
             settingsLoaded={settingsLoaded}
           />
         </div>

--- a/src/components/shared/ExternalComponentGuidanceDialog.tsx
+++ b/src/components/shared/ExternalComponentGuidanceDialog.tsx
@@ -1,0 +1,192 @@
+import { ExternalLinkIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { useTauriDialog } from "@/hooks/useTauriDialog";
+import { openURL } from "@/lib/openUrl";
+import type { ExternalComponentGuidanceCandidate } from "@/rspc/bindings";
+import { commands } from "@/rspc/bindings";
+import { isError } from "@/types/result";
+import type { SelectedDisplayType } from "@/types/ui";
+import {
+  externalComponentGuidanceCopyKey,
+  externalComponentGuidanceDocsUrl,
+  externalComponentGuidanceViewForDisplayTarget,
+} from "./externalComponentGuidance";
+
+type ExternalComponentGuidanceDialogProps = {
+  displayTarget: SelectedDisplayType | null;
+  settingsLoaded?: boolean;
+};
+
+export const ExternalComponentGuidanceDialog = ({
+  displayTarget,
+  settingsLoaded = true,
+}: ExternalComponentGuidanceDialogProps) => {
+  const { t } = useTranslation();
+  const { error } = useTauriDialog();
+  const [candidates, setCandidates] = useState<
+    ExternalComponentGuidanceCandidate[]
+  >([]);
+
+  const view = useMemo(
+    () => externalComponentGuidanceViewForDisplayTarget(displayTarget),
+    [displayTarget],
+  );
+
+  useEffect(() => {
+    if (!settingsLoaded || !view) {
+      setCandidates([]);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const loadCandidates = async () => {
+      const result =
+        await commands.getExternalComponentGuidanceCandidates(view);
+      if (isCancelled) return;
+
+      if (isError(result)) {
+        console.error(
+          "Failed to fetch external component guidance:",
+          result.error,
+        );
+        return;
+      }
+
+      setCandidates(result.data);
+    };
+
+    void loadCandidates();
+    const intervalId = window.setInterval(loadCandidates, 60_000);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [settingsLoaded, view]);
+
+  const candidate = candidates[0] ?? null;
+  const copyKey = candidate
+    ? externalComponentGuidanceCopyKey(candidate)
+    : null;
+
+  const removeCandidate = (key: string) => {
+    setCandidates((current) => current.filter((item) => item.key !== key));
+  };
+
+  const handleAcknowledge = async () => {
+    if (!candidate) return;
+
+    const result = await commands.acknowledgeExternalComponentGuidanceKey(
+      candidate.key,
+    );
+    if (isError(result)) {
+      console.error(
+        "Failed to acknowledge external component guidance:",
+        result.error,
+      );
+      await error(t("externalComponentGuidance.errors.acknowledge"));
+      return;
+    }
+
+    removeCandidate(candidate.key);
+  };
+
+  const handleLater = async () => {
+    if (!candidate) return;
+
+    const result = await commands.deferExternalComponentGuidanceForSession(
+      candidate.key,
+    );
+    if (isError(result)) {
+      console.error(
+        "Failed to defer external component guidance:",
+        result.error,
+      );
+      await error(t("externalComponentGuidance.errors.defer"));
+      return;
+    }
+
+    removeCandidate(candidate.key);
+  };
+
+  const handleOpenDetails = async () => {
+    if (!candidate) return;
+
+    try {
+      await openURL(externalComponentGuidanceDocsUrl(candidate));
+    } catch (err) {
+      console.error("Failed to open external component guidance details:", err);
+      await error(t("externalComponentGuidance.errors.openDetails"));
+    }
+  };
+
+  if (!candidate || !copyKey) {
+    return null;
+  }
+
+  return (
+    <AlertDialog open>
+      <AlertDialogContent className="text-foreground">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("externalComponentGuidance.title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3 text-left">
+              <GuidanceRow
+                label={t("externalComponentGuidance.labels.missing")}
+                value={t(
+                  `externalComponentGuidance.candidates.${copyKey}.missing`,
+                )}
+              />
+              <GuidanceRow
+                label={t("externalComponentGuidance.labels.impact")}
+                value={t(
+                  `externalComponentGuidance.candidates.${copyKey}.impact`,
+                )}
+              />
+              <GuidanceRow
+                label={t("externalComponentGuidance.labels.action")}
+                value={t(
+                  `externalComponentGuidance.candidates.${copyKey}.action`,
+                )}
+              />
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-2">
+          <Button onClick={handleOpenDetails} type="button" variant="outline">
+            <ExternalLinkIcon className="size-4" />
+            {t("externalComponentGuidance.actions.openDetails")}
+          </Button>
+          <AlertDialogCancel onClick={handleLater}>
+            {t("externalComponentGuidance.actions.later")}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleAcknowledge}>
+            {t("externalComponentGuidance.actions.acknowledge")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+const GuidanceRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="space-y-1">
+    <div className="font-medium text-foreground text-sm">{label}</div>
+    <div className="text-muted-foreground text-sm leading-relaxed">{value}</div>
+  </div>
+);

--- a/src/components/shared/ExternalComponentGuidanceDialog.tsx
+++ b/src/components/shared/ExternalComponentGuidanceDialog.tsx
@@ -57,19 +57,24 @@ export const ExternalComponentGuidanceDialog = ({
     let isCancelled = false;
 
     const loadCandidates = async () => {
-      const result =
-        await commands.getExternalComponentGuidanceCandidates(view);
-      if (isCancelled) return;
+      try {
+        const result =
+          await commands.getExternalComponentGuidanceCandidates(view);
+        if (isCancelled) return;
 
-      if (isError(result)) {
-        console.error(
-          "Failed to fetch external component guidance:",
-          result.error,
-        );
-        return;
+        if (isError(result)) {
+          console.error(
+            "Failed to fetch external component guidance:",
+            result.error,
+          );
+          return;
+        }
+
+        setCandidates(result.data);
+      } catch (err) {
+        if (isCancelled) return;
+        console.error("Failed to fetch external component guidance:", err);
       }
-
-      setCandidates(result.data);
     };
 
     void loadCandidates();
@@ -93,37 +98,47 @@ export const ExternalComponentGuidanceDialog = ({
   const handleNeverShowAgain = async () => {
     if (!candidate) return;
 
-    const result = await commands.acknowledgeExternalComponentGuidanceKey(
-      candidate.key,
-    );
-    if (isError(result)) {
-      console.error(
-        "Failed to acknowledge external component guidance:",
-        result.error,
+    try {
+      const result = await commands.acknowledgeExternalComponentGuidanceKey(
+        candidate.key,
       );
-      await error(t("externalComponentGuidance.errors.acknowledge"));
-      return;
-    }
+      if (isError(result)) {
+        console.error(
+          "Failed to acknowledge external component guidance:",
+          result.error,
+        );
+        await error(t("externalComponentGuidance.errors.acknowledge"));
+        return;
+      }
 
-    removeCandidate(candidate.key);
+      removeCandidate(candidate.key);
+    } catch (err) {
+      console.error("Failed to acknowledge external component guidance:", err);
+      await error(t("externalComponentGuidance.errors.acknowledge"));
+    }
   };
 
   const handleLater = async () => {
     if (!candidate) return;
 
-    const result = await commands.deferExternalComponentGuidanceForSession(
-      candidate.key,
-    );
-    if (isError(result)) {
-      console.error(
-        "Failed to defer external component guidance:",
-        result.error,
+    try {
+      const result = await commands.deferExternalComponentGuidanceForSession(
+        candidate.key,
       );
-      await error(t("externalComponentGuidance.errors.defer"));
-      return;
-    }
+      if (isError(result)) {
+        console.error(
+          "Failed to defer external component guidance:",
+          result.error,
+        );
+        await error(t("externalComponentGuidance.errors.defer"));
+        return;
+      }
 
-    removeCandidate(candidate.key);
+      removeCandidate(candidate.key);
+    } catch (err) {
+      console.error("Failed to defer external component guidance:", err);
+      await error(t("externalComponentGuidance.errors.defer"));
+    }
   };
 
   const handleOpenDetails = async () => {

--- a/src/components/shared/ExternalComponentGuidanceDialog.tsx
+++ b/src/components/shared/ExternalComponentGuidanceDialog.tsx
@@ -1,10 +1,8 @@
-import { ExternalLinkIcon } from "lucide-react";
+import { ChevronDownIcon, ExternalLinkIcon, EyeOffIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -12,6 +10,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { openURL } from "@/lib/openUrl";
 import type { ExternalComponentGuidanceCandidate } from "@/rspc/bindings";
@@ -86,7 +90,7 @@ export const ExternalComponentGuidanceDialog = ({
     setCandidates((current) => current.filter((item) => item.key !== key));
   };
 
-  const handleAcknowledge = async () => {
+  const handleNeverShowAgain = async () => {
     if (!candidate) return;
 
     const result = await commands.acknowledgeExternalComponentGuidanceKey(
@@ -172,12 +176,23 @@ export const ExternalComponentGuidanceDialog = ({
             <ExternalLinkIcon className="size-4" />
             {t("externalComponentGuidance.actions.openDetails")}
           </Button>
-          <AlertDialogCancel onClick={handleLater}>
-            {t("externalComponentGuidance.actions.later")}
-          </AlertDialogCancel>
-          <AlertDialogAction onClick={handleAcknowledge}>
-            {t("externalComponentGuidance.actions.acknowledge")}
-          </AlertDialogAction>
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button type="button" variant="secondary">
+                <EyeOffIcon className="size-4" />
+                {t("externalComponentGuidance.actions.hide")}
+                <ChevronDownIcon className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => void handleLater()}>
+                {t("externalComponentGuidance.actions.hideThisSession")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => void handleNeverShowAgain()}>
+                {t("externalComponentGuidance.actions.neverShowAgain")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/shared/ExternalComponentGuidanceDialog.tsx
+++ b/src/components/shared/ExternalComponentGuidanceDialog.tsx
@@ -37,7 +37,7 @@ export const ExternalComponentGuidanceDialog = ({
   displayTarget,
   settingsLoaded = true,
 }: ExternalComponentGuidanceDialogProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { error } = useTauriDialog();
   const [candidates, setCandidates] = useState<
     ExternalComponentGuidanceCandidate[]
@@ -145,7 +145,12 @@ export const ExternalComponentGuidanceDialog = ({
     if (!candidate) return;
 
     try {
-      await openURL(externalComponentGuidanceDocsUrl(candidate));
+      await openURL(
+        externalComponentGuidanceDocsUrl(
+          candidate,
+          i18n.resolvedLanguage ?? i18n.language,
+        ),
+      );
     } catch (err) {
       console.error("Failed to open external component guidance details:", err);
       await error(t("externalComponentGuidance.errors.openDetails"));

--- a/src/components/shared/externalComponentGuidance.test.ts
+++ b/src/components/shared/externalComponentGuidance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ExternalComponentGuidanceCandidate } from "@/rspc/bindings";
 import {
   externalComponentGuidanceCopyKey,
+  externalComponentGuidanceDocsBaseUrl,
   externalComponentGuidanceDocsUrl,
   externalComponentGuidanceViewForDisplayTarget,
 } from "./externalComponentGuidance";
@@ -48,5 +49,19 @@ describe("externalComponentGuidance", () => {
       "smartctlStorageHealth",
     );
     expect(externalComponentGuidanceDocsUrl(smartctl)).toContain("#smartctl");
+  });
+
+  it("uses Japanese docs URLs for Japanese UI languages", () => {
+    const pawnio = candidate("pawnio:cpu-package-temperature:v1");
+
+    expect(externalComponentGuidanceDocsBaseUrl("ja")).toContain(
+      "external-components.ja.md",
+    );
+    expect(externalComponentGuidanceDocsUrl(pawnio, "ja-JP")).toContain(
+      "external-components.ja.md#pawnio",
+    );
+    expect(externalComponentGuidanceDocsBaseUrl("ru")).toContain(
+      "external-components.md",
+    );
   });
 });

--- a/src/components/shared/externalComponentGuidance.test.ts
+++ b/src/components/shared/externalComponentGuidance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ExternalComponentGuidanceCandidate } from "@/rspc/bindings";
+import {
+  externalComponentGuidanceCopyKey,
+  externalComponentGuidanceDocsUrl,
+  externalComponentGuidanceViewForDisplayTarget,
+} from "./externalComponentGuidance";
+
+const candidate = (
+  key: string,
+  overrides: Partial<ExternalComponentGuidanceCandidate> = {},
+): ExternalComponentGuidanceCandidate => ({
+  key,
+  component: "pawnio",
+  usage: "cpuPackageTemperature",
+  reasonKind: "missing",
+  missingSignals: [],
+  affectedDeviceCount: null,
+  diagnosticDetail: null,
+  ...overrides,
+});
+
+describe("externalComponentGuidance", () => {
+  it("maps visible app screens to guidance views", () => {
+    expect(externalComponentGuidanceViewForDisplayTarget("dashboard")).toBe(
+      "dashboard",
+    );
+    expect(externalComponentGuidanceViewForDisplayTarget("cpuDetail")).toBe(
+      "cpuDetail",
+    );
+    expect(
+      externalComponentGuidanceViewForDisplayTarget("settings"),
+    ).toBeNull();
+  });
+
+  it("maps stable candidate keys to copy keys and docs URLs", () => {
+    const pawnio = candidate("pawnio:cpu-package-temperature:v1");
+    const smartctl = candidate("smartctl:storage-health:v1", {
+      component: "smartctl",
+      usage: "storageHealth",
+    });
+
+    expect(externalComponentGuidanceCopyKey(pawnio)).toBe(
+      "pawnioCpuPackageTemperature",
+    );
+    expect(externalComponentGuidanceDocsUrl(pawnio)).toContain("#pawnio");
+    expect(externalComponentGuidanceCopyKey(smartctl)).toBe(
+      "smartctlStorageHealth",
+    );
+    expect(externalComponentGuidanceDocsUrl(smartctl)).toContain("#smartctl");
+  });
+});

--- a/src/components/shared/externalComponentGuidance.ts
+++ b/src/components/shared/externalComponentGuidance.ts
@@ -1,0 +1,50 @@
+import type {
+  ExternalComponentGuidanceCandidate,
+  ExternalComponentGuidanceView,
+} from "@/rspc/bindings";
+import type { SelectedDisplayType } from "@/types/ui";
+
+const EXTERNAL_COMPONENT_DOCS_BASE_URL =
+  "https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.md";
+
+const EXTERNAL_COMPONENT_DOCS_URLS: Record<string, string> = {
+  "pawnio:cpu-package-temperature:v1": `${EXTERNAL_COMPONENT_DOCS_BASE_URL}#pawnio`,
+  "smartctl:storage-health:v1": `${EXTERNAL_COMPONENT_DOCS_BASE_URL}#smartctl`,
+};
+
+type ExternalComponentGuidanceCopyKey =
+  | "pawnioCpuPackageTemperature"
+  | "smartctlStorageHealth"
+  | "generic";
+
+const EXTERNAL_COMPONENT_COPY_KEYS: Record<
+  string,
+  ExternalComponentGuidanceCopyKey
+> = {
+  "pawnio:cpu-package-temperature:v1": "pawnioCpuPackageTemperature",
+  "smartctl:storage-health:v1": "smartctlStorageHealth",
+};
+
+export const externalComponentGuidanceViewForDisplayTarget = (
+  displayTarget: SelectedDisplayType | null,
+): ExternalComponentGuidanceView | null => {
+  switch (displayTarget) {
+    case "dashboard":
+      return "dashboard";
+    case "cpuDetail":
+      return "cpuDetail";
+    default:
+      return null;
+  }
+};
+
+export const externalComponentGuidanceCopyKey = (
+  candidate: ExternalComponentGuidanceCandidate,
+): ExternalComponentGuidanceCopyKey =>
+  EXTERNAL_COMPONENT_COPY_KEYS[candidate.key] ?? "generic";
+
+export const externalComponentGuidanceDocsUrl = (
+  candidate: ExternalComponentGuidanceCandidate,
+) =>
+  EXTERNAL_COMPONENT_DOCS_URLS[candidate.key] ??
+  EXTERNAL_COMPONENT_DOCS_BASE_URL;

--- a/src/components/shared/externalComponentGuidance.ts
+++ b/src/components/shared/externalComponentGuidance.ts
@@ -7,9 +7,12 @@ import type { SelectedDisplayType } from "@/types/ui";
 export const EXTERNAL_COMPONENT_DOCS_BASE_URL =
   "https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.md";
 
-const EXTERNAL_COMPONENT_DOCS_URLS: Record<string, string> = {
-  "pawnio:cpu-package-temperature:v1": `${EXTERNAL_COMPONENT_DOCS_BASE_URL}#pawnio`,
-  "smartctl:storage-health:v1": `${EXTERNAL_COMPONENT_DOCS_BASE_URL}#smartctl`,
+const EXTERNAL_COMPONENT_DOCS_JA_URL =
+  "https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.ja.md";
+
+const EXTERNAL_COMPONENT_DOCS_ANCHORS: Record<string, string> = {
+  "pawnio:cpu-package-temperature:v1": "#pawnio",
+  "smartctl:storage-health:v1": "#smartctl",
 };
 
 type ExternalComponentGuidanceCopyKey =
@@ -43,8 +46,17 @@ export const externalComponentGuidanceCopyKey = (
 ): ExternalComponentGuidanceCopyKey =>
   EXTERNAL_COMPONENT_COPY_KEYS[candidate.key] ?? "generic";
 
+export const externalComponentGuidanceDocsBaseUrl = (
+  language?: string | null,
+) =>
+  language?.toLowerCase().startsWith("ja")
+    ? EXTERNAL_COMPONENT_DOCS_JA_URL
+    : EXTERNAL_COMPONENT_DOCS_BASE_URL;
+
 export const externalComponentGuidanceDocsUrl = (
   candidate: ExternalComponentGuidanceCandidate,
+  language?: string | null,
 ) =>
-  EXTERNAL_COMPONENT_DOCS_URLS[candidate.key] ??
-  EXTERNAL_COMPONENT_DOCS_BASE_URL;
+  `${externalComponentGuidanceDocsBaseUrl(language)}${
+    EXTERNAL_COMPONENT_DOCS_ANCHORS[candidate.key] ?? ""
+  }`;

--- a/src/components/shared/externalComponentGuidance.ts
+++ b/src/components/shared/externalComponentGuidance.ts
@@ -4,7 +4,7 @@ import type {
 } from "@/rspc/bindings";
 import type { SelectedDisplayType } from "@/types/ui";
 
-const EXTERNAL_COMPONENT_DOCS_BASE_URL =
+export const EXTERNAL_COMPONENT_DOCS_BASE_URL =
   "https://github.com/shm11C3/HardwareVisualizer/blob/develop/docs/user/external-components.md";
 
 const EXTERNAL_COMPONENT_DOCS_URLS: Record<string, string> = {

--- a/src/e2e/fixtures/settings.ts
+++ b/src/e2e/fixtures/settings.ts
@@ -52,6 +52,9 @@ export const settingsFixture: ClientSettings_Serialize = {
   textSelectable: false,
   closeToTray: false,
   closeToTrayChoiceMade: true,
+  externalComponentGuidance: {
+    acknowledgedKeys: [],
+  },
   trayWidget: {
     enabled: false,
     metricOrder: ["cpu", "gpu", "gpu-temp"],

--- a/src/e2e/mocks/installTauriMocks.ts
+++ b/src/e2e/mocks/installTauriMocks.ts
@@ -116,6 +116,9 @@ const buildInvokeHandlers = (
   get_hardware_info: () => sysInfoFixture,
   get_process_list: () => processListFixture,
   get_storage_health_latest_records: () => storageHealthFixture,
+  get_external_component_guidance_candidates: () => [],
+  defer_external_component_guidance_for_session: () => null,
+  acknowledge_external_component_guidance_key: () => null,
   get_background_images: () => [],
   get_network_info: () => [],
   // No pending update — keeps the updater UI out of captures.

--- a/src/features/settings/components/advanced/AdvancedSettings.tsx
+++ b/src/features/settings/components/advanced/AdvancedSettings.tsx
@@ -5,15 +5,26 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import { openURL } from "@/lib/openUrl";
 
 export const AdvancedSettings = () => {
   const { t } = useTranslation();
+  const { error } = useTauriDialog();
   const [showGpuUsageSource, setShowGpuUsageSource, isPending] = useTauriStore(
     "showGpuUsageSource",
     false,
   );
+
+  const handleOpenExternalComponentDocs = async () => {
+    try {
+      await openURL(EXTERNAL_COMPONENT_DOCS_BASE_URL);
+    } catch (err) {
+      console.error("Failed to open external components documentation:", err);
+      await error(t("pages.settings.advanced.openExternalComponentsDocsError"));
+    }
+  };
 
   return (
     <div className="p-4">
@@ -52,7 +63,7 @@ export const AdvancedSettings = () => {
           </div>
 
           <Button
-            onClick={() => openURL(EXTERNAL_COMPONENT_DOCS_BASE_URL)}
+            onClick={() => void handleOpenExternalComponentDocs()}
             type="button"
             variant="secondary"
           >

--- a/src/features/settings/components/advanced/AdvancedSettings.tsx
+++ b/src/features/settings/components/advanced/AdvancedSettings.tsx
@@ -1,6 +1,6 @@
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
-import { EXTERNAL_COMPONENT_DOCS_BASE_URL } from "@/components/shared/externalComponentGuidance";
+import { externalComponentGuidanceDocsBaseUrl } from "@/components/shared/externalComponentGuidance";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -11,7 +11,7 @@ import { openURL } from "@/lib/openUrl";
 import { ElevatedStartupModeToggle } from "./ElevatedStartupModeToggle";
 
 export const AdvancedSettings = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { error } = useTauriDialog();
   const [showGpuUsageSource, setShowGpuUsageSource, isPending] = useTauriStore(
     "showGpuUsageSource",
@@ -20,7 +20,11 @@ export const AdvancedSettings = () => {
 
   const handleOpenExternalComponentDocs = async () => {
     try {
-      await openURL(EXTERNAL_COMPONENT_DOCS_BASE_URL);
+      await openURL(
+        externalComponentGuidanceDocsBaseUrl(
+          i18n.resolvedLanguage ?? i18n.language,
+        ),
+      );
     } catch (err) {
       console.error("Failed to open external components documentation:", err);
       await error(t("pages.settings.advanced.openExternalComponentsDocsError"));

--- a/src/features/settings/components/advanced/AdvancedSettings.tsx
+++ b/src/features/settings/components/advanced/AdvancedSettings.tsx
@@ -1,8 +1,12 @@
+import { ArrowSquareOutIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
+import { EXTERNAL_COMPONENT_DOCS_BASE_URL } from "@/components/shared/externalComponentGuidance";
+import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { useTauriStore } from "@/hooks/useTauriStore";
+import { openURL } from "@/lib/openUrl";
 
 export const AdvancedSettings = () => {
   const { t } = useTranslation();
@@ -36,6 +40,25 @@ export const AdvancedSettings = () => {
           ) : (
             <Skeleton className="h-6 w-11 rounded-full" />
           )}
+        </div>
+        <div className="flex w-full flex-col items-start gap-4 py-6 sm:flex-row sm:items-center sm:justify-between xl:w-1/2">
+          <div className="space-y-0.5">
+            <Label className="text-lg">
+              {t("pages.settings.advanced.externalComponents")}
+            </Label>
+            <p className="text-muted-foreground text-sm">
+              {t("pages.settings.advanced.externalComponentsDescription")}
+            </p>
+          </div>
+
+          <Button
+            onClick={() => openURL(EXTERNAL_COMPONENT_DOCS_BASE_URL)}
+            type="button"
+            variant="secondary"
+          >
+            {t("pages.settings.advanced.openExternalComponentsDocs")}
+            <ArrowSquareOutIcon size={16} />
+          </Button>
         </div>
       </div>
     </div>

--- a/src/features/settings/hooks/useSettingsAtom.ts
+++ b/src/features/settings/hooks/useSettingsAtom.ts
@@ -49,6 +49,9 @@ const settingsAtom = atom<ClientSettings>({
   textSelectable: false,
   closeToTray: false,
   closeToTrayChoiceMade: false,
+  externalComponentGuidance: {
+    acknowledgedKeys: [],
+  },
   trayWidget: {
     enabled: false,
     metricOrder: ["cpu", "gpu", "gpu-temp"],
@@ -69,6 +72,7 @@ export const useSettingsAtom = () => {
       | "storageHealth"
       | "closeToTray"
       | "closeToTrayChoiceMade"
+      | "externalComponentGuidance"
       | "trayWidget"
     >]: (value: ClientSettings[K]) => Promise<Result<null, string>>;
   } = {
@@ -130,6 +134,7 @@ export const useSettingsAtom = () => {
       | "storageHealth"
       | "closeToTray"
       | "closeToTrayChoiceMade"
+      | "externalComponentGuidance"
       | "trayWidget"
     >,
   >(

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -432,7 +432,8 @@
         "showGpuUsageSourceDescription": "Display the data source (NVAPI, ADL, WMI, etc.) used to retrieve GPU usage on the dashboard.",
         "externalComponents": "External components",
         "externalComponentsDescription": "View setup guidance for optional components such as PawnIO and smartctl.",
-        "openExternalComponentsDocs": "Open docs"
+        "openExternalComponentsDocs": "Open docs",
+        "openExternalComponentsDocsError": "Failed to open external components documentation."
       }
     },
     "updater": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -165,11 +165,11 @@
   },
 
   "externalComponentGuidance": {
-    "title": "Additional component needed",
+    "title": "Optional components can enable more data",
     "labels": {
-      "missing": "What is missing",
-      "impact": "What cannot be collected",
-      "action": "What you can do"
+      "missing": "Missing component",
+      "impact": "Items that cannot be shown",
+      "action": "Required action"
     },
     "actions": {
       "openDetails": "Open details",
@@ -179,18 +179,18 @@
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
-        "missing": "PawnIO is not available for CPU package temperature collection.",
-        "impact": "CPU package temperature cannot be shown because the ACPI fallback did not provide a CPU temperature.",
+        "missing": "PawnIO",
+        "impact": "CPU package temperature",
         "action": "Install PawnIO, then restart HardwareVisualizer. The details page explains where to get it and where it must be placed."
       },
       "smartctlStorageHealth": {
-        "missing": "smartctl is not available or could not be used for Storage Health collection.",
-        "impact": "Some health-classification signals, such as SMART health, temperature, wear, spare, sector, or media-error data, cannot be collected.",
+        "missing": "smartctl (smartmontools)",
+        "impact": "Storage Health data such as SMART health, temperature, wear, spare, sector, or media-error signals",
         "action": "Install smartmontools and make smartctl available from the command line, then restart HardwareVisualizer."
       },
       "generic": {
-        "missing": "An optional external component is not available.",
-        "impact": "Some hardware details cannot be collected.",
+        "missing": "Optional external component",
+        "impact": "Some hardware details",
         "action": "Open the details page and follow the installation guidance for the missing component."
       }
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -173,8 +173,9 @@
     },
     "actions": {
       "openDetails": "Open details",
-      "later": "Later",
-      "acknowledge": "OK"
+      "hide": "Hide",
+      "hideThisSession": "Hide for this session",
+      "neverShowAgain": "Never show again"
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
@@ -428,7 +429,10 @@
       "advanced": {
         "name": "Advanced",
         "showGpuUsageSource": "Show GPU Usage Source",
-        "showGpuUsageSourceDescription": "Display the data source (NVAPI, ADL, WMI, etc.) used to retrieve GPU usage on the dashboard."
+        "showGpuUsageSourceDescription": "Display the data source (NVAPI, ADL, WMI, etc.) used to retrieve GPU usage on the dashboard.",
+        "externalComponents": "External components",
+        "externalComponentsDescription": "View setup guidance for optional components such as PawnIO and smartctl.",
+        "openExternalComponentsDocs": "Open docs"
       }
     },
     "updater": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -164,6 +164,42 @@
     }
   },
 
+  "externalComponentGuidance": {
+    "title": "Additional component needed",
+    "labels": {
+      "missing": "What is missing",
+      "impact": "What cannot be collected",
+      "action": "What you can do"
+    },
+    "actions": {
+      "openDetails": "Open details",
+      "later": "Later",
+      "acknowledge": "OK"
+    },
+    "candidates": {
+      "pawnioCpuPackageTemperature": {
+        "missing": "PawnIO is not available for CPU package temperature collection.",
+        "impact": "CPU package temperature cannot be shown because the ACPI fallback did not provide a CPU temperature.",
+        "action": "Install PawnIO, then restart HardwareVisualizer. The details page explains where to get it and where it must be placed."
+      },
+      "smartctlStorageHealth": {
+        "missing": "smartctl is not available or could not be used for Storage Health collection.",
+        "impact": "Some health-classification signals, such as SMART health, temperature, wear, spare, sector, or media-error data, cannot be collected.",
+        "action": "Install smartmontools and make smartctl available from the command line, then restart HardwareVisualizer."
+      },
+      "generic": {
+        "missing": "An optional external component is not available.",
+        "impact": "Some hardware details cannot be collected.",
+        "action": "Open the details page and follow the installation guidance for the missing component."
+      }
+    },
+    "errors": {
+      "acknowledge": "Failed to save this guidance preference.",
+      "defer": "Failed to hide this guidance for the current session.",
+      "openDetails": "Failed to open the details page."
+    }
+  },
+
   "pages": {
     "dashboard": {
       "name": "Dashboard",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -165,11 +165,11 @@
   },
 
   "externalComponentGuidance": {
-    "title": "追加コンポーネントが必要です",
+    "title": "任意の追加コンポーネントで表示できる項目があります",
     "labels": {
-      "missing": "何が不足しているか",
-      "impact": "何が取れないか",
-      "action": "ユーザーが何をすればよいか"
+      "missing": "不足コンポーネント",
+      "impact": "表示できなくなる項目",
+      "action": "必要なアクション"
     },
     "actions": {
       "openDetails": "詳細を開く",
@@ -179,18 +179,18 @@
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
-        "missing": "CPU パッケージ温度の取得に必要な PawnIO を利用できません。",
-        "impact": "ACPI fallback でも CPU 温度を取得できなかったため、CPU パッケージ温度を表示できません。",
+        "missing": "PawnIO",
+        "impact": "CPU パッケージ温度",
         "action": "PawnIO をインストールし、HardwareVisualizer を再起動してください。入手先と配置場所は詳細ページで確認できます。"
       },
       "smartctlStorageHealth": {
-        "missing": "Storage Health の取得に必要な smartctl を利用できないか、実行に失敗しました。",
-        "impact": "SMART 全体健康状態、温度、使用率、予備領域、セクター、メディアエラーなどの健康判定用 signal の一部を取得できません。",
+        "missing": "smartctl（smartmontools）",
+        "impact": "Storage Health の SMART 健康状態、温度、使用率、予備領域、セクター、メディアエラーなど",
         "action": "smartmontools をインストールし、コマンドラインから smartctl を実行できるようにしてから HardwareVisualizer を再起動してください。"
       },
       "generic": {
-        "missing": "任意の外部コンポーネントを利用できません。",
-        "impact": "一部のハードウェア詳細を取得できません。",
+        "missing": "任意の外部コンポーネント",
+        "impact": "一部のハードウェア詳細",
         "action": "詳細ページを開き、不足しているコンポーネントの導入手順を確認してください。"
       }
     },

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -432,7 +432,8 @@
         "showGpuUsageSourceDescription": "ダッシュボードにGPU使用率の取得ソース（NVAPI、ADL、WMI等）を表示します。",
         "externalComponents": "外部コンポーネント",
         "externalComponentsDescription": "PawnIO や smartctl などの任意コンポーネントの導入手順を確認します。",
-        "openExternalComponentsDocs": "ドキュメントを開く"
+        "openExternalComponentsDocs": "ドキュメントを開く",
+        "openExternalComponentsDocsError": "外部コンポーネントのドキュメントを開けませんでした。"
       }
     },
     "updater": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -164,6 +164,42 @@
     }
   },
 
+  "externalComponentGuidance": {
+    "title": "追加コンポーネントが必要です",
+    "labels": {
+      "missing": "何が不足しているか",
+      "impact": "何が取れないか",
+      "action": "ユーザーが何をすればよいか"
+    },
+    "actions": {
+      "openDetails": "詳細を開く",
+      "later": "あとで",
+      "acknowledge": "了解"
+    },
+    "candidates": {
+      "pawnioCpuPackageTemperature": {
+        "missing": "CPU パッケージ温度の取得に必要な PawnIO を利用できません。",
+        "impact": "ACPI fallback でも CPU 温度を取得できなかったため、CPU パッケージ温度を表示できません。",
+        "action": "PawnIO をインストールし、HardwareVisualizer を再起動してください。入手先と配置場所は詳細ページで確認できます。"
+      },
+      "smartctlStorageHealth": {
+        "missing": "Storage Health の取得に必要な smartctl を利用できないか、実行に失敗しました。",
+        "impact": "SMART 全体健康状態、温度、使用率、予備領域、セクター、メディアエラーなどの健康判定用 signal の一部を取得できません。",
+        "action": "smartmontools をインストールし、コマンドラインから smartctl を実行できるようにしてから HardwareVisualizer を再起動してください。"
+      },
+      "generic": {
+        "missing": "任意の外部コンポーネントを利用できません。",
+        "impact": "一部のハードウェア詳細を取得できません。",
+        "action": "詳細ページを開き、不足しているコンポーネントの導入手順を確認してください。"
+      }
+    },
+    "errors": {
+      "acknowledge": "この案内の設定を保存できませんでした。",
+      "defer": "このセッションで案内を非表示にできませんでした。",
+      "openDetails": "詳細ページを開けませんでした。"
+    }
+  },
+
   "pages": {
     "dashboard": {
       "name": "ダッシュボード",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -173,8 +173,9 @@
     },
     "actions": {
       "openDetails": "詳細を開く",
-      "later": "あとで",
-      "acknowledge": "了解"
+      "hide": "表示しない",
+      "hideThisSession": "このセッションでは表示しない",
+      "neverShowAgain": "二度と表示しない"
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
@@ -428,7 +429,10 @@
       "advanced": {
         "name": "高度な設定",
         "showGpuUsageSource": "GPU使用率の取得ソースを表示",
-        "showGpuUsageSourceDescription": "ダッシュボードにGPU使用率の取得ソース（NVAPI、ADL、WMI等）を表示します。"
+        "showGpuUsageSourceDescription": "ダッシュボードにGPU使用率の取得ソース（NVAPI、ADL、WMI等）を表示します。",
+        "externalComponents": "外部コンポーネント",
+        "externalComponentsDescription": "PawnIO や smartctl などの任意コンポーネントの導入手順を確認します。",
+        "openExternalComponentsDocs": "ドキュメントを開く"
       }
     },
     "updater": {

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -153,6 +153,42 @@
     }
   },
 
+  "externalComponentGuidance": {
+    "title": "Additional component needed",
+    "labels": {
+      "missing": "What is missing",
+      "impact": "What cannot be collected",
+      "action": "What you can do"
+    },
+    "actions": {
+      "openDetails": "Open details",
+      "later": "Later",
+      "acknowledge": "OK"
+    },
+    "candidates": {
+      "pawnioCpuPackageTemperature": {
+        "missing": "PawnIO is not available for CPU package temperature collection.",
+        "impact": "CPU package temperature cannot be shown because the ACPI fallback did not provide a CPU temperature.",
+        "action": "Install PawnIO, then restart HardwareVisualizer. The details page explains where to get it and where it must be placed."
+      },
+      "smartctlStorageHealth": {
+        "missing": "smartctl is not available or could not be used for Storage Health collection.",
+        "impact": "Some health-classification signals, such as SMART health, temperature, wear, spare, sector, or media-error data, cannot be collected.",
+        "action": "Install smartmontools and make smartctl available from the command line, then restart HardwareVisualizer."
+      },
+      "generic": {
+        "missing": "An optional external component is not available.",
+        "impact": "Some hardware details cannot be collected.",
+        "action": "Open the details page and follow the installation guidance for the missing component."
+      }
+    },
+    "errors": {
+      "acknowledge": "Failed to save this guidance preference.",
+      "defer": "Failed to hide this guidance for the current session.",
+      "openDetails": "Failed to open the details page."
+    }
+  },
+
   "pages": {
     "dashboard": {
       "name": "Главная",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -154,39 +154,39 @@
   },
 
   "externalComponentGuidance": {
-    "title": "Additional component needed",
+    "title": "Требуется дополнительный компонент",
     "labels": {
-      "missing": "What is missing",
-      "impact": "What cannot be collected",
-      "action": "What you can do"
+      "missing": "Что отсутствует",
+      "impact": "Что не удается собрать",
+      "action": "Что можно сделать"
     },
     "actions": {
-      "openDetails": "Open details",
-      "hide": "Hide",
-      "hideThisSession": "Hide for this session",
-      "neverShowAgain": "Never show again"
+      "openDetails": "Открыть подробности",
+      "hide": "Скрыть",
+      "hideThisSession": "Скрыть в этом сеансе",
+      "neverShowAgain": "Больше не показывать"
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
-        "missing": "PawnIO is not available for CPU package temperature collection.",
-        "impact": "CPU package temperature cannot be shown because the ACPI fallback did not provide a CPU temperature.",
-        "action": "Install PawnIO, then restart HardwareVisualizer. The details page explains where to get it and where it must be placed."
+        "missing": "PawnIO недоступен для сбора температуры пакета ЦП.",
+        "impact": "Температура пакета ЦП не может быть показана, потому что резервный сбор через ACPI не предоставил температуру ЦП.",
+        "action": "Установите PawnIO, затем перезапустите HardwareVisualizer. На странице подробностей указано, где его получить и куда поместить."
       },
       "smartctlStorageHealth": {
-        "missing": "smartctl is not available or could not be used for Storage Health collection.",
-        "impact": "Some health-classification signals, such as SMART health, temperature, wear, spare, sector, or media-error data, cannot be collected.",
-        "action": "Install smartmontools and make smartctl available from the command line, then restart HardwareVisualizer."
+        "missing": "smartctl недоступен или не может использоваться для сбора состояния накопителей.",
+        "impact": "Некоторые сигналы классификации состояния, такие как SMART health, температура, износ, резерв, секторы или ошибки носителя, не могут быть собраны.",
+        "action": "Установите smartmontools и сделайте smartctl доступным из командной строки, затем перезапустите HardwareVisualizer."
       },
       "generic": {
-        "missing": "An optional external component is not available.",
-        "impact": "Some hardware details cannot be collected.",
-        "action": "Open the details page and follow the installation guidance for the missing component."
+        "missing": "Необязательный внешний компонент недоступен.",
+        "impact": "Некоторые сведения об оборудовании не могут быть собраны.",
+        "action": "Откройте страницу подробностей и следуйте инструкции по установке отсутствующего компонента."
       }
     },
     "errors": {
-      "acknowledge": "Failed to save this guidance preference.",
-      "defer": "Failed to hide this guidance for the current session.",
-      "openDetails": "Failed to open the details page."
+      "acknowledge": "Не удалось сохранить настройку этой подсказки.",
+      "defer": "Не удалось скрыть эту подсказку для текущего сеанса.",
+      "openDetails": "Не удалось открыть страницу подробностей."
     }
   },
 
@@ -400,9 +400,10 @@
         "name": "Расширенные",
         "showGpuUsageSource": "Показывать источник данных ГП",
         "showGpuUsageSourceDescription": "Отображать на главной панели источник данных (NVAPI, ADL, WMI и т.д.), используемый для получения информации о загрузке ГП.",
-        "externalComponents": "External components",
-        "externalComponentsDescription": "View setup guidance for optional components such as PawnIO and smartctl.",
-        "openExternalComponentsDocs": "Open docs"
+        "externalComponents": "Внешние компоненты",
+        "externalComponentsDescription": "Посмотрите инструкции по настройке необязательных компонентов, таких как PawnIO и smartctl.",
+        "openExternalComponentsDocs": "Открыть документацию",
+        "openExternalComponentsDocsError": "Не удалось открыть документацию по внешним компонентам."
       }
     },
     "updater": {

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -162,8 +162,9 @@
     },
     "actions": {
       "openDetails": "Open details",
-      "later": "Later",
-      "acknowledge": "OK"
+      "hide": "Hide",
+      "hideThisSession": "Hide for this session",
+      "neverShowAgain": "Never show again"
     },
     "candidates": {
       "pawnioCpuPackageTemperature": {
@@ -398,7 +399,10 @@
       "advanced": {
         "name": "Расширенные",
         "showGpuUsageSource": "Показывать источник данных ГП",
-        "showGpuUsageSourceDescription": "Отображать на главной панели источник данных (NVAPI, ADL, WMI и т.д.), используемый для получения информации о загрузке ГП."
+        "showGpuUsageSourceDescription": "Отображать на главной панели источник данных (NVAPI, ADL, WMI и т.д.), используемый для получения информации о загрузке ГП.",
+        "externalComponents": "External components",
+        "externalComponentsDescription": "View setup guidance for optional components such as PawnIO and smartctl.",
+        "openExternalComponentsDocs": "Open docs"
       }
     },
     "updater": {

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -95,6 +95,8 @@ export const commands = {
 	 *  native read path (displays fall back to the daily records).
 	 */
 	getLiveStorageHealth: () => typedError<LiveStorageHealth[], string>(__TAURI_INVOKE("get_live_storage_health")),
+	getExternalComponentGuidanceCandidates: (view: ExternalComponentGuidanceView) => typedError<ExternalComponentGuidanceCandidate[], string>(__TAURI_INVOKE("get_external_component_guidance_candidates", { view })),
+	deferExternalComponentGuidanceForSession: (key: string) => typedError<null, string>(__TAURI_INVOKE("defer_external_component_guidance_for_session", { key })),
 	// ## Get archived CPU/RAM records
 	getDataArchiveRecords: (hardwareType: DataArchiveHardwareType, dataStats: ArchiveDataStats, start: string, end: string) => typedError<ArchiveRecord[], string>(__TAURI_INVOKE("get_data_archive_records", { hardwareType, dataStats, start, end })),
 	// ## Get archived GPU records
@@ -145,6 +147,7 @@ export const commands = {
 	setTextSelectable: (newValue: boolean) => typedError<null, string>(__TAURI_INVOKE("set_text_selectable", { newValue })),
 	setTrayWidgetSettings: (newValue: TrayWidgetSettings_Deserialize) => typedError<null, string>(__TAURI_INVOKE("set_tray_widget_settings", { newValue })),
 	setCloseToTrayPreference: (newValue: boolean) => typedError<null, string>(__TAURI_INVOKE("set_close_to_tray_preference", { newValue })),
+	acknowledgeExternalComponentGuidanceKey: (key: string) => typedError<null, string>(__TAURI_INVOKE("acknowledge_external_component_guidance_key", { key })),
 	readLicenseFile: () => typedError<string, string>(__TAURI_INVOKE("read_license_file")),
 	readThirdPartyNoticesFile: () => typedError<string, string>(__TAURI_INVOKE("read_third_party_notices_file")),
 	openLicenseFilePath: () => typedError<null, string>(__TAURI_INVOKE("open_license_file_path")),
@@ -265,6 +268,7 @@ export type ClientSettings_Deserialize = {
 	textSelectable: boolean,
 	closeToTray: boolean,
 	closeToTrayChoiceMade: boolean,
+	externalComponentGuidance: ExternalComponentGuidanceSettings,
 	trayWidget: TrayWidgetSettings_Deserialize,
 };
 
@@ -298,6 +302,7 @@ export type ClientSettings_Serialize = {
 	textSelectable: boolean,
 	closeToTray: boolean,
 	closeToTrayChoiceMade: boolean,
+	externalComponentGuidance: ExternalComponentGuidanceSettings,
 	trayWidget: TrayWidgetSettings_Serialize,
 };
 
@@ -319,6 +324,28 @@ export type DownloadEvent = { event: "started"; data: {
 } } | { event: "progress"; data: {
 	chunkLength: string,
 } } | { event: "finished" };
+
+export type ExternalComponent = "pawnio" | "smartctl";
+
+export type ExternalComponentGuidanceCandidate = {
+	key: string,
+	component: ExternalComponent,
+	usage: ExternalComponentUsage,
+	reasonKind: ExternalComponentReasonKind,
+	missingSignals: string[],
+	affectedDeviceCount: number | null,
+	diagnosticDetail: string | null,
+};
+
+export type ExternalComponentGuidanceSettings = {
+	acknowledgedKeys?: string[],
+};
+
+export type ExternalComponentGuidanceView = "dashboard" | "cpuDetail" | "storageHealth";
+
+export type ExternalComponentReasonKind = "missing" | "permission" | "misconfigured" | "failed";
+
+export type ExternalComponentUsage = "cpuPackageTemperature" | "storageHealth";
 
 export type GpuArchiveDataType = "usage" | "temp" | "dedicatedMemory";
 


### PR DESCRIPTION
## Summary

Adds External Component Guidance for optional runtime components that were actually attempted, could not be used, and still leave user-visible hardware data unavailable after fallback collection.

- Adds structured Core guidance candidates for PawnIO CPU package temperature and smartctl Storage Health gaps.
- Persists acknowledged guidance keys in settings.json, keeps session-only suppression local to the current app session, and exposes typed Tauri commands for pending/defer/acknowledge flows.
- Adds the frontend guidance dialog with Open details plus a Hide menu for this session / never show again, and adds an Advanced Settings link to the external components documentation.
- Adds docs/user/external-components.md as the source document for the future website, with current GitHub docs links used by the app for now.

## Related Issues

Refs #1484
Refs #1635

## Type of Change

- [ ] Bug fix (fix/ branch)
- [x] New feature (feat/ branch)
- [ ] Refactoring (refactor/ branch)
- [ ] Documentation (docs/ branch)
- [ ] Dependencies update
- [ ] Other (chore/ branch)

## Screenshots / Videos

Not included. The dialog appears only after the relevant collector path records a missing optional component and fallback data is still incomplete.

## Test Plan

- [x] Manual testing
- [x] Unit tests

Validated with:

- cargo test -p hardviz-core
- cargo test -p hardware_visualizer -- --test-threads=1
- cargo test -p hardware_visualizer external_component_guidance -- --test-threads=1
- npm.cmd run format
- npm.cmd run lint
- npm.cmd test
- npm.cmd run build
- git diff --check
- UTF-8 JSON parse for src/lang/en.json, src/lang/ja.json, and src/lang/ru.json

Note: cargo test -p hardware_visualizer without --test-threads=1 still has existing settings-test contention because several tests write the same app-data settings.json concurrently. The sequential full crate run passes.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “External Component Guidance” dialog and UI/settings flow for optional runtime components, including Windows PawnIO CPU temperature and smartctl Storage Health guidance.
  * Guidance is surfaced after best-effort fallback still leaves hardware data unavailable; users can open, hide for the session, or suppress permanently (acknowledgements saved).
* **Bug Fixes**
  * Improved propagation of guidance candidates through metrics snapshots and persistence so UI and archived data remain consistent.
* **Documentation**
  * Added and expanded external-components setup/behavior guides and architecture notes.
* **Localization**
  * Added new end-user strings and settings copy (en/ja/ru) for guidance, actions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->