### PR TITLE
feat(macos): implement motherboard info via system_profiler

### DIFF
--- a/core/src/infrastructure/providers/macos/mod.rs
+++ b/core/src/infrastructure/providers/macos/mod.rs
@@ -5,4 +5,5 @@ pub mod net_sys;
 pub mod smart;
 pub mod sysctl;
 pub mod system_profiler_displays;
+pub mod system_profiler_hardware;
 pub mod system_profiler_memory;

--- a/core/src/infrastructure/providers/macos/system_profiler_hardware.rs
+++ b/core/src/infrastructure/providers/macos/system_profiler_hardware.rs
@@ -1,0 +1,137 @@
+use serde_json::Value;
+
+/// Best-effort hardware overview details extracted from
+/// `system_profiler SPHardwareDataType -json`.
+///
+/// All fields are optional because the output shape can differ between Intel
+/// and Apple Silicon Macs, OS versions, and runtime environments. If a field
+/// cannot be extracted reliably, it stays as `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SpHardwareDetails {
+  /// Marketing model name, e.g. "MacBook Pro".
+  pub machine_name: Option<String>,
+  /// Model identifier, e.g. "Mac16,1".
+  pub machine_model: Option<String>,
+  /// Regional model / part number, e.g. "Z1DS000MAJ/A".
+  pub model_number: Option<String>,
+  /// System serial number, e.g. "K2QJ212W6H".
+  pub serial_number: Option<String>,
+  /// System firmware (boot ROM) version, e.g. "18000.120.36".
+  pub boot_rom_version: Option<String>,
+}
+
+/// Reads the raw JSON output of `system_profiler SPHardwareDataType -json`.
+///
+/// This is a low-level macOS hardware access helper that relies on an external
+/// command. The output shape can differ depending on the machine (e.g. Intel
+/// vs Apple Silicon), system settings, and runtime environment.
+pub fn get_raw_sphardware_json() -> Result<String, String> {
+  let output = std::process::Command::new("system_profiler")
+    .arg("SPHardwareDataType")
+    .arg("-json")
+    .output()
+    .map_err(|e| format!("Failed to execute system_profiler: {e}"))?;
+
+  if output.status.success() {
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+  } else {
+    Err(String::from_utf8_lossy(&output.stderr).to_string())
+  }
+}
+
+/// Parses `system_profiler SPHardwareDataType` JSON and extracts best-effort
+/// hardware overview details.
+///
+/// This parser intentionally tolerates missing fields and partial data.
+/// If a field cannot be extracted reliably, it stays as `None`.
+pub fn parse_sphardware_json(raw: &str) -> Result<SpHardwareDetails, String> {
+  let value: Value = serde_json::from_str(raw)
+    .map_err(|e| format!("Failed to parse system_profiler JSON: {e}"))?;
+
+  let item = value
+    .get("SPHardwareDataType")
+    .and_then(|v| v.as_array())
+    .and_then(|arr| arr.first())
+    .and_then(|v| v.as_object())
+    .ok_or_else(|| "system_profiler JSON missing SPHardwareDataType entry".to_string())?;
+
+  let str_field = |key: &str| -> Option<String> {
+    item
+      .get(key)
+      .and_then(|v| v.as_str())
+      .map(str::trim)
+      .filter(|s| !s.is_empty())
+      .map(str::to_string)
+  };
+
+  Ok(SpHardwareDetails {
+    machine_name: str_field("machine_name"),
+    machine_model: str_field("machine_model"),
+    model_number: str_field("model_number"),
+    serial_number: str_field("serial_number"),
+    boot_rom_version: str_field("boot_rom_version"),
+  })
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_sphardware_json_apple_silicon_shape_extracts_fields() {
+    let raw = r#"{
+      "SPHardwareDataType" : [
+        {
+          "_name" : "hardware_overview",
+          "boot_rom_version" : "18000.120.36",
+          "chip_type" : "Apple M4",
+          "machine_model" : "Mac16,1",
+          "machine_name" : "MacBook Pro",
+          "model_number" : "Z1DS000MAJ/A",
+          "physical_memory" : "24 GB",
+          "serial_number" : "K2QJ212W6H"
+        }
+      ]
+    }"#;
+
+    let details = parse_sphardware_json(raw).expect("parse should succeed");
+    assert_eq!(details.machine_name.as_deref(), Some("MacBook Pro"));
+    assert_eq!(details.machine_model.as_deref(), Some("Mac16,1"));
+    assert_eq!(details.model_number.as_deref(), Some("Z1DS000MAJ/A"));
+    assert_eq!(details.serial_number.as_deref(), Some("K2QJ212W6H"));
+    assert_eq!(details.boot_rom_version.as_deref(), Some("18000.120.36"));
+  }
+
+  #[test]
+  fn parse_sphardware_json_missing_fields_stay_none() {
+    let raw = r#"{
+      "SPHardwareDataType" : [
+        {
+          "_name" : "hardware_overview",
+          "machine_name" : "MacBook Pro",
+          "serial_number" : "   "
+        }
+      ]
+    }"#;
+
+    let details = parse_sphardware_json(raw).expect("parse should succeed");
+    assert_eq!(details.machine_name.as_deref(), Some("MacBook Pro"));
+    assert_eq!(details.machine_model, None);
+    assert_eq!(details.model_number, None);
+    // Whitespace-only values are treated as missing.
+    assert_eq!(details.serial_number, None);
+    assert_eq!(details.boot_rom_version, None);
+  }
+
+  #[test]
+  fn parse_sphardware_json_missing_array_errors() {
+    let raw = r#"{ "SPSomethingElse" : [] }"#;
+    assert!(parse_sphardware_json(raw).is_err());
+  }
+
+  #[test]
+  fn get_raw_sphardware_json_runs_on_macos() {
+    let raw = get_raw_sphardware_json().expect("system_profiler should run");
+    assert!(raw.contains("SPHardwareDataType"));
+  }
+}

--- a/core/src/platform/macos/mod.rs
+++ b/core/src/platform/macos/mod.rs
@@ -10,6 +10,7 @@ use tokio::task;
 
 mod gpu;
 pub mod memory;
+pub mod motherboard;
 pub mod network;
 
 pub struct MacOSPlatform;
@@ -94,9 +95,7 @@ impl MotherboardPlatform for MacOSPlatform {
         + '_,
     >,
   > {
-    Box::pin(async {
-      Err("get_motherboard_info is not implemented for MacOSPlatform".to_string())
-    })
+    motherboard::get_motherboard_info()
   }
 }
 

--- a/core/src/platform/macos/motherboard.rs
+++ b/core/src/platform/macos/motherboard.rs
@@ -1,0 +1,121 @@
+use crate::infrastructure::providers::macos::system_profiler_hardware::{
+  self, SpHardwareDetails,
+};
+use crate::models::hardware::MotherboardInfo;
+use std::future::Future;
+use std::pin::Pin;
+
+/// macOS does not expose a baseboard / BIOS pair, so both the board and
+/// firmware vendor are reported as Apple.
+const APPLE_MANUFACTURER: &str = "Apple Inc.";
+
+/// Returns motherboard / firmware information on macOS.
+///
+/// macOS has no Windows-style `Win32_BaseBoard` + `Win32_BIOS` data. We map the
+/// `system_profiler SPHardwareDataType` hardware overview onto the shared
+/// [`MotherboardInfo`] shape on a best-effort basis:
+///
+/// - `manufacturer` / `bios_vendor` are always `"Apple Inc."`.
+/// - `product` is the marketing model name (e.g. "MacBook Pro"), falling back
+///   to the model identifier when the name is unavailable.
+/// - `version` is the model identifier (e.g. "Mac16,1").
+/// - `serial_number` is the system serial number.
+/// - `bios_version` is the system firmware (boot ROM) version.
+/// - `bios_release_date` is left empty (macOS does not expose it).
+pub fn get_motherboard_info()
+-> Pin<Box<dyn Future<Output = Result<MotherboardInfo, String>> + Send>> {
+  Box::pin(async {
+    tokio::task::spawn_blocking(collect_motherboard_info)
+      .await
+      .map_err(|e| format!("Join error: {e}"))?
+  })
+}
+
+fn collect_motherboard_info() -> Result<MotherboardInfo, String> {
+  let raw = system_profiler_hardware::get_raw_sphardware_json()?;
+  let details = system_profiler_hardware::parse_sphardware_json(&raw)?;
+  Ok(map_motherboard_info(details))
+}
+
+/// Maps best-effort `system_profiler` hardware details onto [`MotherboardInfo`].
+///
+/// `product` prefers the human-readable model name and `version` carries the
+/// model identifier. When only the model identifier is available it is used as
+/// the product, and `version` is left empty to avoid showing the same value
+/// twice (the UI hides empty versions).
+fn map_motherboard_info(details: SpHardwareDetails) -> MotherboardInfo {
+  let (product, version) = match (details.machine_name, details.machine_model) {
+    (Some(name), Some(model)) => (name, model),
+    (Some(name), None) => (name, String::new()),
+    (None, Some(model)) => (model, String::new()),
+    (None, None) => (String::new(), String::new()),
+  };
+
+  MotherboardInfo {
+    manufacturer: APPLE_MANUFACTURER.to_string(),
+    product,
+    version,
+    serial_number: details.serial_number.unwrap_or_default(),
+    bios_vendor: APPLE_MANUFACTURER.to_string(),
+    bios_version: details.boot_rom_version.unwrap_or_default(),
+    bios_release_date: String::new(),
+  }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn map_motherboard_info_full_details() {
+    let details = SpHardwareDetails {
+      machine_name: Some("MacBook Pro".to_string()),
+      machine_model: Some("Mac16,1".to_string()),
+      model_number: Some("Z1DS000MAJ/A".to_string()),
+      serial_number: Some("K2QJ212W6H".to_string()),
+      boot_rom_version: Some("18000.120.36".to_string()),
+    };
+
+    let info = map_motherboard_info(details);
+    assert_eq!(info.manufacturer, "Apple Inc.");
+    assert_eq!(info.product, "MacBook Pro");
+    assert_eq!(info.version, "Mac16,1");
+    assert_eq!(info.serial_number, "K2QJ212W6H");
+    assert_eq!(info.bios_vendor, "Apple Inc.");
+    assert_eq!(info.bios_version, "18000.120.36");
+    assert_eq!(info.bios_release_date, "");
+  }
+
+  #[test]
+  fn map_motherboard_info_model_only_avoids_duplicate_version() {
+    let details = SpHardwareDetails {
+      machine_name: None,
+      machine_model: Some("Mac16,1".to_string()),
+      ..SpHardwareDetails::default()
+    };
+
+    let info = map_motherboard_info(details);
+    assert_eq!(info.product, "Mac16,1");
+    assert_eq!(info.version, "");
+  }
+
+  #[test]
+  fn map_motherboard_info_missing_details_default_to_empty() {
+    let info = map_motherboard_info(SpHardwareDetails::default());
+    assert_eq!(info.manufacturer, "Apple Inc.");
+    assert_eq!(info.product, "");
+    assert_eq!(info.version, "");
+    assert_eq!(info.serial_number, "");
+    assert_eq!(info.bios_version, "");
+  }
+
+  #[tokio::test]
+  async fn get_motherboard_info_returns_apple_manufacturer() {
+    let info = get_motherboard_info()
+      .await
+      .expect("get_motherboard_info should succeed on macOS");
+    assert_eq!(info.manufacturer, "Apple Inc.");
+    assert_eq!(info.bios_vendor, "Apple Inc.");
+    assert!(!info.serial_number.is_empty());
+  }
+}

--- a/src/features/hardware/dashboard/Dashboard.tsx
+++ b/src/features/hardware/dashboard/Dashboard.tsx
@@ -106,7 +106,8 @@ export const Dashboard = () => {
     },
     motherboard: {
       icon: <DesktopIcon size={24} color="oklch(70% 0.14 150)" />,
-      component: os === "windows" ? <MotherboardDataInfo /> : null,
+      component:
+        os === "windows" || os === "macos" ? <MotherboardDataInfo /> : null,
     },
   };
 

--- a/src/features/hardware/dashboard/components/DashboardItemSelector.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItemSelector.tsx
@@ -40,7 +40,7 @@ export const DashboardItemSelector = ({
   const items: DashboardSelectItemType[] = [
     "title",
     ...dashBoardItems.filter(
-      (item) => item !== "motherboard" || os === "windows",
+      (item) => item !== "motherboard" || os === "windows" || os === "macos",
     ),
   ];
 

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -943,7 +943,9 @@ export const MotherboardDataInfo = () => {
         [t("shared.serialNumber")]: mb.serialNumber,
         [t("shared.biosVendor")]: mb.biosVendor,
         [t("shared.biosVersion")]: mb.biosVersion,
-        [t("shared.biosReleaseDate")]: mb.biosReleaseDate,
+        ...(mb.biosReleaseDate
+          ? { [t("shared.biosReleaseDate")]: mb.biosReleaseDate }
+          : {}),
       }}
     />
   );


### PR DESCRIPTION
## Summary

Implements `get_motherboard_info` for macOS, which was previously an unimplemented stub that emitted `motherboard_info_failed - get_motherboard_info is not implemented for MacOSPlatform` on every startup.

macOS has no Windows-style `Win32_BaseBoard` + `Win32_BIOS` data, so we read the `system_profiler SPHardwareDataType -json` hardware overview and map it onto the shared `MotherboardInfo` shape on a best-effort basis:

- `manufacturer` / `bios_vendor` → `"Apple Inc."`
- `product` → marketing model name (e.g. `MacBook Pro`), falling back to the model identifier
- `version` → model identifier (e.g. `Mac16,1`)
- `serial_number` → system serial number
- `bios_version` → system firmware (boot ROM) version
- `bios_release_date` → left empty (macOS does not expose it)

Frontend: the motherboard dashboard item is now shown on macOS in addition to Windows. The BIOS release date row is hidden when empty. Linux remains stubbed and gated off.

### Architecture
- `core/src/infrastructure/providers/macos/system_profiler_hardware.rs` (new) — JSON fetch + pure parser (`SpHardwareDetails`)
- `core/src/platform/macos/motherboard.rs` (new) — maps `SpHardwareDetails` → `MotherboardInfo`
- `core/src/platform/macos/mod.rs` — wires the impl into `MotherboardPlatform`
- `Dashboard.tsx` / `DashboardItemSelector.tsx` — open the OS gate to macOS
- `DashboardItems.tsx` — hide empty BIOS release date row

## Related Issues

<!-- Follow-up to ongoing macOS hardware support. -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- N/A — verified via unit tests against real system_profiler output on Apple Silicon. -->

## Test Plan

- [x] Manual testing
- [x] Unit tests

Added unit tests:
- Parser: Apple Silicon shape extraction, missing fields stay `None`, missing array errors, live `system_profiler` invocation (macOS-gated)
- Mapping: full details, model-only avoids duplicate version, missing details default to empty, live `get_motherboard_info` returns Apple manufacturer

Verification (all green):
- `cargo test -p hardviz-core` — 8 added tests pass
- `cargo clippy -p hardviz-core --all-targets` — 0 warnings
- `tsc --noEmit` — 0 errors
- `biome check` (changed files) — clean
- `vitest` (useExportToClipboard) — 16 pass

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Motherboard information is now available on macOS. Users can view hardware details including machine name, model, serial number, and BIOS version on the hardware dashboard.

* **Improvements**
  * BIOS release date is now displayed only when available, reducing unnecessary empty fields in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->