### PR TITLE
docs: add README discussion links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -50,6 +50,7 @@ Web サイト: <https://hardviz.com/>
     - [背景画像](#背景画像)
   - [権限とセキュリティについて](#権限とセキュリティについて)
   - [ロードマップ](#ロードマップ)
+  - [フィードバックと Discussion](#フィードバックと-discussion)
   - [コントリビューション](#コントリビューション)
   - [コード署名ポリシー（英語版のみ）](#コード署名ポリシー英語版のみ)
   - [ライセンス](#ライセンス)
@@ -203,6 +204,24 @@ winget install shm11C3.HardwareVisualizer
 | ゲームモード                     | 計画中     |
 | 消費電力の推定機能               | 検討中     |
 | プラグインシステム               | 検討中     |
+
+## フィードバックと Discussion
+
+質問、まだ曖昧なアイデア、実装方針が決まっていない要望は、Issue を作成する前に
+[GitHub Discussions](https://github.com/shm11C3/HardwareVisualizer/discussions)
+へ投稿してください。
+
+- [UI フィードバック](https://github.com/shm11C3/HardwareVisualizer/discussions/1699):
+  読みやすさ、画面遷移、ダッシュボードのレイアウト、グラフ、設定、トレイ /
+  ウィジェット、見た目のカスタマイズについて。
+- [機能アイデア](https://github.com/shm11C3/HardwareVisualizer/discussions/1700):
+  新しいワークフロー、ハードウェア対応、アラート、履歴、カスタマイズ、エクスポート、
+  その他の改善案について。
+- [匿名アンケート](https://hardviz.com/survey/?source=web):
+  GitHub に公開投稿したくない場合はこちらから送信できます。
+
+再現手順のある不具合や、実装内容が具体的な要望は
+[CONTRIBUTING.md](CONTRIBUTING.md) のテンプレートから Issue を作成してください。
 
 ## コントリビューション
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Web: <https://hardviz.com/>
     - [Background Image](#background-image)
   - [Permissions \& Security Notes](#permissions--security-notes)
   - [Roadmap](#roadmap)
+  - [Feedback and Discussions](#feedback-and-discussions)
   - [Contributing](#contributing)
   - [FAQ](#faq)
   - [Code Signing Policy](#code-signing-policy)
@@ -210,6 +211,24 @@ Flexible graph customization available.
 | Game Mode                    | Planned  |
 | Power Consumption Estimation | Idea     |
 | Plugin System                | Idea     |
+
+## Feedback and Discussions
+
+Have a question, rough idea, or open-ended request? Please use
+[GitHub Discussions](https://github.com/shm11C3/HardwareVisualizer/discussions)
+before opening an implementation issue.
+
+- [UI feedback](https://github.com/shm11C3/HardwareVisualizer/discussions/1699):
+  readability, navigation, dashboard layout, charts, settings, tray/widget, and
+  visual customization.
+- [Feature ideas](https://github.com/shm11C3/HardwareVisualizer/discussions/1700):
+  new workflows, hardware support, alerts, history, customization, export, or
+  other improvement ideas.
+- [Anonymous survey](https://hardviz.com/survey/?source=web): use this if you
+  prefer not to post publicly on GitHub.
+
+If you have a reproducible bug or a concrete implementation request, open an
+Issue from the templates in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add a Feedback and Discussions section to the English and Japanese READMEs.
- Link the main GitHub Discussions page, focused UI and feature feedback threads, and the anonymous survey form.
- Clarify that reproducible bugs and concrete implementation requests should still use the Issue templates.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A - documentation-only change.

## Test Plan

- [x] Manual testing
- [ ] Unit tests
- `git diff --check -- README.md README.ja.md`

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Feedback and Discussions" section with guidance on sharing feedback through GitHub Discussions and anonymous surveys, and instructions for reporting bugs or feature requests via GitHub Issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->