### PR TITLE
perf(macos): native vibrancy instead of CSS backdrop-filter blur

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -396,6 +396,39 @@ pub mod commands {
     Ok(())
   }
 
+  /// Apply (or clear) native macOS window vibrancy.
+  ///
+  /// When enabled, installs an `NSVisualEffectView` behind the (transparent)
+  /// webview so the frosted-glass look is composited by the OS instead of the
+  /// CSS `backdrop-filter: blur`, which was measured to continuously pin the
+  /// WebKit render/GPU processes on macOS (see #1718). No-op elsewhere.
+  #[cfg(target_os = "macos")]
+  pub fn apply_window_vibrancy(app: &tauri::AppHandle, enabled: bool) {
+    use tauri::window::{Effect, EffectsBuilder};
+
+    let Some(window) = app.get_webview_window("main") else {
+      return;
+    };
+
+    let result = if enabled {
+      window.set_effects(EffectsBuilder::new().effect(Effect::HudWindow).build())
+    } else {
+      window.set_effects(None::<tauri::utils::config::WindowEffectsConfig>)
+    };
+
+    if let Err(e) = result {
+      log_error!(
+        "Failed to update window vibrancy",
+        "settings::apply_window_vibrancy",
+        Some(e.to_string())
+      );
+    }
+  }
+
+  /// No-op on non-macOS platforms (native vibrancy is a macOS feature).
+  #[cfg(not(target_os = "macos"))]
+  pub fn apply_window_vibrancy(_app: &tauri::AppHandle, _enabled: bool) {}
+
   #[tauri::command]
   #[specta::specta]
   pub async fn set_transparent_ui(
@@ -403,12 +436,16 @@ pub mod commands {
     state: tauri::State<'_, AppState>,
     new_value: bool,
   ) -> Result<(), String> {
-    let mut settings = state.settings.lock().unwrap();
+    {
+      let mut settings = state.settings.lock().unwrap();
 
-    if let Err(e) = settings.set_transparent_ui(new_value) {
-      emit_error(&window)?;
-      return Err(e);
+      if let Err(e) = settings.set_transparent_ui(new_value) {
+        emit_error(&window)?;
+        return Err(e);
+      }
     }
+
+    apply_window_vibrancy(window.app_handle(), new_value);
     Ok(())
   }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,6 +157,7 @@ pub fn run() {
 
   let app_state = settings::AppState::new();
   let elevated_startup_mode = app_state.settings.lock().unwrap().elevated_startup_mode;
+  let transparent_ui = app_state.settings.lock().unwrap().transparent_ui;
 
   // Core-owned shared sensor history. App-side commands and the collector
   // loop read/write through this store. Persistence no longer shares it; the
@@ -236,6 +237,11 @@ pub fn run() {
       // Initialize UI and real-time monitoring (independent of DB)
       commands::ui::init(app);
       builder.mount_events(app);
+
+      // Apply native macOS vibrancy up front when transparent UI is enabled, so
+      // the frosted glass is composited by the OS instead of the costly CSS
+      // backdrop-filter blur (see #1718). No-op on other platforms.
+      settings::commands::apply_window_vibrancy(app.handle(), transparent_ui);
 
       // Real-time pipeline: collector publishes MetricsSnapshot to the
       // EventBus, WindowAdapter subscribes and emits HardwareMonitorUpdate.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import {
   SquaresFourIcon,
 } from "@phosphor-icons/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { platform } from "@tauri-apps/plugin-os";
 import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";
 import { clearTauriStore } from "@/lib/tauriStore";
@@ -172,6 +173,7 @@ const AppContent = () => {
 
   useKeydown({ isDecorated: Boolean(isDecorated), setDecorated });
   const { isFullScreen, toggleFullScreen } = useFullScreenMode();
+  const isMacOS = platform() === "macos";
   const windowOpacityRatio = settings.transparentUi
     ? settings.windowOpacity / 100
     : 1;
@@ -267,6 +269,7 @@ const AppContent = () => {
         className={cn(
           "min-h-screen bg-background bg-cover text-foreground duration-300 ease-in-out",
           settings.transparentUi && "transparent-ui",
+          settings.transparentUi && isMacOS && "native-vibrancy",
         )}
         style={
           {

--- a/src/index.css
+++ b/src/index.css
@@ -539,6 +539,16 @@
   --transparent-backdrop-filter: blur(var(--transparent-backdrop-blur));
 }
 
+/*
+ * macOS: render the frosted glass natively via NSVisualEffectView (Tauri window
+ * effects, see #1718) instead of CSS `backdrop-filter: blur`, which was measured
+ * to continuously pin the WebKit render/GPU processes. Disabling the filter here
+ * removes that cost; translucency is kept so the native vibrancy shows through.
+ */
+.transparent-ui.native-vibrancy {
+  --transparent-backdrop-filter: none;
+}
+
 .dark .transparent-ui {
   --transparent-surface-alpha: var(--transparent-surface-opacity-percent, 44%);
   --transparent-border-alpha: 58%;


### PR DESCRIPTION
> **Draft for review** — implements the native-vibrancy replacement from #1718. Compiles and type-checks, but the visual result (material choice, look on light/dark themes) still needs to be verified by running the app on macOS.

## What

On macOS, render the Transparent UI frosted glass with **native vibrancy** (`NSVisualEffectView` via Tauri window effects) instead of the CSS `backdrop-filter: blur`.

## Why

The A/B test on #1718 showed the CSS `backdrop-filter: blur` is what drives the elevated GPU / compositor load: the app's WebKit cluster CPU jumped from **~1.5% (idle) to ~28%** the moment Transparent UI was enabled, and system GPU utilization rose from ~38% to ~55%. Native vibrancy is composited by the OS and should remove that continuous WebKit cost while preserving the frosted-glass look.

## How

**Rust** (`src-tauri/`)
- `commands/settings.rs`: new `apply_window_vibrancy(app, enabled)` — on macOS calls `window.set_effects(EffectsBuilder::new().effect(Effect::HudWindow).build())`, or `set_effects(None)` to clear. No-op on other platforms (`#[cfg]`).
- `set_transparent_ui` now applies/clears vibrancy after persisting the setting.
- `lib.rs`: applies vibrancy once at startup from the persisted `transparent_ui` value, so the effect is correct on a fresh launch (not only after toggling).
- No new Tauri command → no rspc/specta bindings regeneration.

**Frontend** (`src/`)
- `App.tsx`: on macOS, add a `native-vibrancy` class to the root when Transparent UI is on (`platform() === "macos"`).
- `index.css`: `.transparent-ui.native-vibrancy` overrides `--transparent-backdrop-filter: none`, disabling **all** the CSS `backdrop-filter` rules (they all read that var) while keeping surface translucency so the native vibrancy shows through.

## How to test (macOS)

1. `pnpm tauri:dev` (or build the app).
2. Settings → enable **Transparent UI**.
3. In Activity Monitor / `top`, watch `com.apple.WebKit.WebContent` + `com.apple.WebKit.GPU` CPU — expected to stay low (vs ~28% on `develop`).
4. Confirm the window still looks frosted/translucent.

## Review notes / known limitations

- **Visual verification pending** — I could not run the GUI here. Please sanity-check the look.
- Material is `Effect::HudWindow`; easy to swap (`Sidebar`, `UnderWindowBackground`, `WindowBackground`, …) if a different frost is preferred.
- On macOS the **Backdrop blur slider** is now a no-op (native material has no CSS radius). Hiding it on macOS is a small follow-up, kept out of this PR to limit scope (and to avoid conflicting with #1719).
- Non-macOS platforms are unchanged (CSS blur path retained).
- Verified locally: `cargo check`, `cargo clippy`, `tsc --noEmit`, `biome check` all pass.

Refs #1718
