### PR TITLE
docs: update signing status documentation

### DIFF
--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -20,32 +20,37 @@ risk. Users should verify the domain before downloading.
 
 ## Current signing status
 
-| Platform      | Signing status        | Verification                 |
-| ------------- | --------------------- | ---------------------------- |
-| Windows       | Pending               | Winget, SHA-256, attestation |
-| macOS         | Signed and notarized  | Gatekeeper, codesign         |
-| Linux         | Unsigned              | SHA-256, attestation         |
-| Tauri updater | Signed updater assets | Update-path only             |
+| Platform      | Signing status                 | Verification                               |
+| ------------- | ------------------------------ | ------------------------------------------ |
+| Windows       | Signed (v1.9.0+ installers)    | Authenticode, Winget, SHA-256, attestation |
+| macOS         | Signed and notarized           | Gatekeeper, codesign, SHA-256, attestation |
+| Linux         | Unsigned packages              | SHA-256, attestation                       |
+| Tauri updater | Signed updater assets          | Update-path only                           |
 
-Windows Authenticode signing is currently pending. Until Windows code signing is
-available, use official distribution locations and verify GitHub Release
-downloads with SHA-256 checksums and GitHub Artifact Attestations.
+Windows release installers are Authenticode signed starting with v1.9.0.
+Earlier Windows releases may be unsigned. For all platforms, use official
+distribution locations and verify GitHub Release downloads with SHA-256
+checksums and GitHub Artifact Attestations where available.
 
-SHA-256 checksums and GitHub Artifact Attestations are planned to start with
-v1.8.1 and later releases that include verification metadata.
+SHA-256 checksums and GitHub Artifact Attestations are generated for v1.8.1 and
+later releases that include verification metadata.
 
-Tauri updater signatures protect the in-app update path. They do not replace
-platform code signing, SHA-256 checksums, or GitHub Artifact Attestations.
+Tauri updater `.sig` assets protect the in-app update path. They do not replace
+platform code signing, Linux package signing, SHA-256 checksums, or GitHub
+Artifact Attestations for manual downloads.
 
 ## Windows
 
-Status: Authenticode code signing is pending.
+Status: Authenticode signed for v1.9.0 and later release installers.
 
-We are currently working on Windows Authenticode signing through SSL.com.
+Windows `.exe` and `.msi` release installers built by the official publish
+workflow are Authenticode signed through SSL.com eSigner starting with v1.9.0.
+Earlier Windows release installers may be unsigned.
 
-Until Windows code signing is available, verify downloads using:
+Verify Windows downloads using:
 
 - official distribution locations
+- Authenticode signature validation
 - SHA-256 checksums
 - GitHub Artifact Attestations
 
@@ -59,17 +64,18 @@ winget show shm11C3.HardwareVisualizer
 Winget is an official installation path, but it is not a replacement for
 Authenticode signing, SHA-256 checksums, or GitHub Artifact Attestations.
 
-Windows SmartScreen may show a warning while Authenticode signing and reputation
-are not fully established.
+Windows SmartScreen may still show a warning for a validly signed installer
+while publisher or file reputation is being established. Authenticode signature
+validation and SmartScreen reputation are related but separate checks.
 
-### Planned signing process
+### Signing process
 
-The planned SSL.com signing process applies to Windows installer packages, such
-as `.exe` and `.msi` files, published on GitHub Releases.
+The SSL.com signing process applies to Windows installer packages, such as
+`.exe` and `.msi` files, published on GitHub Releases.
 
 - Artifacts are built from this repository using CI.
 - Only CI-built artifacts will be signed for release distribution.
-- Certificate material and signing access will be handled through the SSL.com
+- Certificate material and signing access are handled through the SSL.com
   signing workflow.
 
 ### Team roles
@@ -95,7 +101,8 @@ for copy-pasteable commands.
 
 ## Linux
 
-Status: not cryptographically signed yet.
+Status: Linux packages are not signed with a Linux package-signing mechanism
+yet.
 
 Linux artifacts, such as AppImage, `.deb`, and `.rpm` files, are published
 through GitHub Releases.
@@ -106,13 +113,17 @@ Until Linux package signing is implemented, verify downloads using:
 - SHA-256 checksums
 - GitHub Artifact Attestations
 
+Release assets ending in `.sig`, including Linux `.sig` assets, are Tauri
+updater signatures. They are not GPG, Sigstore/cosign, repository, or package
+manager signatures for manual Linux package verification.
+
 We may add Linux artifact signing, such as Sigstore/cosign or GPG, in a future
 release.
 
 ## Release integrity controls
 
 For v1.8.1 and later releases that include verification metadata, the release
-workflow is planned to provide two repository-generated verification layers:
+workflow provides two repository-generated verification layers:
 
 - `SHA256SUMS.txt` is attached to the GitHub Release and lists SHA-256 checksums
   for all release assets except itself.
@@ -134,8 +145,8 @@ computes SHA-256 locally without uploading the selected file.
 Tauri updater artifacts are signed using the Tauri updater signing mechanism.
 
 These signatures protect the application update path, but they are not a
-replacement for platform code signing, SHA-256 checksums, or GitHub Artifact
-Attestations.
+replacement for Windows Authenticode signing, macOS notarization, Linux package
+signing, SHA-256 checksums, or GitHub Artifact Attestations.
 
 ## Verification guide
 

--- a/docs/download-verification.ja.md
+++ b/docs/download-verification.ja.md
@@ -20,7 +20,7 @@
 ## SHA-256 チェックサム
 
 v1.8.1 以降の GitHub Release では、リリース assets の正規チェックサム一覧として
-`SHA256SUMS.txt` を Assets セクションに含める予定です。
+`SHA256SUMS.txt` を Assets セクションに含めています。
 
 インストーラーと同じ GitHub Release から `SHA256SUMS.txt` をダウンロードし、
 対象ファイル名の SHA-256 値と照合してください。
@@ -47,7 +47,7 @@ v1.8.1 より前のリリースでは、`SHA256SUMS.txt` が提供されてい�
 
 ## GitHub Artifact Attestations
 
-v1.8.1 以降のリリース assets で GitHub Artifact Attestations を生成する予定です。
+v1.8.1 以降のリリース assets では GitHub Artifact Attestations を生成しています。
 
 これは高度な検証手順です。多くのユーザーはまず、ファイルの SHA-256 が
 `SHA256SUMS.txt` に記載された値と一致することを確認してください。
@@ -61,6 +61,35 @@ gh attestation verify ./HardwareVisualizer_x.x.x_x64_en-US.msi -R shm11C3/Hardwa
 ```
 
 v1.8.1 より前のリリースでは、GitHub Artifact Attestations が提供されていない場合があります。
+
+## Windows Authenticode 署名
+
+Windows の `.exe` / `.msi` リリースインストーラーは、v1.9.0 以降 Authenticode
+署名済みです。v1.9.0 より前の Windows リリースインストーラーは未署名の場合があります。
+
+インストーラーの署名は PowerShell で検証できます。
+
+```powershell
+Get-AuthenticodeSignature .\HardwareVisualizer_x.x.x_x64_en-US.msi | Format-List
+```
+
+NSIS 形式のセットアップ実行ファイルを確認する場合:
+
+```powershell
+Get-AuthenticodeSignature .\HardwareVisualizer_x.x.x_x64-setup.exe | Format-List
+```
+
+成功している場合、出力に `Status: Valid` が表示されます。署名者証明書やタイムスタンプの詳細も
+同じ出力で確認できます。
+
+Windows SDK tools が入っている場合は、`signtool` でも同じポリシー検証を実行できます。
+
+```powershell
+signtool verify /pa /v .\HardwareVisualizer_x.x.x_x64-setup.exe
+```
+
+有効な署名が付いていても、発行元またはファイルの reputation が十分に確立するまでは
+Windows SmartScreen の警告が表示される場合があります。
 
 ## macOS の署名と notarization
 
@@ -86,6 +115,19 @@ codesign --verify --deep --strict --verbose=2 /Applications/HardwareVisualizer.a
 ```
 
 `spctl` の出力に `accepted` が含まれ、詳細出力に Developer ID の情報が表示されれば成功です。
+
+## Linux package signing
+
+AppImage、`.deb`、`.rpm` などの Linux パッケージは、現時点では GPG、Sigstore/cosign、
+リポジトリメタデータ署名などの Linux package signing では署名されていません。
+Linux 向けダウンロードは、利用可能な場合 `SHA256SUMS.txt` と GitHub Artifact Attestations
+で検証してください。
+
+## Tauri updater の `.sig` assets
+
+Release assets に含まれる `.sig` ファイルは、アプリ内アップデート経路で使用する
+Tauri updater 署名です。Windows Authenticode 署名、macOS notarization、Linux package signing、
+SHA-256 チェックサム、GitHub Artifact Attestations の代替ではありません。
 
 ## Winget
 

--- a/docs/download-verification.md
+++ b/docs/download-verification.md
@@ -22,9 +22,8 @@ available.
 
 ## SHA-256 checksums
 
-GitHub Releases are planned to include `SHA256SUMS.txt` starting with v1.8.1
-in the release Assets section as the canonical checksum list for release
-assets.
+Starting with v1.8.1, GitHub Releases include `SHA256SUMS.txt` in the release
+Assets section as the canonical checksum list for release assets.
 
 Download `SHA256SUMS.txt` from the same GitHub Release as your installer and
 compare the SHA-256 value for the matching filename.
@@ -51,8 +50,8 @@ For releases before v1.8.1, `SHA256SUMS.txt` may not be available.
 
 ## GitHub Artifact Attestations
 
-GitHub Artifact Attestations are planned to be generated for release assets
-starting with v1.8.1.
+Starting with v1.8.1, GitHub Artifact Attestations are generated for release
+assets.
 
 This is an advanced verification step. Most users should first verify that the
 file matches the SHA-256 value published in `SHA256SUMS.txt`.
@@ -66,6 +65,36 @@ gh attestation verify ./HardwareVisualizer_x.x.x_x64_en-US.msi -R shm11C3/Hardwa
 ```
 
 For releases before v1.8.1, GitHub Artifact Attestations may not be available.
+
+## Windows Authenticode signature
+
+Windows `.exe` and `.msi` release installers are Authenticode signed starting
+with v1.9.0. Earlier Windows release installers may be unsigned.
+
+Verify the installer signature with PowerShell:
+
+```powershell
+Get-AuthenticodeSignature .\HardwareVisualizer_x.x.x_x64_en-US.msi | Format-List
+```
+
+For the NSIS setup executable:
+
+```powershell
+Get-AuthenticodeSignature .\HardwareVisualizer_x.x.x_x64-setup.exe | Format-List
+```
+
+Successful output should report `Status: Valid`. You can also inspect the
+signer certificate and timestamp details in the command output.
+
+If you have Windows SDK tools installed, `signtool` can perform the same policy
+check:
+
+```powershell
+signtool verify /pa /v .\HardwareVisualizer_x.x.x_x64-setup.exe
+```
+
+Windows SmartScreen may still show a reputation warning for a validly signed
+installer while publisher or file reputation is being established.
 
 ## macOS signature and notarization
 
@@ -92,6 +121,20 @@ codesign --verify --deep --strict --verbose=2 /Applications/HardwareVisualizer.a
 
 Successful `spctl` output should report `accepted`, and the detailed output
 should identify a Developer ID source.
+
+## Linux package signing
+
+Linux packages, such as AppImage, `.deb`, and `.rpm` files, are not currently
+signed with a Linux package-signing mechanism such as GPG, Sigstore/cosign, or
+repository metadata signing. Verify Linux downloads with `SHA256SUMS.txt` and
+GitHub Artifact Attestations when available.
+
+## Tauri updater `.sig` assets
+
+Release assets ending in `.sig` are Tauri updater signatures for the in-app
+update path. They do not replace Windows Authenticode signing, macOS
+notarization, Linux package signing, SHA-256 checksums, or GitHub Artifact
+Attestations for manual downloads.
 
 ## Winget
 


### PR DESCRIPTION
## Summary

- Update the code signing policy to mark Windows release installers as Authenticode signed starting with v1.9.0.
- Replace stale planned wording for `SHA256SUMS.txt` and GitHub Artifact Attestations with current availability from v1.8.1 onward.
- Add English and Japanese verification steps for Windows Authenticode signatures.
- Clarify that release `.sig` assets are Tauri updater signatures and do not replace platform or Linux package signing.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Manual checks:

- Confirmed latest release `v1.9.0` includes `SHA256SUMS.txt` and Windows release assets.
- Confirmed the `v1.9.0` publish workflow Windows job ran `Setup CodeSignTool (SSL.com eSigner)` successfully.
- Confirmed workflow logs include `Signed:` lines for `HardwareVisualizer_1.9.0_x64_en-US.msi` and `HardwareVisualizer_1.9.0_x64-setup.exe`.
- Ran `npm run lint`.
- Ran `npm run format`.

Note: local Biome commands exited 0 but emitted the existing `.codex/hooks.json` internalError/io sandbox diagnostic.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced download verification guides with detailed, platform-specific instructions for validating release authenticity
  * Added Windows Authenticode signature verification procedures
  * Clarified Linux package verification methods using checksums and attestations
  * Improved explanations of different signature types and their respective purposes in the verification workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->