### PR TITLE
docs: add Super I/O sensor handoff prompts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ documentation.
 - [Tauri app crate guide](../src-tauri/README.md)
 - [Add a new language](development/add-language.md)
 - [E2E capture harness](development/e2e-captures.md)
+- [Super I/O sensor work handoff](development/sensor-handoff/)
 - [GitHub label guide](development/labels.md)
 - [Download verification](download-verification.md)
 - [Documentation guide](documentation-guide.md)

--- a/docs/development/sensor-handoff/01-spec-gate.md
+++ b/docs/development/sensor-handoff/01-spec-gate.md
@@ -1,0 +1,91 @@
+# Session 1: Resolve the Super I/O Spec Gate
+
+> Status: completed by
+> [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734)
+> / commit `a8c167b1`.
+>
+> The chosen path was Option B: scope-flip only the Phase 2 raw chip-id
+> diagnostic surface to `Implementation-ready (rev 3)`. Keep this prompt as
+> historical context. Re-run it only if the ready scope expands beyond raw
+> chip-id diagnostics.
+
+## Original goal
+
+Resolve the `docs/specs/sensors/superio-access.md` draft gate that blocks
+Draft PR #1732 from becoming a merge-ready clean-room implementation PR.
+
+## Follow-up for #1732
+
+Update the PR body to pin:
+
+- `docs/specs/sensors/pawnio-interface.md` revision 4.
+- `docs/specs/sensors/superio-access.md` revision 3, commit `a8c167b1`.
+
+Then complete the implementer attestation item that every pinned spec is
+`Implementation-ready` with no unresolved `TODO(provenance)` markers.
+
+## Historical prompt
+
+```md
+# 目的
+
+#1635 / Draft PR #1732 のブロッカーである `docs/specs/sensors/superio-access.md` の Draft gate を解消したい。
+
+現在 #1732 は `LpcIO` で Super I/O chip ID registers (`0x20` / `0x21`) を読む diagnostic 実装だが、参照している `superio-access.md` が `Draft — not implementation-ready` のため clean-room implementation PR としてはmerge-readyではない。
+
+このセッションでは実装コードには触らず、spec側を整理する。
+
+# やること
+
+1. `docs/specs/sensors/README.md`
+2. `.github/instructions/clean-room-sensors.instructions.md`
+3. `docs/specs/sensors/superio-access.md`
+4. `docs/specs/sensors/pawnio-interface.md`
+
+を読み、clean-room gateを確認する。
+
+そのうえで、次のどちらが良いか判断してほしい。
+
+## Option A
+
+`superio-access.md` 全体を `Implementation-ready` にする。
+
+## Option B
+
+まず #1732 の範囲だけ、つまり:
+
+- LpcIO slot 0 / slot 1
+- config port pairs `0x2E/0x2F`, `0x4E/0x4F`
+- Nuvoton enter / exit sequence
+- ITE enter / exit sequence
+- chip ID registers `0x20` / `0x21`
+- absent id rule `0x00/0x00` or `0xFF/0xFF`
+- `Global\Access_ISABUS.HTP.Method` mutex
+
+に限定して implementation-ready にする。
+
+# 成果物
+
+- `docs/specs/sensors/superio-access.md` の改訂案
+- 必要なら別specに分割する案
+- revision bump
+- status update
+- unresolved open questions の整理
+- #1732 のPR本文に反映すべき provenance text
+
+# 制約
+
+- 実装コードは変更しない。
+- spec author ロールとして作業する。
+- vendor datasheet / public hardware spec / independently collected dump は参照してよい。
+- ただし、LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors / decompiled tool のコードや構造をspecに持ち込まない。
+- copyleft実装はnormative sourceにしない。
+- 不確かな点は fact table に入れず、Open questions に残す。
+
+# 最終回答に含めること
+
+- Option A / B の推奨
+- 変更したファイル
+- まだ残るblocker
+- #1732 をready化するために必要なPR本文更新案
+```

--- a/docs/development/sensor-handoff/02-hardware-validation.md
+++ b/docs/development/sensor-handoff/02-hardware-validation.md
@@ -2,15 +2,15 @@
 
 ## Goal
 
-Run Draft PR #1732's `getSuperIoChipIdDiagnostics()` command on real
-Windows self-built PC hardware and capture evidence.
+Run Draft PR #1732's Super I/O chip-id diagnostic on real Windows
+self-built PC hardware and capture evidence.
 
 ## Paste this prompt into the next session
 
 ```md
 # 目的
 
-Draft PR #1732 の `getSuperIoChipIdDiagnostics()` を Windows 自作PC実機で検証したい。
+Draft PR #1732 の Super I/O chip-id diagnostic を Windows 自作PC実機で検証したい。
 
 このセッションではコード追加よりも、実機からの証拠収集を優先する。
 
@@ -18,8 +18,9 @@ Draft PR #1732 の `getSuperIoChipIdDiagnostics()` を Windows 自作PC実機で
 
 PR #1732:
 - Branch: feat/1635-superio-chip-id-diagnostics
-- Command: `get_super_io_chip_id_diagnostics`
-- TS binding: `commands.getSuperIoChipIdDiagnostics()`
+- Session target: `getSuperIoChipIdDiagnostics()` diagnostic flow
+- Backend Tauri command: `get_super_io_chip_id_diagnostics`
+- TypeScript binding: `commands.getSuperIoChipIdDiagnostics()`
 
 # やること
 

--- a/docs/development/sensor-handoff/02-hardware-validation.md
+++ b/docs/development/sensor-handoff/02-hardware-validation.md
@@ -1,0 +1,81 @@
+# Session 2: Validate the Chip-ID Diagnostic on Real Hardware
+
+## Goal
+
+Run Draft PR #1732's `getSuperIoChipIdDiagnostics()` command on real
+Windows self-built PC hardware and capture evidence.
+
+## Paste this prompt into the next session
+
+```md
+# 目的
+
+Draft PR #1732 の `getSuperIoChipIdDiagnostics()` を Windows 自作PC実機で検証したい。
+
+このセッションではコード追加よりも、実機からの証拠収集を優先する。
+
+# 前提
+
+PR #1732:
+- Branch: feat/1635-superio-chip-id-diagnostics
+- Command: `get_super_io_chip_id_diagnostics`
+- TS binding: `commands.getSuperIoChipIdDiagnostics()`
+
+# やること
+
+1. #1732 のブランチを checkout する。
+2. Windows環境でビルド/起動する。
+3. PawnIO runtime / `LpcIO.bin` or `LpcIO.amx` の配置状況を確認する。
+4. HardwareVisualizer を通常権限で起動して command を実行する。
+5. HardwareVisualizer を管理者権限で起動して command を実行する。
+6. 結果JSONを保存する。
+
+# 収集したい情報
+
+- motherboard model
+- CPU
+- OS version
+- PawnIO runtime installedか
+- `PawnIOLib.dll` path
+- `LpcIO.bin` / `LpcIO.amx` path
+- 通常権限での結果
+- 管理者権限での結果
+- slot 0 / slot 1 の結果
+- Nuvoton attempt
+  - idHigh
+  - idLow
+  - chipId
+  - absent
+  - error
+  - exitError
+- ITE attempt
+  - idHigh
+  - idLow
+  - chipId
+  - absent
+  - error
+  - exitError
+
+# 期待する確認ポイント
+
+- PawnIO absent / access denied / openable が区別できるか
+- `0x80070005` が権限不足として見えるか
+- Nuvoton / ITE のどちらかで meaningful な chip ID が取れるか
+- `0x00/0x00` または `0xFF/0xFF` が absent として返るか
+- HWiNFO / LibreHardwareMonitor / FanControl 等を起動中でも mutex timeout / access issue がどう出るか
+
+# 実装変更の扱い
+
+- 原則、実装変更はしない。
+- ただし diagnostic output が足りない場合は、最小限の追加だけ提案する。
+- 変更が必要なら、その場で大きく直さず、別PR/別セッションに切る。
+
+# 最終回答に含めること
+
+- 実行環境
+- 通常権限の結果
+- 管理者権限の結果
+- raw JSON
+- 判断: #1732 のdiagnosticは実機検証に使えるか
+- 次に必要な修正があるか
+```

--- a/docs/development/sensor-handoff/03-chip-id-mapping.md
+++ b/docs/development/sensor-handoff/03-chip-id-mapping.md
@@ -1,0 +1,67 @@
+# Session 3: Chip-ID Mapping and Hardware-Monitor Base Discovery
+
+## Goal
+
+After chip ID bytes are readable, add chip model classification and
+hardware-monitor base discovery.
+
+## Paste this prompt into the next session
+
+```md
+# 目的
+
+#1732 の次の実装段階として、Super I/O chip ID diagnostic の結果から chip model を識別し、hardware-monitor base address discovery に進めたい。
+
+ただし、このセッションは clean-room implementation セッションなので、実装前に必ず spec readiness を確認すること。
+
+# 事前確認
+
+最初に以下を確認する。
+
+1. `docs/specs/sensors/superio-access.md` が、この実装範囲について `Implementation-ready` になっているか。
+2. chip ID table / hardware-monitor base discovery に必要なspecが存在するか。
+3. まだ Draft なら、実装せずに止めて、必要なspec gapを列挙する。
+
+# やりたい実装範囲
+
+可能なら以下を実装する。
+
+- Nuvoton / ITE の chip ID → chip model mapping
+- recognized / unknown / absent の分類
+- hardware-monitor logical device select
+  - Nuvoton: logical device `0x0B`
+  - ITE: logical device `0x04`
+- base address registers `0x60 / 0x61` のread
+- base address absent rule
+  - `0x0000`
+  - `0xFFFF`
+- `ioctl_find_bars`
+- diagnostic outputに以下を追加
+  - chipModel
+  - recognized
+  - hardwareMonitorBase
+  - findBars result
+  - detectionStage errors
+
+# 制約
+
+- temperature / fan / voltage はまだ読まない。
+- fan control / limit / alarm register には触らない。
+- mutex `Global\Access_ISABUS.HTP.Method` をtransaction全体で保持する。
+- re-detection cachingは設計だけでよい。実装する場合は別commitでもよい。
+- prohibited sources は参照しない。
+
+# テスト
+
+- pure helper は `core/src/utils/**` に置き、macOS/Linux CIでもテストされるようにする。
+- Windows-only providerも `x86_64-pc-windows-gnu` などでcompile確認する。
+- `RUSTFLAGS="-D warnings"` でも確認する。
+
+# 最終回答に含めること
+
+- spec readinessの判定
+- 実装した範囲
+- まだ実装しなかった範囲
+- validation結果
+- 次PRに切るべき作業
+```

--- a/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
+++ b/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
@@ -1,0 +1,93 @@
+# Session 4: Nuvoton or ITE Temperature/Fan RPM Decode
+
+## Goal
+
+Implement real motherboard temperature and fan RPM decoding for **one**
+Super I/O family per session/PR.
+
+## Paste this prompt into the next session
+
+````md
+# 目的
+
+Super I/O chip detection / hardware-monitor base discovery の次段階として、マザーボード温度とファンRPMを読みたい。
+
+このセッションでは、まず Nuvoton または ITE のどちらか一方だけを対象にする。
+両方を同時にやらない。
+
+# 最初に決めること
+
+対象を一つ選ぶ。
+
+- Nuvoton NCT67xx / NCT679x
+- ITE IT86xx / IT87xx
+
+選んだ対象について、必要なspecが `Implementation-ready` になっているか確認する。
+Draftなら実装せず、spec gapを整理して終了する。
+
+# 実装範囲
+
+対象chip familyについて:
+
+- temperature sensor registers
+- fan tachometer registers
+- fan RPM conversion
+- disconnected / stopped fan handling
+- invalid range filter
+- sensor name labeling
+- diagnostic source metadata
+
+# やらないこと
+
+- fan control
+- PWM write
+- threshold write
+- alarm clear
+- voltage read
+- UI実装
+- persistence
+- unrelated CPU/GPU sensor変更
+
+# モデル設計
+
+必要ならCore側に以下を追加する。
+
+```rust
+pub struct MotherboardTemperature {
+  pub name: String,
+  pub temperature_celsius: f32,
+  pub source: String,
+}
+
+pub struct MotherboardFanSpeed {
+  pub name: String,
+  pub rpm: u32,
+  pub source: String,
+}
+```
+
+ただし、最終的な `MetricsSnapshot` 接続は別セッションでもよい。
+
+# テスト方針
+
+- decode関数はpure helperにする。
+- 実機dump / synthetic register bytes をfixture化する。
+- macOS/Linux CIでもdecode testが動くようにする。
+- Windows providerはcross compile確認する。
+- 実機検証結果があれば、それに基づくfixtureを追加する。
+
+# clean-room制約
+
+- 実装コードは `docs/specs/sensors/**` とこのrepoだけから書く。
+- LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors / decompiled tools は参照禁止。
+- 足りない情報があれば、実装せずspec authorセッションへ戻す。
+
+# 最終回答に含めること
+
+- 対象chip family
+- 参照spec revision
+- 実装したregister decode
+- 実装しなかったregister
+- 実機検証の有無
+- 次のPRでやるべきこと
+````

--- a/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
+++ b/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
@@ -61,12 +61,22 @@ pub struct MotherboardTemperature {
 
 pub struct MotherboardFanSpeed {
   pub name: String,
-  pub rpm: u32,
+  pub rpm: Option<u32>,
+  pub status: FanSpeedStatus,
   pub source: String,
+}
+
+pub enum FanSpeedStatus {
+  Active,
+  Stopped,
+  Disconnected,
+  Invalid,
 }
 ```
 
 ただし、最終的な `MetricsSnapshot` 接続は別セッションでもよい。
+decode flowでは tachometer raw value から `rpm` と `status` を分けて返す。
+実測0 RPM、停止、未接続、範囲外を同じ `0` に潰さない。
 
 # テスト方針
 

--- a/docs/development/sensor-handoff/05-metrics-ui.md
+++ b/docs/development/sensor-handoff/05-metrics-ui.md
@@ -34,7 +34,15 @@ Core:
 ```rust
 pub struct FanSpeed {
   pub name: String,
-  pub rpm: u32,
+  pub rpm: Option<u32>,
+  pub status: FanSpeedStatus,
+}
+
+pub enum FanSpeedStatus {
+  Active,
+  Stopped,
+  Disconnected,
+  Invalid,
 }
 
 pub struct MetricsSnapshot {
@@ -77,6 +85,7 @@ Frontend:
 - センサーがない場合はセクションを出さない
 - 温度単位は既存 `settings.temperatureUnit` に従う
 - fan RPMは単位変換しない
+- fan status は Active / Stopped / Disconnected / Invalid を区別する
 - CPU thermal zonesとは別セクションにする
 - Motherboard cardだけに表示する
 

--- a/docs/development/sensor-handoff/05-metrics-ui.md
+++ b/docs/development/sensor-handoff/05-metrics-ui.md
@@ -1,0 +1,99 @@
+# Session 5: Metrics Stream and Motherboard UI Wiring
+
+## Goal
+
+Expose motherboard temperatures and fan RPMs through the live metrics
+pipeline and the Dashboard Motherboard card.
+
+## Paste this prompt into the next session
+
+````md
+# 目的
+
+Core側で取得できるようになった motherboard temperature / fan RPM を、HardwareVisualizer の metrics stream と Dashboard の Motherboard card に接続する。
+
+このセッションはUI/metrics接続が主目的。低レベルSuper I/O register実装はしない。
+
+# 前提
+
+低レベルprovider側で、少なくとも以下が返せる状態になっていること。
+
+- motherboard temperatures
+- motherboard fan speeds
+- source / sensor name
+
+もし低レベルproviderがまだない場合、このセッションでは mock / fixture だけでパイプラインを作るか、作業を止める。
+
+# 実装方針
+
+CPUの `sensor_temperatures` には混ぜない。
+マザーボード用に分離する。
+
+Core:
+
+```rust
+pub struct FanSpeed {
+  pub name: String,
+  pub rpm: u32,
+}
+
+pub struct MetricsSnapshot {
+  // existing fields...
+  pub motherboard_temperatures: Vec<SensorTemperature>,
+  pub motherboard_fan_speeds: Vec<FanSpeed>,
+}
+```
+
+Tauri wire:
+
+```rust
+pub struct HardwareMonitorUpdate {
+  // existing fields...
+  pub motherboard_temperatures: Vec<NameValue>,
+  pub motherboard_fan_speeds: Vec<FanSpeedValue>,
+}
+```
+
+Frontend:
+
+- `motherboardTempsAtom`
+- `motherboardFanSpeedsAtom`
+- `useHardwareEventListener` に追加
+- `MotherboardDataInfo` に表示
+- i18n:
+  - `motherboardTemperatures`
+  - `fanSpeeds`
+
+# render performance注意
+
+過去に live metrics / thermal sensor rows の再レンダリング問題があったため:
+
+- unchanged arraysでatomを更新しない
+- row renderingをmemo化する
+- 既存の render-fanout test に近い形で回帰テストを追加する
+
+# 表示ルール
+
+- センサーがない場合はセクションを出さない
+- 温度単位は既存 `settings.temperatureUnit` に従う
+- fan RPMは単位変換しない
+- CPU thermal zonesとは別セクションにする
+- Motherboard cardだけに表示する
+
+# テスト
+
+- `useHardwareEventListener` test
+- atom更新test
+- Motherboard card rendering test
+- generated bindings更新確認
+- `npm run build`
+- 必要なら `DashboardItems.renderFanout.test.tsx` 系の回帰テスト
+
+# 最終回答に含めること
+
+- Core → Tauri → frontend の接続範囲
+- UI表示仕様
+- render-fanout対策
+- validation結果
+- 実機センサーなし環境での挙動
+````

--- a/docs/development/sensor-handoff/06-external-component-guidance.md
+++ b/docs/development/sensor-handoff/06-external-component-guidance.md
@@ -30,15 +30,12 @@ pawnio:cpu-package-temperature:v1
 pawnio:motherboard-sensors:v1
 ```
 
-またはより具体的に:
-
-```text
-pawnio-lpcio:motherboard-sensors:v1
-```
+このkeyを canonical value として使う。frontend copy、event handling、
+persisted guidance state、docs/user の案内で別名を作らない。
 
 # やること
 
-- key名を決める
+- `pawnio:motherboard-sensors:v1` を guidance key として実装する
 - `ExternalComponentUsage` に MotherboardSensors を追加するか検討
 - missing signals:
   - motherboard-temperature

--- a/docs/development/sensor-handoff/06-external-component-guidance.md
+++ b/docs/development/sensor-handoff/06-external-component-guidance.md
@@ -1,0 +1,79 @@
+# Session 6: External Component Guidance for PawnIO LpcIO
+
+## Goal
+
+Add user-facing guidance for the motherboard-sensor PawnIO LpcIO path,
+separate from the existing CPU package temperature PawnIO guidance.
+
+## Paste this prompt into the next session
+
+````md
+# 目的
+
+PawnIO LpcIO / Super I/O motherboard sensor 用の External Component Guidance を設計・実装したい。
+
+既存の PawnIO CPU package temperature guidance とは別扱いにする。
+
+# 背景
+
+既存:
+
+```text
+pawnio:cpu-package-temperature:v1
+```
+
+これは CPU package temperature 用。
+
+新しく必要:
+
+```text
+pawnio:motherboard-sensors:v1
+```
+
+またはより具体的に:
+
+```text
+pawnio-lpcio:motherboard-sensors:v1
+```
+
+# やること
+
+- key名を決める
+- `ExternalComponentUsage` に MotherboardSensors を追加するか検討
+- missing signals:
+  - motherboard-temperature
+  - motherboard-fan-speed
+- reason分類:
+  - PawnIO runtime missing
+  - LpcIO module missing
+  - access denied / elevation required
+  - unsupported / unknown Super I/O chip
+- docs/user/external-components.md / .ja.md に案内追加
+- frontend dialog copy追加
+- view filtering:
+  - Dashboard / Motherboard card でだけ出すか
+  - SettingsのExternal Componentsから見えるようにするか
+
+# 注意
+
+- すぐにdialogを出しすぎない。
+- chip ID diagnosticが未実行なだけでguidanceを出さない。
+- motherboard sensor displayが有効で、かつ必要な信号が取れない場合に限定する。
+- CPU温度のPawnIO guidanceと混同しない。
+
+# 成果物
+
+- guidance key設計
+- core model更新
+- tauri wire更新
+- frontend copy / i18n
+- docs/user更新
+- tests
+
+# 最終回答に含めること
+
+- 追加したguidance key
+- 表示条件
+- CPU temperature guidanceとの差分
+- 残タスク
+````

--- a/docs/development/sensor-handoff/README.md
+++ b/docs/development/sensor-handoff/README.md
@@ -10,8 +10,12 @@ small and scoped so clean-room boundaries and PR scope stay clean.
   — `feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO`
 - Branch: `feat/1635-superio-chip-id-diagnostics`
 - Base: `develop`
-- Current scope: read Super I/O chip-id registers (`0x20` / `0x21`)
-  through PawnIO `LpcIO`, nothing more.
+- Current scope: Phase 2 raw Super I/O chip-id diagnostic through PawnIO
+  `LpcIO`, covering slot 0 / slot 1 selection, Nuvoton and ITE
+  configuration-mode enter/exit sequences, chip-id register reads
+  (`0x20` / `0x21`), absent-id classification, and the
+  `Global\Access_ISABUS.HTP.Method` ISA mutex contract. It still reads no
+  hardware-monitor data.
 - Spec gate: resolved by
   [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734)
   / commit `a8c167b1`. `docs/specs/sensors/superio-access.md` is now

--- a/docs/development/sensor-handoff/README.md
+++ b/docs/development/sensor-handoff/README.md
@@ -1,0 +1,91 @@
+# Super I/O Sensor Work — Session Handoff (#1635)
+
+This folder contains ready-to-paste prompts for continuing the Windows
+native Super I/O sensor work (#1635). Each session is intentionally
+small and scoped so clean-room boundaries and PR scope stay clean.
+
+## Status snapshot (updated 2026-06-27)
+
+- Draft PR: [#1732](https://github.com/shm11C3/HardwareVisualizer/pull/1732)
+  — `feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO`
+- Branch: `feat/1635-superio-chip-id-diagnostics`
+- Base: `develop`
+- Current scope: read Super I/O chip-id registers (`0x20` / `0x21`)
+  through PawnIO `LpcIO`, nothing more.
+- Spec gate: resolved by
+  [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734)
+  / commit `a8c167b1`. `docs/specs/sensors/superio-access.md` is now
+  `Implementation-ready (rev 3)` for the Phase 2 raw chip-id diagnostic
+  scope only.
+- #1732 still needs PR hygiene before it can leave Draft:
+  - re-pin provenance to `pawnio-interface.md` rev 4 and
+    `superio-access.md` rev 3,
+  - complete the implementer attestation box for ready specs,
+  - file and link the Phase 2 child issue under #1635,
+  - decide `LpcIO.bin` distribution/bundling and LGPL third-party notice
+    handling.
+- Next execution session: [02-hardware-validation.md](02-hardware-validation.md).
+
+## Sessions
+
+| File | Session | Role | Current state |
+| --- | --- | --- | --- |
+| [01-spec-gate.md](01-spec-gate.md) | Resolve the `superio-access.md` draft gate | spec author | Done via #1734 / `a8c167b1` |
+| [02-hardware-validation.md](02-hardware-validation.md) | Validate the chip-id diagnostic on real Windows hardware | tester | Next |
+| [03-chip-id-mapping.md](03-chip-id-mapping.md) | chip-id -> model mapping + hardware-monitor base discovery | clean-room implementer | Not started; needs new ready specs for chip tables/base discovery |
+| [04-nuvoton-ite-decode.md](04-nuvoton-ite-decode.md) | Nuvoton OR ITE temperature + fan RPM decode (one per PR) | clean-room implementer | Not started; blocked on per-family ready specs and dumps |
+| [05-metrics-ui.md](05-metrics-ui.md) | Wire motherboard temps/fans into metrics stream + dashboard | implementer | Not started; blocked until low-level provider returns motherboard temps/fans |
+| [06-external-component-guidance.md](06-external-component-guidance.md) | PawnIO LpcIO guidance (separate from CPU-temp guidance) | implementer | Not started; can be split once motherboard-sensor failure states are defined |
+
+Recommended order from here: #1732 PR hygiene -> 02 -> 03 -> 04 -> 05 -> 06.
+Sessions 04, 05, and 06 each become their own PR. Keep 03 separate unless it is
+only a small diagnostic extension.
+
+## Common preamble (paste at the start of every session)
+
+```md
+対象リポジトリ: /Users/shm11c3/Develop/HardwareVisualizer
+
+現在の関連Draft PR:
+- #1732: feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO
+- Branch: feat/1635-superio-chip-id-diagnostics
+- Base: develop
+
+この作業は #1635 の Windows native sensor / Super I/O / PawnIO 関連作業です。
+
+重要:
+- clean-room sensor rules を守ること。
+- 実装側セッションでは LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors / decompiled monitoring tool を参照しないこと。
+- 参照してよいのは、このrepo内の `docs/specs/sensors/**` とこのrepo自身。
+- spec author セッションだけは、vendor datasheet / public hardware spec / independently collected dump を扱ってよいが、実装コードやcopyleft実装からコード構造を持ち込まないこと。
+- PR作成時は `CONTRIBUTING.md` に従い、branch prefix / commit prefix / PR title / PR type checkbox を揃えること。
+- HardwareVisualizer のPR baseは基本 `develop`。
+- `src/rspc/bindings.ts` は生成物。必要なら `npm run tauri:dev` など既存の生成経路で更新し、手編集しない。
+- `superio-access.md` は `Implementation-ready (rev 3)` だが、ready範囲は Phase 2 raw chip-id diagnostic のみ。
+- chip-model mapping / hardware-monitor base discovery / temperature / fan RPM には、別途 ready spec が必要。
+- Draft PR #1732 は、PR本文の provenance re-pin / attestation / Phase 2 child issue link / `LpcIO.bin` distribution方針が未更新。
+```
+
+## #1732 operating policy
+
+```md
+# #1732 運用方針
+
+#1732 は、PR本文の provenance re-pin / attestation / Phase 2 child issue
+link / `LpcIO.bin` distribution方針が更新されるまでは Draft として維持する。
+
+このPRでやるのは:
+- LpcIOでchip IDを読む最初のdiagnostic
+- clean-room gate / next steps / 実機検証計画の明文化
+- gate解消済みspecへのprovenance re-pin
+
+このPRでやらない:
+- 温度取得
+- ファンRPM取得
+- hardware-monitor base decode
+- UI表示
+- External Component Guidance本実装
+
+CIが赤くなった場合だけ、このPR内で最小修正する。
+TODO本体は別セッション・別PRで進める。
+```

--- a/docs/development/sensor-handoff/README.md
+++ b/docs/development/sensor-handoff/README.md
@@ -21,9 +21,11 @@ small and scoped so clean-room boundaries and PR scope stay clean.
   - re-pin provenance to `pawnio-interface.md` rev 4 and
     `superio-access.md` rev 3,
   - complete the implementer attestation box for ready specs,
-  - file and link the Phase 2 child issue under #1635,
   - decide `LpcIO.bin` distribution/bundling and LGPL third-party notice
     handling.
+- Phase 2 child tracking stays in #1732 and these handoff docs for now;
+  do not create a separate child issue unless the scope grows beyond the
+  chip-id diagnostic.
 - Next execution session: [02-hardware-validation.md](02-hardware-validation.md).
 
 ## Sessions
@@ -63,7 +65,7 @@ only a small diagnostic extension.
 - `src/rspc/bindings.ts` は生成物。必要なら `npm run tauri:dev` など既存の生成経路で更新し、手編集しない。
 - `superio-access.md` は `Implementation-ready (rev 3)` だが、ready範囲は Phase 2 raw chip-id diagnostic のみ。
 - chip-model mapping / hardware-monitor base discovery / temperature / fan RPM には、別途 ready spec が必要。
-- Draft PR #1732 は、PR本文の provenance re-pin / attestation / Phase 2 child issue link / `LpcIO.bin` distribution方針が未更新。
+- Draft PR #1732 は、PR本文の provenance re-pin / attestation / `LpcIO.bin` distribution方針が未更新。
 ```
 
 ## #1732 operating policy
@@ -71,8 +73,8 @@ only a small diagnostic extension.
 ```md
 # #1732 運用方針
 
-#1732 は、PR本文の provenance re-pin / attestation / Phase 2 child issue
-link / `LpcIO.bin` distribution方針が更新されるまでは Draft として維持する。
+#1732 は、PR本文の provenance re-pin / attestation / `LpcIO.bin`
+distribution方針が更新されるまでは Draft として維持する。
 
 このPRでやるのは:
 - LpcIOでchip IDを読む最初のdiagnostic


### PR DESCRIPTION
## Summary

- Add docs/development/sensor-handoff prompts for the remaining #1635 Super I/O follow-up sessions.
- Update the handoff snapshot after #1734: superio-access.md is now Implementation-ready (rev 3) for the Phase 2 raw chip-id diagnostic scope.
- Link the handoff folder from docs/README.md.

## Related

Relates to #1635, #1732, and #1734.

## Type of Change

- [ ] Bug fix (fix/ branch)
- [ ] New feature (feat/ branch)
- [ ] Refactoring (refactor/ branch)
- [x] Documentation (docs/ branch)
- [ ] Dependencies update
- [ ] Other (chore/ branch)

## Validation

- npm run lint (exit 0; Biome reported the existing .codex/hooks.json internalError/io sandbox warning, with no fixes applied)
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Super I/O sensor work handoff guide with session-based steps (Sessions 1–6) and a recommended order for follow-up work.
  * Added dedicated session docs for spec gating, real-hardware validation, chip-ID mapping, Nuvoton/ITE decoding, metrics streaming + motherboard UI wiring, and external component guidance.
  * Updated the main development README to link to the new handoff materials and reflect the current handoff status/scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->