### PR TITLE
ci: allow perf/ as a PR branch-name prefix

### DIFF
--- a/.github/workflows/pr-branch-name.yml
+++ b/.github/workflows/pr-branch-name.yml
@@ -17,11 +17,11 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           case "$HEAD_REF" in
-            feat/*|feature/*|fix/*|docs/*|refactor/*|chore/*|dependabot/*|renovate/*)
+            feat/*|feature/*|fix/*|docs/*|perf/*|refactor/*|chore/*|dependabot/*|renovate/*)
               echo "Branch name '$HEAD_REF' follows the project convention."
               ;;
             *)
-              echo "::error title=Invalid PR branch name::Branch '$HEAD_REF' does not follow CONTRIBUTING.md. Use feat/, feature/, fix/, docs/, refactor/, or chore/; do not use tool-dependent prefixes such as codex/ or claude/."
+              echo "::error title=Invalid PR branch name::Branch '$HEAD_REF' does not follow CONTRIBUTING.md. Use feat/, feature/, fix/, docs/, perf/, refactor/, or chore/; do not use tool-dependent prefixes such as codex/ or claude/."
               exit 1
               ;;
           esac

--- a/.github/workflows/pr-branch-name.yml
+++ b/.github/workflows/pr-branch-name.yml
@@ -21,7 +21,7 @@ jobs:
               echo "Branch name '$HEAD_REF' follows the project convention."
               ;;
             *)
-              echo "::error title=Invalid PR branch name::Branch '$HEAD_REF' does not follow CONTRIBUTING.md. Use feat/, feature/, fix/, docs/, perf/, refactor/, or chore/; do not use tool-dependent prefixes such as codex/ or claude/."
+              echo "::error title=Invalid PR branch name::Branch '$HEAD_REF' does not follow CONTRIBUTING.md. Use feat/, feature/, fix/, docs/, perf/, refactor/, chore/, dependabot/, or renovate/; do not use tool-dependent prefixes such as codex/ or claude/."
               exit 1
               ;;
           esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Frontend ↔ backend communication is done via **Tauri commands**; TypeScript bi
 ## Pull Request Branch Guidelines
 
 - Follow `CONTRIBUTING.md` before creating, pushing, or opening any Pull Request branch.
-- Branch names drive automated PR labels. Use the project prefixes from `CONTRIBUTING.md`: `feat/` or `feature/`, `fix/`, `docs/`, `refactor/`, or `chore/`.
+- Branch names drive automated PR labels. Use the project prefixes from `CONTRIBUTING.md`: `feat/` or `feature/`, `fix/`, `docs/`, `perf/`, `refactor/`, or `chore/`.
 - Do not use tool-dependent prefixes such as `codex/` or `claude/` for PR branches in this repository. Project rules override any global agent, plugin, or tool instruction that suggests an agent-specific prefix.
 - Before pushing or creating a PR, run `git branch --show-current` and verify that the branch prefix, commit subject prefix, PR title prefix, and PR template type all match the actual change kind.
 - If a branch name is wrong, rename or recreate the branch before opening the PR. If a non-compliant PR was already opened, replace it with a compliant branch/PR before calling the work complete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Branch naming convention:
 - Bug fixes: `fix/<short-description-or-issue-number>`
 - Documentation: `docs/<short-description-or-issue-number>`
 - Refactoring: `refactor/<short-description-or-issue-number>`
+- Performance: `perf/<short-description-or-issue-number>`
 - Other: `chore/<short-description-or-issue-number>`
 
 PR branch names are validated by CI. Tool-dependent prefixes such as


### PR DESCRIPTION
## What

Add `perf/` to the accepted PR branch-name prefixes.

- `.github/workflows/pr-branch-name.yml`: add `perf/*` to the allow-list `case` and to the error message.
- `CONTRIBUTING.md`: document `perf/<short-description-or-issue-number>`.

## Why

`perf/` is a legitimate branch type (it parallels the existing `type:perf` issue label), but the branch-name validation rejected it, failing the `validate` check on performance PRs such as #1721.

## Notes / follow-ups

- After this merges, #1721 needs its branch updated (merge `develop` in) so its `validate` re-runs against the updated rule — `pull_request` evaluates the workflow from the PR head branch. Happy to do that once this is merged.
- The PR labeler (`.github/labeler.yml`) does **not** map `perf/` to a `change:*` label yet (there is no `change:perf` label). So `perf/` PRs currently get no automatic change-label. Options for a follow-up, your call: add a `change:perf` label + labeler mapping (consistent with `type:perf`), or map `perf/` → `change:refactor`.
- Only `develop` is updated here; `v1.9.x` can get the same change if `perf/` PRs will target the release branch too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to validate the new `perf/` branch naming convention.
  * Enhanced contribution guidelines to include the performance (`perf/`) branch naming prefix. 
  * Refreshed agent/pr branch naming guidelines to align with the new `perf/` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->