### PR TITLE
fix(database): run schema migrations at startup via Core's migrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,17 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,12 +94,6 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -347,18 +330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,30 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
-name = "borsh"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,28 +392,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytemuck"
@@ -1445,12 +1370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,7 +1892,6 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
- "tauri-plugin-sql",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
@@ -1993,9 +1911,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3935,26 +3850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,12 +3890,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4233,15 +4122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4319,35 +4199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,23 +4216,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.6",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4577,12 +4411,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -5138,19 +4966,16 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rust_decimal",
  "rustls",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
  "thiserror 2.0.18",
- "time",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
- "uuid",
  "webpki-roots 0.26.11",
 ]
 
@@ -5224,7 +5049,6 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
- "rust_decimal",
  "serde",
  "sha1",
  "sha2",
@@ -5232,9 +5056,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.18",
- "time",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -5265,7 +5087,6 @@ dependencies = [
  "memchr",
  "once_cell",
  "rand 0.8.6",
- "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
@@ -5273,9 +5094,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.18",
- "time",
  "tracing",
- "uuid",
  "whoami",
 ]
 
@@ -5300,10 +5119,8 @@ dependencies = [
  "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
- "time",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -5524,12 +5341,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -5824,27 +5635,6 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
-]
-
-[[package]]
-name = "tauri-plugin-sql"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbdb4f17a7984ef0aa425b11e543a44d11f2fddbdee3fc61970091f8adfb914"
-dependencies = [
- "futures-core",
- "indexmap 2.14.0",
- "log",
- "rust_decimal",
- "serde",
- "serde_json",
- "sqlx",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -6781,7 +6571,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -7868,15 +7657,6 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ sqlx = { version = "0.8.6", features = [
     "runtime-tokio-rustls",
     "macros",
     "chrono",
+    "migrate",
 ] }
 
 [target.'cfg(windows)'.dependencies]

--- a/core/src/infrastructure/database/migrate.rs
+++ b/core/src/infrastructure/database/migrate.rs
@@ -1,0 +1,187 @@
+//! Schema migration runner executed against Core's own connection pool.
+//!
+//! Core owns the database path and pool ([`super::db`]), so it also owns
+//! applying schema migrations. App supplies the ordered migration set
+//! (see `src-tauri/src/infrastructure/database/migration.rs`) and calls
+//! [`run`] once at startup, before any persistence worker writes.
+//!
+//! This replaces the previous reliance on `tauri-plugin-sql` to apply
+//! migrations, which never ran: the database is never loaded through the
+//! plugin (there is no `preload` entry and the frontend never calls
+//! `Database.load`), so the registered migrations stayed dormant and any
+//! table added by a newer migration (e.g. `storage_devices`) was missing.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use sqlx::error::BoxDynError;
+use sqlx::migrate::{
+  Migration as SqlxMigration, MigrationSource, MigrationType, Migrator,
+};
+use sqlx::sqlite::SqlitePool;
+
+use super::db;
+
+/// One forward (`Up`) schema migration.
+///
+/// Deliberately mirrors the historical `tauri-plugin-sql` migration shape
+/// so the `sqlx` checksum of already-applied migrations keeps matching:
+/// the checksum is derived from `sql` alone, and migrations are resolved
+/// as [`MigrationType::ReversibleUp`] exactly as the plugin did. Existing
+/// databases carry `_sqlx_migrations` rows written by the plugin, so the
+/// SQL text of previously-applied versions must stay byte-identical.
+#[derive(Debug, Clone)]
+pub struct SchemaMigration {
+  pub version: i64,
+  pub description: &'static str,
+  pub sql: &'static str,
+}
+
+#[derive(Debug)]
+struct SchemaMigrationSource(Vec<SchemaMigration>);
+
+impl MigrationSource<'static> for SchemaMigrationSource {
+  fn resolve(
+    self,
+  ) -> Pin<
+    Box<dyn Future<Output = Result<Vec<SqlxMigration>, BoxDynError>> + Send + 'static>,
+  > {
+    Box::pin(async move {
+      let migrations = self
+        .0
+        .into_iter()
+        .map(|m| {
+          SqlxMigration::new(
+            m.version,
+            m.description.into(),
+            MigrationType::ReversibleUp,
+            m.sql.into(),
+            false,
+          )
+        })
+        .collect();
+      Ok(migrations)
+    })
+  }
+}
+
+/// Apply all pending migrations to the configured database.
+///
+/// Idempotent: `sqlx` records applied versions in `_sqlx_migrations` and
+/// skips them on subsequent runs. Must be called after [`db::init`] and
+/// before persistence workers start.
+pub async fn run(migrations: Vec<SchemaMigration>) -> Result<(), String> {
+  let pool = db::get_pool()
+    .await
+    .map_err(|e| format!("Failed to open database for migration: {e}"))?;
+  run_on_pool(&pool, migrations).await
+}
+
+/// Apply `migrations` to an already-open pool.
+///
+/// [`run`] is the production entry point — it opens Core's configured
+/// pool via [`db::get_pool`]. This variant lets callers supply their own
+/// pool (notably tests that run against a temporary database) without
+/// touching the process-wide [`db::init`] path.
+pub async fn run_on_pool(
+  pool: &SqlitePool,
+  migrations: Vec<SchemaMigration>,
+) -> Result<(), String> {
+  let migrator = Migrator::new(SchemaMigrationSource(migrations))
+    .await
+    .map_err(|e| format!("Failed to build migrator: {e}"))?;
+  migrator
+    .run(pool)
+    .await
+    .map_err(|e| format!("Failed to run migrations: {e}"))?;
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use sqlx::Row;
+  use sqlx::sqlite::SqlitePool;
+  use tempfile::NamedTempFile;
+
+  fn migrations() -> Vec<SchemaMigration> {
+    vec![
+      SchemaMigration {
+        version: 1,
+        description: "create_a",
+        sql: "CREATE TABLE a (id INTEGER PRIMARY KEY);",
+      },
+      SchemaMigration {
+        version: 2,
+        description: "create_b",
+        sql: "CREATE TABLE b (id INTEGER PRIMARY KEY);",
+      },
+    ]
+  }
+
+  async fn file_pool() -> (NamedTempFile, SqlitePool) {
+    let file = NamedTempFile::new().unwrap();
+    let url = format!("sqlite:{}", file.path().to_string_lossy());
+    let pool = SqlitePool::connect(&url).await.unwrap();
+    (file, pool)
+  }
+
+  async fn max_applied_version(pool: &SqlitePool) -> i64 {
+    let row: (Option<i64>,) =
+      sqlx::query_as("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    row.0.unwrap_or(0)
+  }
+
+  #[tokio::test]
+  async fn applies_pending_migrations() {
+    let (_file, pool) = file_pool().await;
+
+    run_on_pool(&pool, migrations()).await.unwrap();
+
+    let tables: Vec<String> = sqlx::query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('a', 'b') ORDER BY name",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|row| row.get::<String, _>("name"))
+    .collect();
+
+    assert_eq!(tables, vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(max_applied_version(&pool).await, 2);
+  }
+
+  #[tokio::test]
+  async fn reapplying_only_runs_new_migrations() {
+    let (_file, pool) = file_pool().await;
+
+    // Simulates the real upgrade path: an existing DB already at an older
+    // version is brought forward when a newer migration is appended.
+    run_on_pool(&pool, migrations()).await.unwrap();
+
+    let mut next = migrations();
+    next.push(SchemaMigration {
+      version: 3,
+      description: "create_c",
+      sql: "CREATE TABLE c (id INTEGER PRIMARY KEY);",
+    });
+
+    // Re-running with the unchanged v1/v2 SQL must not trip a checksum
+    // mismatch, and only v3 is applied.
+    run_on_pool(&pool, next).await.unwrap();
+
+    let has_c: (i64,) = sqlx::query_as(
+      "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = 'c'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(has_c.0, 1);
+    assert_eq!(max_applied_version(&pool).await, 3);
+  }
+}

--- a/core/src/infrastructure/database/mod.rs
+++ b/core/src/infrastructure/database/mod.rs
@@ -1,14 +1,16 @@
 //! SQLite-backed persistence used by [`crate::persistence`].
 //!
-//! The schema is owned by App-side migrations (Tauri's `tauri-plugin-sql`
-//! enforces them at startup), but every read / write that Core executes
-//! goes through this module. Callers initialize the database location
-//! once at startup via [`db::init`]; Core never resolves the path itself
-//! because path resolution depends on Tauri's bundle identifier.
+//! Core owns the database: callers initialize its location once at startup
+//! via [`db::init`] (Core never resolves the path itself because that
+//! depends on Tauri's bundle identifier), and Core applies the schema
+//! migrations through [`migrate::run`] before any worker writes. App owns
+//! the ordered migration definitions and hands them to the runner. Every
+//! read / write that Core executes goes through this module.
 
 pub mod archive_queries;
 pub mod db;
 pub mod gpu_archive;
 pub mod hardware_archive;
+pub mod migrate;
 pub mod process_stats;
 pub mod storage_health;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,6 @@ tauri-specta = { version = "=2.0.0-rc.24", features = ["derive", "typescript"] }
 specta-typescript = "0.0.11"
 specta = "=2.0.0-rc.24"
 tauri-plugin-shell = "2.3.5"
-tauri-plugin-sql = { version = "2.4.0", features = ["sqlite"] }
 sqlx = { version = "0.8.6", features = [
     "sqlite",
     "runtime-tokio-rustls",

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -57,7 +57,7 @@ src-tauri/src/
 ├── workers/              ← WorkersState — holds Core controller / adapter handles
 ├── tray/                 ← tray widget windows, surface helpers, and UI policy
 ├── infrastructure/       ← App-only DB code
-│   └── database/migration.rs   SQL migration definitions for tauri-plugin-sql
+│   └── database/migration.rs   SQL migration definitions (run by Core's migrator)
 ├── models/               ← App-side DTOs (HardwareMonitorUpdate, settings, storage health, …)
 ├── enums/                ← App-side enums (TemperatureUnit, hardware, settings, …)
 ├── utils/                ← App-side helpers (file paths, color, Tauri-aware logger)
@@ -111,7 +111,8 @@ Commands → Services → (Core API)         ─ App-owned
 The `platform/` and `infrastructure/providers/` directories that the
 architecture document references now live in [`core/src/`](../core); the
 App crate retains only the App-specific `infrastructure/database/`
-(migrations registered with `tauri-plugin-sql`).
+(the ordered schema migration definitions, executed at startup by Core's
+migrator in `hardviz_core::infrastructure::database::migrate`).
 
 ## Frontend integration
 

--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -1,30 +1,30 @@
-use tauri_plugin_sql::{Migration, MigrationKind};
+use hardviz_core::infrastructure::database::migrate::SchemaMigration;
 
 pub fn get_max_migration_version() -> i64 {
   get_migrations()
     .iter()
-    .filter(|m| matches!(m.kind, MigrationKind::Up))
     .map(|m| m.version)
     .max()
     .unwrap_or(0)
 }
 
-pub fn get_migrations() -> Vec<Migration> {
+/// Ordered forward migrations applied at startup by Core's migrator
+/// ([`hardviz_core::infrastructure::database::migrate::run`]). Append-only:
+/// the SQL of an already-released version must never change, or `sqlx`
+/// will reject it as a checksum mismatch on existing databases.
+pub fn get_migrations() -> Vec<SchemaMigration> {
   vec![
-    // Up Migrations
-    Migration {
+    SchemaMigration {
       version: 1,
       description: "create_initial_tables",
       sql: "CREATE TABLE DATA_ARCHIVE (id INTEGER PRIMARY KEY, cpu_avg INTEGER, cpu_max INTEGER, cpu_min INTEGER, ram_avg INTEGER, ram_max INTEGER, ram_min INTEGER, timestamp DATETIME);",
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 2,
       description: "create_gpu_tables",
       sql: "CREATE TABLE GPU_DATA_ARCHIVE (id INTEGER PRIMARY KEY, gpu_name TEXT, usage_avg INTEGER, usage_max INTEGER, usage_min INTEGER, temperature_avg INTEGER, temperature_max INTEGER, temperature_min INTEGER, timestamp DATETIME);",
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 3,
       description: "add_gpu_memory_usage_columns",
       sql: r#"
@@ -32,21 +32,18 @@ pub fn get_migrations() -> Vec<Migration> {
         ALTER TABLE GPU_DATA_ARCHIVE ADD COLUMN dedicated_memory_max INTEGER;
         ALTER TABLE GPU_DATA_ARCHIVE ADD COLUMN dedicated_memory_min INTEGER;
       "#,
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 4,
       description: "create_process_stats",
       sql: "CREATE TABLE PROCESS_STATS (id INTEGER PRIMARY KEY AUTOINCREMENT, pid INTEGER NOT NULL, process_name TEXT NOT NULL,  cpu_usage REAL NOT NULL,  memory_usage INTEGER NOT NULL, execution_sec INTEGER NOT NULL, timestamp DATETIME NOT NULL);",
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 5,
       description: "add_gpu_id_column",
       sql: "ALTER TABLE GPU_DATA_ARCHIVE ADD COLUMN gpu_id TEXT;",
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 6,
       description: "create_storage_smart_daily_snapshots",
       sql: r#"
@@ -84,53 +81,19 @@ pub fn get_migrations() -> Vec<Migration> {
           FOREIGN KEY(device_id) REFERENCES storage_devices(id)
         );
       "#,
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 7,
       description: "rename_storage_smart_daily_snapshots_to_storage_health_daily_records",
       sql: r#"
         ALTER TABLE storage_smart_daily_snapshots
         RENAME TO storage_health_daily_records;
       "#,
-      kind: MigrationKind::Up,
     },
-    Migration {
+    SchemaMigration {
       version: 8,
       description: "add_process_stats_timestamp_index",
       sql: "CREATE INDEX IF NOT EXISTS idx_process_stats_timestamp ON PROCESS_STATS(timestamp);",
-      kind: MigrationKind::Up,
-    },
-    // Down Migrations
-    Migration {
-      version: 4,
-      description: "drop_process_stats",
-      sql: "DROP TABLE IF EXISTS PROCESS_STATS;",
-      kind: MigrationKind::Down,
-    },
-    Migration {
-      version: 6,
-      description: "drop_storage_smart_daily_snapshots",
-      sql: r#"
-        DROP TABLE IF EXISTS storage_smart_daily_snapshots;
-        DROP TABLE IF EXISTS storage_devices;
-      "#,
-      kind: MigrationKind::Down,
-    },
-    Migration {
-      version: 7,
-      description: "rename_storage_health_daily_records_to_storage_smart_daily_snapshots",
-      sql: r#"
-        ALTER TABLE storage_health_daily_records
-        RENAME TO storage_smart_daily_snapshots;
-      "#,
-      kind: MigrationKind::Down,
-    },
-    Migration {
-      version: 8,
-      description: "drop_process_stats_timestamp_index",
-      sql: "DROP INDEX IF EXISTS idx_process_stats_timestamp;",
-      kind: MigrationKind::Down,
     },
   ]
 }
@@ -144,7 +107,7 @@ mod tests {
     let migrations = get_migrations();
     let v5 = migrations
       .iter()
-      .find(|m| m.version == 5 && matches!(m.kind, MigrationKind::Up))
+      .find(|m| m.version == 5)
       .expect("Version 5 up migration must exist");
     assert!(v5.sql.contains("gpu_id TEXT"));
     assert!(v5.sql.contains("GPU_DATA_ARCHIVE"));
@@ -155,7 +118,7 @@ mod tests {
     let migrations = get_migrations();
     let v6 = migrations
       .iter()
-      .find(|m| m.version == 6 && matches!(m.kind, MigrationKind::Up))
+      .find(|m| m.version == 6)
       .expect("Version 6 up migration must exist");
     assert!(v6.sql.contains("CREATE TABLE storage_devices"));
     assert!(
@@ -170,7 +133,7 @@ mod tests {
     let migrations = get_migrations();
     let v7 = migrations
       .iter()
-      .find(|m| m.version == 7 && matches!(m.kind, MigrationKind::Up))
+      .find(|m| m.version == 7)
       .expect("Version 7 up migration must exist");
     assert!(v7.sql.contains("ALTER TABLE storage_smart_daily_snapshots"));
     assert!(v7.sql.contains("RENAME TO storage_health_daily_records"));
@@ -181,7 +144,7 @@ mod tests {
     let migrations = get_migrations();
     let v8 = migrations
       .iter()
-      .find(|m| m.version == 8 && matches!(m.kind, MigrationKind::Up))
+      .find(|m| m.version == 8)
       .expect("Version 8 up migration must exist");
     assert!(v8.sql.contains("CREATE INDEX IF NOT EXISTS"));
     assert!(v8.sql.contains("idx_process_stats_timestamp"));
@@ -196,23 +159,55 @@ mod tests {
   #[test]
   fn migration_count() {
     let migrations = get_migrations();
-    let up_count = migrations
-      .iter()
-      .filter(|m| matches!(m.kind, MigrationKind::Up))
-      .count();
-    assert_eq!(up_count, 8);
+    assert_eq!(migrations.len(), 8);
   }
 
   #[test]
   fn migration_up_versions_sequential() {
     let migrations = get_migrations();
-    let mut up_versions: Vec<_> = migrations
-      .iter()
-      .filter(|m| matches!(m.kind, MigrationKind::Up))
-      .map(|m| m.version)
-      .collect();
+    let mut up_versions: Vec<_> = migrations.iter().map(|m| m.version).collect();
     up_versions.sort();
     let expected: Vec<i64> = (1..=up_versions.len() as i64).collect();
     assert_eq!(up_versions, expected);
+  }
+
+  /// Regression for the reported `no such table: storage_devices` insert
+  /// failure: applying the exact migration set the app ships must create the
+  /// storage-health tables and let the previously-failing insert succeed.
+  /// Guards against the migrations silently never running again.
+  #[tokio::test]
+  async fn shipped_migrations_create_storage_tables_and_allow_insert() {
+    use hardviz_core::infrastructure::database::migrate;
+    use sqlx::sqlite::SqlitePool;
+
+    // A file-backed (not `:memory:`) throwaway DB so every pooled connection
+    // shares the same schema the migrator just created.
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite:{}", file.path().to_string_lossy());
+    let pool = SqlitePool::connect(&url).await.unwrap();
+
+    migrate::run_on_pool(&pool, get_migrations())
+      .await
+      .expect("the shipped migration set must apply cleanly");
+
+    for table in ["storage_devices", "storage_health_daily_records"] {
+      let exists: (i64,) = sqlx::query_as(
+        "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = $1",
+      )
+      .bind(table)
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+      assert_eq!(exists.0, 1, "table `{table}` must exist after migrations");
+    }
+
+    // The exact statement shape that used to fail now succeeds.
+    sqlx::query(
+      "INSERT INTO storage_devices (id, display_name, first_seen_at, last_seen_at) \
+       VALUES ('disk-x', 'Disk X', '2026-06-21T00:00:00Z', '2026-06-21T00:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert into storage_devices must succeed after migrations");
   }
 }

--- a/src-tauri/src/infrastructure/database/mod.rs
+++ b/src-tauri/src/infrastructure/database/mod.rs
@@ -1,9 +1,11 @@
 //! Tauri-aware database glue.
 //!
-//! Schema migrations live here because they consume
-//! `tauri_plugin_sql::Migration`, which is App-only. Read/write
-//! workloads (archive writers, scheduled deletion, schema preflight)
-//! moved to [`hardviz_core::infrastructure::database`] and
+//! App owns the ordered schema migration definitions ([`migration`]).
+//! They are executed at startup by Core's migrator
+//! ([`hardviz_core::infrastructure::database::migrate`]) against Core's
+//! pool, before any persistence worker writes. Read/write workloads
+//! (archive writers, scheduled deletion, schema preflight) moved to
+//! [`hardviz_core::infrastructure::database`] and
 //! [`hardviz_core::persistence`] in #1407.
 
 pub mod migration;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,23 @@ const TYPED_ERROR_IMPL: &str = r#"async function typedError<T, E>(result: Promis
 // @ts-expect-error tauri-specta's generated contract assertion leaves E unused under noUnusedLocals.
 "#;
 
+/// Apply pending schema migrations against Core's pool, synchronously.
+///
+/// Runs on a short-lived current-thread runtime because this executes
+/// during `run()` setup, before the Tauri (and its Tokio) runtime starts —
+/// the same pattern the DB preflight uses. [`db::init`] must have been
+/// called first so Core can resolve the database file.
+fn apply_pending_migrations() -> Result<(), String> {
+  let migrations = infrastructure::database::migration::get_migrations();
+  let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .map_err(|e| format!("Failed to build runtime for migrations: {e}"))?;
+  runtime.block_on(hardviz_core::infrastructure::database::migrate::run(
+    migrations,
+  ))
+}
+
 pub fn run() {
   let builder = Builder::<tauri::Wry>::new()
     .events(collect_events![models::hardware::HardwareMonitorUpdate,])
@@ -160,18 +177,37 @@ pub fn run() {
   let _ = hardviz_core::infrastructure::database::db::init(db_path.clone());
 
   let app_max_version = infrastructure::database::migration::get_max_migration_version();
-  let db_error = hardviz_core::persistence::preflight::check_db_compatibility(
+  let mut db_error = hardviz_core::persistence::preflight::check_db_compatibility(
     &db_path,
     app_max_version,
   );
-  let is_db_ok = db_error.is_none();
 
-  let migrations = infrastructure::database::migration::get_migrations();
+  // Core owns the database pool, so it also applies the schema migrations —
+  // synchronously here, before any persistence worker writes. These were
+  // previously registered with `tauri-plugin-sql` but never ran, because
+  // the DB is never loaded through the plugin (no `preload`, no frontend
+  // `Database.load`), leaving newer tables such as `storage_devices`
+  // missing. A migration failure is surfaced as a DB-incompatible startup
+  // so the existing recovery dialog handles it.
+  if db_error.is_none()
+    && let Err(e) = apply_pending_migrations()
+  {
+    log_error!(
+      "Failed to apply database migrations",
+      "lib::run",
+      Some(e.clone())
+    );
+    db_error = Some(hardviz_core::persistence::preflight::DbStartupError::Other(
+      e,
+    ));
+  }
+
+  let is_db_ok = db_error.is_none();
 
   let store_for_setup = Arc::clone(&history_store);
   let guidance_for_setup = Arc::clone(&external_component_guidance_state);
 
-  let mut tauri_builder = tauri::Builder::<Wry>::default()
+  let tauri_builder = tauri::Builder::<Wry>::default()
     .invoke_handler(builder.invoke_handler())
     .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
       lifecycle::on_second_instance(app);
@@ -387,14 +423,6 @@ pub fn run() {
     .manage(lifecycle::CloseToTrayRuntimeState::default())
     .manage(workers::WorkersState::default())
     .manage(app_updates::PendingUpdate(Mutex::new(None)));
-
-  if is_db_ok {
-    tauri_builder = tauri_builder.plugin(
-      tauri_plugin_sql::Builder::new()
-        .add_migrations("sqlite:hv-database.db", migrations)
-        .build(),
-    );
-  }
 
   let mut context = tauri::generate_context!();
   utils::tauri::apply_runtime_config(context.config_mut());


### PR DESCRIPTION
## Summary

Root-cause fix for the storage-health startup error `Failed to insert storage health daily records: ... no such table: storage_devices` (and its sibling `no such table: storage_health_daily_records`). This is the follow-up that **#1684** explicitly deferred.

### Root cause — migrations never ran

The schema migrations were registered with `tauri-plugin-sql`, but they **never executed**. `tauri-plugin-sql` only runs migrations for a database listed in `plugins.sql.preload`, or when the frontend calls `Database.load()`. This app does neither: there is no `preload` entry, `@tauri-apps/plugin-sql` is not a frontend dependency, and there is no `sql` capability. So the registered set stayed dormant and any database created before a given migration never gained that migration's tables — a DB last opened at schema **v5** never got v6's `storage_devices` / `storage_health_daily_records`.

Meanwhile every Core read/write goes through Core's own `SqlitePool` (`db::get_pool`), which never migrates.

### Why the #1684 guard wasn't enough

#1684 made the **read** command degrade to an empty result on a missing table, reasoning the write/live paths were unaffected because the live collector is only built inside the `is_db_ok` block. But `check_db_compatibility` returns *compatible* whenever `db_version <= app_version` (a v5 DB against a binary shipping up to v8 is compatible — the app is *expected* to migrate up). So `is_db_ok` is **true** for exactly the affected databases: the Storage Health worker starts and its `INSERT INTO storage_devices …` fails with `no such table` — the originally reported error, on the **write** path the read guard does not cover.

### Fix — Core applies the migrations

Core owns the database pool, so it now also applies the schema migrations:

- New `core/src/infrastructure/database/migrate.rs` runs the ordered set through `sqlx`'s `Migrator` against Core's pool.
- App still **owns** the migration definitions (`src-tauri/src/infrastructure/database/migration.rs`) and hands them to the runner. `lib.rs` invokes it synchronously at startup — after the preflight and before any persistence worker writes (the same short-lived current-thread runtime the preflight already uses).
- Resolution mirrors the plugin's exactly (`MigrationType::ReversibleUp`, **byte-identical SQL**), so `sqlx` checksums of the already-applied v1–v5 rows on existing databases keep matching; v6–v8 apply on top. No manual SQL or data migration is required.
- A migration failure is surfaced as a DB-incompatible startup, so the existing recovery dialog handles it.
- The now-dead `tauri-plugin-sql` dependency and the never-reachable Down migrations are removed.

This is complementary to #1684: the read guard stays as defense-in-depth; this PR makes the tables actually exist, so both the read and the write paths are healthy.

## Related Issues

Follow-up to #1684 (the root cause it deferred). No separate tracking issue.

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A — backend-only startup change.

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- `hardviz-core … migrate`: `applies_pending_migrations`, `reapplying_only_runs_new_migrations` — verify the migrator applies pending versions and that re-running with unchanged earlier SQL does not trip a checksum mismatch (the real upgrade path).
- `hardware_visualizer … migration::shipped_migrations_create_storage_tables_and_allow_insert` (**new regression test**): applies the **shipped** migration set to a throwaway file-backed DB and asserts `storage_devices` + `storage_health_daily_records` are created and the previously-failing `INSERT INTO storage_devices` now succeeds — a direct guard for the reported error, and proof it does not recur.
- Existing `storage_health` read/write tests (incl. #1684's missing-table guard) still pass.

CI-parity, all green locally:

- `cargo test --workspace -- --test-threads=1` — all pass, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

> Note: the app GUI was not launched manually in this change; the new regression test reproduces the exact failing insert against the shipped migration set instead.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database schema migration system for enhanced reliability and consistency during application startup.

* **Chores**
  * Removed unused database plugin dependency and updated internal infrastructure dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->