### PR TITLE
fix(storage-health): tolerate missing table in latest_records

### DIFF
--- a/core/src/infrastructure/database/storage_health.rs
+++ b/core/src/infrastructure/database/storage_health.rs
@@ -54,7 +54,22 @@ pub async fn delete_old_data(retention_days: u32) -> Result<(), sqlx::Error> {
 
 pub async fn latest_records() -> Result<Vec<StorageHealthRecord>, sqlx::Error> {
   let pool = db::get_pool().await?;
-  let rows = sqlx::query(
+  latest_records_from_pool(&pool).await
+}
+
+/// Reads the most recent health record per active device.
+///
+/// The `storage_health_daily_records` table is created by an app-side
+/// migration. When a database predates that migration — e.g. an older build
+/// without the storage-health schema was the last to open this file — the
+/// table does not exist yet. In that case we return an empty result instead of
+/// surfacing a hard `no such table` error: there genuinely are no records, and
+/// the rows appear once the migration runs. This mirrors the startup preflight
+/// check, which also treats a missing migration table as compatible.
+async fn latest_records_from_pool(
+  pool: &sqlx::SqlitePool,
+) -> Result<Vec<StorageHealthRecord>, sqlx::Error> {
+  let rows = match sqlx::query(
     r#"
     SELECT
       s.device_id,
@@ -97,8 +112,13 @@ pub async fn latest_records() -> Result<Vec<StorageHealthRecord>, sqlx::Error> {
       display_name COLLATE NOCASE
     "#,
   )
-  .fetch_all(&pool)
-  .await?;
+  .fetch_all(pool)
+  .await
+  {
+    Ok(rows) => rows,
+    Err(error) if is_missing_table_error(&error) => return Ok(Vec::new()),
+    Err(error) => return Err(error),
+  };
 
   rows
     .into_iter()
@@ -277,6 +297,14 @@ async fn update_active_devices_in_transaction(
   Ok(())
 }
 
+/// Returns `true` when the error is SQLite's "no such table" error, signalling
+/// that the storage-health schema migration has not run against this database
+/// yet. Matched on the message string to stay consistent with the startup
+/// preflight check in `crate::persistence::preflight`.
+fn is_missing_table_error(error: &sqlx::Error) -> bool {
+  error.to_string().contains("no such table")
+}
+
 fn to_i64(value: Option<u64>) -> Option<i64> {
   value.and_then(|v| i64::try_from(v).ok())
 }
@@ -396,6 +424,23 @@ mod tests {
       warning_reasons: vec!["test reason".to_string()],
       collected_at: "2026-05-10T00:00:00Z".to_string(),
     }
+  }
+
+  #[tokio::test]
+  async fn latest_records_returns_empty_when_table_missing() {
+    // A database that predates the storage-health migration has no
+    // `storage_health_daily_records` table. Reading must degrade to an empty
+    // result rather than surfacing a hard `no such table` error. Uses a fresh
+    // in-memory pool to avoid touching the process-wide `db::init` path.
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+      .await
+      .expect("in-memory sqlite pool");
+
+    let records = latest_records_from_pool(&pool)
+      .await
+      .expect("missing table must not be an error");
+
+    assert!(records.is_empty());
   }
 
   #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the runtime error `Failed to fetch latest storage health records: error returned from database: (code: 1) no such table: storage_health_daily_records`.

### Root cause
The `storage_health_daily_records` table is created by an app-side migration (`tauri_plugin_sql` / `add_migrations`), which only runs when the startup DB-compatibility preflight passes (`is_db_ok`). The read command `get_storage_health_latest_records` is registered **unconditionally** and reads through Core's own `SqlitePool` (`db::get_pool`), which never runs migrations. When a database predates the storage-health migration (e.g. an older build was the last to open the file), the read fails with `no such table` and emits an ERROR log on every poll.

The write/live paths do not hit this: the live collector is only constructed inside the `is_db_ok` block, so it is absent (and returns early) when migrations have not run. The read path was the only reachable consumer of the un-migrated table.

### Fix
Treat a missing table as "no records yet" and return an empty result, mirroring the startup preflight check (`persistence::preflight`) which already treats a missing migration table as compatible. Real rows appear automatically once the migration runs against the database — no manual SQL or data migration required.

The query is extracted into `latest_records_from_pool` so the missing-table branch can be unit-tested against a fresh in-memory pool, without touching the process-wide `db::init` (`OnceLock`) state shared by the existing integration test.

### Scope note
This is the minimal, defensive fix for the reported symptom. The deeper asymmetry — migrations owned by `tauri_plugin_sql` (gated by `is_db_ok`) while Core reads through its own never-migrating pool — is intentionally left for a follow-up. With this guard the read degrades gracefully regardless of gating.

## Related Issues

<!-- Diagnosed alongside the macOS motherboard work; tracked separately. -->

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- N/A -->

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Added `latest_records_returns_empty_when_table_missing`: reads via a fresh in-memory pool with no schema and asserts an empty (non-error) result.

Verification (all green):
- `cargo test -p hardviz-core storage_health` — 27 pass (incl. new test)
- `cargo clippy --workspace -- -D warnings` — 0 warnings
- `cargo fmt --all -- --check` — clean
- `cargo tauri-test storage_health` — pass

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database resilience for storage health records, gracefully handling missing tables by returning empty data instead of errors during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->