### PR TITLE
feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO

### DIFF
--- a/core/src/infrastructure/providers/windows/mod.rs
+++ b/core/src/infrastructure/providers/windows/mod.rs
@@ -8,5 +8,6 @@ mod pawn_io;
 pub mod pdh_provider;
 pub mod setupdi_provider;
 pub mod smart;
+pub mod super_io_diagnostics;
 pub mod thermal_zone;
 pub mod wmi_provider;

--- a/core/src/infrastructure/providers/windows/pawn_io.rs
+++ b/core/src/infrastructure/providers/windows/pawn_io.rs
@@ -19,13 +19,17 @@ const INTEL_MSR_MODULE_FILE: &str = "IntelMSR.amx";
 const INTEL_MSR_LEGACY_MODULE_FILE: &str = "IntelMSR.bin";
 const RYZEN_SMU_MODULE_FILE: &str = "RyzenSMU.amx";
 const RYZEN_SMU_LEGACY_MODULE_FILE: &str = "RyzenSMU.bin";
+const LPC_IO_MODULE_FILE: &str = "LpcIO.bin";
+const LPC_IO_LEGACY_MODULE_FILE: &str = "LpcIO.amx";
 
 pub(crate) const ACCESS_PCI_MUTEX: &str = "Global\\Access_PCI";
+pub(crate) const ACCESS_ISABUS_MUTEX: &str = "Global\\Access_ISABUS.HTP.Method";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PawnIoModule {
   IntelMsr,
   RyzenSmu,
+  LpcIo,
 }
 
 impl PawnIoModule {
@@ -33,6 +37,7 @@ impl PawnIoModule {
     match self {
       Self::IntelMsr => &[INTEL_MSR_MODULE_FILE, INTEL_MSR_LEGACY_MODULE_FILE],
       Self::RyzenSmu => &[RYZEN_SMU_MODULE_FILE, RYZEN_SMU_LEGACY_MODULE_FILE],
+      Self::LpcIo => &[LPC_IO_MODULE_FILE, LPC_IO_LEGACY_MODULE_FILE],
     }
   }
 
@@ -203,11 +208,57 @@ impl PawnIoClient {
       .map(|out| out[0])
   }
 
+  pub(crate) fn select_lpc_slot(&self, slot: u64) -> Result<(), String> {
+    self.execute_no_output("ioctl_select_slot", &[slot])
+  }
+
+  pub(crate) fn pio_outb(&self, port: u16, value: u8) -> Result<(), String> {
+    self.execute_no_output("ioctl_pio_outb", &[port as u64, value as u64])
+  }
+
+  pub(crate) fn superio_inb(&self, register: u8) -> Result<u8, String> {
+    self
+      .execute("ioctl_superio_inb", &[register as u64])
+      .map(|out| out[0] as u8)
+  }
+
+  pub(crate) fn superio_outb(&self, register: u8, value: u8) -> Result<(), String> {
+    self.execute_no_output("ioctl_superio_outb", &[register as u64, value as u64])
+  }
+
   fn execute(&self, name: &str, input: &[u64]) -> Result<Vec<u64>, String> {
+    let output = self.execute_raw(name, input, 1)?;
+    if output.is_empty() {
+      return Err(format!("pawnio_execute {name} returned no output cells"));
+    }
+
+    Ok(output)
+  }
+
+  fn execute_no_output(&self, name: &str, input: &[u64]) -> Result<(), String> {
+    self.execute_raw(name, input, 0).map(|_| ())
+  }
+
+  fn execute_raw(
+    &self,
+    name: &str,
+    input: &[u64],
+    output_cells: usize,
+  ) -> Result<Vec<u64>, String> {
     let name =
       CString::new(name).map_err(|e| format!("invalid PawnIO function name: {e}"))?;
-    let mut output = [0_u64; 1];
+    // Always back the output pointer with at least one cell so PawnIOLib
+    // receives a valid, aligned, non-null pointer even for no-output IOCTLs,
+    // but tell it the true cell count (`output_cells`) so a 0-output IOCTL is
+    // never told it has space to write.
+    let mut output = vec![0_u64; output_cells.max(1)];
     let mut return_size = 0_usize;
+    // SAFETY: `self.handle` is returned by `pawnio_open` and kept alive by
+    // `PawnIoClient`; `name` is a NUL-terminated `CString` that outlives the
+    // call; `input` and `output` pointers reference valid contiguous `u64`
+    // buffers for the exact element counts passed to PawnIOLib. For no-output
+    // IOCTLs, `output_cells` is 0 but the backing vector still provides a
+    // non-null pointer and PawnIOLib receives an output count of 0.
     let hr = unsafe {
       (self.library.execute)(
         self.handle,
@@ -215,7 +266,7 @@ impl PawnIoClient {
         input.as_ptr(),
         input.len(),
         output.as_mut_ptr(),
-        output.len(),
+        output_cells,
         &mut return_size,
       )
     };
@@ -226,14 +277,8 @@ impl PawnIoClient {
         format_hresult(hr)
       ));
     }
-    if return_size == 0 {
-      return Err(format!(
-        "pawnio_execute {} returned no output cells",
-        name.to_string_lossy()
-      ));
-    }
 
-    Ok(output[..return_size.min(output.len())].to_vec())
+    Ok(output[..return_size.min(output_cells)].to_vec())
   }
 }
 
@@ -243,9 +288,11 @@ impl Drop for PawnIoClient {
   }
 }
 
-// SAFETY: the PawnIO handle is only used behind the process-wide CPU
-// temperature sampler mutex, and the DLL remains loaded for the full handle
-// lifetime through `PawnIoLibrary`.
+// SAFETY: the PawnIO handle is owned by `PawnIoClient` and closed exactly once
+// in `Drop`. Callers serialize stateful module transactions with the
+// appropriate ecosystem mutex (`Access_PCI` for SMN, `Access_ISABUS` for
+// Super I/O). The DLL remains loaded for the full handle lifetime through
+// `PawnIoLibrary`.
 unsafe impl Send for PawnIoClient {}
 
 type PawnIoVersion = unsafe extern "system" fn(*mut u32) -> i32;

--- a/core/src/infrastructure/providers/windows/super_io_diagnostics.rs
+++ b/core/src/infrastructure/providers/windows/super_io_diagnostics.rs
@@ -1,0 +1,171 @@
+use std::time::Duration;
+
+use super::pawn_io::{
+  ACCESS_ISABUS_MUTEX, NamedMutex, PawnIoClient, PawnIoDiscovery, PawnIoModule,
+};
+use crate::models::hardware::{
+  PawnIoRuntimeDiagnostics, SuperIoChipIdAttempt, SuperIoChipIdDiagnostics,
+  SuperIoChipIdSlotProbe, SuperIoVendor,
+};
+use crate::utils::super_io::{chip_id, is_absent_id, slot_ports};
+
+const ISABUS_MUTEX_TIMEOUT: Duration = Duration::from_millis(50);
+const CHIP_ID_HIGH_REGISTER: u8 = 0x20;
+const CHIP_ID_LOW_REGISTER: u8 = 0x21;
+
+/// Read raw Super I/O chip-id registers through PawnIO's `LpcIO` module.
+///
+/// This diagnostic intentionally stops at chip-id discovery. It does not read
+/// hardware-monitor registers, fan counters, voltages, or temperature sensors.
+/// Writes are limited to configuration-mode enter/exit key sequences and the
+/// ITE documented exit register, matching `docs/specs/sensors/superio-access.md`.
+pub fn read_super_io_chip_id_diagnostics() -> SuperIoChipIdDiagnostics {
+  let (client, discovery) = match PawnIoClient::open(PawnIoModule::LpcIo) {
+    Ok((client, discovery)) => (client, discovery),
+    Err(error) => {
+      return SuperIoChipIdDiagnostics {
+        platform_supported: true,
+        pawnio: Some(map_pawnio_discovery(&error.discovery)),
+        slots: Vec::new(),
+        error: Some(error.reason),
+      };
+    }
+  };
+
+  let pawnio = map_pawnio_discovery(&discovery);
+  let _mutex = match NamedMutex::acquire(ACCESS_ISABUS_MUTEX, ISABUS_MUTEX_TIMEOUT) {
+    Ok(mutex) => mutex,
+    Err(reason) => {
+      return SuperIoChipIdDiagnostics {
+        platform_supported: true,
+        pawnio: Some(pawnio),
+        slots: Vec::new(),
+        error: Some(reason),
+      };
+    }
+  };
+
+  SuperIoChipIdDiagnostics {
+    platform_supported: true,
+    pawnio: Some(pawnio),
+    slots: vec![probe_slot(&client, 0), probe_slot(&client, 1)],
+    error: None,
+  }
+}
+
+fn probe_slot(client: &PawnIoClient, slot: u8) -> SuperIoChipIdSlotProbe {
+  let Some((index_port, data_port)) = slot_ports(slot) else {
+    return SuperIoChipIdSlotProbe {
+      slot,
+      index_port: 0,
+      data_port: 0,
+      attempts: Vec::new(),
+      error: Some(format!("unsupported Super I/O LpcIO slot {slot}")),
+    };
+  };
+  let mut probe = SuperIoChipIdSlotProbe {
+    slot,
+    index_port,
+    data_port,
+    attempts: Vec::new(),
+    error: None,
+  };
+
+  if let Err(reason) = client.select_lpc_slot(slot as u64) {
+    probe.error = Some(reason);
+    return probe;
+  }
+
+  probe.attempts.push(probe_nuvoton(client, index_port));
+  probe.attempts.push(probe_ite(client, slot, index_port));
+  probe
+}
+
+fn probe_nuvoton(client: &PawnIoClient, index_port: u16) -> SuperIoChipIdAttempt {
+  let result = enter_nuvoton(client, index_port).and_then(|_| read_chip_id(client));
+  let exit_error = exit_nuvoton(client, index_port).err();
+  attempt_from_result(SuperIoVendor::Nuvoton, result, exit_error)
+}
+
+fn probe_ite(client: &PawnIoClient, slot: u8, index_port: u16) -> SuperIoChipIdAttempt {
+  let result = enter_ite(client, slot, index_port).and_then(|_| read_chip_id(client));
+  let exit_error = exit_ite(client).err();
+  attempt_from_result(SuperIoVendor::Ite, result, exit_error)
+}
+
+fn enter_nuvoton(client: &PawnIoClient, index_port: u16) -> Result<(), String> {
+  client.pio_outb(index_port, 0x87)?;
+  client.pio_outb(index_port, 0x87)
+}
+
+fn exit_nuvoton(client: &PawnIoClient, index_port: u16) -> Result<(), String> {
+  client.pio_outb(index_port, 0xAA)
+}
+
+fn enter_ite(client: &PawnIoClient, slot: u8, index_port: u16) -> Result<(), String> {
+  let fourth_key = if slot == 0 { 0x55 } else { 0xAA };
+  for key in [0x87, 0x01, 0x55, fourth_key] {
+    client.pio_outb(index_port, key)?;
+  }
+  Ok(())
+}
+
+fn exit_ite(client: &PawnIoClient) -> Result<(), String> {
+  client.superio_outb(0x02, 0x02)
+}
+
+fn read_chip_id(client: &PawnIoClient) -> Result<(u8, u8), String> {
+  let high = client.superio_inb(CHIP_ID_HIGH_REGISTER)?;
+  let low = client.superio_inb(CHIP_ID_LOW_REGISTER)?;
+  Ok((high, low))
+}
+
+fn attempt_from_result(
+  vendor: SuperIoVendor,
+  result: Result<(u8, u8), String>,
+  exit_error: Option<String>,
+) -> SuperIoChipIdAttempt {
+  match result {
+    Ok((id_high, id_low)) => {
+      let absent = is_absent_id(id_high, id_low);
+      SuperIoChipIdAttempt {
+        vendor,
+        id_high: Some(id_high),
+        id_low: Some(id_low),
+        chip_id: (!absent).then_some(chip_id(id_high, id_low)),
+        absent,
+        error: None,
+        exit_error,
+      }
+    }
+    Err(error) => SuperIoChipIdAttempt {
+      vendor,
+      id_high: None,
+      id_low: None,
+      chip_id: None,
+      absent: false,
+      error: Some(error),
+      exit_error,
+    },
+  }
+}
+
+fn map_pawnio_discovery(discovery: &PawnIoDiscovery) -> PawnIoRuntimeDiagnostics {
+  PawnIoRuntimeDiagnostics {
+    install_location: discovery
+      .install_location
+      .as_ref()
+      .map(|p| p.display().to_string()),
+    dll_path: discovery.dll_path.as_ref().map(|p| p.display().to_string()),
+    module_path: discovery
+      .module_path
+      .as_ref()
+      .map(|p| p.display().to_string()),
+    pawnio_available: discovery.pawnio_available,
+    library_loadable: discovery.library_loadable,
+    driver_openable: discovery.driver_openable,
+    module_loadable: discovery.module_loadable,
+    version: discovery.version,
+    fallback_reason: discovery.fallback_reason.clone(),
+  }
+}

--- a/core/src/models/hardware.rs
+++ b/core/src/models/hardware.rs
@@ -114,6 +114,23 @@ pub struct SuperIoChipIdDiagnostics {
   pub error: Option<String>,
 }
 
+impl SuperIoChipIdDiagnostics {
+  /// Result for platforms that do not have a Super I/O `LpcIO` path.
+  ///
+  /// Reports `platform_supported = false` with an explanatory message
+  /// instead of an error, so callers can branch on support uniformly.
+  pub fn unsupported_platform() -> Self {
+    Self {
+      platform_supported: false,
+      pawnio: None,
+      slots: Vec::new(),
+      error: Some(
+        "Super I/O LpcIO diagnostics are available on Windows only".to_string(),
+      ),
+    }
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PawnIoRuntimeDiagnostics {
   pub install_location: Option<String>,

--- a/core/src/models/hardware.rs
+++ b/core/src/models/hardware.rs
@@ -106,6 +106,53 @@ pub struct MotherboardInfo {
   pub bios_release_date: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuperIoChipIdDiagnostics {
+  pub platform_supported: bool,
+  pub pawnio: Option<PawnIoRuntimeDiagnostics>,
+  pub slots: Vec<SuperIoChipIdSlotProbe>,
+  pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PawnIoRuntimeDiagnostics {
+  pub install_location: Option<String>,
+  pub dll_path: Option<String>,
+  pub module_path: Option<String>,
+  pub pawnio_available: bool,
+  pub library_loadable: bool,
+  pub driver_openable: bool,
+  pub module_loadable: bool,
+  pub version: Option<u32>,
+  pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuperIoChipIdSlotProbe {
+  pub slot: u8,
+  pub index_port: u16,
+  pub data_port: u16,
+  pub attempts: Vec<SuperIoChipIdAttempt>,
+  pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuperIoChipIdAttempt {
+  pub vendor: SuperIoVendor,
+  pub id_high: Option<u8>,
+  pub id_low: Option<u8>,
+  pub chip_id: Option<u16>,
+  pub absent: bool,
+  pub error: Option<String>,
+  pub exit_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuperIoVendor {
+  Nuvoton,
+  Ite,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CpuInfo {
   pub name: String,

--- a/core/src/platform/linux/mod.rs
+++ b/core/src/platform/linux/mod.rs
@@ -1,8 +1,10 @@
 use crate::enums::error::BackendError;
-use crate::models::hardware::{GpuMemoryUsage, GraphicInfo, NetworkInfo};
+use crate::models::hardware::{
+  GpuMemoryUsage, GraphicInfo, NetworkInfo, SuperIoChipIdDiagnostics,
+};
 use crate::platform::traits::{
   GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform,
+  ProcessElevationPlatform, SuperIoPlatform,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -99,6 +101,12 @@ impl MotherboardPlatform for LinuxPlatform {
     Box::pin(async {
       Err("get_motherboard_info is not implemented for LinuxPlatform".to_string())
     })
+  }
+}
+
+impl SuperIoPlatform for LinuxPlatform {
+  fn get_super_io_chip_id_diagnostics(&self) -> SuperIoChipIdDiagnostics {
+    SuperIoChipIdDiagnostics::unsupported_platform()
   }
 }
 

--- a/core/src/platform/macos/mod.rs
+++ b/core/src/platform/macos/mod.rs
@@ -1,8 +1,10 @@
 use crate::enums::error::BackendError;
-use crate::models::hardware::{GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo};
+use crate::models::hardware::{
+  GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo, SuperIoChipIdDiagnostics,
+};
 use crate::platform::traits::{
   GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform,
+  ProcessElevationPlatform, SuperIoPlatform,
 };
 use std::future::Future;
 use std::pin::Pin;
@@ -96,6 +98,12 @@ impl MotherboardPlatform for MacOSPlatform {
     >,
   > {
     motherboard::get_motherboard_info()
+  }
+}
+
+impl SuperIoPlatform for MacOSPlatform {
+  fn get_super_io_chip_id_diagnostics(&self) -> SuperIoChipIdDiagnostics {
+    SuperIoChipIdDiagnostics::unsupported_platform()
   }
 }
 

--- a/core/src/platform/traits.rs
+++ b/core/src/platform/traits.rs
@@ -86,6 +86,18 @@ pub trait MotherboardPlatform: Send + Sync {
   >;
 }
 
+/// Trait that defines platform-specific Super I/O chip-id diagnostics.
+pub trait SuperIoPlatform: Send + Sync {
+  /// Read raw Super I/O chip-id diagnostics.
+  ///
+  /// This is a blocking, read-only probe. Platforms without a Super I/O
+  /// LpcIO path return a result with `platform_supported = false` rather
+  /// than erroring, so the caller can branch on support uniformly.
+  fn get_super_io_chip_id_diagnostics(
+    &self,
+  ) -> models::hardware::SuperIoChipIdDiagnostics;
+}
+
 /// Trait that defines process elevation operations.
 pub trait ProcessElevationPlatform: Send + Sync {
   /// Returns whether the current process is running with elevated privileges.
@@ -101,6 +113,7 @@ pub trait Platform:
   + GpuPlatform
   + NetworkPlatform
   + MotherboardPlatform
+  + SuperIoPlatform
   + ProcessElevationPlatform
 {
 }

--- a/core/src/platform/windows/mod.rs
+++ b/core/src/platform/windows/mod.rs
@@ -1,10 +1,10 @@
 use crate::enums::error::BackendError;
 use crate::models::hardware::{
-  GpuMemoryUsage, GraphicInfo, MotherboardInfo, NetworkInfo,
+  GpuMemoryUsage, GraphicInfo, MotherboardInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
 use crate::platform::traits::{
   GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform,
+  ProcessElevationPlatform, SuperIoPlatform,
 };
 
 use std::future::Future;
@@ -95,6 +95,12 @@ impl MotherboardPlatform for WindowsPlatform {
     &self,
   ) -> Pin<Box<dyn Future<Output = Result<MotherboardInfo, String>> + Send + '_>> {
     motherboard::get_motherboard_info()
+  }
+}
+
+impl SuperIoPlatform for WindowsPlatform {
+  fn get_super_io_chip_id_diagnostics(&self) -> SuperIoChipIdDiagnostics {
+    crate::infrastructure::providers::windows::super_io_diagnostics::read_super_io_chip_id_diagnostics()
   }
 }
 

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -2,4 +2,5 @@ pub mod formatter;
 pub mod ip;
 pub mod logger;
 pub mod rounding;
+pub mod super_io;
 pub mod thermal;

--- a/core/src/utils/super_io.rs
+++ b/core/src/utils/super_io.rs
@@ -1,0 +1,71 @@
+//! Pure helpers for Super I/O chip-id decoding.
+//!
+//! These are platform-neutral pure functions so the spec-encoded facts from
+//! `docs/specs/sensors/superio-access.md` stay unit-testable on every OS,
+//! mirroring [`crate::utils::thermal`]. The Windows `LpcIO` provider performs
+//! the actual port I/O and then uses these helpers to interpret the bytes.
+//!
+//! Implemented from docs/specs/sensors/superio-access.md (chip-id register and
+//! configuration-port facts). No other external sensor source was used.
+
+/// Super I/O configuration index/data port pair for an `LpcIO` slot.
+///
+/// A board straps its Super I/O chip to one of two pairs: slot 0 is the
+/// primary `0x2E`/`0x2F` pair and slot 1 is the secondary `0x4E`/`0x4F` pair
+/// (`superio-access.md` "Configuration port pairs").
+pub const fn slot_ports(slot: u8) -> Option<(u16, u16)> {
+  match slot {
+    0 => Some((0x2E, 0x2F)),
+    1 => Some((0x4E, 0x4F)),
+    _ => None,
+  }
+}
+
+/// Combine the chip-id high (`0x20`) and low (`0x21`) configuration registers
+/// into a single 16-bit identifier.
+pub const fn chip_id(id_high: u8, id_low: u8) -> u16 {
+  ((id_high as u16) << 8) | id_low as u16
+}
+
+/// Whether a chip-id reading means "no responding Super I/O chip".
+///
+/// `superio-access.md` ("Common configuration registers"): reading `0xFF` (or
+/// `0x00`) from both id registers means no chip answered on that port pair.
+pub const fn is_absent_id(id_high: u8, id_low: u8) -> bool {
+  matches!((id_high, id_low), (0x00, 0x00) | (0xFF, 0xFF))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn slot_ports_match_super_io_config_pairs() {
+    assert_eq!(slot_ports(0), Some((0x2E, 0x2F)));
+    assert_eq!(slot_ports(1), Some((0x4E, 0x4F)));
+  }
+
+  #[test]
+  fn slot_ports_reject_unknown_slots() {
+    assert_eq!(slot_ports(2), None);
+    assert_eq!(slot_ports(0xFF), None);
+  }
+
+  #[test]
+  fn chip_id_combines_high_and_low_bytes() {
+    // ITE chip ids literally encode the part number, e.g. IT8728F -> 0x8728.
+    assert_eq!(chip_id(0x87, 0x28), 0x8728);
+    assert_eq!(chip_id(0x00, 0x00), 0x0000);
+    assert_eq!(chip_id(0xFF, 0xFF), 0xFFFF);
+  }
+
+  #[test]
+  fn absent_ids_are_zero_or_all_ones() {
+    assert!(is_absent_id(0x00, 0x00));
+    assert!(is_absent_id(0xFF, 0xFF));
+    assert!(!is_absent_id(0x87, 0x28));
+    // A mixed reading is a real (present) responder, not "absent".
+    assert!(!is_absent_id(0x00, 0xFF));
+    assert!(!is_absent_id(0xFF, 0x00));
+  }
+}

--- a/src-tauri/src/commands/hardware.rs
+++ b/src-tauri/src/commands/hardware.rs
@@ -189,6 +189,26 @@ pub fn get_network_info() -> Result<Vec<NetworkInfo>, BackendError> {
 }
 
 ///
+/// ## Get Super I/O chip-id diagnostics through PawnIO LpcIO
+///
+/// This diagnostic only reads raw chip-id registers (`0x20` / `0x21`) after
+/// the documented Nuvoton and ITE configuration-mode enter sequences. It does
+/// not read temperatures, fan counters, voltages, or any hardware-monitor data.
+///
+#[command]
+#[specta::specta]
+pub async fn get_super_io_chip_id_diagnostics()
+-> Result<models::hardware::SuperIoChipIdDiagnostics, String> {
+  use crate::services::hardware_service;
+
+  Ok(
+    hardware_service::get_super_io_chip_id_diagnostics()
+      .await
+      .into(),
+  )
+}
+
+///
 /// ## Get latest Storage Health records for the dashboard
 ///
 #[command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
       hardware::get_memory_usage_history,
       hardware::get_gpu_usage_history,
       hardware::get_network_info,
+      hardware::get_super_io_chip_id_diagnostics,
       hardware::get_gpu_memory_usage,
       hardware::get_storage_health_latest_records,
       hardware::get_live_storage_health,

--- a/src-tauri/src/models/hardware.rs
+++ b/src-tauri/src/models/hardware.rs
@@ -193,6 +193,58 @@ pub struct MotherboardInfo {
   pub bios_release_date: String,
 }
 
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperIoChipIdDiagnostics {
+  pub platform_supported: bool,
+  pub pawnio: Option<PawnIoRuntimeDiagnostics>,
+  pub slots: Vec<SuperIoChipIdSlotProbe>,
+  pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PawnIoRuntimeDiagnostics {
+  pub install_location: Option<String>,
+  pub dll_path: Option<String>,
+  pub module_path: Option<String>,
+  pub pawnio_available: bool,
+  pub library_loadable: bool,
+  pub driver_openable: bool,
+  pub module_loadable: bool,
+  pub version: Option<u32>,
+  pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperIoChipIdSlotProbe {
+  pub slot: u8,
+  pub index_port: u16,
+  pub data_port: u16,
+  pub attempts: Vec<SuperIoChipIdAttempt>,
+  pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperIoChipIdAttempt {
+  pub vendor: SuperIoVendor,
+  pub id_high: Option<u8>,
+  pub id_low: Option<u8>,
+  pub chip_id: Option<u16>,
+  pub absent: bool,
+  pub error: Option<String>,
+  pub exit_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum SuperIoVendor {
+  Nuvoton,
+  Ite,
+}
+
 #[derive(Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct SysInfo {
@@ -402,6 +454,68 @@ impl From<core_hw::MotherboardInfo> for MotherboardInfo {
       bios_vendor: src.bios_vendor,
       bios_version: src.bios_version,
       bios_release_date: src.bios_release_date,
+    }
+  }
+}
+
+impl From<core_hw::SuperIoChipIdDiagnostics> for SuperIoChipIdDiagnostics {
+  fn from(src: core_hw::SuperIoChipIdDiagnostics) -> Self {
+    Self {
+      platform_supported: src.platform_supported,
+      pawnio: src.pawnio.map(Into::into),
+      slots: src.slots.into_iter().map(Into::into).collect(),
+      error: src.error,
+    }
+  }
+}
+
+impl From<core_hw::PawnIoRuntimeDiagnostics> for PawnIoRuntimeDiagnostics {
+  fn from(src: core_hw::PawnIoRuntimeDiagnostics) -> Self {
+    Self {
+      install_location: src.install_location,
+      dll_path: src.dll_path,
+      module_path: src.module_path,
+      pawnio_available: src.pawnio_available,
+      library_loadable: src.library_loadable,
+      driver_openable: src.driver_openable,
+      module_loadable: src.module_loadable,
+      version: src.version,
+      fallback_reason: src.fallback_reason,
+    }
+  }
+}
+
+impl From<core_hw::SuperIoChipIdSlotProbe> for SuperIoChipIdSlotProbe {
+  fn from(src: core_hw::SuperIoChipIdSlotProbe) -> Self {
+    Self {
+      slot: src.slot,
+      index_port: src.index_port,
+      data_port: src.data_port,
+      attempts: src.attempts.into_iter().map(Into::into).collect(),
+      error: src.error,
+    }
+  }
+}
+
+impl From<core_hw::SuperIoChipIdAttempt> for SuperIoChipIdAttempt {
+  fn from(src: core_hw::SuperIoChipIdAttempt) -> Self {
+    Self {
+      vendor: src.vendor.into(),
+      id_high: src.id_high,
+      id_low: src.id_low,
+      chip_id: src.chip_id,
+      absent: src.absent,
+      error: src.error,
+      exit_error: src.exit_error,
+    }
+  }
+}
+
+impl From<core_hw::SuperIoVendor> for SuperIoVendor {
+  fn from(src: core_hw::SuperIoVendor) -> Self {
+    match src {
+      core_hw::SuperIoVendor::Nuvoton => Self::Nuvoton,
+      core_hw::SuperIoVendor::Ite => Self::Ite,
     }
   }
 }

--- a/src-tauri/src/services/hardware_service.rs
+++ b/src-tauri/src/services/hardware_service.rs
@@ -100,31 +100,22 @@ pub async fn get_storage_health_latest_records()
 
 pub async fn get_super_io_chip_id_diagnostics()
 -> hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
-  #[cfg(target_os = "windows")]
-  {
-    tokio::task::spawn_blocking(|| {
-      hardviz_core::infrastructure::providers::windows::super_io_diagnostics::read_super_io_chip_id_diagnostics()
-    })
-    .await
-    .unwrap_or_else(|e| hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
-      platform_supported: true,
+  tokio::task::spawn_blocking(|| {
+    let platform =
+      PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+    Ok::<_, String>(platform.get_super_io_chip_id_diagnostics())
+  })
+  .await
+  .map_err(|e| format!("Failed to join Super I/O diagnostic task: {e}"))
+  .and_then(|result| result)
+  .unwrap_or_else(
+    |error| hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
+      platform_supported: cfg!(target_os = "windows"),
       pawnio: None,
       slots: Vec::new(),
-      error: Some(format!("Failed to join Super I/O diagnostic task: {e}")),
-    })
-  }
-
-  #[cfg(not(target_os = "windows"))]
-  {
-    hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
-      platform_supported: false,
-      pawnio: None,
-      slots: Vec::new(),
-      error: Some(
-        "Super I/O LpcIO diagnostics are available on Windows only".to_string(),
-      ),
-    }
-  }
+      error: Some(error),
+    },
+  )
 }
 
 ///

--- a/src-tauri/src/services/hardware_service.rs
+++ b/src-tauri/src/services/hardware_service.rs
@@ -98,6 +98,35 @@ pub async fn get_storage_health_latest_records()
   hardviz_core::infrastructure::database::storage_health::latest_records().await
 }
 
+pub async fn get_super_io_chip_id_diagnostics()
+-> hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
+  #[cfg(target_os = "windows")]
+  {
+    tokio::task::spawn_blocking(|| {
+      hardviz_core::infrastructure::providers::windows::super_io_diagnostics::read_super_io_chip_id_diagnostics()
+    })
+    .await
+    .unwrap_or_else(|e| hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
+      platform_supported: true,
+      pawnio: None,
+      slots: Vec::new(),
+      error: Some(format!("Failed to join Super I/O diagnostic task: {e}")),
+    })
+  }
+
+  #[cfg(not(target_os = "windows"))]
+  {
+    hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
+      platform_supported: false,
+      pawnio: None,
+      slots: Vec::new(),
+      error: Some(
+        "Super I/O LpcIO diagnostics are available on Windows only".to_string(),
+      ),
+    }
+  }
+}
+
 ///
 /// Read Live Storage Health signals from the startup-cached device list
 /// (ADR 0006). Nothing is persisted.
@@ -200,5 +229,16 @@ mod tests {
       .expect_err("missing collector should be reported");
 
     assert!(error.contains("unavailable"));
+  }
+
+  #[cfg(not(target_os = "windows"))]
+  #[tokio::test]
+  async fn super_io_chip_id_diagnostics_reports_unsupported_platform() {
+    let diagnostics = get_super_io_chip_id_diagnostics().await;
+
+    assert!(!diagnostics.platform_supported);
+    assert!(diagnostics.pawnio.is_none());
+    assert!(diagnostics.slots.is_empty());
+    assert!(diagnostics.error.unwrap().contains("Windows only"));
   }
 }

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -73,6 +73,14 @@ export const commands = {
 	// ## Get network information
 	getNetworkInfo: () => typedError<NetworkInfo[], BackendError>(__TAURI_INVOKE("get_network_info")),
 	/**
+	 *  ## Get Super I/O chip-id diagnostics through PawnIO LpcIO
+	 * 
+	 *  This diagnostic only reads raw chip-id registers (`0x20` / `0x21`) after
+	 *  the documented Nuvoton and ITE configuration-mode enter sequences. It does
+	 *  not read temperatures, fan counters, voltages, or any hardware-monitor data.
+	 */
+	getSuperIoChipIdDiagnostics: () => typedError<SuperIoChipIdDiagnostics, string>(__TAURI_INVOKE("get_super_io_chip_id_diagnostics")),
+	/**
 	 *  ## Get realtime GPU memory usage (best-effort)
 	 * 
 	 *  **Platform support**: Currently implemented only on macOS. On other
@@ -97,7 +105,7 @@ export const commands = {
 	getLiveStorageHealth: () => typedError<LiveStorageHealth[], string>(__TAURI_INVOKE("get_live_storage_health")),
 	/**
 	 *  ## Re-detect Storage Devices
-	 *
+	 * 
 	 *  Re-detects connected storage devices, refreshes the Live Storage
 	 *  Health cache, collects current Storage Health signals, updates
 	 *  today's Storage Health Records, and returns the latest active records
@@ -489,6 +497,18 @@ export type NetworkInfo = {
 	defaultIpv6Gateway: string[],
 };
 
+export type PawnIoRuntimeDiagnostics = {
+	installLocation: string | null,
+	dllPath: string | null,
+	modulePath: string | null,
+	pawnioAvailable: boolean,
+	libraryLoadable: boolean,
+	driverOpenable: boolean,
+	moduleLoadable: boolean,
+	version: number | null,
+	fallbackReason: string | null,
+};
+
 export type ProcessInfo = ProcessInfo_Serialize | ProcessInfo_Deserialize;
 
 export type ProcessInfo_Deserialize = {
@@ -571,6 +591,33 @@ export type StorageInfo = {
 
 export type StorageWarningLevel = "none" | "warning" | "critical" | "unknown";
 
+export type SuperIoChipIdAttempt = {
+	vendor: SuperIoVendor,
+	idHigh: number | null,
+	idLow: number | null,
+	chipId: number | null,
+	absent: boolean,
+	error: string | null,
+	exitError: string | null,
+};
+
+export type SuperIoChipIdDiagnostics = {
+	platformSupported: boolean,
+	pawnio: PawnIoRuntimeDiagnostics | null,
+	slots: SuperIoChipIdSlotProbe[],
+	error: string | null,
+};
+
+export type SuperIoChipIdSlotProbe = {
+	slot: number,
+	indexPort: number,
+	dataPort: number,
+	attempts: SuperIoChipIdAttempt[],
+	error: string | null,
+};
+
+export type SuperIoVendor = "nuvoton" | "ite";
+
 export type SysInfo = {
 	cpu: CpuInfo | null,
 	memory: MemoryInfo | null,
@@ -640,3 +687,4 @@ function makeEvent<T>(name: string) {
 
     return Object.assign(fn, base);
 }
+


### PR DESCRIPTION
<!--
Clean-room sensor implementation PR (#1635).
Rules: .github/instructions/clean-room-sensors.instructions.md
Process: docs/specs/sensors/README.md
-->

> [!NOTE]
> **Ready for review (Phase 2 scope).** The clean-room spec gate is resolved
> (`superio-access.md` Implementation-ready rev 3, #1734) and the implementer
> attestation is complete. This PR intentionally ships only the read-only
> chip-id diagnostic. Remaining hardware validation (ITE board, PawnIO-absent
> host, concurrent monitors) and Phase 3/4 register decode are tracked under
> "Next steps" as separate work and do **not** block this slice.

## Summary

Adds a **read-only Super I/O chip-id diagnostic** so we can confirm, on a
real self-built PC, whether the motherboard's Super I/O chip (Nuvoton /
ITE) is reachable through PawnIO **before** building any temperature / fan
/ voltage decode on top of it.

New backend command `get_super_io_chip_id_diagnostics`:

- opens the PawnIO `LpcIO` module,
- holds `Global\Access_ISABUS.HTP.Method` for the whole transaction,
- probes slot 0 (`0x2E`/`0x2F`) and slot 1 (`0x4E`/`0x4F`),
- runs the documented Nuvoton (`0x87,0x87`) and ITE
  (`0x87,0x01,0x55,0x55` / `...,0xAA`) configuration-mode enter
  sequences,
- reads **only** chip-id registers `0x20` / `0x21`,
- best-effort exits configuration mode,
- returns per-slot, per-vendor raw bytes plus a combined `chipId` and an
  `absent` flag, plus PawnIO/LpcIO runtime discovery state.

It deliberately reads **no** hardware-monitor data (no temperatures, fans,
voltages). On non-Windows it returns `platformSupported: false`.

### Why PawnIO (not WMI / not a bespoke driver)

- Self-built-PC board temperatures and fan RPM live on the Super I/O /
  EC, which Windows WMI does not expose in general.
- Reading Super I/O means LPC/ISA port I/O, which user-mode cannot do
  directly; it needs a signed kernel I/O driver.
- Writing our own driver duplicates exactly what PawnIO already provides
  (the WinRing0 replacement adopted by LHM / FanControl). So we depend on
  PawnIO **only as the I/O transport** and keep all chip detection/decode
  as our own MIT, clean-room code.

## Related Issues

- Relates to #1635 (native CPU / Super I/O sensor monitoring via PawnIO)
- Relates to #1734 (resolved `superio-access.md` Phase 2 spec gate)

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Clean-room provenance

```text
Implemented from docs/specs/sensors/pawnio-interface.md revision 4 (commit 7a16b773).
Implemented from docs/specs/sensors/superio-access.md revision 3 (commit a8c167b1), limited to the Phase 2 raw chip-id diagnostic scope.
No other external sensor documentation was used.
```

`superio-access.md` revision 3 intentionally makes only the raw chip-id
diagnostic implementation-ready. Chip-model tables, hardware-monitor base
discovery, `ioctl_find_bars`, temperature/fan/voltage register maps, and
all hardware-monitor data reads remain out of scope until later specs are
implementation-ready.

### Implementer attestation

- [x] This implementation references only `docs/specs/sensors/**` and this repository.
- [x] Every pinned spec is `Implementation-ready` with no unresolved `TODO(provenance)` markers.
- [x] I did not consult LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors, or any decompiled monitoring tool while writing this implementation.
- [x] Register access added by this PR is read-only; the only writes are the Super I/O configuration enter/exit key sequences and the ITE exit register documented as required for reads, and the `Access_ISABUS.HTP.Method` mutex is held for the whole transaction.

### Reviewer attestation

Reviewers: copy the checklist below into your approval review comment, with both boxes checked. Do not approve without it.

```markdown
- [ ] I reviewed this implementation only against `docs/specs/sensors/**`, this repository, and the pinned spec revision.
- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors, or decompiled monitoring tools while reviewing this implementation.
```

## PawnIO LpcIO distribution stance

This diagnostic PR does **not** bundle or redistribute PawnIO, `PawnIOLib.dll`,
or PawnIO.Modules blobs. `LpcIO.bin` / `LpcIO.amx` must already be present on
disk in a discovered PawnIO location.

Because this PR does not ship PawnIO components, it does not add PawnIO /
PawnIO.Modules to the bundled third-party notices. Any future PR that bundles
signed `.bin` modules must pin the PawnIO.Modules release, update Windows
third-party notices, and document the LGPL-2.1-or-later source/attribution
handling before shipping those artifacts.

## What's included

| Area | Change |
| --- | --- |
| `core/.../windows/pawn_io.rs` | `PawnIoModule::LpcIo`; `LpcIO.bin`/`.amx` discovery; `ACCESS_ISABUS_MUTEX`; wrappers `select_lpc_slot` / `pio_outb` / `superio_inb` / `superio_outb`; `execute_no_output`/`execute_raw` split |
| `core/.../windows/super_io_diagnostics.rs` (new) | mutex-guarded slot 0/1 probe, Nuvoton+ITE enter/exit, chip-id read |
| `core/src/utils/super_io.rs` (new) | pure `slot_ports` / `chip_id` / `is_absent_id` (+ unit tests that run on every OS) |
| `core/src/models/hardware.rs` | `SuperIoChipIdDiagnostics` core model tree |
| `src-tauri/.../models/hardware.rs` | Specta wire types + `From` conversions |
| `src-tauri/.../services/hardware_service.rs` | `get_super_io_chip_id_diagnostics` (Windows: `spawn_blocking`; else unsupported) |
| `src-tauri/.../commands/hardware.rs`, `lib.rs` | command + registration |
| `src/rspc/bindings.ts` | regenerated bindings |

### Drive-by FFI fix

No-output IOCTLs (`ioctl_select_slot`, `ioctl_pio_outb`,
`ioctl_superio_outb`) now pass an output-cell count of **0** to
PawnIOLib. Previously `execute` always advertised 1 output cell, which
contradicts the LpcIO contract for write/select IOCTLs.

## Next steps (tracked work, not in this PR)

**Process / gate**

- [x] Resolve the `superio-access.md` draft gate by scope-flipping the Phase 2 chip-id subset to `Implementation-ready (rev 3)` (#1734).
- [x] Re-pin provenance and finish the implementer attestation boxes.
- [x] Record that this PR does not bundle or redistribute PawnIO `LpcIO` blobs; module files must already be on disk.
- [x] Keep the Phase 2 diagnostic follow-up tracked in this PR and `docs/development/sensor-handoff/`; no separate child issue is required for the current scope.
- [ ] If bundling PawnIO.Modules blobs is desired later, track it as a separate packaging/legal-notice task.

**Validate on real hardware (highest priority before building further)**

- [x] Run `get_super_io_chip_id_diagnostics` elevated on a real Nuvoton-class board; captured raw `idHigh`/`idLow` per slot/vendor (see evidence below).
- [ ] Run `get_super_io_chip_id_diagnostics` elevated on a real ITE board; capture raw `idHigh`/`idLow` per slot/vendor.
- [x] Confirm present-but-access-denied (`0x80070005`, needs elevation) and present-and-openable states are distinguishable on the validated machine.
- [ ] Confirm PawnIO-absent state is distinguishable on a machine or environment without PawnIO installed.
- [ ] Confirm `Access_ISABUS.HTP.Method` open-before-create behaves with HWiNFO / LibreHardwareMonitor / FanControl running concurrently.

**Spec authoring (clean-room "dirty room" role)**

- [ ] Phase 3 Nuvoton (NCT67xx) register map: chip-id table, hardware-monitor base, bank select, temp + fan tach registers, RPM conversion.
- [ ] Phase 4 ITE (IT86xx/87xx) register map: chip-id table, EC base, temp + fan tach registers.

**Implementation (after specs are Implementation-ready)**

- [ ] Map chip-id -> chip model/vendor; cache detection (no per-sample re-detect).
- [ ] Discover hardware-monitor base + `ioctl_find_bars`.
- [ ] Read motherboard temperatures + fan RPM; add range/sanity filtering.
- [ ] Add `FanSpeed` + `motherboardTemperatures`/`motherboardFanSpeeds` to `MetricsSnapshot` -> `HardwareMonitorUpdate` (keep separate from CPU `sensor_temperatures`).
- [ ] Frontend: Motherboard card temps + RPM, i18n, render-fanout-safe atoms.
- [ ] External Component Guidance entry for "PawnIO LpcIO unavailable" (distinct from the CPU-temperature PawnIO guidance).

## Real hardware validation evidence

Captured on 2026-06-27 against PR head `d521b4263eebfdef0e211c15e26c26e345d0eff9` on a real Windows self-built PC.

Environment:

- Motherboard: NZXT N7 B650E
- CPU: AMD Ryzen 7 7800X3D 8-Core Processor
- OS: Microsoft Windows 11 Pro 10.0.26200, 64-bit
- PawnIO runtime: installed; service running
- `PawnIOLib.dll`: `C:\Program Files\PawnIO\PawnIOLib.dll`
- `LpcIO` module: `C:\Program Files\PawnIO\LpcIO.bin`
- Concurrent HWiNFO / LibreHardwareMonitor / FanControl process check: none running during this capture

Non-elevated run result:

- `PawnIOLib.dll` was found and loaded.
- `LpcIO.bin` was found.
- `pawnio_open` failed with `0x80070005`, distinguishing the present-but-access-denied state from missing runtime/module.

Elevated run result:

- PawnIO opened successfully.
- `LpcIO.bin` loaded successfully.
- Slot 0 Nuvoton attempt returned raw bytes `idHigh=216` (`0xD8`), `idLow=2` (`0x02`), combined `chipId=55298` (`0xD802`), `absent=false`, `error=null`, `exitError=null`.
- Slot 0 ITE attempt returned `0xFF/0xFF`, classified as `absent=true`.
- Slot 1 Nuvoton and ITE attempts both returned `0xFF/0xFF`, classified as `absent=true`.
- No per-slot, per-attempt, or top-level diagnostic error was returned.

Raw non-elevated JSON:

```json
{
  "error": "pawnio_open failed: 0x80070005",
  "pawnio": {
    "dllPath": "C:\\Program Files\\PawnIO\\PawnIOLib.dll",
    "driverOpenable": false,
    "fallbackReason": "pawnio_open failed: 0x80070005",
    "installLocation": "C:\\Program Files\\PawnIO",
    "libraryLoadable": true,
    "moduleLoadable": false,
    "modulePath": "C:\\Program Files\\PawnIO\\LpcIO.bin",
    "pawnioAvailable": true,
    "version": 131072
  },
  "platformSupported": true,
  "slots": []
}
```

Raw elevated JSON:

```json
{
  "error": null,
  "pawnio": {
    "dllPath": "C:\\Program Files\\PawnIO\\PawnIOLib.dll",
    "driverOpenable": true,
    "fallbackReason": null,
    "installLocation": "C:\\Program Files\\PawnIO",
    "libraryLoadable": true,
    "moduleLoadable": true,
    "modulePath": "C:\\Program Files\\PawnIO\\LpcIO.bin",
    "pawnioAvailable": true,
    "version": 131072
  },
  "platformSupported": true,
  "slots": [
    {
      "attempts": [
        {
          "absent": false,
          "chipId": 55298,
          "error": null,
          "exitError": null,
          "idHigh": 216,
          "idLow": 2,
          "vendor": "nuvoton"
        },
        {
          "absent": true,
          "chipId": null,
          "error": null,
          "exitError": null,
          "idHigh": 255,
          "idLow": 255,
          "vendor": "ite"
        }
      ],
      "dataPort": 47,
      "error": null,
      "indexPort": 46,
      "slot": 0
    },
    {
      "attempts": [
        {
          "absent": true,
          "chipId": null,
          "error": null,
          "exitError": null,
          "idHigh": 255,
          "idLow": 255,
          "vendor": "nuvoton"
        },
        {
          "absent": true,
          "chipId": null,
          "error": null,
          "exitError": null,
          "idHigh": 255,
          "idLow": 255,
          "vendor": "ite"
        }
      ],
      "dataPort": 79,
      "error": null,
      "indexPort": 78,
      "slot": 1
    }
  ]
}
```

Validation judgment: the diagnostic is usable for real-hardware Phase 2 triage on this Nuvoton-class board. Remaining validation gaps before treating the broader hardware matrix as complete: ITE board evidence, PawnIO-absent evidence, and mutex behavior while HWiNFO / LibreHardwareMonitor / FanControl are running.

## Open questions / uncertainties

- **IOCTL output-cell counts** for `ioctl_select_slot` / `ioctl_pio_outb` / `ioctl_superio_outb` are read from the spec table as "-" (0). If a given signed `LpcIO` build actually returns a status cell, `execute_no_output` would need adjusting. Needs hardware confirmation.
- **ITE exit when a Nuvoton enter matched (and vice versa)** is a non-blocking Phase 2 open question in `superio-access.md`; this diagnostic exits with the same vendor's sequence it entered with, best-effort.
- **Boards whose EC/firmware claims `0x2E`/`0x2F`** may return ambiguous ids; that is exactly why this diagnostic captures both slots' raw bytes before any chip-specific logic.
- PR creation and CI status were checked with `gh`; CI is now green including Windows jobs. Local real-hardware validation captured below confirms the diagnostic path on one Nuvoton-class board; ITE, PawnIO-absent, and concurrent-monitor mutex validation remain pending.

## Screenshots / Videos

n/a (diagnostic command; no UI yet)

## Test Plan

- [x] Unit tests - `cargo test -p hardviz-core` **238 passed** (incl. new portable `utils::super_io` tests), `cargo test -p hardware_visualizer` **210 passed** (incl. non-Windows unsupported-platform case)
- [x] `cargo check --workspace` (host) + cross `cargo check -p hardviz-core --target x86_64-pc-windows-gnu` with `RUSTFLAGS="-D warnings"`
- [x] `npm run build`
- [x] **Manual testing on real Windows Nuvoton-class hardware** - non-elevated access-denied and elevated `LpcIO` chip-id diagnostic captured below; ITE / PawnIO-absent / concurrent-monitor validation remains pending

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo fmt`; `npm run build` clean)
- [x] Tests pass (host)
- [x] No new warnings or errors (incl. `-D warnings` on the Windows target)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Super I/O chip ID diagnostics, including slot probing and vendor-specific detection details (with per-attempt results and computed chip ID).
  * Exposed a new frontend-accessible command to fetch these diagnostics.
  * Added new diagnostics data models and shared decoding helpers for slot/ID interpretation.
* **Bug Fixes**
  * Improved robustness of the diagnostics result mapping, including clearer behavior when no data is returned.
  * Added stronger coordination to prevent conflicting hardware reads, and ensured non-Windows platforms report as unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->