### PR TITLE
docs: resolve Super I/O chip-id spec gate

### DIFF
--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -166,12 +166,13 @@ or unresolved blocking open question invalidates the flip.
 | [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, blob distribution (signed `.bin`), elevation requirement, licensing facts | Phase 1 | Implementation-ready (rev 4) |
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
-| [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |
+| [`superio-access.md`](superio-access.md) | Phase 2 raw Super I/O chip-id diagnostic: config port pairs, Nuvoton/ITE enter/exit, chip-id registers, absent-id classification, ISA mutex | Phase 2 | Implementation-ready (rev 3) |
 
-Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) are
+Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) and hardware-monitor base discovery are
 **not yet written**; they are the Phase 3 / Phase 4 deliverables and
 will be added as separate documents validated against user-submitted
-register dumps.
+register dumps. The current `superio-access.md` readiness is intentionally
+limited to the Phase 2 raw chip-id diagnostic scope.
 
 ## Safety policy (applies to all documents and implementations)
 

--- a/docs/specs/sensors/superio-access.md
+++ b/docs/specs/sensors/superio-access.md
@@ -1,139 +1,166 @@
-# Spec: Super I/O configuration access and chip detection
+# Spec: Super I/O configuration access and chip-id diagnostics
 
 | Field | Value |
 | --- | --- |
-| Revision | 2 |
-| Status | Draft — not implementation-ready |
-| Scope | The generic LPC/ISA access mechanism shared by PC Super I/O chips: configuration port pairs, vendor enter/exit key sequences, logical-device selection, chip identification, and locating the hardware-monitor I/O block. Applies to Nuvoton NCT67xx and ITE IT86xx/87xx families. Excludes: per-chip register maps (temperatures, fans, voltages) — those are the Phase 3/4 documents. |
-| Issue phase | Phases 2–4 (#1635) — mechanism shared by all of them |
+| Revision | 3 |
+| Status | Implementation-ready (rev 3) |
+| Scope | Phase 2 raw Super I/O chip-id diagnostics only: PawnIO `LpcIO` slot selection for the standard configuration port pairs, Nuvoton/ITE configuration-mode enter/exit sequences, chip-id register reads (`0x20` / `0x21`), absent-id classification for raw diagnostics, and the ISA mutex requirement. Excludes: chip-model tables, logical-device hardware-monitor base discovery, `ioctl_find_bars`, temperature/fan/voltage register maps, and all hardware-monitor data reads. |
+| Issue phase | Phase 2 (#1635) — sensor report / chip-id diagnostic mechanism |
 
 ## Sources
 
 | ID | Source | Notes |
 | --- | --- | --- |
-| S1 | Nuvoton, *NCT6779D* datasheet (representative of the NCT67xx family): "Extended Function Registers" and "Hardware Monitor" chapters | Primary for Nuvoton facts. `TODO(provenance)`: pin section/page numbers per chip in the Phase 3 documents |
-| S2 | ITE, *IT8728F Preliminary Specification* (representative of the IT87xx family): "MB PnP Mode" and "Environment Controller" chapters | Primary for ITE facts. `TODO(provenance)`: pin per chip in Phase 4 |
-| S3 | PawnIO `LpcIO.p` module source (LGPL-2.1-or-later) | Upstream-published interface definition of the module this project calls (interoperability facts: slot mapping, allowed ports, mutex name). Not used as a source for any chip register fact. No code was copied. |
+| S1 | Nuvoton, *NCT6779D* datasheet (representative NCT67xx document), "Extended Function Registers" chapter | Primary for the Phase 2 Nuvoton configuration-mode enter/exit sequence and global chip-id configuration registers used by this revision. Per-chip Nuvoton ID tables and hardware-monitor registers remain out of scope for this revision and must be re-pinned in Phase 3 documents before implementation. |
+| S2 | ITE, *IT8728F Preliminary Specification* (representative IT87xx document), "MB PnP Mode" / configuration-register section | Primary for the Phase 2 ITE MB PnP enter/exit sequence and global chip-id configuration registers used by this revision. Per-chip ITE ID tables and Environment Controller registers remain out of scope for this revision and must be re-pinned in Phase 4 documents before implementation. |
+| S3 | [`pawnio-interface.md`](pawnio-interface.md) revision 4, `LpcIO` module IOCTL contracts and mutex conventions | Primary clean-room interface source for PawnIO `LpcIO` slot mapping, `ioctl_superio_inb` / `ioctl_superio_outb` / `ioctl_pio_outb`, and the caller-held `Global\Access_ISABUS.HTP.Method` mutex. |
+| S4 | HardwareVisualizer issue #1635 and Draft PR #1732 scope statement | Project policy source for Phase 2 behavior: return raw per-slot/per-vendor bytes for hardware triage, do not classify chip models yet, and do not read hardware-monitor data in the chip-id diagnostic PR. |
 
-Facts below are uniform across the respective vendors' datasheet
-series; each per-chip Phase 3/4 document must still re-verify them
-against the exact datasheet for that chip before implementation relies
-on chip-specific values.
+Facts below are implementation-ready only for the Phase 2 diagnostic
+scope named in the header. Future Phase 3/4 work must not implement
+chip-model mapping, hardware-monitor base discovery, temperatures, fans,
+or voltages from this revision; those facts need separate
+implementation-ready per-chip documents.
+
+## Phase 2 readiness and default enablement
+
+| Scope | Status | Default enablement |
+| --- | --- | --- |
+| Raw chip-id diagnostic over PawnIO `LpcIO` slot 0 / slot 1 | Implementation-ready for Phase 2 from S1–S4 | Enabled for the diagnostic command; safe to expose raw bytes and errors |
+| Chip-id to model mapping | Deferred; no ready ID table in this revision | Disabled until a Phase 3/4 per-chip spec pins the table |
+| Hardware-monitor base discovery and `ioctl_find_bars` | Deferred; logical-device/base-register facts are not part of this revision's ready scope | Disabled until a later Super I/O mechanism revision or per-chip spec is implementation-ready |
+| Temperature, fan RPM, voltage decode | Deferred; no register maps in this revision | Disabled until per-chip decode specs are implementation-ready |
 
 ## Configuration port pairs
 
 | Fact | Source |
 | --- | --- |
-| Super I/O chips are configured through an index/data port pair: primary `0x2E` (index) / `0x2F` (data), secondary `0x4E` / `0x4F`. A board straps the chip to one pair | S1, S2 |
-| PawnIO `LpcIO` exposes the pairs as slot 0 (`0x2E`/`0x2F`) and slot 1 (`0x4E`/`0x4F`) via `ioctl_select_slot` | S3 |
+| A Super I/O chip's configuration interface uses an index/data port pair. The standard primary pair is `0x2E` (index) / `0x2F` (data); the standard secondary pair is `0x4E` (index) / `0x4F` (data). A board straps the chip to one pair. | S1, S2 |
+| PawnIO `LpcIO` exposes those pairs as slot 0 (`0x2E`/`0x2F`) and slot 1 (`0x4E`/`0x4F`) via `ioctl_select_slot`. | S3 |
+| A Phase 2 diagnostic probes both slots independently and reports the raw result for each; it must not assume slot 0 is the only valid pair. | S3, S4 |
 
 ## Vendor key sequences (configuration mode)
 
-These are **writes**, permitted because reading any configuration
-register requires them. They alter no monitoring/control state.
+These are **writes**, permitted because reading the global chip-id
+configuration registers requires entering configuration mode. They are
+not hardware-monitor/control writes and they do not alter sensor values,
+fan control, limits, alarms, or power state.
 
-| Vendor | Enter configuration (extended function / MB PnP) mode | Exit | Source |
+| Vendor | Enter configuration mode | Exit configuration mode | Source |
 | --- | --- | --- | --- |
-| Nuvoton (NCT67xx; Winbond lineage) | write `0x87`, `0x87` to the index port | write `0xAA` to the index port | S1 |
-| ITE (IT86xx/87xx) | at `0x2E`: write `0x87`, `0x01`, `0x55`, `0x55` to the index port; at `0x4E`: write `0x87`, `0x01`, `0x55`, `0xAA` | set bit 1 of configuration register `0x02` (write index `0x02`, then data `0x02`) | S2 |
+| Nuvoton NCT67xx / Winbond lineage | Write `0x87`, then `0x87`, to the selected index port. | Write `0xAA` to the selected index port. | S1 |
+| ITE IT86xx/IT87xx | For slot 0 (`0x2E`/`0x2F`): write `0x87`, `0x01`, `0x55`, `0x55` to the selected index port. For slot 1 (`0x4E`/`0x4F`): write `0x87`, `0x01`, `0x55`, `0xAA` to the selected index port. | Set bit 1 of configuration register `0x02` by writing register index `0x02`, then value `0x02`. | S2 |
 
-## Common configuration registers
+## Phase 2 configuration registers
 
-Once in configuration mode, registers are read by writing the register
-index to the index port and reading the data port.
+Once in configuration mode, the Phase 2 diagnostic reads only the global
+chip-id registers by writing the register index to the selected index
+port and reading the selected data port. It does not select logical
+devices and it does not read any hardware-monitor I/O block.
 
-| Index | Meaning | Source |
-| --- | --- | --- |
-| `0x07` | Logical device select (write the logical device number; **write required** for device-scoped registers) | S1, S2 |
-| `0x20` | Chip ID, high byte | S1, S2 |
-| `0x21` | Chip ID, low byte | S1, S2 |
-| `0x60` / `0x61` | Selected logical device's base address, high/low byte | S1, S2 |
-
-- ITE chip IDs literally encode the part number (example: the IT8728F
-  reads `0x87`/`0x28`). (S2)
-- Nuvoton chip IDs are family-specific opaque values; the per-chip
-  Phase 3 document carries the exact ID table with datasheet
-  citations. (S1)
-- Reading `0xFF` (or `0x00`) from both ID registers on both port pairs
-  means no responding Super I/O chip; detection reports "absent".
-
-## Hardware-monitor I/O block
-
-| Vendor | Logical device | Register access | Source |
+| Index | Meaning in this revision | Access | Source |
 | --- | --- | --- | --- |
-| Nuvoton NCT67xx | `0x0B` ("Hardware Monitor") | address port = base + `0x05`, data port = base + `0x06`; banked register space — write the bank number to hardware-monitor register `0x4E` (**write required**), then address registers within the bank | S1 |
-| ITE IT86xx/87xx | `0x04` ("Environment Controller", EC) | address port = base + `0x05`, data port = base + `0x06`; flat register space (no banks) | S2 |
+| `0x02` | ITE configuration-mode control register; writing value `0x02` exits MB PnP mode. | ITE exit write only | S2 |
+| `0x20` | Chip ID high byte | Read | S1, S2 |
+| `0x21` | Chip ID low byte | Read | S1, S2 |
 
-- The base address is read from configuration registers
-  `0x60`/`0x61` of the selected logical device. A base of `0x0000`
-  or `0xFFFF` means the block is not mapped; detection reports
-  "absent". (S1, S2)
-- PawnIO `LpcIO` only allows port reads/writes within the
-  configuration pair and the BAR ranges it discovered via
-  `ioctl_find_bars`; the hardware-monitor base must therefore be
-  discovered through `LpcIO` itself before its ports are accessible.
-  (S3)
+- ITE chip IDs encode the part number in the two raw bytes; for the
+  representative IT8728F source, the raw bytes are `0x87` / `0x28`.
+  A Phase 2 diagnostic may combine the bytes into `0x8728` for display,
+  but it must still return the raw high/low bytes. (S2, S4)
+- Nuvoton chip IDs are family/model-specific values. This revision does
+  not carry a Nuvoton ID table; a Phase 2 diagnostic may combine and
+  display the raw high/low bytes, but it must report the model as
+  unknown until a Phase 3 Nuvoton spec pins an ID table. (S1, S4)
+- For the Phase 2 diagnostic only, a raw reading of `0x00`/`0x00` or
+  `0xFF`/`0xFF` is classified as "absent / no usable responder" for
+  triage. Mixed values are not collapsed to absent; return them as raw
+  responder bytes so they can be reviewed in hardware dumps. (S4)
 
-## Detection procedure
+## Phase 2 detection procedure
 
-For each slot (0, then 1):
+For each slot, in slot order 0 then 1:
 
-1. Acquire the ISA mutex (below); select the slot
-   (`ioctl_select_slot`).
-2. Try each vendor's enter sequence in turn; after each, read chip ID
-   registers `0x20`/`0x21`.
-3. On a recognized ID: select the vendor's hardware-monitor logical
-   device (`0x07` ← device number), read the base address
-   (`0x60`/`0x61`), run `ioctl_find_bars`, then exit configuration
-   mode.
-4. On no recognized ID: exit configuration mode (best-effort with the
-   matching vendor exit) and continue.
-5. Release the mutex. Cache the detection result; re-detection on
-   every sample is unnecessary.
+1. Acquire `Global\Access_ISABUS.HTP.Method` with a bounded timeout.
+   If acquisition times out or fails, report the error and do not issue
+   any port I/O without the mutex.
+2. Select the slot with PawnIO `LpcIO` `ioctl_select_slot`.
+3. Nuvoton attempt:
+   - enter configuration mode with the Nuvoton sequence,
+   - read `0x20` and `0x21`,
+   - best-effort exit with the Nuvoton sequence,
+   - report raw bytes, combined `chipId`, absent classification, any
+     read/enter error, and any exit error.
+4. ITE attempt:
+   - enter MB PnP mode with the ITE sequence matching the selected
+     slot,
+   - read `0x20` and `0x21`,
+   - best-effort exit with the ITE exit register write,
+   - report raw bytes, combined `chipId`, absent classification, any
+     read/enter error, and any exit error.
+5. Release the mutex after both vendor attempts for the selected slot.
+
+The Phase 2 command is a diagnostic, not a sampling path. It may run on
+demand and does not need re-detection caching. Future sampling paths must
+cache detection results rather than entering configuration mode on every
+sample.
 
 ## Concurrency and the ISA mutex
 
-- The whole transaction — enter key, configuration reads, bank select,
-  hardware-monitor index/data reads, exit — must execute under the
-  ecosystem mutex `Global\Access_ISABUS.HTP.Method`, because the
-  index/data port protocol is stateful: an interleaved write from
-  another monitor changes the selected index/bank between our write
-  and read. (Issue #1635 convention; see
-  [`pawnio-interface.md`](pawnio-interface.md))
-- The PawnIO `LpcIO` module does not acquire the mutant itself: each
-  port/config ioctl is documented with a caller-must-hold warning for
-  `\BaseNamedObjects\Access_ISABUS.HTP.Method` (S3). The client-side
-  mutex above is therefore mandatory for single calls and multi-IOCTL
-  sequences alike.
-- Acquisition uses a bounded timeout; on timeout the sample is skipped
-  (never proceed unlocked).
+- The whole slot transaction — slot select, vendor enter key,
+  chip-id register reads, and vendor exit — must execute under
+  `Global\Access_ISABUS.HTP.Method`. Super I/O index/data access is
+  stateful, so an interleaved write from another monitor can change the
+  selected index between this client's write and read. (S3)
+- PawnIO `LpcIO` does not acquire the mutex itself. The caller must hold
+  the mutex before each port/config IOCTL, and the same mutex guard must
+  cover the multi-IOCTL sequence. (S3)
+- Mutex acquisition uses a bounded timeout; timeout means the diagnostic
+  reports a skipped/failed attempt and never proceeds unlocked. (S3)
 
 ## Safety notes
 
-Writes are limited to exactly:
+Writes allowed by this Phase 2 revision are limited to exactly:
 
-- vendor enter/exit key sequences,
-- logical device select (`0x07`),
-- hardware-monitor/EC **address** port (index selection),
-- Nuvoton bank select (hardware-monitor register `0x4E`).
+- vendor enter key sequences on the selected index port,
+- Nuvoton exit key `0xAA` on the selected index port,
+- ITE exit write to configuration register `0x02` with value `0x02`.
 
-No hardware-monitor data register is written except the documented
-Nuvoton bank-select register (`0x4E`) above. No sensor value,
-fan-control, limit, alarm, or other configuration data register is
-written in any phase of #1635.
+This revision does **not** allow writes to hardware-monitor data
+registers, fan-control registers, PWM registers, limits, alarms, bank
+selection registers, or any other device-scoped register. It also does
+not allow reads from hardware-monitor data registers.
+
+## Deferred / not ready in this revision
+
+The following items were present in earlier drafts but are intentionally
+not implementation-ready in rev 3. They must be specified in later
+revisions or per-chip documents before implementation:
+
+- logical-device selection for Nuvoton Hardware Monitor or ITE
+  Environment Controller,
+- hardware-monitor base-address registers and absent-base rules,
+- PawnIO `ioctl_find_bars` usage for Super I/O hardware-monitor ports,
+- Nuvoton bank selection and banked hardware-monitor register space,
+- ITE EC register map,
+- chip-id-to-model tables,
+- temperature, fan RPM, and voltage registers or conversions.
 
 ## Open questions
 
-- Some boards' embedded controllers or firmware claim the `0x2E`/`0x2F`
-  pair (or mirror a different device); the Phase 2 dump tool should
-  capture both slots' raw ID bytes so unknown responders can be
-  triaged from user dumps before any chip-specific logic runs.
-- Whether ITE's exit (`0x02` bit 1) is required-or-harmful when the
-  enter sequence matched a Nuvoton chip (and vice versa) — the
-  detection loop above exits with the vendor sequence matching the
-  attempted enter key; verify on hardware via Phase 2 dumps.
-- Per-chip ID tables and hardware-monitor register maps: deferred to
-  the Phase 3 (Nuvoton) / Phase 4 (ITE) documents.
+- Non-blocking for Phase 2: Some boards' embedded controllers or
+  firmware may claim or mirror the `0x2E`/`0x2F` or `0x4E`/`0x4F` pairs.
+  The Phase 2 diagnostic is designed to return both slots' raw bytes and
+  errors for triage instead of making chip-specific decisions.
+- Non-blocking for Phase 2: Whether an ITE exit sequence is required or
+  harmful after a Nuvoton enter sequence matched, and vice versa, still
+  needs hardware validation. The Phase 2 procedure exits only with the
+  same vendor sequence it entered with, records exit errors, and performs
+  no further device access based on the result.
+- Non-blocking for Phase 2: Per-chip ID tables, hardware-monitor base
+  discovery, and hardware-monitor register maps are deferred to the
+  Phase 3 Nuvoton and Phase 4 ITE documents. The Phase 2 diagnostic does
+  not require them because it reports raw chip-id bytes only.
 
 ## Revision history
 
@@ -141,3 +168,4 @@ written in any phase of #1635.
 | --- | --- | --- |
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Corrected `Access_ISABUS.HTP.Method` ownership: the LpcIO module documents caller-held acquisition and takes no mutex itself. Still Draft — Phase 3/4 datasheet pinning outstanding. |
+| 3 | 2026-06-27 | Narrowed the ready scope to the Phase 2 raw chip-id diagnostic used by PR #1732; removed hardware-monitor base discovery and decode facts from the implementation-ready surface; added scoped enablement, bounded Phase 2 procedure, non-blocking open-question annotations, and status → Implementation-ready. |


### PR DESCRIPTION
## Summary

Resolves the **Super I/O Spec Gate** (Session 1 of `docs/development/sensor-handoff/`) that blocks Draft PR #1732 from becoming a merge-ready clean-room implementation PR.

`docs/specs/sensors/superio-access.md` was `Status: Draft — not implementation-ready` (rev 2), so per `.github/instructions/clean-room-sensors.instructions.md` and the implementation gate in `docs/specs/sensors/README.md`, #1732 could not satisfy the implementer attestation ("every pinned spec is `Implementation-ready` with no `TODO(provenance)`").

This is a **spec-author ("dirty room") docs-only change**. No Rust/TS implementation code is touched.

## What changed

- `docs/specs/sensors/superio-access.md` → **rev 3, `Implementation-ready (rev 3)`**
- `docs/specs/sensors/README.md` → updated the Current-documents registry row + per-chip note.

### Approach: scoped flip (Option B), not a full Phases 2–4 flip

I deliberately did **not** flip the whole Phases 2–4 mechanism to ready, because the per-chip register maps, hardware-monitor base discovery, and decode facts have no pinned datasheet provenance yet (they are the Phase 3/4 deliverables). Flipping them would have left unverified facts in a "ready" document.

Instead the ready scope is narrowed to exactly what Draft PR #1732's diagnostic uses:

- PawnIO `LpcIO` slot 0 / slot 1 config port pairs (`0x2E`/`0x2F`, `0x4E`/`0x4F`)
- Nuvoton enter (`0x87,0x87`) / exit (`0xAA`) sequences
- ITE MB PnP enter (`0x87,0x01,0x55,0x55` / `…,0xAA`) / exit (`0x02` ← `0x02`) sequences
- chip-id registers `0x20` / `0x21`
- absent-id classification (`0x00/0x00` or `0xFF/0xFF`) for raw triage
- the `Global\Access_ISABUS.HTP.Method` mutex held across the whole transaction

To stay honest, hardware-monitor base discovery (`0x60`/`0x61`), logical-device select (`0x07`), `ioctl_find_bars`, Nuvoton bank select, EC/HWMON register maps, and temperature/fan/voltage decode were **removed from the ready surface** and listed under a new "Deferred / not ready in this revision" section.

### Status-transition checklist (`docs/specs/sensors/README.md` → Draft → Implementation-ready)

- [x] Every `TODO(provenance)` marker resolved — the two `TODO(provenance)` markers were tied to Phase 3/4 per-chip pinning, which is now out of the ready scope; none remain in the document.
- [x] Every Open-questions entry resolved or annotated in place with the exact `Non-blocking for <phase>: …` form (all 3 now `Non-blocking for Phase 2:`).
- [x] No normative fact rests solely on a copyleft source — the prior LGPL `LpcIO.p` source row is replaced by a reference to the already-`Implementation-ready` `pawnio-interface.md` (rev 4); register facts cite the Nuvoton/ITE datasheets and project policy.
- [x] Scoped-enablement table added (new "Phase 2 readiness and default enablement" section) consistent with each row's verification state.
- [x] Revision bumped to 3, revision history records the transition, Status set to `Implementation-ready (rev 3)`.

## Related Issues

- Relates to #1635 (native CPU / Super I/O sensor monitoring via PawnIO)
- Unblocks the clean-room gate for #1732

## Follow-ups (not in this PR)

- #1732 can now re-pin provenance to `superio-access.md` revision 3 and check its remaining implementer attestation box.
- Phase 3 (Nuvoton) / Phase 4 (ITE) per-chip specs still need authoring before any chip-model mapping, hardware-monitor base discovery, or temperature/fan decode is implemented.

## Type of Change

- [x] Documentation (`docs/` branch)

## Test Plan

Docs-only; no code paths change. Verified:

- `superio-access.md` carries `Revision 3` + `Status: Implementation-ready (rev 3)` and contains no `TODO(provenance)` / `Draft — not implementation-ready` markers.
- `README.md` registry row reflects `Implementation-ready (rev 3)`.
- All Open-questions entries start with the exact `Non-blocking for Phase 2:` annotation.
- `git diff --check` clean (no whitespace errors).

## Checklist

- [x] Self-reviewed the change
- [x] Documentation-only; no lint/test-affecting code changed
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the sensors documentation to show that the Super I/O guide is now implementation-ready for Phase 2 raw chip-ID diagnostics.
  * Added notes that broader register maps and hardware-monitor discovery will come later in separate documents.
  * Tightened the spec to describe only the supported diagnostic flow, readouts, safety limits, and deferred items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->