### PR TITLE
chore(types): enable stricter TypeScript config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,6 +10,10 @@
     "enabled": true,
     "rules": {
       "preset": "recommended",
+      "complexity": {
+        // TypeScript's noPropertyAccessFromIndexSignature requires bracket access for index signatures.
+        "useLiteralKeys": "off"
+      },
       "nursery": {
         "useSortedClasses": {
           "level": "error",

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -170,6 +170,8 @@ export const DoughnutChart = ({
                     </g>
                   );
                 }
+
+                return null;
               }}
             />
           </PolarRadiusAxis>

--- a/src/components/icons/LineChartIcon.tsx
+++ b/src/components/icons/LineChartIcon.tsx
@@ -1,6 +1,10 @@
 import type { LineGraphType } from "@/rspc/bindings";
 
-const MonotoneChartIcon = ({ className }: { className?: string }) => (
+const MonotoneChartIcon = ({
+  className,
+}: {
+  className?: string | undefined;
+}) => (
   <svg
     width="24"
     height="24"
@@ -17,7 +21,7 @@ const MonotoneChartIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const StepChartIcon = ({ className }: { className?: string }) => (
+const StepChartIcon = ({ className }: { className?: string | undefined }) => (
   <svg
     width="24"
     height="24"
@@ -34,7 +38,7 @@ const StepChartIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const LinearChartIcon = ({ className }: { className?: string }) => (
+const LinearChartIcon = ({ className }: { className?: string | undefined }) => (
   <svg
     width="24"
     height="24"
@@ -47,7 +51,7 @@ const LinearChartIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const BasisChartIcon = ({ className }: { className?: string }) => (
+const BasisChartIcon = ({ className }: { className?: string | undefined }) => (
   <svg
     width="24"
     height="24"

--- a/src/components/shared/ScreenTemplate.tsx
+++ b/src/components/shared/ScreenTemplate.tsx
@@ -2,9 +2,9 @@ import type { JSX } from "react";
 import { BurnInShift } from "./BurnInShift";
 
 interface ScreenTemplateProps {
-  title?: string;
-  icon?: JSX.Element;
-  enabledBurnInShift?: boolean;
+  title?: string | undefined;
+  icon?: JSX.Element | undefined;
+  enabledBurnInShift?: boolean | undefined;
   children: React.ReactNode;
 }
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -95,7 +95,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
-    checked={checked}
+    {...(checked !== undefined && { checked })}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -82,8 +82,8 @@ export const Slider = React.forwardRef<
         "relative flex w-full touch-none select-none items-center",
         className,
       )}
-      value={value}
-      onValueChange={onValueChange}
+      {...(value !== undefined && { value })}
+      {...(onValueChange !== undefined && { onValueChange })}
       {...props}
     >
       <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">

--- a/src/features/hardware/dashboard/Dashboard.tsx
+++ b/src/features/hardware/dashboard/Dashboard.tsx
@@ -180,8 +180,8 @@ const DataArea = ({
   className = "rounded-2xl bg-card",
 }: {
   children: React.ReactNode;
-  title?: string;
-  icon?: JSX.Element;
+  title?: string | undefined;
+  icon?: JSX.Element | undefined;
   border?: boolean;
   className?: string;
 }) => {

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -677,8 +677,8 @@ const StorageHealthOverview = ({
   refreshing = false,
   summary,
 }: {
-  onRefresh?: () => void;
-  onSelectDevice?: (deviceId: string) => void;
+  onRefresh?: (() => void) | undefined;
+  onSelectDevice?: ((deviceId: string) => void) | undefined;
   refreshError?: string | null;
   refreshing?: boolean;
   summary: StorageHealthSummaryViewModel | null;
@@ -817,7 +817,7 @@ const StorageDeviceHealthOverview = ({
 }: {
   devices: StorageHealthDeviceViewModel[];
   selectedDeviceId?: string | null;
-  onSelect?: (deviceId: string) => void;
+  onSelect?: ((deviceId: string) => void) | undefined;
 }) => {
   const { t } = useTranslation();
 

--- a/src/features/hardware/hooks/dashboard/useDashboardSelector.test.ts
+++ b/src/features/hardware/hooks/dashboard/useDashboardSelector.test.ts
@@ -98,7 +98,7 @@ describe("useDashboardSelector", () => {
   it("loads stored value when it exists in the store", async () => {
     // Arrange: Store already has a value
     const storedItems: DashboardSelectItemType[] = ["cpu", "memory", "title"];
-    fakeStore.data.dashboardVisibleItems = storedItems;
+    fakeStore.data["dashboardVisibleItems"] = storedItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,
@@ -116,7 +116,7 @@ describe("useDashboardSelector", () => {
   it("toggles visibility of an item by adding it when not present", async () => {
     // Arrange: Start with only some items visible
     const initialItems: DashboardSelectItemType[] = ["cpu", "memory"];
-    fakeStore.data.dashboardVisibleItems = initialItems;
+    fakeStore.data["dashboardVisibleItems"] = initialItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,
@@ -142,7 +142,7 @@ describe("useDashboardSelector", () => {
   it("toggles visibility of an item by removing it when present", async () => {
     // Arrange: Start with multiple items visible
     const initialItems: DashboardSelectItemType[] = ["cpu", "memory", "gpu"];
-    fakeStore.data.dashboardVisibleItems = initialItems;
+    fakeStore.data["dashboardVisibleItems"] = initialItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,
@@ -166,7 +166,7 @@ describe("useDashboardSelector", () => {
   it("prevents empty selection when trying to remove the last item", async () => {
     // Arrange: Start with only one item visible
     const initialItems: DashboardSelectItemType[] = ["cpu"];
-    fakeStore.data.dashboardVisibleItems = initialItems;
+    fakeStore.data["dashboardVisibleItems"] = initialItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,
@@ -189,7 +189,7 @@ describe("useDashboardSelector", () => {
   it("calls toggleTitleIconVisibility with true when title is in visibleItems", async () => {
     // Arrange: Start with 'title' included
     const initialItems: DashboardSelectItemType[] = ["cpu", "title"];
-    fakeStore.data.dashboardVisibleItems = initialItems;
+    fakeStore.data["dashboardVisibleItems"] = initialItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,
@@ -210,7 +210,7 @@ describe("useDashboardSelector", () => {
   it("calls toggleTitleIconVisibility with false when title is not in visibleItems", async () => {
     // Arrange: Start without 'title'
     const initialItems: DashboardSelectItemType[] = ["cpu", "memory"];
-    fakeStore.data.dashboardVisibleItems = initialItems;
+    fakeStore.data["dashboardVisibleItems"] = initialItems;
 
     const { result } = renderHook(() => useDashboardSelector(), {
       wrapper: Provider,

--- a/src/features/settings/components/general/BurnInShiftSettings.tsx
+++ b/src/features/settings/components/general/BurnInShiftSettings.tsx
@@ -58,7 +58,7 @@ export const BurnInShiftSettings = () => {
           type="single"
           collapsible
           className="w-full xl:w-1/3"
-          defaultValue={defaultOpen ? "burnInShiftSettings" : undefined}
+          {...(defaultOpen && { defaultValue: "burnInShiftSettings" })}
         >
           <AccordionItem value="burnInShiftSettings">
             <AccordionTrigger>

--- a/src/features/settings/components/general/TrayWidgetSettings.test.tsx
+++ b/src/features/settings/components/general/TrayWidgetSettings.test.tsx
@@ -37,8 +37,8 @@ vi.mock("react-i18next", () => ({
         "pages.settings.general.trayWidget.metric.cpu": "CPU",
         "pages.settings.general.trayWidget.metric.gpu": "GPU",
         "pages.settings.general.trayWidget.metric.gpu-temp": "GPU temperature",
-        "pages.settings.general.trayWidget.dragMetric": `Drag ${params?.metric}`,
-        "pages.settings.general.trayWidget.seconds": `${params?.count}s`,
+        "pages.settings.general.trayWidget.dragMetric": `Drag ${params?.["metric"]}`,
+        "pages.settings.general.trayWidget.seconds": `${params?.["count"]}s`,
       };
 
       return translations[key] || key;

--- a/src/features/settings/components/insights/DataRetentionSettings.tsx
+++ b/src/features/settings/components/insights/DataRetentionSettings.tsx
@@ -137,7 +137,7 @@ export const DataRetentionSettings = () => {
           <div className="flex items-center space-x-2">
             <Checkbox
               id={scheduledDataDeletionId}
-              checked={settings.hardwareArchive.scheduledDataDeletion}
+              checked={settings.hardwareArchive.scheduledDataDeletion ?? false}
               onCheckedChange={handleScheduledDataDeletion}
             />
             <Label

--- a/src/features/settings/components/insights/InsightsToggle.tsx
+++ b/src/features/settings/components/insights/InsightsToggle.tsx
@@ -41,7 +41,7 @@ export const InsightsToggle = () => {
             </div>
 
             <Switch
-              checked={settings.hardwareArchive.enabled}
+              checked={settings.hardwareArchive.enabled ?? false}
               onCheckedChange={handleCheckedChange}
             />
           </div>

--- a/src/features/settings/hooks/useUploadImageForm.ts
+++ b/src/features/settings/hooks/useUploadImageForm.ts
@@ -27,9 +27,7 @@ export const useUploadImage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      picture: undefined,
-    },
+    defaultValues: {},
   });
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {

--- a/src/features/updater/AppUpdate.test.tsx
+++ b/src/features/updater/AppUpdate.test.tsx
@@ -16,9 +16,9 @@ vi.mock("react-i18next", () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       const translations: Record<string, string> = {
         "pages.updater.title": "Update Available",
-        "pages.updater.description": `Version ${params?.version || ""} is available`,
-        "pages.updater.releaseNotesDescription": `View release notes at ${params?.releaseNotesUrl || ""}`,
-        "pages.updater.currentVersion": `Current: ${params?.currentVersion || ""}`,
+        "pages.updater.description": `Version ${params?.["version"] || ""} is available`,
+        "pages.updater.releaseNotesDescription": `View release notes at ${params?.["releaseNotesUrl"] || ""}`,
+        "pages.updater.currentVersion": `Current: ${params?.["currentVersion"] || ""}`,
         "pages.updater.later": "Later",
         "pages.updater.updateAndRestart": "Update and Restart",
         "pages.updater.needRestart": "Please restart to complete the update",

--- a/src/hooks/useColorTheme.test.ts
+++ b/src/hooks/useColorTheme.test.ts
@@ -20,7 +20,7 @@ describe("useColorTheme", () => {
   // Reset document class list before each test execution
   beforeEach(() => {
     document.documentElement.classList.remove("dark", "light");
-    document.documentElement.dataset.theme = "";
+    document.documentElement.dataset["theme"] = "";
     vi.clearAllMocks();
 
     // Set default mock behavior

--- a/src/hooks/useColorTheme.ts
+++ b/src/hooks/useColorTheme.ts
@@ -45,7 +45,7 @@ export const useColorTheme = (theme: Theme) => {
 
   useEffect(() => {
     document.documentElement.classList.remove(...defaultTheme);
-    document.documentElement.dataset.theme = "";
+    document.documentElement.dataset["theme"] = "";
 
     // Apply System Theme
     if (theme === "system") {
@@ -64,6 +64,6 @@ export const useColorTheme = (theme: Theme) => {
       applyTheme("dark");
     }
 
-    document.documentElement.dataset.theme = theme;
+    document.documentElement.dataset["theme"] = theme;
   }, [theme, systemTheme, applyTheme]);
 };

--- a/src/hooks/useTauriDialog.ts
+++ b/src/hooks/useTauriDialog.ts
@@ -30,8 +30,8 @@ export const useTauriDialog = () => {
       kind?: Kind;
     }): Promise<boolean> => {
       return await showAsk(message, {
-        title: title ? t(`error.title.${title}`) : undefined,
-        kind,
+        ...(title !== undefined && { title: t(`error.title.${title}`) }),
+        ...(kind !== undefined && { kind }),
       });
     },
     [t],
@@ -48,8 +48,8 @@ export const useTauriDialog = () => {
       kind?: Kind;
     }): Promise<boolean> => {
       return await showConfirm(message, {
-        title: title ? t(`error.title.${title}`) : undefined,
-        kind,
+        ...(title !== undefined && { title: t(`error.title.${title}`) }),
+        ...(kind !== undefined && { kind }),
       });
     },
     [t],
@@ -66,8 +66,8 @@ export const useTauriDialog = () => {
       kind?: Kind;
     }): Promise<MessageDialogResult> => {
       return await showMessage(message, {
-        title: title ? t(`error.title.${title}`) : undefined,
-        kind,
+        ...(title !== undefined && { title: t(`error.title.${title}`) }),
+        ...(kind !== undefined && { kind }),
       });
     },
     [t],

--- a/src/hooks/useTauriStore.test.ts
+++ b/src/hooks/useTauriStore.test.ts
@@ -59,7 +59,7 @@ describe("useTauriStore", () => {
 
   it("When key exists on initial load, value from store is returned", async () => {
     // Arrange: State where value is already saved in fakeStore
-    fakeStore.data.testKey = "storedValue";
+    fakeStore.data["testKey"] = "storedValue";
     const { result } = renderHook(() =>
       useTauriStore<string>("testKey", "defaultValue"),
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Enable the TypeScript compiler-side strictness slice first, before broader Biome hardening.

This PR adds:

- `noImplicitOverride`
- `noImplicitReturns`
- `allowUnreachableCode: false`
- `allowUnusedLabels: false`
- `noPropertyAccessFromIndexSignature`
- `exactOptionalPropertyTypes`

The code changes are the matching TypeScript fixes: bracket access for index-signature values, explicit `| undefined` where optional props are forwarded, conditional prop spreading for third-party components, and one explicit `return null` for the chart label callback.

`biome.jsonc` only disables `complexity.useLiteralKeys` because it conflicts with TypeScript's `noPropertyAccessFromIndexSignature`. The broader Biome type-aware hardening and `noUncheckedIndexedAccess` remain follow-up work.

## Related Issues

Related: #1679

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [x] Unit tests

Validation performed:

- `npm run build`
- `npm run lint`
- `npm run lint:ci`
- `npm test`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox and switch controls to properly initialize with boolean default values when settings are undefined, preventing invalid UI states.

* **Refactor**
  * Strengthened type safety across components with stricter TypeScript configuration.
  * Improved component prop handling through conditional spreading and optional chaining patterns to enhance code robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->