### PR TITLE
docs: document feat label color guidance

### DIFF
--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -91,6 +91,9 @@ is the primary user-facing entry point.
 Use `feat:` labels for product or platform capability areas. These labels
 answer "what capability is affected?"
 
+Use an indigo or blue-purple color for all `feat:*` labels so capability labels
+read visually as feature-oriented work.
+
 - `feat:hardware-monitoring`
 - `feat:storage-health`
 - `feat:gpu-monitoring`


### PR DESCRIPTION
## Summary

- Documents that `feat:*` labels should use an indigo or blue-purple color.
- Keeps the documented convention aligned with the GitHub labels updated to `#7c3aed`.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Manual testing: verified all `feat:*` GitHub labels now use `7c3aed`; verified legacy labels are absent; ran `git diff --check HEAD~1..HEAD`.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development documentation with visual styling guidance for feature labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->