### PR TITLE
docs: adjust feat label color guidance

### DIFF
--- a/docs/development/labels.md
+++ b/docs/development/labels.md
@@ -91,8 +91,9 @@ is the primary user-facing entry point.
 Use `feat:` labels for product or platform capability areas. These labels
 answer "what capability is affected?"
 
-Use an indigo or blue-purple color for all `feat:*` labels so capability labels
-read visually as feature-oriented work.
+Keep `feat:*` colors visually distinct from GitHub helper labels such as
+`good first issue`. Treat the GitHub label configuration as the source of truth
+for exact colors.
 
 - `feat:hardware-monitoring`
 - `feat:storage-health`


### PR DESCRIPTION
## Summary

- Documents that `feat:*` label colors should stay visually distinct from GitHub helper labels such as `good first issue`.
- Keeps exact color values out of the documentation and leaves GitHub label configuration as the source of truth.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Manual testing: verified `feat:*` GitHub labels remain visually distinct from `good first issue`, legacy labels are absent, and `git diff --check -- docs/development/labels.md` passes.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised the development guidance for `feat:*` labels to remove earlier color ambiguity.
  * Updated the instructions to ensure `feat:*` colors remain visually distinct from GitHub helper labels and to treat the repository’s GitHub label configuration as the authoritative source for exact color values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->