### PR TITLE
fix(macos): dedupe window-vibrancy to fix Publish LTO link failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "winapi",
- "window-vibrancy 0.7.1",
+ "window-vibrancy",
  "windows 0.62.2",
  "wmi",
 ]
@@ -5384,7 +5384,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "window-vibrancy 0.6.0",
+ "window-vibrancy",
  "windows 0.61.3",
 ]
 
@@ -6850,21 +6850,6 @@ dependencies = [
  "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
- "windows-version",
-]
-
-[[package]]
-name = "window-vibrancy"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010797bd7c40396fbc59d3105089fed0885fe267a0ef4a0a4646df54e28647f6"
-dependencies = [
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "raw-window-handle",
- "windows-sys 0.60.2",
  "windows-version",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,7 +94,12 @@ dirs = "6.0.0"
 libc = "0.2"
 core-foundation = "0.10.1"
 objc2 = "0.6.4"
-window-vibrancy = "0.7"
+# Pin to 0.6 so the single copy in the tree matches the one Tauri depends on.
+# Two semver-incompatible copies (0.6 + 0.7) each compile the same
+# `NSVisualEffectViewTagged` Objective-C class, and the release profile's LTO
+# (`lto = true`, `codegen-units = 1`) then fails the macOS link with
+# "symbol multiply defined" for `__CLASS_NSVisualEffectViewTagged` (see #1724/#1718).
+window-vibrancy = "0.6"
 objc2-app-kit = { version = "0.3.2", features = [
     "NSAttributedString",
     "NSButton",


### PR DESCRIPTION
## Summary

The **Publish** workflow's macOS jobs (both `aarch64` and `x64`) have been failing at the `tauri-action` build step since v1.9.1. This PR fixes the root cause by deduplicating the `window-vibrancy` crate.

## Symptom

Both macOS matrix jobs failed during the final link with ([run 28133734272](https://github.com/shm11C3/HardwareVisualizer/actions/runs/28133734272)):

```
warning: Linking globals named '__CLASS_NSVisualEffectViewTagged': symbol multiply defined!
error: failed to load bitcode of module "window_vibrancy-5c70b546b75f830b.window_vibrancy.4debfa536d366173-cgu.0.rcgu.o":
error: could not compile `hardware_visualizer` (bin "hardware_visualizer") due to 1 previous error; 1 warning emitted
```

Linux and Windows publish jobs were green; only macOS failed.

## Root cause

#1724 added a direct dependency `window-vibrancy = "0.7"`, but **Tauri 2.11.3 already depends on `window-vibrancy = "^0.6"`** (macOS & Windows targets). That left two semver-incompatible copies in the tree:

| Consumer | window-vibrancy |
|---|---|
| `hardware_visualizer` (this app) | `0.7.1` |
| `tauri v2.11.3` | `0.6.0` |

Both versions compile the same Objective-C class `NSVisualEffectViewTagged`. The release profile enables link-time optimization:

```toml
[profile.release]
lto = true
codegen-units = 1
```

so the macOS link merges both bitcode modules and fails on the duplicate global `__CLASS_NSVisualEffectViewTagged`.

**Why CI stayed green:** the `ci` profile sets `lto = false`, so the duplicate symbol is never merged. **Why only macOS:** `NSVisualEffectViewTagged` is a macOS-only AppKit subclass; Linux/Windows use other vibrancy backends with no such class.

## Fix

Pin our dependency to `window-vibrancy = "0.6"` so it unifies with Tauri's copy into a **single** `window-vibrancy 0.6.0` in the dependency tree, eliminating the duplicate symbol.

- The API the #1724 code uses is identical in 0.6.0, so **no Rust code changes are needed**:
  - `apply_vibrancy(window, NSVisualEffectMaterial, Option<NSVisualEffectState>, Option<f64>)`
  - `clear_vibrancy(window) -> Result<bool>`
  - `NSVisualEffectMaterial::{HudWindow, Menu, UnderWindowBackground}`
- `Cargo.lock` change is limited to dropping the `window-vibrancy 0.7.1` entry and repointing both consumers to the single copy. `cargo metadata --locked` accepts the result (no further resolution changes).

## Verification

- ✅ Confirmed only one `window-vibrancy` (`0.6.0`) remains in `Cargo.lock`, referenced by both `hardware_visualizer` and `tauri`.
- ✅ Verified the 0.6.0 public API matches the call sites added in #1724 (signatures + enum variants checked against the 0.6.0 source).
- ✅ `cargo metadata --locked` succeeds.
- ⚠️ A full macOS release/LTO build can't run on the Linux CI sandbox; the next tag push (or a manual `workflow_dispatch` of Publish) should be used to confirm the macOS jobs go green.

Refs #1724 #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ANFjj5uRP57YUtAdoL4P8

---
_Generated by [Claude Code](https://claude.ai/code/session_017ANFjj5uRP57YUtAdoL4P8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build reliability by pinning a dependency to a compatible version, helping prevent app launch or linking issues on that platform.
  * Added notes to clarify the version choice for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->