### PR TITLE
docs: refresh sensor handoff for Phase 3

### DIFF
--- a/docs/development/sensor-handoff/01-spec-gate.md
+++ b/docs/development/sensor-handoff/01-spec-gate.md
@@ -8,6 +8,10 @@
 > diagnostic surface to `Implementation-ready (rev 3)`. Keep this prompt as
 > historical context. Re-run it only if the ready scope expands beyond raw
 > chip-id diagnostics.
+>
+> For Phase 3, do not start here — use
+> [07-phase3-nuvoton-spec.md](07-phase3-nuvoton-spec.md) or
+> [08-phase4-ite-spec.md](08-phase4-ite-spec.md).
 
 ## Original goal
 

--- a/docs/development/sensor-handoff/02-hardware-validation.md
+++ b/docs/development/sensor-handoff/02-hardware-validation.md
@@ -1,35 +1,44 @@
-# Session 2: Validate the Chip-ID Diagnostic on Real Hardware
+# Session 2: Validate the Chip-ID Diagnostic and Capture Register Dumps
 
 ## Goal
 
-Run Draft PR #1732's Super I/O chip-id diagnostic on real Windows
-self-built PC hardware and capture evidence.
+Run the merged Phase 2 Super I/O chip-id diagnostic on real Windows
+self-built PC hardware, finish the open validation cases, and capture
+raw register dumps that Phase 3 / Phase 4 spec authoring needs.
+
+## State
+
+- ✅ Nuvoton-class board: non-elevated access-denied + elevated chip-id captured.
+- ⬜ ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior.
+- ⬜ Raw hardware-monitor register dumps for the detected chip(s) — the
+  primary input for clean-room Phase 3/4 specs.
 
 ## Paste this prompt into the next session
 
 ```md
 # 目的
 
-Draft PR #1732 の Super I/O chip-id diagnostic を Windows 自作PC実機で検証したい。
+#1635 Phase 2 (merged) の Super I/O chip-id diagnostic を Windows 自作PC実機で
+検証し、まだ取れていないケースと、Phase 3/4 spec authoring に必要な register dump を集めたい。
 
 このセッションではコード追加よりも、実機からの証拠収集を優先する。
 
 # 前提
 
-PR #1732:
-- Branch: feat/1635-superio-chip-id-diagnostics
-- Session target: `getSuperIoChipIdDiagnostics()` diagnostic flow
+- #1732 は develop にマージ済み（merge commit d8bb4bb8）。develop で作業する。
 - Backend Tauri command: `get_super_io_chip_id_diagnostics`
 - TypeScript binding: `commands.getSuperIoChipIdDiagnostics()`
+- 既に Nuvoton系で 非昇格access-denied / 昇格chip-id 取得済み。残りを埋める。
 
 # やること
 
-1. #1732 のブランチを checkout する。
+1. develop を checkout する。
 2. Windows環境でビルド/起動する。
 3. PawnIO runtime / `LpcIO.bin` or `LpcIO.amx` の配置状況を確認する。
 4. HardwareVisualizer を通常権限で起動して command を実行する。
 5. HardwareVisualizer を管理者権限で起動して command を実行する。
 6. 結果JSONを保存する。
+7. 可能なら ITE機 / PawnIO非導入機 / 他モニタ併用 でも実行する。
 
 # 収集したい情報
 
@@ -65,6 +74,13 @@ PR #1732:
 - `0x00/0x00` または `0xFF/0xFF` が absent として返るか
 - HWiNFO / LibreHardwareMonitor / FanControl 等を起動中でも mutex timeout / access issue がどう出るか
 
+# Phase 3/4 spec authoring 用に追加で残したい dump
+
+- 検出された chip ID と確定した chip model
+- hardware-monitor base address（取得できれば）
+- temperature / fan tachometer register 周辺の raw bytes（independently collected dump として）
+- これらは clean-room spec の normative source になり得るので、取得手順と環境を併記する
+
 # 実装変更の扱い
 
 - 原則、実装変更はしない。
@@ -77,6 +93,6 @@ PR #1732:
 - 通常権限の結果
 - 管理者権限の結果
 - raw JSON
-- 判断: #1732 のdiagnosticは実機検証に使えるか
+- Phase 3/4 spec authoring に渡せる register dump
 - 次に必要な修正があるか
 ```

--- a/docs/development/sensor-handoff/03-chip-id-mapping.md
+++ b/docs/development/sensor-handoff/03-chip-id-mapping.md
@@ -10,7 +10,7 @@ hardware-monitor base discovery.
 ```md
 # 目的
 
-#1732 の次の実装段階として、Super I/O chip ID diagnostic の結果から chip model を識別し、hardware-monitor base address discovery に進めたい。
+マージ済み Phase 2 chip-id diagnostic の次の実装段階として、Super I/O chip ID diagnostic の結果から chip model を識別し、hardware-monitor base address discovery に進めたい。
 
 ただし、このセッションは clean-room implementation セッションなので、実装前に必ず spec readiness を確認すること。
 
@@ -20,7 +20,8 @@ hardware-monitor base discovery.
 
 1. `docs/specs/sensors/superio-access.md` が、この実装範囲について `Implementation-ready` になっているか。
 2. chip ID table / hardware-monitor base discovery に必要なspecが存在するか。
-3. まだ Draft なら、実装せずに止めて、必要なspec gapを列挙する。
+3. Nuvotonなら `superio-nuvoton-*`、ITEなら `superio-ite-*` の per-family spec が `Implementation-ready` か確認する。
+4. まだ Draft / 未作成なら、実装せずに止めて、必要なspec gapを列挙する。
 
 # やりたい実装範囲
 

--- a/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
+++ b/docs/development/sensor-handoff/04-nuvoton-ite-decode.md
@@ -25,6 +25,11 @@ Super I/O chip detection / hardware-monitor base discovery の次段階として
 選んだ対象について、必要なspecが `Implementation-ready` になっているか確認する。
 Draftなら実装せず、spec gapを整理して終了する。
 
+想定spec:
+
+- Nuvoton: `docs/specs/sensors/superio-nuvoton-nct67xx.md`
+- ITE: `docs/specs/sensors/superio-ite-it86xx-it87xx.md`
+
 # 実装範囲
 
 対象chip familyについて:

--- a/docs/development/sensor-handoff/07-phase3-nuvoton-spec.md
+++ b/docs/development/sensor-handoff/07-phase3-nuvoton-spec.md
@@ -1,0 +1,77 @@
+# Session 7: Phase 3 Nuvoton Register-Map Spec
+
+## Goal
+
+Author an implementation-ready clean-room spec for Nuvoton
+NCT67xx/NCT679x motherboard temperature and fan RPM reads.
+
+## Paste this prompt into the next session
+
+```md
+# 目的
+
+#1635 Phase 3 として、Nuvoton NCT67xx / NCT679x 系 Super I/O の temperature / fan RPM 読み取りに必要な clean-room spec を作成したい。
+
+完了済み:
+- Phase 2 chip-id diagnostic は #1732 で develop にマージ済み
+- `docs/specs/sensors/superio-access.md` は Implementation-ready (rev 3)
+- ただし ready 範囲は raw chip-id diagnostic まで
+
+このセッションは **spec author** ロール。実装コードは触らない。
+
+# やること
+
+1. `docs/specs/sensors/README.md` と `.github/instructions/clean-room-sensors.instructions.md` を読む。
+2. `docs/specs/sensors/superio-access.md` rev 3 を読む。
+3. Nuvoton NCT67xx / NCT679x 系に必要な vendor datasheet / public hardware spec / independently collected dump を使って、fact-only specを作成する。
+
+# 作るspec候補
+
+`docs/specs/sensors/superio-nuvoton-nct67xx.md`
+
+# specに含めたい内容
+
+- Scope / Revision / Status
+- Sources table
+- 対象chip family / supported chip IDs
+- chip ID high/low registerの解釈（Phase 2 specとの接続）
+- hardware-monitor logical device
+- hardware-monitor base address discovery
+- bank select register
+- temperature sensor registers
+- fan tachometer registers
+- fan RPM conversion
+- stopped / disconnected fan handling
+- invalid range / plausibility rules
+- read transaction order
+- required writes for reads only
+- safety policy:
+  - fan control / PWM / threshold / alarm clear は対象外
+  - no sensor-setting writes
+- open questions
+- implementation-ready transition checklist
+
+# 重要制約
+
+- LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors / decompiled tools のコード・構造・識別子をspecに持ち込まない。
+- copyleft実装はnormative sourceにしない。
+- 不明点はOpen questionsへ。
+- TODO(provenance) が残るなら Draft のままにする。
+- Implementation-readyにするなら、READMEのstatus transition条件を満たすこと。
+
+# 成果物
+
+- 新規specファイル、または既存specへの追加
+- `docs/specs/sensors/README.md` の Current documents 更新
+- rev history
+- 次実装PRに書くべき provenance text
+
+# 最終回答に含めること
+
+- 作成/変更したspec
+- Status（DraftかImplementation-readyか）
+- 対象chip IDs
+- 実装可能になった範囲
+- まだ残るOpen questions
+- 次の clean-room implementer セッションへの指示
+```

--- a/docs/development/sensor-handoff/08-phase4-ite-spec.md
+++ b/docs/development/sensor-handoff/08-phase4-ite-spec.md
@@ -1,0 +1,77 @@
+# Session 8: Phase 4 ITE Register-Map Spec
+
+## Goal
+
+Author an implementation-ready clean-room spec for ITE IT86xx/IT87xx
+motherboard temperature and fan RPM reads.
+
+## Paste this prompt into the next session
+
+```md
+# 目的
+
+#1635 Phase 4 として、ITE IT86xx / IT87xx 系 Super I/O の temperature / fan RPM 読み取りに必要な clean-room spec を作成したい。
+
+完了済み:
+- Phase 2 chip-id diagnostic は #1732 で develop にマージ済み
+- `docs/specs/sensors/superio-access.md` は Implementation-ready (rev 3)
+- ただし ready 範囲は raw chip-id diagnostic まで
+
+このセッションは **spec author** ロール。実装コードは触らない。
+
+# やること
+
+1. `docs/specs/sensors/README.md` と `.github/instructions/clean-room-sensors.instructions.md` を読む。
+2. `docs/specs/sensors/superio-access.md` rev 3 を読む。
+3. ITE IT86xx / IT87xx 系に必要な vendor datasheet / public hardware spec / independently collected dump を使って、fact-only specを作成する。
+
+# 作るspec候補
+
+`docs/specs/sensors/superio-ite-it86xx-it87xx.md`
+
+# specに含めたい内容
+
+- Scope / Revision / Status
+- Sources table
+- 対象chip family / supported chip IDs
+- chip ID high/low registerの解釈（Phase 2 specとの接続）
+- EC / hardware-monitor logical device
+- EC base address discovery
+- temperature sensor registers
+- fan tachometer registers
+- fan RPM conversion
+- divisor / counter handling
+- stopped / disconnected fan handling
+- invalid range / plausibility rules
+- read transaction order
+- required writes for reads only
+- safety policy:
+  - fan control / PWM / threshold / alarm clear は対象外
+  - no sensor-setting writes
+- open questions
+- implementation-ready transition checklist
+
+# 重要制約
+
+- LibreHardwareMonitor / OpenHardwareMonitor / Linux kernel / lm-sensors / decompiled tools のコード・構造・識別子をspecに持ち込まない。
+- copyleft実装はnormative sourceにしない。
+- 不明点はOpen questionsへ。
+- TODO(provenance) が残るなら Draft のままにする。
+- Implementation-readyにするなら、READMEのstatus transition条件を満たすこと。
+
+# 成果物
+
+- 新規specファイル、または既存specへの追加
+- `docs/specs/sensors/README.md` の Current documents 更新
+- rev history
+- 次実装PRに書くべき provenance text
+
+# 最終回答に含めること
+
+- 作成/変更したspec
+- Status（DraftかImplementation-readyか）
+- 対象chip IDs
+- 実装可能になった範囲
+- まだ残るOpen questions
+- 次の clean-room implementer セッションへの指示
+```

--- a/docs/development/sensor-handoff/README.md
+++ b/docs/development/sensor-handoff/README.md
@@ -6,56 +6,54 @@ small and scoped so clean-room boundaries and PR scope stay clean.
 
 ## Status snapshot (updated 2026-06-27)
 
-- Draft PR: [#1732](https://github.com/shm11C3/HardwareVisualizer/pull/1732)
-  — `feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO`
-- Branch: `feat/1635-superio-chip-id-diagnostics`
-- Base: `develop`
-- Current scope: Phase 2 raw Super I/O chip-id diagnostic through PawnIO
-  `LpcIO`, covering slot 0 / slot 1 selection, Nuvoton and ITE
-  configuration-mode enter/exit sequences, chip-id register reads
-  (`0x20` / `0x21`), absent-id classification, and the
-  `Global\Access_ISABUS.HTP.Method` ISA mutex contract. It still reads no
-  hardware-monitor data.
-- Spec gate: resolved by
-  [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734)
-  / commit `a8c167b1`. `docs/specs/sensors/superio-access.md` is now
-  `Implementation-ready (rev 3)` for the Phase 2 raw chip-id diagnostic
-  scope only.
-- #1732 still needs PR hygiene before it can leave Draft:
-  - re-pin provenance to `pawnio-interface.md` rev 4 and
-    `superio-access.md` rev 3,
-  - complete the implementer attestation box for ready specs,
-  - decide `LpcIO.bin` distribution/bundling and LGPL third-party notice
-    handling.
-- Phase 2 child tracking stays in #1732 and these handoff docs for now;
-  do not create a separate child issue unless the scope grows beyond the
-  chip-id diagnostic.
-- Next execution session: [02-hardware-validation.md](02-hardware-validation.md).
+- ✅ **Phase 1** — CPU package temperature (PawnIO `IntelMSR` / `RyzenSMU`). Shipped.
+- ✅ **Phase 2** — Super I/O chip-id diagnostic via PawnIO `LpcIO`. **Merged.**
+  - PR [#1732](https://github.com/shm11C3/HardwareVisualizer/pull/1732) merged into `develop` (commit `d8bb4bb8`).
+  - Spec gate resolved by [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734) (`a8c167b1`); `docs/specs/sensors/superio-access.md` is `Implementation-ready (rev 3)` for the **Phase 2 raw chip-id diagnostic scope only**.
+  - Code: `core/src/infrastructure/providers/windows/super_io_diagnostics.rs` (chip-id `0x20`/`0x21` only), routed through the `SuperIoPlatform` trait + `PlatformFactory` (post-review refactor). Pure helpers in `core/src/utils/super_io.rs`.
+  - Command: `get_super_io_chip_id_diagnostics` / TS `commands.getSuperIoChipIdDiagnostics()`.
+  - Hardware validation: Nuvoton-class board captured (non-elevated access-denied + elevated chip-id). **Still open:** ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior — fold these into the Phase 3 hardware-dump session below.
+- ⬜ **Phase 3** — Nuvoton NCT67xx/NCT679x register map (temps + fan RPM). **Spec not written.** ← current focus.
+- ⬜ **Phase 4** — ITE IT86xx/87xx register map (temps + fan RPM). **Spec not written.**
+
+### What unblocks the next code
+
+No further *reading* implementation can start until the per-chip
+register-map specs (Phase 3 / Phase 4) and hardware-monitor base
+discovery are authored and flipped to `Implementation-ready`. The
+`superio-access.md` ready scope stops at the raw chip-id diagnostic.
+So **spec authoring comes first** ([07](07-phase3-nuvoton-spec.md) /
+[08](08-phase4-ite-spec.md)), ideally informed by real chip-id +
+register dumps collected via [02](02-hardware-validation.md).
 
 ## Sessions
 
 | File | Session | Role | Current state |
 | --- | --- | --- | --- |
-| [01-spec-gate.md](01-spec-gate.md) | Resolve the `superio-access.md` draft gate | spec author | Done via #1734 / `a8c167b1` |
-| [02-hardware-validation.md](02-hardware-validation.md) | Validate the chip-id diagnostic on real Windows hardware | tester | Next |
-| [03-chip-id-mapping.md](03-chip-id-mapping.md) | chip-id -> model mapping + hardware-monitor base discovery | clean-room implementer | Not started; needs new ready specs for chip tables/base discovery |
-| [04-nuvoton-ite-decode.md](04-nuvoton-ite-decode.md) | Nuvoton OR ITE temperature + fan RPM decode (one per PR) | clean-room implementer | Not started; blocked on per-family ready specs and dumps |
-| [05-metrics-ui.md](05-metrics-ui.md) | Wire motherboard temps/fans into metrics stream + dashboard | implementer | Not started; blocked until low-level provider returns motherboard temps/fans |
-| [06-external-component-guidance.md](06-external-component-guidance.md) | PawnIO LpcIO guidance (separate from CPU-temp guidance) | implementer | Not started; can be split once motherboard-sensor failure states are defined |
+| [01-spec-gate.md](01-spec-gate.md) | Resolve the `superio-access.md` draft gate | spec author | ✅ Done (#1734 / `a8c167b1`) |
+| [02-hardware-validation.md](02-hardware-validation.md) | Validate chip-id + capture register dumps on real Windows hardware | tester | 🔶 Partial (Nuvoton-class captured; ITE / PawnIO-absent / concurrent pending) |
+| [07-phase3-nuvoton-spec.md](07-phase3-nuvoton-spec.md) | Author the Nuvoton register-map spec | spec author | ⬜ **Next** |
+| [08-phase4-ite-spec.md](08-phase4-ite-spec.md) | Author the ITE register-map spec | spec author | ⬜ Not started |
+| [03-chip-id-mapping.md](03-chip-id-mapping.md) | chip-id -> model mapping + hardware-monitor base discovery | clean-room implementer | ⬜ Blocked on ready Phase 3/4 specs |
+| [04-nuvoton-ite-decode.md](04-nuvoton-ite-decode.md) | Nuvoton OR ITE temperature + fan RPM decode (one per PR) | clean-room implementer | ⬜ Blocked on ready per-family specs + dumps |
+| [05-metrics-ui.md](05-metrics-ui.md) | Wire motherboard temps/fans into metrics stream + dashboard | implementer | ⬜ Blocked until the provider returns motherboard temps/fans |
+| [06-external-component-guidance.md](06-external-component-guidance.md) | PawnIO LpcIO guidance (separate from CPU-temp guidance) | implementer | ⬜ Blocked until motherboard-sensor failure states are defined |
 
-Recommended order from here: #1732 PR hygiene -> 02 -> 03 -> 04 -> 05 -> 06.
-Sessions 04, 05, and 06 each become their own PR. Keep 03 separate unless it is
-only a small diagnostic extension.
+Recommended order from here:
+`02 dumps` → `07 (and/or 08) spec authoring` → `03 mapping + base discovery`
+→ `04 decode` → `05 metrics/UI` → `06 guidance`.
+Sessions 03/04/05/06 each become their own PR; split 04 per chip family
+(Nuvoton PR, then ITE PR).
 
 ## Common preamble (paste at the start of every session)
 
 ```md
 対象リポジトリ: /Users/shm11c3/Develop/HardwareVisualizer
 
-現在の関連Draft PR:
+#1732 は develop にマージ済み:
 - #1732: feat(sensors): Super I/O chip-id diagnostic via PawnIO LpcIO
-- Branch: feat/1635-superio-chip-id-diagnostics
-- Base: develop
+- Merge commit: d8bb4bb8
+- Command: get_super_io_chip_id_diagnostics / commands.getSuperIoChipIdDiagnostics()
 
 この作業は #1635 の Windows native sensor / Super I/O / PawnIO 関連作業です。
 
@@ -68,30 +66,26 @@ only a small diagnostic extension.
 - HardwareVisualizer のPR baseは基本 `develop`。
 - `src/rspc/bindings.ts` は生成物。必要なら `npm run tauri:dev` など既存の生成経路で更新し、手編集しない。
 - `superio-access.md` は `Implementation-ready (rev 3)` だが、ready範囲は Phase 2 raw chip-id diagnostic のみ。
-- chip-model mapping / hardware-monitor base discovery / temperature / fan RPM には、別途 ready spec が必要。
-- Draft PR #1732 は、PR本文の provenance re-pin / attestation / `LpcIO.bin` distribution方針が未更新。
+- chip-model mapping / hardware-monitor base discovery / temperature / fan RPM には、別途 Phase 3/4 の ready spec が必要。
+- Phase 3 の前に、Nuvoton/ITE実機dumpやvendor datasheetに基づくspec authoringを行うこと。
 ```
 
-## #1732 operating policy
+## Post-#1732 operating policy
 
 ```md
-# #1732 運用方針
+# #1732 後の運用方針
 
-#1732 は、PR本文の provenance re-pin / attestation / `LpcIO.bin`
-distribution方針が更新されるまでは Draft として維持する。
+#1732 は develop にマージ済み。
+今後 #1732 のブランチには追加実装しない。
 
-このPRでやるのは:
-- LpcIOでchip IDを読む最初のdiagnostic
-- clean-room gate / next steps / 実機検証計画の明文化
-- gate解消済みspecへのprovenance re-pin
+次の作業は別ブランチ・別PRで進める。
 
-このPRでやらない:
+次PRでまだやらない:
 - 温度取得
 - ファンRPM取得
 - hardware-monitor base decode
 - UI表示
 - External Component Guidance本実装
 
-CIが赤くなった場合だけ、このPR内で最小修正する。
-TODO本体は別セッション・別PRで進める。
+Phase 3/4のspecが ready になるまで、低レベル読み取り実装に進まない。
 ```


### PR DESCRIPTION
## Summary

Phase 2 (Super I/O chip-id diagnostic, #1732) is merged into `develop`
and the spec gate is resolved (#1734). This docs-only PR refreshes the
sensor handoff prompts so the next session targets **Phase 3/4
register-map spec authoring** instead of the (now-merged) Phase 2 work.

- `README.md`: Phase 1 + Phase 2 marked done; roadmap repointed at Phase 3
  Nuvoton spec authoring. Refreshed session table, ordering, common
  preamble, and replaced the obsolete "#1732 operating policy" block with
  a post-merge policy.
- Added `07-phase3-nuvoton-spec.md` and `08-phase4-ite-spec.md`
  (spec-author prompts) — the real blocker before any temperature / fan
  reading.
- `02-hardware-validation.md`: retargeted to `develop`, notes the
  Nuvoton-class evidence already captured, and asks for the register dumps
  Phase 3/4 specs need.
- `01-spec-gate.md`: links forward to the Phase 3/4 spec sessions.
- `03` / `04`: now require per-family ready specs
  (`superio-nuvoton-*` / `superio-ite-*`) before implementation.

## Related Issues

- Relates to #1635

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

n/a (internal handoff docs)

## Test Plan

Docs only; no code or spec changes.

- [x] Manual review of the updated prompts and Markdown fences

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (docs only)
- [x] Tests pass (n/a — docs only)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sensor handoff guide to reflect the latest project state and next steps.
  * Added clearer guidance for Phase 3 and Phase 4 work, including which documents to start from and which specs to use.
  * Expanded hardware validation notes with updated checklist items and artifact requirements for future spec writing.
  * Added new phase-specific spec authoring pages for Nuvoton and ITE sensor register mapping work.
  * Revised the handoff README to show completed progress, current scope, and the recommended path for upcoming work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->