### PR TITLE
feat(ci): sign Windows installers with SSL.com eSigner

### DIFF
--- a/.github/scripts/sign-codesigntool.ps1
+++ b/.github/scripts/sign-codesigntool.ps1
@@ -29,6 +29,9 @@ $toolDir = $env:CODESIGNTOOL_DIR
 if (-not $toolDir) { throw "CODESIGNTOOL_DIR is not set" }
 if (-not $env:ES_USERNAME) { throw "ES_USERNAME is not set" }
 if (-not $env:ES_PASSWORD) { throw "ES_PASSWORD is not set" }
+# Required for non-interactive (headless CI) signing: without it CodeSignTool
+# blocks on a manual OTP prompt instead of generating the OTP from the secret.
+if (-not $env:ES_TOTP_SECRET) { throw "ES_TOTP_SECRET is not set" }
 
 $absInput = (Resolve-Path -LiteralPath $FilePath).Path
 
@@ -43,8 +46,9 @@ $signArgs = @(
   "-input_file_path=$absInput",
   "-output_dir_path=$outDir"
 )
-if ($env:ES_TOTP_SECRET) { $signArgs += "-totp_secret=$($env:ES_TOTP_SECRET)" }
-if ($env:CREDENTIAL_ID)  { $signArgs += "-credential_id=$($env:CREDENTIAL_ID)" }
+$signArgs += "-totp_secret=$($env:ES_TOTP_SECRET)"
+# credential_id is only required when the eSigner account has more than one certificate.
+if ($env:CREDENTIAL_ID) { $signArgs += "-credential_id=$($env:CREDENTIAL_ID)" }
 
 Write-Host "Signing with CodeSignTool: $absInput"
 

--- a/.github/scripts/sign-codesigntool.ps1
+++ b/.github/scripts/sign-codesigntool.ps1
@@ -1,0 +1,72 @@
+#!/usr/bin/env pwsh
+# Sign a single file with SSL.com eSigner CodeSignTool (cloud signing).
+#
+# This wrapper is invoked by Tauri's `bundle.windows.signCommand` with the file
+# to sign passed as the only argument (the `%1` placeholder). CodeSignTool does
+# not sign in place: it writes the signed file into an output *directory* and it
+# must be run from inside its own install directory. So we sign into a temporary
+# directory and then move the signed file back over the original path, which is
+# what Tauri expects `%1` to be after signing.
+#
+# Required environment variables (provided by the GitHub Actions workflow):
+#   CODESIGNTOOL_DIR - directory that contains CodeSignTool.bat
+#   ES_USERNAME      - SSL.com / eSigner account username
+#   ES_PASSWORD      - SSL.com / eSigner account password
+#   ES_TOTP_SECRET   - eSigner TOTP secret, enables non-interactive OTP generation
+#   CREDENTIAL_ID    - eSigner credential id (required when the account has >1 certificate)
+#
+# NOTE: secrets are passed to CodeSignTool.bat as CLI flags. Avoid using cmd.exe
+# special characters (& | < > ^ %) in the eSigner password to prevent quoting issues.
+
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$FilePath
+)
+
+$ErrorActionPreference = "Stop"
+
+$toolDir = $env:CODESIGNTOOL_DIR
+if (-not $toolDir) { throw "CODESIGNTOOL_DIR is not set" }
+if (-not $env:ES_USERNAME) { throw "ES_USERNAME is not set" }
+if (-not $env:ES_PASSWORD) { throw "ES_PASSWORD is not set" }
+
+$absInput = (Resolve-Path -LiteralPath $FilePath).Path
+
+$tempBase = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$outDir = Join-Path $tempBase ("codesign-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+$signArgs = @(
+  "sign",
+  "-username=$($env:ES_USERNAME)",
+  "-password=$($env:ES_PASSWORD)",
+  "-input_file_path=$absInput",
+  "-output_dir_path=$outDir"
+)
+if ($env:ES_TOTP_SECRET) { $signArgs += "-totp_secret=$($env:ES_TOTP_SECRET)" }
+if ($env:CREDENTIAL_ID)  { $signArgs += "-credential_id=$($env:CREDENTIAL_ID)" }
+
+Write-Host "Signing with CodeSignTool: $absInput"
+
+# CodeSignTool.bat can only run from inside its own directory.
+Push-Location $toolDir
+try {
+  & ".\CodeSignTool.bat" @signArgs
+  $code = $LASTEXITCODE
+}
+finally {
+  Pop-Location
+}
+
+$signedFile = Join-Path $outDir ([System.IO.Path]::GetFileName($absInput))
+
+# CodeSignTool sometimes exits 0 while printing an error and producing no output,
+# so verify the signed artifact actually exists before trusting the result.
+if ($code -ne 0 -or -not (Test-Path -LiteralPath $signedFile)) {
+  Remove-Item -Recurse -Force $outDir -ErrorAction SilentlyContinue
+  throw "CodeSignTool failed (exit code $code) for: $absInput"
+}
+
+Move-Item -LiteralPath $signedFile -Destination $absInput -Force
+Remove-Item -Recurse -Force $outDir -ErrorAction SilentlyContinue
+Write-Host "Signed: $absInput"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,11 +157,17 @@ jobs:
         run: |
           # Windows build bundles its own JRE, so no separate Java setup is needed.
           $version = "v1.3.2"
+          # SHA256 of the official CodeSignTool-v1.3.2-windows.zip asset, pinned for supply-chain integrity.
+          $expectedSha256 = "4afc32e8b7f79bbe1de7e4e7049aaad4e0f754357613b9bbec0e3052f06fd36b"
           $url = "https://github.com/SSLcom/CodeSignTool/releases/download/$version/CodeSignTool-$version-windows.zip"
           $zip = Join-Path $env:RUNNER_TEMP "codesigntool.zip"
           $dest = Join-Path $env:RUNNER_TEMP "codesigntool"
           Write-Host "Downloading CodeSignTool $version ..."
           Invoke-WebRequest -Uri $url -OutFile $zip
+          $actualSha256 = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            throw "CodeSignTool checksum mismatch: expected $expectedSha256, got $actualSha256"
+          }
           Expand-Archive -Path $zip -DestinationPath $dest -Force
           $bat = Get-ChildItem -Path $dest -Recurse -Filter "CodeSignTool.bat" | Select-Object -First 1
           if (-not $bat) { throw "CodeSignTool.bat not found after extracting $url" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,9 +137,11 @@ jobs:
           TAG="${GITHUB_REF_NAME}"      # v1.x.x
 
           if [ "${{ env.ENABLE_WINDOWS_SIGNING }}" = "true" ] && [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            # Use forward slashes so the path is safe inside the JSON signCommand.
+            WS="${GITHUB_WORKSPACE//\\//}"
             node .github/scripts/update-tauri-config.ts \
             --tag "$TAG" \
-            --sign "trusted-signing-cli -e https://eus.codesigning.azure.net/ -a hardware-monitor -c hv-certificate %1"
+            --sign "pwsh -NoProfile -ExecutionPolicy Bypass -File ${WS}/.github/scripts/sign-codesigntool.ps1 %1"
           elif [ "${{ runner.os }}" = "macOS" ]; then
             node .github/scripts/update-tauri-config.ts \
             --tag "$TAG" \
@@ -149,9 +151,22 @@ jobs:
             --tag "$TAG"
           fi
 
-      - name: Setup Azure Code Signing
+      - name: Setup CodeSignTool (SSL.com eSigner)
         if: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' }}
-        run: cargo install trusted-signing-cli
+        shell: pwsh
+        run: |
+          # Windows build bundles its own JRE, so no separate Java setup is needed.
+          $version = "v1.3.2"
+          $url = "https://github.com/SSLcom/CodeSignTool/releases/download/$version/CodeSignTool-$version-windows.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "codesigntool.zip"
+          $dest = Join-Path $env:RUNNER_TEMP "codesigntool"
+          Write-Host "Downloading CodeSignTool $version ..."
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          $bat = Get-ChildItem -Path $dest -Recurse -Filter "CodeSignTool.bat" | Select-Object -First 1
+          if (-not $bat) { throw "CodeSignTool.bat not found after extracting $url" }
+          "CODESIGNTOOL_DIR=$($bat.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "CODESIGNTOOL_DIR=$($bat.Directory.FullName)"
 
       - name: Setup Apple API Key for notarization
         if: runner.os == 'macOS'
@@ -175,9 +190,10 @@ jobs:
       - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AZURE_CLIENT_ID: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.AZURE_CLIENT_ID || '' }}
-          AZURE_CLIENT_SECRET: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.AZURE_CLIENT_SECRET || '' }}
-          AZURE_TENANT_ID: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.AZURE_TENANT_ID || '' }}
+          ES_USERNAME: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.ES_USERNAME || '' }}
+          ES_PASSWORD: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.ES_PASSWORD || '' }}
+          ES_TOTP_SECRET: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.ES_TOTP_SECRET || '' }}
+          CREDENTIAL_ID: ${{ env.ENABLE_WINDOWS_SIGNING == 'true' && matrix.platform == 'windows-latest' && secrets.CREDENTIAL_ID || '' }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,9 @@ jobs:
     permissions:
       contents: write
     env:
-      ENABLE_WINDOWS_SIGNING: false
+      # Toggle Windows code signing via the repository variable of the same name
+      # (Settings → Secrets and variables → Actions → Variables). Defaults to off.
+      ENABLE_WINDOWS_SIGNING: ${{ vars.ENABLE_WINDOWS_SIGNING || 'false' }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/internal/windows-code-signing-setup.md
+++ b/docs/internal/windows-code-signing-setup.md
@@ -1,0 +1,127 @@
+# Windows コード署名 (SSL.com eSigner) セットアップ手順
+
+このドキュメントでは、GitHub Actions で Windows 向けビルドに SSL.com eSigner の
+クラウド署名 (CodeSignTool) を適用するための手順を説明します。
+
+署名は Tauri の `bundle.windows.signCommand` に CodeSignTool を据える方式で行います。
+これにより NSIS (`.exe`) / MSI、およびインストーラ内部にネストされたバイナリが、
+単一の経路で署名されます。
+
+## 前提条件
+
+- SSL.com の **Individual Validation (IV)** コード署名証明書を保有していること。
+- その証明書が **eSigner クラウド署名 (Cloud Signing) に enroll 済み**であること。
+  - USB トークンに発行済みの証明書は後からクラウドへ移行できません。購入・発行の
+    段階で eSigner Cloud Signing オプションを選択しておく必要があります。
+- 2023-06-01 以降の CA/Browser Forum 要件によりコード署名鍵はハードウェア保管が
+  必須ですが、eSigner のクラウド HSM がこれを満たすため、USB トークンを CI に
+  配布せずヘッドレスで署名できます。
+
+## 1. eSigner 認証情報の取得
+
+ヘッドレス署名には次の 4 つが必要です。
+
+- **ユーザー名 / パスワード**: SSL.com アカウントの認証情報。
+- **credential_id**: 証明書が複数ある場合に必須（単一の場合は省略可）。
+- **TOTP secret**: 非対話で OTP を生成するためのシークレット。
+
+### TOTP secret の取得
+
+1. eSigner のポータルにログインする。
+2. 対象証明書の QR コードを表示する（登録 PIN の入力が必要）。
+3. QR コードの横に表示される **secret code** の値を控える。これが TOTP secret です。
+
+> 2FA アプリ (Authy 等) が QR コードから OTP を生成するのと同じ値です。CodeSignTool
+> はこの値を使って署名時に OTP を自動生成します。
+
+## 2. GitHub Secrets の設定
+
+GitHub リポジトリの **Settings > Secrets and variables > Actions** で以下のシークレットを追加します。
+
+| シークレット名   | 値                                                       |
+| ---------------- | -------------------------------------------------------- |
+| `ES_USERNAME`    | SSL.com / eSigner のユーザー名                           |
+| `ES_PASSWORD`    | SSL.com / eSigner のパスワード                           |
+| `ES_TOTP_SECRET` | 手順 1 で取得した TOTP secret                            |
+| `CREDENTIAL_ID`  | eSigner の credential ID（証明書が複数ある場合に必須）   |
+
+> パスワードに cmd.exe の特殊文字 (`& | < > ^ %`) を含めると署名ラッパー内の引数
+> 受け渡しで問題になり得るため、避けることを推奨します。
+
+## 3. 署名の有効化
+
+`.github/workflows/publish.yml` の `ENABLE_WINDOWS_SIGNING` を `true` にします
+（既定では安全のため `false`）。
+
+```yaml
+env:
+  ENABLE_WINDOWS_SIGNING: true
+```
+
+## 4. 仕組み
+
+- `Setup CodeSignTool (SSL.com eSigner)` ステップが CodeSignTool の Windows 版
+  (`v1.3.2`、JRE 同梱のため別途 Java 不要) を GitHub Releases から固定バージョンで
+  ダウンロード・展開し、`CODESIGNTOOL_DIR` を後続ステップへ公開します。
+- `update-tauri-config.ts --sign` が `tauri.conf.json` の
+  `bundle.windows.signCommand` に署名ラッパー
+  (`pwsh ... .github/scripts/sign-codesigntool.ps1 %1`) を注入します。
+- Tauri はビルド成果物ごとにこのラッパーを呼び出します。CodeSignTool は in-place
+  署名ではなく出力ディレクトリへ署名するため、ラッパーは一時ディレクトリへ署名した
+  うえで元のパスへ署名済みファイルを戻します。
+- この経路により、`tauri-action` のビルドで生成される NSIS (`.exe`) / MSI が
+  署名されます。
+- CodeSignTool はクラウド署名時に RFC 3161 タイムスタンプを自動付与します
+  （`tauri.conf.json` の `timestampUrl` は空のままで問題ありません）。
+
+## 5. 動作確認
+
+alpha または beta タグをプッシュして、`publish-tauri` の Windows ジョブが正常に
+完了することを確認します。
+
+```bash
+git tag v1.0.0-alpha.1
+git push origin v1.0.0-alpha.1
+```
+
+GitHub Actions のログで以下を確認します。
+
+- **Setup CodeSignTool**: ダウンロードに成功し、`CODESIGNTOOL_DIR=...` が出力されている。
+- **署名**: 成果物ごとに `Signing with CodeSignTool: ...` と `Signed: ...` が出力されている。
+
+ダウンロードした成果物の署名は Windows 上で確認できます。
+
+```powershell
+Get-AuthenticodeSignature .\HardwareVisualizer_x.x.x_x64_en-US.msi | Format-List
+signtool verify /pa /v .\HardwareVisualizer_x.x.x_x64-setup.exe
+```
+
+## トラブルシューティング
+
+### `invalid/expired OTP` 系のエラー
+
+- `ES_TOTP_SECRET` が QR コードの secret code と一致しているか確認する。
+- runner の時刻ずれがないか確認する（TOTP は時刻ベース）。
+
+### `ES_USERNAME is not set` / `ES_PASSWORD is not set`
+
+- シークレットが未設定、または `ENABLE_WINDOWS_SIGNING` が `false` のままになっていないか確認する。
+
+### `CodeSignTool failed (exit code ...)`
+
+- 認証情報・`credential_id`・証明書の eSigner enroll 状態を確認する。
+- `sign` コマンドは既定でマルウェアスキャンを行いません（スキャンは別コマンド
+  `scan_code`）。スキャン起因のブロックではないかも合わせて確認する。
+
+## ポリシー更新
+
+署名を有効化して署名付きリリースを公開したら、ルートの
+[`CODE_SIGNING_POLICY.md`](../../CODE_SIGNING_POLICY.md) の Windows の状態を
+「Pending」から実状（Signed / Authenticode）へ更新してください。
+
+## 参考 URL
+
+- eSigner (Cloud Signing): <https://www.ssl.com/products/software-integrity/signing-service/>
+- CodeSignTool コマンドガイド: <https://www.ssl.com/guide/esigner-codesigntool-command-guide/>
+- GitHub Actions 統合ガイド: <https://www.ssl.com/how-to/cloud-code-signing-integration-with-github-actions/>
+- Tauri Windows 署名: <https://v2.tauri.app/distribute/sign/windows/>

--- a/docs/internal/windows-code-signing-setup.md
+++ b/docs/internal/windows-code-signing-setup.md
@@ -62,7 +62,8 @@ env:
 
 - `Setup CodeSignTool (SSL.com eSigner)` ステップが CodeSignTool の Windows 版
   (`v1.3.2`、JRE 同梱のため別途 Java 不要) を GitHub Releases から固定バージョンで
-  ダウンロード・展開し、`CODESIGNTOOL_DIR` を後続ステップへ公開します。
+  ダウンロードし、SHA256 を検証してから展開し、`CODESIGNTOOL_DIR` を後続ステップへ
+  公開します。
 - `update-tauri-config.ts --sign` が `tauri.conf.json` の
   `bundle.windows.signCommand` に署名ラッパー
   (`pwsh ... .github/scripts/sign-codesigntool.ps1 %1`) を注入します。

--- a/docs/internal/windows-code-signing-setup.md
+++ b/docs/internal/windows-code-signing-setup.md
@@ -50,13 +50,12 @@ GitHub リポジトリの **Settings > Secrets and variables > Actions** で以�
 
 ## 3. 署名の有効化
 
-`.github/workflows/publish.yml` の `ENABLE_WINDOWS_SIGNING` を `true` にします
-（既定では安全のため `false`）。
+リポジトリ変数 `ENABLE_WINDOWS_SIGNING` を `true` にします
+（**Settings → Secrets and variables → Actions → Variables**）。ワークフローは
+`vars.ENABLE_WINDOWS_SIGNING` を参照し、未設定時は `false`（署名オフ）です。
 
-```yaml
-env:
-  ENABLE_WINDOWS_SIGNING: true
-```
+> 先に手順 2 の Secrets を設定してから有効化してください。Secrets 未設定のまま
+> 有効化すると、署名ステップが `ES_USERNAME is not set` 等で失敗します。
 
 ## 4. 仕組み
 


### PR DESCRIPTION
## Summary

Switches Windows code signing from the (disabled) Azure Trusted Signing path to **SSL.com eSigner** cloud signing, using an **Individual Validation (IV)** certificate.

Signing is wired through Tauri's `bundle.windows.signCommand`, so each artifact — the NSIS `.exe`, the MSI, and the binaries nested inside them — is signed during the bundle.

## How it works

- **`.github/scripts/sign-codesigntool.ps1`** (new): the `signCommand` wrapper. CodeSignTool signs into an output directory (not in place) and must run from its own folder, so the wrapper signs into a temp dir and moves the signed file back over the path Tauri passes as `%1`.
- **`.github/workflows/publish.yml`**:
  - `--sign` now injects `pwsh … sign-codesigntool.ps1 %1` into `signCommand`.
  - "Setup Azure Code Signing" → **"Setup CodeSignTool"**: downloads CodeSignTool `v1.3.2` (Windows build, JRE bundled — no separate Java needed) and exports `CODESIGNTOOL_DIR`.
  - `AZURE_*` env → `ES_USERNAME` / `ES_PASSWORD` / `ES_TOTP_SECRET` / `CREDENTIAL_ID`.
- **`docs/internal/windows-code-signing-setup.md`** (new): setup / activation guide.

## Why eSigner + IV works in CI

The post-2023 CA/Browser Forum rule requires hardware key storage for IV/OV/EV certs, but it is satisfied by eSigner's cloud HSM (no USB token). So an IV certificate enrolled in eSigner cloud signing can sign headlessly from GitHub Actions.

## Activation (follow-up, not in this PR)

1. Add repo secrets: `ES_USERNAME`, `ES_PASSWORD`, `ES_TOTP_SECRET`, `CREDENTIAL_ID`.
2. Flip `ENABLE_WINDOWS_SIGNING` to `true`.

The change is gated behind `ENABLE_WINDOWS_SIGNING` (still `false`), so this PR is a no-op for releases until the secrets are added.

## To verify on the first real signed run

- CodeSignTool throughput: each file is a cloud round-trip (sequential, not batch signing).
- The eSigner password should avoid cmd special characters (`& | < > ^ %`) because of the `CodeSignTool.bat` argument layer.

Follows #1681.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `ENABLE_WINDOWS_SIGNING` flag to control whether Windows builds perform code signing.
* **Chores**
  * Switched Windows code signing to SSL.com eSigner (CodeSignTool), using a dedicated signing wrapper script.
  * Improved workflow robustness by confirming the signed output file is actually generated.
* **Documentation**
  * Added internal guidance for setting up headless Windows signing in CI, including required secrets, verification steps, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->