### PR TITLE
chore: migrate GitHub label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug to help us improve
 title: "[BUG] "
-labels: ["bug"]
+labels: ["type:bug"]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: "[Feature request] "
-labels: ["enhancement"]
+labels: ["type:feature"]
 body:
   - type: textarea
     id: problem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,8 @@ updates:
     open-pull-requests-limit: 40
     labels:
       - "change:deps"
-      - "area:rust"
+      - "area:core"
+      - "area:tauri"
     ignore:
       - dependency-name: "tauri"
       - dependency-name: "tauri-build"
@@ -72,7 +73,8 @@ updates:
       default-days: 5
     labels:
       - "change:deps"
-      - "area:rust"
+      - "area:core"
+      - "area:tauri"
 
   - package-ecosystem: "github-actions"
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     cooldown:
       default-days: 5
     open-pull-requests-limit: 40
+    labels:
+      - "change:deps"
+      - "area:javascript"
+      - "area:frontend"
 
     ignore:
       - dependency-name: "@tauri-apps/*"
@@ -48,6 +52,9 @@ updates:
     cooldown:
       default-days: 5
     open-pull-requests-limit: 40
+    labels:
+      - "change:deps"
+      - "area:rust"
     ignore:
       - dependency-name: "tauri"
       - dependency-name: "tauri-build"
@@ -63,6 +70,9 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
+    labels:
+      - "change:deps"
+      - "area:rust"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -75,3 +85,6 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 5
+    labels:
+      - "change:deps"
+      - "area:github-actions"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,11 +14,19 @@
   - changed-files:
       - any-glob-to-any-file:
           - "core/**"
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "rust-toolchain.toml"
+          - ".cargo/**"
 
 "area:tauri":
   - changed-files:
       - any-glob-to-any-file:
           - "src-tauri/**"
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "rust-toolchain.toml"
+          - ".cargo/**"
 
 "area:github-actions":
   - changed-files:
@@ -32,17 +40,6 @@
       - any-glob-to-any-file:
           - "**/*.md"
           - "docs/**"
-
-"area:rust":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "Cargo.toml"
-          - "**/Cargo.toml"
-          - "Cargo.lock"
-          - "rust-toolchain.toml"
-          - ".cargo/**"
-          - "core/**"
-          - "src-tauri/**"
 
 "area:javascript":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,50 +1,124 @@
-frontend:
+"area:frontend":
   - changed-files:
       - any-glob-to-any-file:
           - "src/**"
           - "index.html"
           - "package.json"
+          - "package-lock.json"
+          - "vite.config.*"
+          - "vitest.config.*"
+          - "playwright*.config.*"
+          - "tsconfig*.json"
 
-hardviz_core:
+"area:core":
   - changed-files:
       - any-glob-to-any-file:
           - "core/**"
 
-hardviz_tauri:
+"area:tauri":
   - changed-files:
       - any-glob-to-any-file:
           - "src-tauri/**"
 
-github_actions:
+"area:github-actions":
   - changed-files:
       - any-glob-to-any-file:
           - ".github/workflows/**"
           - ".github/actions/**"
+          - ".github/scripts/**"
 
-docs:
+"area:docs":
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.md"
           - "docs/**"
 
-dependencies:
+"area:rust":
   - changed-files:
       - any-glob-to-any-file:
+          - "Cargo.toml"
+          - "**/Cargo.toml"
           - "Cargo.lock"
-          - "package-lock.json"
+          - "rust-toolchain.toml"
+          - ".cargo/**"
+          - "core/**"
+          - "src-tauri/**"
 
-configuration:
+"area:javascript":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "package-lock.json"
+          - "src/**"
+          - "vite.config.*"
+          - "vitest.config.*"
+          - "playwright*.config.*"
+          - "tsconfig*.json"
+
+"area:config":
   - changed-files:
       - any-glob-to-any-file:
           - "tsconfig*.json"
           - "vite.config.*"
           - "vitest.config.*"
+          - "playwright*.config.*"
+          - "Cargo.toml"
+          - "**/Cargo.toml"
+          - "*.conf.json"
+          - "src-tauri/*.conf.json"
+          - ".cargo/**"
+
+"change:deps":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Cargo.lock"
+          - "package-lock.json"
+          - "package.json"
+          - "Cargo.toml"
+          - "**/Cargo.toml"
+          - "rust-toolchain.toml"
+
+"change:config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tsconfig*.json"
+          - "vite.config.*"
+          - "vitest.config.*"
+          - "playwright*.config.*"
           - "Cargo.toml"
           - "**/Cargo.toml"
           - "*.conf.json"
 
-feature:
+"change:feature":
   - head-branch: ["^feat/.*", "^feature/.*"]
 
-bug:
+"change:fix":
   - head-branch: ["^fix/.*"]
+
+"change:docs":
+  - head-branch: ["^docs/.*"]
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+"change:refactor":
+  - head-branch: ["^refactor/.*"]
+
+"change:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - ".github/scripts/**"
+
+"change:test":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.test.*"
+          - "src/setupVitest.ts"
+          - "src/e2e/**"
+          - "e2e/**"
+          - "e2e-native/**"
+          - "playwright*.config.*"
+          - "vitest.config.*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   exclude:
-    labels: [ignore-for-release, no-release-notes]
+    labels: ["release:skip", ignore-for-release, no-release-notes]
     authors:
       - dependabot[bot]
       - dependabot
@@ -8,10 +8,24 @@ changelog:
 
   categories:
     - title: Added
-      labels: [feature, enhancement]
+      labels: ["change:feature", feature, enhancement]
     - title: Fixed
-      labels: [bug]
+      labels: ["change:fix", bug]
     - title: Maintenance
-      labels: [ci, docs, dependencies, configuration]
+      labels:
+        [
+          "change:ci",
+          "change:docs",
+          "change:deps",
+          "change:config",
+          "change:test",
+          "change:refactor",
+          ci,
+          docs,
+          documentation,
+          dependencies,
+          configuration,
+          refactor,
+        ]
     - title: Other Changes
       labels: ["*"]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,9 +8,9 @@ changelog:
 
   categories:
     - title: Added
-      labels: ["change:feature", feature, enhancement]
+      labels: ["change:feature"]
     - title: Fixed
-      labels: ["change:fix", bug]
+      labels: ["change:fix"]
     - title: Maintenance
       labels:
         [
@@ -20,12 +20,6 @@ changelog:
           "change:config",
           "change:test",
           "change:refactor",
-          ci,
-          docs,
-          documentation,
-          dependencies,
-          configuration,
-          refactor,
         ]
     - title: Other Changes
       labels: ["*"]

--- a/.github/workflows/auto-update-licenses.yml
+++ b/.github/workflows/auto-update-licenses.yml
@@ -90,3 +90,7 @@ jobs:
             ./docs/third-party-notices
           token: ${{ steps.generate-token.outputs.token }}
           delete-branch: true
+          labels: |
+            change:docs
+            area:docs
+            source:automation

--- a/.github/workflows/auto-update-npm.yml
+++ b/.github/workflows/auto-update-npm.yml
@@ -59,6 +59,8 @@ jobs:
           branch: chore/auto-npm-update
           delete-branch: true
           labels: |
-            dependencies
-            automated
+            change:deps
+            area:javascript
+            area:frontend
+            source:automation
           signoff: false

--- a/.github/workflows/auto-update-safe-chain.yml
+++ b/.github/workflows/auto-update-safe-chain.yml
@@ -101,6 +101,8 @@ jobs:
             .github/actions/setup-safe-chain/action.yml
           delete-branch: true
           labels: |
-            dependencies
-            automated
+            change:deps
+            change:ci
+            area:github-actions
+            source:automation
           signoff: false

--- a/.github/workflows/auto-update-tauri.yml
+++ b/.github/workflows/auto-update-tauri.yml
@@ -63,7 +63,8 @@ jobs:
           branch: chore/auto-tauri-update
           delete-branch: true
           labels: |
-            dependencies
-            automated
-            tauri
+            change:deps
+            area:tauri
+            area:rust
+            source:automation
           signoff: false

--- a/.github/workflows/auto-update-tauri.yml
+++ b/.github/workflows/auto-update-tauri.yml
@@ -65,6 +65,5 @@ jobs:
           labels: |
             change:deps
             area:tauri
-            area:rust
             source:automation
           signoff: false

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -113,32 +113,47 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const label = 'performance-regression';
+            const labels = ['type:performance', 'status:regression', 'source:performance-test'];
             const title = 'Performance test threshold exceeded';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            // Ensure label exists
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
+            const labelDetails = {
+              'type:performance': {
+                color: '17e0f0',
+                description: 'Runtime, build, bundle, memory, or responsiveness work',
+              },
+              'status:regression': {
                 color: 'e11d48',
-                description: 'Automated performance test detected a threshold violation',
-              });
+                description: 'Known regression from a previous working state',
+              },
+              'source:performance-test': {
+                color: 'ededed',
+                description: 'Created by the scheduled performance workflow',
+              },
+            };
+
+            // Ensure labels exist
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  ...labelDetails[label],
+                });
+              }
             }
 
             // Check for existing open issue
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: label,
+              labels: labels.join(','),
               state: 'open',
               per_page: 1,
             });
@@ -160,6 +175,6 @@ jobs:
                 repo: context.repo.repo,
                 title,
                 body,
-                labels: [label],
+                labels,
               });
             }

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -139,7 +139,11 @@ jobs:
                   repo: context.repo.repo,
                   name: label,
                 });
-              } catch {
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
                 await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ PR branch names are validated by CI. Tool-dependent prefixes such as
 `codex/` or `claude/` are not accepted; choose a project prefix that
 matches the change type before pushing or opening the PR.
 
+Labels are grouped by purpose. Use the
+[GitHub label guide](docs/development/labels.md) when triaging issues or
+checking pull request labels.
+
 When submitting a Pull Request (PR), please:
 
 - Provide a concise description of the change

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ documentation.
 - [Tauri app crate guide](../src-tauri/README.md)
 - [Add a new language](development/add-language.md)
 - [E2E capture harness](development/e2e-captures.md)
+- [GitHub label guide](development/labels.md)
 - [Download verification](download-verification.md)
 - [Documentation guide](documentation-guide.md)
 

--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -1,0 +1,146 @@
+# GitHub Label Guide
+
+HardwareVisualizer uses labels to answer different questions on issues and pull
+requests. Keep these label groups separate so issue triage, pull request
+automation, and release notes do not overload the same labels.
+
+## Label Groups
+
+### Issue Type
+
+Use exactly one `type:` label on open issues whenever possible. These labels
+describe the kind of work being requested, not the files that may change.
+
+- `type:bug` - user-visible malfunction or incorrect behavior.
+- `type:feature` - new user-facing capability or meaningful enhancement.
+- `type:performance` - runtime, build, bundle, memory, or responsiveness work.
+- `type:investigation` - research or diagnosis before the implementation shape
+  is known.
+- `type:security` - public security hardening or vulnerability-adjacent work.
+  Do not use public issues for private vulnerability reports.
+- `type:task` - maintenance work that is not naturally a bug, feature,
+  performance, docs, or CI item.
+- `type:docs` - documentation-only issue.
+
+Do not use `change:` labels on issues. `change:` describes a pull request.
+
+### Pull Request Change
+
+Use one or more `change:` labels on pull requests. These labels drive release
+note categories and are assigned mostly by `.github/labeler.yml`, Dependabot,
+or repository automation.
+
+- `change:feature` - feature branch work (`feat/` or `feature/`).
+- `change:fix` - bug-fix branch work (`fix/`).
+- `change:docs` - documentation changes.
+- `change:refactor` - refactoring changes.
+- `change:ci` - CI, GitHub Actions, or repository automation changes.
+- `change:deps` - dependency or lockfile updates.
+- `change:config` - build, TypeScript, Vite, Vitest, Cargo, or Tauri config.
+- `change:test` - test harness, fixtures, or coverage changes.
+
+Release notes read `change:` labels first. During the migration from legacy
+labels, `.github/release.yml` also keeps the old labels as a fallback so
+already-merged pull requests still categorize correctly.
+
+Dependabot is the special case to watch. By default, Dependabot can create and
+apply `dependencies` plus ecosystem labels such as `javascript`, `rust`, or
+`github_actions`. Each `updates` entry in `.github/dependabot.yml` must define
+explicit `labels:` so Dependabot uses the project labels instead of those
+defaults. Create the referenced labels before merging label automation changes;
+Dependabot ignores custom labels that do not already exist.
+
+### Area
+
+Use `area:` labels for the code or repository boundary affected by a pull
+request. They can also be useful on implementation-ready issues, but avoid
+guessing before the likely owner is clear.
+
+- `area:frontend` - React, TypeScript, UI components, browser tests, or Vite.
+- `area:backend` - backend behavior that spans App and Core.
+- `area:core` - `core/**` or Tauri-independent domain/runtime code.
+- `area:tauri` - `src-tauri/**`, Tauri commands, app wiring, or bundling.
+- `area:github-actions` - workflows and composite actions under `.github/**`.
+- `area:rust` - Rust-only implementation or dependency work.
+- `area:javascript` - JavaScript/TypeScript dependency or tooling work.
+- `area:docs` - documentation files or docs automation.
+- `area:config` - project configuration files.
+
+### Screen
+
+Use `screen:` labels when an issue is clearly tied to one visible app surface.
+These labels answer "where does the user see this?"
+
+- `screen:dashboard`
+- `screen:insight`
+- `screen:process`
+- `screen:snapshot`
+- `screen:settings`
+- `screen:tray`
+- `screen:updater`
+
+If the work crosses screens or is backend-only, skip `screen:` unless one screen
+is the primary user-facing entry point.
+
+### Feature
+
+Use `feature:` labels for product or platform capability areas. These labels
+answer "what capability is affected?"
+
+- `feature:hardware-monitoring`
+- `feature:storage-health`
+- `feature:gpu-monitoring`
+- `feature:process-stats`
+- `feature:live-metrics`
+- `feature:charts`
+- `feature:background-images`
+- `feature:tray-widget`
+- `feature:external-components`
+- `feature:e2e`
+- `feature:i18n`
+- `feature:release`
+- `feature:supply-chain`
+- `feature:design-system`
+
+Prefer one or two precise `feature:` labels over broad combinations.
+
+### Status And Source
+
+Use `status:` for current workflow state and `source:` for automated origin.
+These labels are optional and should not replace the type/change labels.
+
+- `status:investigating` - actively being investigated.
+- `status:regression` - known regression from a previous working state.
+- `status:needs-info` - waiting for reporter or maintainer information.
+- `status:blocked` - cannot proceed until an external dependency changes.
+- `source:automation` - created or maintained by repository automation.
+- `source:performance-test` - created by the scheduled performance workflow.
+
+Keep GitHub standard helper labels such as `good first issue`, `help wanted`,
+`duplicate`, `invalid`, `question`, and `wontfix` when they describe workflow
+state better than project-specific labels.
+
+## Migration Notes
+
+The following legacy labels are deprecated for new work:
+
+- `bug` -> `type:bug` on issues, `change:fix` on pull requests.
+- `enhancement` and `feature` -> `type:feature` on issues,
+  `change:feature` on pull requests.
+- `performance` -> `type:performance` on issues. Pull requests should use the
+  appropriate `change:` label plus a feature or area label.
+- `performance-regression` -> `type:performance` + `status:regression` +
+  `source:performance-test`.
+- `docs` and `documentation` -> `type:docs` on issues, `change:docs` and
+  `area:docs` on pull requests.
+- `ci` and `github_actions` -> `change:ci` + `area:github-actions`.
+- `dependencies` -> `change:deps`.
+- `configuration` -> `change:config` + `area:config`.
+- `frontend`, `backend`, `rust`, `javascript`, `tauri`, `hardviz_core`, and
+  `hardviz_tauri` -> `area:*`.
+- `hardware` and `monitoring` -> use a precise `feature:*` label.
+- `testing` and `automation testing` -> `change:test` or `feature:e2e`.
+- `automated` -> `source:automation`.
+
+Do not delete legacy labels until the next release is cut and no open pull
+request depends on them for generated release notes.

--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -39,9 +39,8 @@ or repository automation.
 - `change:config` - build, TypeScript, Vite, Vitest, Cargo, or Tauri config.
 - `change:test` - test harness, fixtures, or coverage changes.
 
-Release notes read `change:` labels first. During the migration from legacy
-labels, `.github/release.yml` also keeps the old labels as a fallback so
-already-merged pull requests still categorize correctly.
+Release notes read `change:` labels only. Do not add unprefixed project labels
+such as `feature`, `bug`, `docs`, or `dependencies` as release-note fallbacks.
 
 Dependabot is the special case to watch. By default, Dependabot can create and
 apply `dependencies` plus ecosystem labels such as `javascript`, `rust`, or
@@ -122,7 +121,8 @@ state better than project-specific labels.
 
 ## Migration Notes
 
-The following legacy labels are deprecated for new work:
+The following legacy labels were removed from GitHub after the replacement
+labels were created:
 
 - `bug` -> `type:bug` on issues, `change:fix` on pull requests.
 - `enhancement` and `feature` -> `type:feature` on issues,
@@ -142,5 +142,7 @@ The following legacy labels are deprecated for new work:
 - `testing` and `automation testing` -> `change:test` or `feature:e2e`.
 - `automated` -> `source:automation`.
 
-Do not delete legacy labels until the next release is cut and no open pull
-request depends on them for generated release notes.
+Do not recreate removed unprefixed project labels. Keep only GitHub standard
+helper labels, such as `good first issue`, `help wanted`, `duplicate`,
+`invalid`, `question`, and `wontfix`, when they describe workflow state better
+than project-specific labels.

--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -87,25 +87,25 @@ is the primary user-facing entry point.
 
 ### Feature
 
-Use `feature:` labels for product or platform capability areas. These labels
+Use `feat:` labels for product or platform capability areas. These labels
 answer "what capability is affected?"
 
-- `feature:hardware-monitoring`
-- `feature:storage-health`
-- `feature:gpu-monitoring`
-- `feature:process-stats`
-- `feature:live-metrics`
-- `feature:charts`
-- `feature:background-images`
-- `feature:tray-widget`
-- `feature:external-components`
-- `feature:e2e`
-- `feature:i18n`
-- `feature:release`
-- `feature:supply-chain`
-- `feature:design-system`
+- `feat:hardware-monitoring`
+- `feat:storage-health`
+- `feat:gpu-monitoring`
+- `feat:process-stats`
+- `feat:live-metrics`
+- `feat:charts`
+- `feat:background-images`
+- `feat:tray-widget`
+- `feat:external-components`
+- `feat:e2e`
+- `feat:i18n`
+- `feat:release`
+- `feat:supply-chain`
+- `feat:design-system`
 
-Prefer one or two precise `feature:` labels over broad combinations.
+Prefer one or two precise `feat:` labels over broad combinations.
 
 ### Status And Source
 
@@ -143,8 +143,8 @@ labels were created:
 - `frontend`, `backend`, `javascript`, `tauri`, `hardviz_core`, and
   `hardviz_tauri` -> `area:*`.
 - `rust` -> `area:core`, `area:tauri`, or both, depending on the affected crate.
-- `hardware` and `monitoring` -> use a precise `feature:*` label.
-- `testing` and `automation testing` -> `change:test` or `feature:e2e`.
+- `hardware` and `monitoring` -> use a precise `feat:*` label.
+- `testing` and `automation testing` -> `change:test` or `feat:e2e`.
 - `automated` -> `source:automation`.
 
 Do not recreate removed unprefixed project labels. Keep only GitHub standard

--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -60,10 +60,14 @@ guessing before the likely owner is clear.
 - `area:core` - `core/**` or Tauri-independent domain/runtime code.
 - `area:tauri` - `src-tauri/**`, Tauri commands, app wiring, or bundling.
 - `area:github-actions` - workflows and composite actions under `.github/**`.
-- `area:rust` - Rust-only implementation or dependency work.
 - `area:javascript` - JavaScript/TypeScript dependency or tooling work.
 - `area:docs` - documentation files or docs automation.
 - `area:config` - project configuration files.
+
+Rust work is labeled by crate boundary, not by language alone. Use
+`area:core` for the Tauri-independent Core crate and `area:tauri` for the
+Tauri/App crate. Use both labels for root Cargo, toolchain, or workspace changes
+that can affect both crates.
 
 ### Screen
 
@@ -136,8 +140,9 @@ labels were created:
 - `ci` and `github_actions` -> `change:ci` + `area:github-actions`.
 - `dependencies` -> `change:deps`.
 - `configuration` -> `change:config` + `area:config`.
-- `frontend`, `backend`, `rust`, `javascript`, `tauri`, `hardviz_core`, and
+- `frontend`, `backend`, `javascript`, `tauri`, `hardviz_core`, and
   `hardviz_tauri` -> `area:*`.
+- `rust` -> `area:core`, `area:tauri`, or both, depending on the affected crate.
 - `hardware` and `monitoring` -> use a precise `feature:*` label.
 - `testing` and `automation testing` -> `change:test` or `feature:e2e`.
 - `automated` -> `source:automation`.

--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -56,7 +56,8 @@ request. They can also be useful on implementation-ready issues, but avoid
 guessing before the likely owner is clear.
 
 - `area:frontend` - React, TypeScript, UI components, browser tests, or Vite.
-- `area:backend` - backend behavior that spans App and Core.
+- `area:backend` - manually assigned during triage for backend behavior that
+  spans App and Core.
 - `area:core` - `core/**` or Tauri-independent domain/runtime code.
 - `area:tauri` - `src-tauri/**`, Tauri commands, app wiring, or bundling.
 - `area:github-actions` - workflows and composite actions under `.github/**`.

--- a/perf-monitor/README.md
+++ b/perf-monitor/README.md
@@ -122,7 +122,9 @@ The GitHub Actions workflow (`.github/workflows/perf-test.yml`) runs daily at 03
 - Builds the app and perf-monitor on the active performance matrix
 - Currently runs the performance gate on Windows only
 - Uploads JSON results as artifacts
-- Creates a GitHub Issue labeled `performance-regression` if any threshold is exceeded
+- Creates or updates a GitHub Issue when any threshold is exceeded
+- Labels performance test issues with `type:performance`, `status:regression`,
+  and `source:performance-test`
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- Add a GitHub label guide that separates issue-only `type:*`, PR-only `change:*`, ownership `area:*`, product `feat:*`, visible `screen:*`, status, and source labels.
- Update PR labeler, release-note categories, Dependabot labels, issue templates, auto-update PR labels, and performance-test issue creation to use the new taxonomy.
- Remove legacy release-note label fallbacks so generated changelogs use `change:*` labels only.
- Delete old unprefixed project labels from GitHub while keeping standard helper labels such as `good first issue`, `help wanted`, `duplicate`, `invalid`, `question`, and `wontfix`.
- Document the Dependabot edge case: explicit `labels:` entries suppress the default `dependencies` and ecosystem labels, while missing custom labels are ignored.
- Rename product capability labels from `feature:*` to `feat:*`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Manual checks performed:

- Parsed updated YAML files with Ruby `YAML.load_file`.
- Ran `actionlint` on changed workflows.
- Ran `git diff --cached --check` before each commit.
- Confirmed GitHub labels now contain only the new prefixed project labels plus retained GitHub standard helper labels.
- Confirmed Open Issues and Open PRs no longer use deprecated classification labels.
- Confirmed GitHub labels and Open Issues use `feat:*` with no remaining `feature:*` labels.

Not run:

- `npm run lint` / `npm run format`.
- `npm test` / `cargo tauri-test`.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured GitHub labels into a namespaced system (e.g., `type:*`, `change:*`, `area:*`) and expanded matching rules for better categorization.
  * Updated issue/PR automation (including issue templates, Dependabot, and auto-update workflows) to apply the new labels consistently.
  * Adjusted release-notes generation and performance test failure reporting to use the new label sets.

* **Documentation**
  * Added a comprehensive GitHub label guide and linked it from the main documentation.
  * Updated contribution guidance to reference the label guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->