### PR TITLE
docs: record Nuvoton Phase 3 spec validation

### DIFF
--- a/docs/development/sensor-handoff/02-hardware-validation.md
+++ b/docs/development/sensor-handoff/02-hardware-validation.md
@@ -9,8 +9,12 @@ raw register dumps that Phase 3 / Phase 4 spec authoring needs.
 ## State
 
 - ✅ Nuvoton-class board: non-elevated access-denied + elevated chip-id captured.
+- ⚠️ Nuvoton-class board: elevated LDN B config-space base captured
+  (`CR30=0x09`, normal HM base `0x0290`, read-only HM base `0x0000`),
+  but `ioctl_find_bars=0x80070490` and `pio_outb(0x0295)=0x80070005`
+  blocked the temperature/RPM byte dump.
 - ⬜ ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior.
-- ⬜ Raw hardware-monitor register dumps for the detected chip(s) — the
+- ⬜ Raw hardware-monitor temperature/RPM byte dumps for the detected chip(s) — the
   primary input for clean-room Phase 3/4 specs.
 
 ## Paste this prompt into the next session

--- a/docs/development/sensor-handoff/README.md
+++ b/docs/development/sensor-handoff/README.md
@@ -4,7 +4,7 @@ This folder contains ready-to-paste prompts for continuing the Windows
 native Super I/O sensor work (#1635). Each session is intentionally
 small and scoped so clean-room boundaries and PR scope stay clean.
 
-## Status snapshot (updated 2026-06-27)
+## Status snapshot (updated 2026-06-28)
 
 - ✅ **Phase 1** — CPU package temperature (PawnIO `IntelMSR` / `RyzenSMU`). Shipped.
 - ✅ **Phase 2** — Super I/O chip-id diagnostic via PawnIO `LpcIO`. **Merged.**
@@ -12,8 +12,8 @@ small and scoped so clean-room boundaries and PR scope stay clean.
   - Spec gate resolved by [#1734](https://github.com/shm11C3/HardwareVisualizer/pull/1734) (`a8c167b1`); `docs/specs/sensors/superio-access.md` is `Implementation-ready (rev 3)` for the **Phase 2 raw chip-id diagnostic scope only**.
   - Code: `core/src/infrastructure/providers/windows/super_io_diagnostics.rs` (chip-id `0x20`/`0x21` only), routed through the `SuperIoPlatform` trait + `PlatformFactory` (post-review refactor). Pure helpers in `core/src/utils/super_io.rs`.
   - Command: `get_super_io_chip_id_diagnostics` / TS `commands.getSuperIoChipIdDiagnostics()`.
-  - Hardware validation: ✅ validated on a Nuvoton-class board (non-elevated access-denied + elevated chip-id), captured in #1732 — enough to unblock Phase 3 Nuvoton. **Non-blocking follow-ups:** ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior.
-- ⬜ **Phase 3** — Nuvoton NCT67xx/NCT679x register map (temps + fan RPM). **Spec not written.** ← current focus.
+  - Hardware validation: ✅ validated on a Nuvoton-class board (non-elevated access-denied + elevated chip-id), captured in #1732; elevated Phase 3 probing later captured LDN B `CR30=0x09` and HM base `0x0290`. This is enough to inform Phase 3 spec authoring, but not enough to ready the register-map spec because temperature/RPM bytes were not captured. **Still blocking Phase 3 ready:** exact `0xD802` source and hardware-monitor byte dump. **Follow-ups:** ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior.
+- ⬜ **Phase 3** — Nuvoton NCT67xx/NCT679x register map (temps + fan RPM). **Draft rev 3 written, not ready.** Official NCT6796D datasheet facts are pinned, but the observed board is `0xD802` while NCT6796D is `0xD421`; elevated probing found HM base `0x0290` but PawnIO `LpcIO` did not permit the HM index/data byte dump.
 - ⬜ **Phase 4** — ITE IT86xx/87xx register map (temps + fan RPM). **Spec not written.**
 
 ### What unblocks the next code
@@ -22,17 +22,17 @@ No further *reading* implementation can start until the per-chip
 register-map specs (Phase 3 / Phase 4) and hardware-monitor base
 discovery are authored and flipped to `Implementation-ready`. The
 `superio-access.md` ready scope stops at the raw chip-id diagnostic.
-So **spec authoring comes first** ([07](07-phase3-nuvoton-spec.md) /
-[08](08-phase4-ite-spec.md)), ideally informed by real chip-id +
-register dumps collected via [02](02-hardware-validation.md).
+For Phase 3, the next blocker is exact-chip provenance for `0xD802`
+plus a hardware-monitor byte dump collected via
+[02](02-hardware-validation.md).
 
 ## Sessions
 
 | File | Session | Role | Current state |
 | --- | --- | --- | --- |
 | [01-spec-gate.md](01-spec-gate.md) | Resolve the `superio-access.md` draft gate | spec author | ✅ Done (#1734 / `a8c167b1`) |
-| [02-hardware-validation.md](02-hardware-validation.md) | Validate chip-id + capture register dumps on real Windows hardware | tester | ✅ Done for Nuvoton Phase 3 (#1732); ITE / PawnIO-absent / concurrent-monitor validation remains as non-blocking follow-up |
-| [07-phase3-nuvoton-spec.md](07-phase3-nuvoton-spec.md) | Author the Nuvoton register-map spec | spec author | ⬜ **Next** |
+| [02-hardware-validation.md](02-hardware-validation.md) | Validate chip-id + capture register dumps on real Windows hardware | tester | ⚠️ Chip-id and LDN B base done for Nuvoton, but hardware-monitor temperature/RPM byte dump still blocks Phase 3 ready; ITE / PawnIO-absent / concurrent-monitor validation remains follow-up |
+| [07-phase3-nuvoton-spec.md](07-phase3-nuvoton-spec.md) | Author the Nuvoton register-map spec | spec author | ⚠️ Draft rev 3; blocked on `0xD802` primary-source mapping and hardware-monitor byte dump |
 | [08-phase4-ite-spec.md](08-phase4-ite-spec.md) | Author the ITE register-map spec | spec author | ⬜ Not started |
 | [03-chip-id-mapping.md](03-chip-id-mapping.md) | chip-id -> model mapping + hardware-monitor base discovery | clean-room implementer | ⬜ Blocked on ready Phase 3/4 specs |
 | [04-nuvoton-ite-decode.md](04-nuvoton-ite-decode.md) | Nuvoton OR ITE temperature + fan RPM decode (one per PR) | clean-room implementer | ⬜ Blocked on ready per-family specs + dumps |
@@ -40,8 +40,8 @@ register dumps collected via [02](02-hardware-validation.md).
 | [06-external-component-guidance.md](06-external-component-guidance.md) | PawnIO LpcIO guidance (separate from CPU-temp guidance) | implementer | ⬜ Blocked until motherboard-sensor failure states are defined |
 
 Recommended order from here:
-`07 (and/or 08) spec authoring` → `03 mapping + base discovery`
-→ `04 decode` → `05 metrics/UI` → `06 guidance`.
+`02 Nuvoton hardware-monitor byte dump + exact-chip source` → `07 ready flip`
+→ `03 mapping + base discovery` → `04 decode` → `05 metrics/UI` → `06 guidance`.
 Remaining 02 follow-ups (ITE / PawnIO-absent / concurrent monitors) are
 non-blocking for Nuvoton Phase 3 and can be captured alongside that work.
 Sessions 03/04/05/06 each become their own PR; split 04 per chip family

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -167,14 +167,14 @@ or unresolved blocking open question invalidates the flip.
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
 | [`superio-access.md`](superio-access.md) | Phase 2 raw Super I/O chip-id diagnostic: config port pairs, Nuvoton/ITE enter/exit, chip-id registers, absent-id classification, ISA mutex | Phase 2 | Implementation-ready (rev 3) |
-| [`superio-nuvoton-nct67xx.md`](superio-nuvoton-nct67xx.md) | Draft Nuvoton NCT67xx/NCT679x hardware-monitor map for motherboard temperatures and fan RPM, including base discovery, banked register access, decode placeholders, and open provenance/dump requirements | Phase 3 | Draft — not implementation-ready |
+| [`superio-nuvoton-nct67xx.md`](superio-nuvoton-nct67xx.md) | Draft Nuvoton NCT67xx/NCT679x hardware-monitor map for motherboard temperatures and fan RPM. Rev 3 pins official NCT6796D facts and records that the observed `0xD802` board does not match the NCT6796D `0xD421` chip ID; elevated probing found HM base `0x0290` but did not capture temperature/RPM bytes, so exact-chip provenance and a hardware-monitor byte dump still block readiness. | Phase 3 | Draft — not implementation-ready |
 
-The Nuvoton Phase 3 document is currently a draft and still contains
-`TODO(provenance)` markers; it is **not** a clean-room implementation
-input yet. The ITE IT86xx/87xx register map and hardware-monitor base
-discovery for ITE are still not written and remain the Phase 4
-deliverable. The current `superio-access.md` readiness is intentionally
-limited to the Phase 2 raw chip-id diagnostic scope.
+The Nuvoton Phase 3 document is currently a draft; it is **not** a
+clean-room implementation input yet. The ITE IT86xx/87xx register map
+and hardware-monitor base discovery for ITE are still not written and
+remain the Phase 4 deliverable. The current `superio-access.md`
+readiness is intentionally limited to the Phase 2 raw chip-id
+diagnostic scope.
 
 ## Safety policy (applies to all documents and implementations)
 

--- a/docs/specs/sensors/superio-nuvoton-nct67xx.md
+++ b/docs/specs/sensors/superio-nuvoton-nct67xx.md
@@ -2,34 +2,53 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 1 |
+| Revision | 3 |
 | Status | Draft — not implementation-ready |
-| Scope | Phase 3 Nuvoton-family register-map draft for motherboard temperature and fan RPM reads. Covers the intended clean-room facts that must be pinned before implementation: chip-id applicability, Hardware Monitor logical-device base discovery, banked hardware-monitor access, temperature registers, fan tachometer registers, and RPM decode. Excludes voltage decode, fan-control/PWM writes, threshold/limit writes, alarm clearing, UI integration, and any Rust implementation. |
-| Issue phase | Phase 3 (#1635) — Nuvoton NCT67xx / NCT679x temperature and fan RPM specification |
+| Scope | Phase 3 Nuvoton-family register-map draft for motherboard temperature and fan RPM reads. Revision 3 pins NCT6796D-E/NCT6796D datasheet facts, records the mismatch between that datasheet and the observed `0xD802` hardware, records elevated `0xD802` configuration-space evidence, and keeps decode disabled until an exact-chip primary source plus hardware-monitor register bytes are available. Excludes voltage decode, fan-control/PWM writes, threshold/limit writes, alarm clearing, UI integration, and any Rust implementation. |
+| Issue phase | Phase 3 (#1635) - Nuvoton NCT67xx / NCT679x temperature and fan RPM specification |
 
-This revision is intentionally a **Draft**. It records the required
-shape of the Nuvoton-family spec and the facts already available from
-the Phase 2 clean-room diagnostic, but it still contains
-`TODO(provenance)` markers for the per-chip datasheet page/section
-pinning and for real hardware register dumps. No implementation may use
-this document as a ready clean-room input until those markers are
-resolved and the status is flipped using the checklist in
-[`README.md`](README.md).
+This revision is intentionally a **Draft**. It verifies the prior draft
+against the official NCT6796D datasheet and finds that the datasheet's
+configuration-space chip ID is `0xD421`, while the Phase 2 real board
+dump observed `0xD802`. Therefore the NCT6796D facts below are useful
+primary-source register-map evidence, but they do **not** prove that the
+observed board can safely use this map. A later elevated local probe
+confirmed that the `0xD802` responder exposes Logical Device B with
+normal HM base `0x0290`, but it did not capture temperature or fan RPM
+bytes. No implementation may use this document as a ready clean-room
+input until the blocking items in
+[Open questions](#open-questions) are resolved and the status is flipped
+using the checklist in [`README.md`](README.md).
 
 ## Sources
 
 | ID | Source | Notes |
 | --- | --- | --- |
-| S1 | Nuvoton, *NCT6796D* datasheet, revision V0.6, Hardware Monitor / configuration-register sections | Primary candidate source for this document. TODO(provenance): pin exact section and page numbers for every NCT6796D-derived fact before flipping this document to implementation-ready. |
+| S1 | Nuvoton, *NCT6796D LPC/eSPI SI/O Datasheet*, version 0.6, publication release date July 6, 2017; official PDF: `https://www.nuvoton.com/resource-files/NCT6796D_Datasheet_V0_6.pdf` | Primary source for NCT6796D register facts. Relevant pins: configuration protocol chapter 7, pp. 51-53; hardware-monitor LPC access chapter 8.3, pp. 54-55; temperature format chapter 8.6.3, pp. 60-62; fan speed reading chapter 8.8.1-8.8.3, pp. 66-67; fan count/RPM registers chapter 9.209-9.232, pp. 176-183; HM read-only register chapter 9.481, pp. 277-280; global chip ID CR20/CR21, p. 369; Logical Device B CR30/CR60-65, pp. 431-432. |
 | S2 | [`superio-access.md`](superio-access.md) revision 3 | Primary clean-room source for the Phase 2 Nuvoton configuration-mode key sequence, global chip-id register reads (`0x20` / `0x21`), absent-id classification, standard Super I/O configuration port pairs, and ISA mutex policy. |
-| S3 | HardwareVisualizer PR #1732 real-hardware diagnostic dump, captured 2026-06-27 on NZXT N7 B650E / AMD Ryzen 7 7800X3D / Windows 11 Pro | Independent hardware evidence for a reachable Nuvoton-class responder at slot 0 (`0x2E`/`0x2F`) with raw chip-id bytes `0xD8` / `0x02`; not sufficient by itself to classify the exact chip model or decode hardware-monitor registers. |
+| S3 | HardwareVisualizer PR #1732 real-hardware diagnostic dump, captured 2026-06-27 on NZXT N7 B650E / AMD Ryzen 7 7800X3D / Windows 11 Pro | Independent hardware evidence for a reachable Nuvoton-class responder at slot 0 (`0x2E`/`0x2F`) with raw chip-id bytes `0xD8` / `0x02`; this is not the NCT6796D `0xD4` / `0x21` ID from S1. |
 | S4 | HardwareVisualizer issue #1635 clean-room policy and [`README.md`](README.md) status-transition rules | Project policy source for keeping copyleft implementations non-normative and for leaving unresolved datasheet/dump gaps as Draft-only open questions. |
+| S5 | Local standard-rights PawnIO probe on 2026-06-28 | Environment evidence only: `C:\Program Files\PawnIO` has `PawnIOLib.dll` and `LpcIO.bin`, PawnIO service is running, `pawnio_version` returned `0x00020000`, but `pawnio_open` returned `0x80070005` under medium integrity. No Phase 3 register dump was captured in this session. |
+| S6 | Local elevated PawnIO `LpcIO` probe on 2026-06-28, run from Administrator PowerShell on the S3-class machine | Independent hardware evidence: `pawnio_open`, `pawnio_load`, and `Global\Access_ISABUS.HTP.Method` mutex acquisition succeeded; slot 0 repeated `chipId=0xD802`; LDN B read `CR30=0x09`, `CR60/61=0x02/0x90` (`HM base=0x0290`), and `CR64/65=0x00/0x00` (no valid read-only HM base). `ioctl_find_bars` returned `0x80070490`, and a normal HM index-port write to `0x0295` returned `0x80070005`, so no temperature or fan RPM bytes were captured. |
 
 No LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors,
 or decompiled monitoring-tool source is a normative source for this
-revision. If such sources are consulted later as non-normative leads,
-they must be added to this table as non-normative leads and no fact may
-rest solely on them.
+revision. No fact below rests on those implementations.
+
+## Validation outcome
+
+Revision 3 does **not** pass the implementation-ready gate:
+
+- The only official datasheet fetched and verified in this session is
+  NCT6796D/NCT6796D-E. It identifies global CR20/CR21 as `0xD4`/`0x21`
+  (`chipId=0xD421`), not the observed board's `0xD8`/`0x02`
+  (`chipId=0xD802`). (S1, S3)
+- The observed `0xD802` chip still needs an exact primary-source model
+  mapping or an exact-chip datasheet. (S3)
+- Elevated PawnIO access captured the observed chip's LDN B activation
+  and normal HM base, but PawnIO `LpcIO` did not permit the normal HM
+  index/data port transaction, so no temperature or fan RPM register
+  bytes were captured. (S6)
 
 ## Detection
 
@@ -39,71 +58,99 @@ rest solely on them.
 | --- | --- |
 | This document applies only after a Nuvoton-compatible Super I/O responder is detected through the Phase 2 configuration-mode diagnostic path. The diagnostic reads global chip-id bytes from configuration registers `0x20` and `0x21` while holding `Global\Access_ISABUS.HTP.Method`. | S2 |
 | A raw chip-id reading of `0x00`/`0x00` or `0xFF`/`0xFF` is treated as absent/no usable responder for the Phase 2 diagnostic. Mixed values must stay visible as raw bytes for triage. | S2 |
+| NCT6796D's global CR20 high byte is `0xD4` and CR21 low byte is `0x21`, so the configuration-space chip ID is `0xD421`. | S1 p. 369 |
 | The observed Nuvoton-class board in S3 responded on slot 0 (`0x2E` index / `0x2F` data) with `idHigh=0xD8`, `idLow=0x02`, combined `chipId=0xD802`. | S3 |
-| This revision does not classify `0xD802` as a specific Nuvoton model. Model classification must wait for a vendor chip-id table, board documentation, or another independent source. | S1, S3 |
+| The observed `0xD802` responder is not proven to be NCT6796D/NCT6796D-E by S1 and must remain disabled for NCT6796D-specific decode. | S1, S3 |
+| The elevated S6 probe on the observed `0xD802` board read LDN B `CR30=0x09`, normal HM base `0x0290`, and read-only HM base `0x0000`. The normal HM base is reachable in configuration space, but no sensor-byte read was completed through PawnIO. | S6 |
 
 ### Scoped enablement
 
 | Scope | Status | Default enablement |
 | --- | --- | --- |
 | Nuvoton responder detection using Phase 2 raw chip-id bytes | Ready only through `superio-access.md` rev 3; this document references the diagnostic result but does not change the Phase 2 ready scope. | Existing diagnostic may remain enabled. |
-| Chip-id `0xD802` model mapping | Draft. Observed in S3, but exact model is unresolved. TODO(provenance): pin a primary source that maps `0xD802` to a model/revision, or keep model-specific decode disabled. | Disabled for model-specific decode. |
-| Hardware Monitor logical-device selection and base discovery | Draft. Intended mechanism recorded below, but page-level datasheet provenance and hardware dump confirmation are not yet pinned. | Disabled. |
-| Temperature register reads | Draft. Register numbers and source-to-label mapping remain TODO(provenance). | Disabled. |
-| Fan tachometer reads and RPM decode | Draft. Register numbers, counter width/order, stopped/disconnected values, and RPM formula remain TODO(provenance). | Disabled. |
+| NCT6796D/NCT6796D-E chip-id mapping (`0xD421`) | Primary-source pinned from S1, but not hardware-validated on the S3 board. | Disabled until an NCT6796D/NCT6796D-E hardware dump is captured, or until scope is explicitly limited to datasheet-only support. |
+| Observed chip-id `0xD802` | Draft. Observed in S3, but exact Nuvoton model/revision is unresolved. S1 disproves treating it as NCT6796D. | Disabled. |
+| Hardware Monitor logical-device selection and base discovery | Draft. NCT6796D facts are pinned from S1; the observed `0xD802` board partially matches the LDN B/base shape with `CR30=0x09` and HM base `0x0290`, but the exact chip remains unresolved and the read-only HM base is `0x0000`. | Disabled. |
+| Temperature register reads | Draft. NCT6796D register facts are pinned from S1, but S6 did not capture hardware-monitor temperature bytes for the observed board. | Disabled. |
+| Fan tachometer / RPM reads | Draft. NCT6796D register facts are pinned from S1, but S6 did not capture hardware-monitor fan count/RPM bytes for the observed board. | Disabled. |
 
-## Register map (facts)
+## Register map facts
 
 ### Configuration-space fields needed before hardware-monitor access
 
-These entries describe the intended facts that must be pinned from S1
-before implementation. They are not implementation-ready while any
-`TODO(provenance)` marker remains.
+These fields are NCT6796D facts from S1. They are not implementation-ready
+for the observed S3 hardware while the exact `0xD802` model is unresolved.
 
-| Address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
+| Address | Name | Bits | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| `0x20` | Chip ID high byte | `7:0` | High byte of the Super I/O chip-id value used by the Phase 2 diagnostic. | Raw byte | S2 |
-| `0x21` | Chip ID low byte | `7:0` | Low byte of the Super I/O chip-id value used by the Phase 2 diagnostic. | Raw byte | S2 |
-| `0x07` | Logical Device Number select | `7:0` | Selects the logical device whose device-scoped configuration registers are accessed. TODO(provenance): pin exact Nuvoton register name/page. | Raw logical-device number | S1 TODO(provenance) |
-| `0x0B` | Hardware Monitor logical device number | `7:0` | Logical-device number expected to expose the Nuvoton hardware-monitor I/O base. TODO(provenance): pin exact Nuvoton device name/page. | Raw logical-device number | S1 TODO(provenance) |
-| `0x60` | Hardware Monitor base-address high byte | `7:0` | High byte of the hardware-monitor I/O base address after selecting the Hardware Monitor logical device. TODO(provenance): pin exact register name/page. | Base address high byte | S1 TODO(provenance) |
-| `0x61` | Hardware Monitor base-address low byte | `7:0` | Low byte of the hardware-monitor I/O base address after selecting the Hardware Monitor logical device. TODO(provenance): pin exact register name/page and alignment/disabled-value rules. | Base address low byte | S1 TODO(provenance) |
+| `0x20` | Chip ID high byte | `7:0` | NCT6796D high byte `0xD4`. | Raw byte | S1 p. 369 |
+| `0x21` | Chip ID low byte | `7:0` | NCT6796D low byte `0x21`. | Raw byte | S1 p. 369 |
+| `0x07` | Logical Device Number select | `7:0` | Selects which logical device's registers are accessed at indexes `0x30` and above. | Raw logical-device number | S1 pp. 51-52 |
+| `0x0B` | Logical Device B / Hardware Monitor logical device | `7:0` | Selects Logical Device B, whose CR30 enables Hardware Monitor & SB-TSI and whose CR60/61 and CR64/65 define HM base addresses. | Raw logical-device number | S1 pp. 431-432 |
+| `0x30` after LDN `0x0B` | Hardware Monitor & SB-TSI activation | bit `0` | `0` inactive, `1` active. Discovery may read this bit. This spec does not permit writing it. | Boolean active bit | S1 p. 431 |
+| `0x60` / `0x61` after LDN `0x0B` | HM base address | `15:0` | Selects the normal Hardware Monitor base address in `<0x100:0xFFE>` on a 2-byte boundary. | I/O base address | S1 p. 431 |
+| `0x64` / `0x65` after LDN `0x0B` | Read-only HM base address | `15:0` | Selects the read-only Hardware Monitor base address in `<0x100:0xFFE>` on a 2-byte boundary. | I/O base address | S1 p. 431 |
 
 ### Hardware-monitor I/O access fields
 
-| Address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
+| Address | Name | Bits | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| `base + 0x05` | Hardware Monitor address/index port | `7:0` | I/O port used to select a hardware-monitor register. TODO(provenance): pin exact Nuvoton naming/page. | Port offset from discovered base | S1 TODO(provenance) |
-| `base + 0x06` | Hardware Monitor data port | `7:0` | I/O port used to read or write the selected hardware-monitor register. TODO(provenance): pin exact Nuvoton naming/page. | Port offset from discovered base | S1 TODO(provenance) |
-| `0x4E` | Hardware Monitor bank-select register | `7:0` | Bank selector for the banked hardware-monitor register space. Writing this selector is required to read banked registers, but must be limited to the read transaction. TODO(provenance): pin bank bit layout and reset/side-effect notes. | Bank number / selector bits | S1 TODO(provenance) |
+| `base + 0x05` | Hardware Monitor address/index port | `7:0` | I/O port used to select a hardware-monitor internal register; standard index/data locations are usually `0x295`/`0x296`. | Port offset from discovered HM base | S1 pp. 54-55 |
+| `base + 0x06` | Hardware Monitor data port | `7:0` | I/O port used to read or write the selected hardware-monitor internal register. | Port offset from discovered HM base | S1 pp. 54-55 |
+| internal `0x4E` | Hardware Monitor bank-select register | `7:0` | Selects the bank for banked hardware-monitor internal registers. Bank writes are allowed only as read-transaction plumbing. | Bank selector | S1 p. 55 |
 
 ### Temperature sensor registers
 
-Do not implement from this table yet. It is a placeholder for the
-primary-source facts and hardware-dump validation still needed for
-Phase 3.
+NCT6796D exposes SYSTIN, CPUTIN, AUXTIN0, AUXTIN1, AUXTIN2, AUXTIN3,
+and AUXTIN4 temperature values. The data format for those sensors is
+9-bit two's-complement with 0.5 C resolution when using the high/low
+temperature-source registers. The HM read-only table also exposes byte
+temperature readings for all seven sources. (S1 pp. 60-62, 277-280)
 
-| Address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
+| Access path | Address | Name | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| TODO(provenance) | TODO(provenance) | TODO(provenance) | Temperature input reading for one Nuvoton hardware-monitor source. Must distinguish board/socket/auxiliary sensors from CPU package temperature already covered by Phase 1 specs. | TODO(provenance): signedness, resolution, Celsius conversion, invalid values | S1 TODO(provenance), S3 TODO(register dump) |
+| Read-only HM base | offset `0x10` | SYSTIN temperature reading | System temperature input. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x11` | CPUTIN temperature reading | CPU socket/board temperature input. Distinct from Phase 1 CPU package temperature. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x12` | AUXTIN0 temperature reading | Auxiliary temperature input 0. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x13` | AUXTIN1 temperature reading | Auxiliary temperature input 1. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x14` | AUXTIN2 temperature reading | Auxiliary temperature input 2. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x15` | AUXTIN3 temperature reading | Auxiliary temperature input 3. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Read-only HM base | offset `0x16` | AUXTIN4 temperature reading | Auxiliary temperature input 4. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
+| Banked HM registers | bank `0x04`, indexes `0x90`-`0x95` | SYSTIN through AUXTIN3 temperature readings | Alternate banked readings for SYSTIN, CPUTIN, and AUXTIN0-3. AUXTIN4 is not listed in this table. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 p. 176 |
 
-### Fan tachometer registers
+### Fan tachometer / RPM registers
 
-Do not implement from this table yet. It is a placeholder for the
-primary-source facts and hardware-dump validation still needed for
-Phase 3.
+NCT6796D provides 13-bit fan count readings and 16-bit direct fan RPM
+readings. For 13-bit count reads, the datasheet requires reading the
+high byte first, then the low byte. `RPM = 1.35e6 / count`. For 16-bit
+RPM reads, the datasheet requires reading the high byte first, then the
+low byte; the combined 16-bit value is the RPM value in decimal. (S1
+p. 66)
 
-| Address | Name (vendor mnemonic) | Bits | Meaning | Units / encoding | Source |
-| --- | --- | --- | --- | --- | --- |
-| TODO(provenance) | TODO(provenance) | TODO(provenance) | Fan tachometer count for one Nuvoton FANIN source. | TODO(provenance): counter width, byte order, divisor/prescale interaction, stopped/disconnected count values | S1 TODO(provenance), S3 TODO(register dump) |
+| Fan input | 13-bit count registers | 16-bit RPM registers | Read order / conversion | Source |
+| --- | --- | --- | --- | --- |
+| SYSFANIN | bank `0x04`, high `0xB0`, low `0xB1` | bank `0x04`, high `0xC0`, low `0xC1` | Count high then low; RPM high then low. | S1 pp. 66, 176, 180 |
+| CPUFANIN | bank `0x04`, high `0xB2`, low `0xB3` | bank `0x04`, high `0xC2`, low `0xC3` | Count high then low; RPM high then low. | S1 pp. 66, 177, 180-181 |
+| AUXFANIN0 | bank `0x04`, high `0xB4`, low `0xB5` | bank `0x04`, high `0xC4`, low `0xC5` | Count high then low; RPM high then low. | S1 pp. 66, 177-178, 181 |
+| AUXFANIN1 | bank `0x04`, high `0xB6`, low `0xB7` | bank `0x04`, high `0xC6`, low `0xC7` | Count high then low; RPM high then low. | S1 pp. 66, 178, 181-182 |
+| AUXFANIN2 | bank `0x04`, high `0xB8`, low `0xB9` | bank `0x04`, high `0xC8`, low `0xC9` | Count high then low; RPM high then low. | S1 pp. 66, 178-179, 182 |
+| AUXFANIN3 | bank `0x04`, high `0xBA`, low `0xBB` | bank `0x04`, high `0xCA`, low `0xCB` | Count high then low; RPM high then low. | S1 pp. 66, 179, 182-183 |
+| AUXFANIN4 | bank `0x04`, high `0xCC`, low `0xCD` per summary table | bank `0x04`, high `0xCE`, low `0xCF` per summary table; read-only HM offsets `0x46`/`0x47` also list AUXFANIN4 RPM | Count high then low; RPM high then low. Detailed banked-register sections for `0xCC`-`0xCF` were not found in S1 text extraction, so enablement needs hardware dump confirmation. | S1 pp. 66, 279 |
+
+The HM read-only register table provides direct count/RPM offsets for
+the first six fan inputs and RPM offsets for AUXFANIN4:
+
+| Read-only HM offset range | Meaning | Source |
+| --- | --- | --- |
+| `0x2E`-`0x39` | SYSFANIN, CPUFANIN, AUXFANIN0, AUXFANIN1, AUXFANIN2, AUXFANIN3 count high/low readings. | S1 p. 279 |
+| `0x3A`-`0x47` | SYSFANIN, CPUFANIN, AUXFANIN0, AUXFANIN1, AUXFANIN2, AUXFANIN3, AUXFANIN4 RPM high/low readings. | S1 p. 279 |
 
 ## Read procedure and decode
 
 ### Discovery procedure (draft)
 
-The discovery procedure below is not implementation-ready until every
-S1 `TODO(provenance)` marker is pinned and a real hardware dump confirms
-the decoded base on at least the target Nuvoton-class board.
+This procedure is not implementation-ready until the exact `0xD802`
+chip is identified or matching hardware is validated for NCT6796D.
 
 1. Acquire `Global\Access_ISABUS.HTP.Method` with a bounded timeout
    before any Super I/O index/data or hardware-monitor I/O transaction.
@@ -112,77 +159,71 @@ the decoded base on at least the target Nuvoton-class board.
 2. Use the Phase 2 Nuvoton configuration-mode procedure to read the raw
    chip-id bytes from `0x20` / `0x21`. If the responder is absent under
    the Phase 2 absent-id rules, stop. (S2)
-3. Select the Hardware Monitor logical device by writing the logical
-   device selector and the Hardware Monitor logical-device number.
-   TODO(provenance): pin exact selector register, logical-device number,
-   and any activation precondition from S1.
-4. Read the hardware-monitor base-address high and low bytes and combine
-   them into a base address.
-   TODO(provenance): pin disabled-base values, required alignment, and
-   validity rules from S1.
-5. Exit configuration mode using the Phase 2 Nuvoton exit sequence.
+3. Treat `0xD421` as NCT6796D/NCT6796D-E candidate hardware. Treat
+   `0xD802` as an unresolved Nuvoton-class responder and keep decode
+   disabled. (S1, S3)
+4. Select Logical Device B by writing `0x07` then `0x0B` in
+   configuration mode. (S1)
+5. Read CR30, CR60/61, and CR64/65. CR30 bit 0 indicates whether
+   Hardware Monitor & SB-TSI is active; CR60/61 is the normal HM base;
+   CR64/65 is the read-only HM base. (S1)
+6. Exit configuration mode using the Phase 2 Nuvoton exit sequence.
    (S2)
-6. Cache the detected slot, chip-id bytes, optional model mapping, and
-   base address. Sampling paths must not re-enter configuration mode on
-   every metrics tick.
+7. Cache the detected slot, chip-id bytes, optional model mapping, and
+   base addresses. Sampling paths must not re-enter configuration mode
+   on every metrics tick.
 
 ### Hardware-monitor register read procedure (draft)
 
-1. Acquire `Global\Access_ISABUS.HTP.Method` for the whole banked
+1. Acquire `Global\Access_ISABUS.HTP.Method` for the whole
    hardware-monitor transaction. (S2)
-2. For each required register, write the required bank selector to the
-   hardware-monitor bank-select register.
-   TODO(provenance): pin the exact bank selector encoding and whether
-   the bank register is itself banked.
-3. Write the register address to `base + 0x05`, then read the selected
-   byte from `base + 0x06`.
-   TODO(provenance): pin address/data port offsets and any ordering or
-   delay requirement from S1.
-4. Release the mutex after all bytes for one coherent sample have been
+2. For banked reads, write internal register `0x4E` through the normal
+   HM index/data ports to select the required bank. (S1)
+3. Write the target register address to `base + 0x05`, then read the
+   selected byte from `base + 0x06`. (S1)
+4. For 13-bit fan count and 16-bit fan RPM reads, read the high byte
+   first, then the low byte. (S1)
+5. Release the mutex after all bytes for one coherent sample have been
    read.
 
 ### Temperature decode (draft)
 
-Temperature decode is unresolved in this revision.
-
-- TODO(provenance): pin each temperature register, source label,
-  Celsius conversion, signedness, resolution, and invalid-value rules
-  from S1.
-- TODO(provenance): confirm at least one real hardware dump maps the
-  observed board's meaningful motherboard/auxiliary temperatures to the
-  selected source labels without relying on third-party monitoring-code
-  heuristics.
+- For high/low temperature-source registers, decode the 9-bit
+  two's-complement value as 0.5 C units. (S1 p. 60)
+- For HM read-only byte temperature offsets, do not enable decode until
+  an exact hardware dump confirms the access path and plausible source
+  labels for the board. (S1, S3, S6)
+- Do not merge motherboard/board temperature inputs with Phase 1 CPU
+  package temperature sources.
 
 ### Fan RPM decode (draft)
 
-Fan RPM decode is unresolved in this revision.
-
-- TODO(provenance): pin fan tachometer register addresses, counter
-  width, byte order, divisor/prescale handling, stopped/disconnected
-  counter values, and the RPM conversion formula from S1.
-- TODO(provenance): confirm with a real hardware dump that a changing
-  fan speed changes the expected tachometer count and that a stopped or
-  disconnected fan is filtered to "unavailable" rather than an
-  implausible RPM.
+- For 13-bit count registers, combine the high and low fields into a
+  13-bit count and calculate `RPM = 1.35e6 / count`. (S1 p. 66)
+- For 16-bit RPM registers, combine high then low bytes and interpret
+  the resulting 16-bit integer as RPM. (S1 p. 66)
+- Do not surface zero, max-count, or otherwise implausible values until
+  stopped/disconnected handling is verified by real hardware dump.
 
 ## Quirks
 
 - No model-specific quirks are implementation-ready in this revision.
-- Chip-id `0xD802` is observed on one Nuvoton-class board (S3), but the
-  exact model/revision is intentionally unresolved. Treat it as a
-  draft-only applicability clue, not as a model-specific decode key.
+- Chip-id `0xD802` is observed on one Nuvoton-class board (S3), but S1
+  identifies NCT6796D as `0xD421`. Treat `0xD802` as a draft-only
+  applicability clue, not as a decode key.
 
 ## Safety notes
 
 - This document is read-oriented. Required writes are limited to
   read-transaction plumbing: Nuvoton configuration-mode enter/exit
   keys documented by S2, logical-device selection required for base
-  discovery once pinned from S1, and hardware-monitor bank selection
-  required for banked register reads once pinned from S1.
+  discovery, and hardware-monitor bank selection required for banked
+  register reads.
 - The implementation must never write fan-control registers, PWM duty
   registers, Smart Fan policy registers, sensor source-selection
   registers, threshold/limit registers, alarm-clear registers, GPIO
-  registers, or any other register that can alter board behavior.
+  registers, CR30 activation bits, or any other register that can alter
+  board behavior.
 - All Super I/O and hardware-monitor index/data sequences must hold
   `Global\Access_ISABUS.HTP.Method` for the complete multi-I/O
   transaction. Interleaving another monitor's index write between this
@@ -193,29 +234,32 @@ Fan RPM decode is unresolved in this revision.
 
 ## Open questions
 
-- TODO(provenance): Pin a primary-source Nuvoton chip-id table for the
-  NCT67xx/NCT679x family, including whether `0xD802` maps to one
-  model, multiple revisions, or an OEM/board-specific variant.
-- TODO(provenance): Pin the exact Hardware Monitor logical-device
-  selector, logical-device number, activation requirements, base-address
-  registers, disabled values, and base alignment rules.
-- TODO(provenance): Pin the hardware-monitor address/data port offsets
-  and bank-select register behavior, including whether bank writes have
-  any side effects beyond selecting the bank.
-- TODO(provenance): Pin the temperature register map and each source's
-  unit conversion, signedness, resolution, invalid values, and source
-  label.
-- TODO(provenance): Pin the fan tachometer register map, byte order,
-  counter width, divisor/prescale handling, stopped/disconnected
-  handling, and RPM formula.
-- TODO(provenance): Capture a Phase 3 hardware dump on the S3 board
-  after adding a dump-only diagnostic in the same PR or a dedicated
-  validation branch. The dump must include chip-id, decoded base, banked
-  temperature bytes, banked fan tachometer bytes, and enough manual
-  context to distinguish connected fans from empty headers.
-- TODO(provenance): Decide whether model-specific support should default
-  to disabled until both a vendor chip-id mapping and one board-level
-  dump are available for the exact chip-id.
+- Blocking for Phase 3 ready: Identify the observed `0xD802` responder
+  with a primary Nuvoton source, board documentation, or another
+  independent source. The NCT6796D datasheet fetched in this session
+  maps NCT6796D to `0xD421`, so `0xD802` must not use the NCT6796D
+  register map by assumption.
+- Blocking for Phase 3 ready: Complete a Phase 3 hardware-monitor byte
+  dump on the S3 board. S6 captured chip-id and LDN B `CR30/CR60-65`
+  under elevation, but `ioctl_find_bars` returned `0x80070490` and the
+  normal HM index-port write to `0x0295` returned `0x80070005`; the
+  remaining dump must include normal HM banked temperature/RPM bytes
+  and manual context for connected versus empty fan headers.
+- Blocking for Phase 3 ready: Confirm whether the observed chip exposes
+  the same normal HM behavior as S1 before enabling any register reads.
+  S6 observed normal HM base `0x0290` but read-only HM base `0x0000` on
+  the unresolved `0xD802` chip, so the S1 read-only HM path is not
+  hardware-validated for this board.
+- Blocking for Phase 3 ready: Define stopped, disconnected, max-count,
+  zero, and implausible fan handling from primary-source text or
+  hardware dump evidence.
+- Blocking for Phase 3 ready: Confirm AUXFANIN4 count/RPM banked
+  registers for the exact supported chip. S1's summary table lists
+  Bank 4 `0xCC`-`0xCF`, but the extracted detailed register sections
+  only reached AUXFANIN3 for the normal Bank 4 speed registers.
+- Blocking for Phase 3 ready: Decide whether a future revision will
+  support NCT6796D/NCT6796D-E only, the observed `0xD802` chip only, or
+  a broader NCT67xx/NCT679x table with per-chip scoped enablement.
 
 ## Implementation-ready transition checklist
 
@@ -223,14 +267,15 @@ Before this document can become `Implementation-ready (rev N)`, the
 Phase 3 spec-author PR must satisfy the directory-level checklist in
 [`README.md`](README.md) and at minimum:
 
-- remove every `TODO(provenance)` marker or move unresolved items to
-  Open questions with the required non-blocking annotation,
-- pin exact S1 section/page references for every register, conversion,
-  and procedure fact,
+- resolve the exact chip-id/model mapping for every enabled scope,
+- pin exact S1 or replacement primary-source section/page references
+  for every register, conversion, and procedure fact,
 - ensure no normative fact rests solely on a copyleft implementation,
-- record the exact real-hardware dump(s) used for validation,
+- record the exact elevated real-hardware dump(s) used for validation,
 - set scoped enablement so unsupported or unverified chip IDs remain
-  disabled by default, and
+  disabled by default,
+- resolve or explicitly annotate every open question according to the
+  README status-transition rules, and
 - bump the revision and status in the header and revision history.
 
 ## Provenance text for a future clean-room implementation PR
@@ -250,3 +295,5 @@ No other external sensor documentation was used.
 | Revision | Date | Change |
 | --- | --- | --- |
 | 1 | 2026-06-28 | Initial Phase 3 Nuvoton-family draft; records Phase 2 diagnostic linkage, expected hardware-monitor spec shape, safety constraints, and unresolved provenance/dump requirements. |
+| 2 | 2026-06-28 | Fetched and verified the official NCT6796D V0.6 datasheet; pinned NCT6796D configuration, HM base, temperature, and fan RPM facts; recorded that S1 maps NCT6796D to `0xD421` while the observed S3 board is `0xD802`; recorded standard-rights PawnIO dump failure (`0x80070005`). Status remains Draft. |
+| 3 | 2026-06-28 | Added elevated PawnIO `LpcIO` evidence for the observed `0xD802` board: LDN B active, normal HM base `0x0290`, read-only HM base `0x0000`, and blocked HM index/data access (`ioctl_find_bars=0x80070490`, `pio_outb(0x0295)=0x80070005`). Status remains Draft. |


### PR DESCRIPTION
## Summary
- pin official NCT6796D V0.6 datasheet facts and keep the observed `0xD802` board disabled because NCT6796D maps to `0xD421`
- record elevated PawnIO `LpcIO` evidence for the observed board: `chipId=0xD802`, LDN B `CR30=0x09`, HM base `0x0290`, and read-only HM base `0x0000`
- update sensor handoff docs so Phase 3 remains Draft until exact-chip provenance and hardware-monitor temperature/RPM bytes are captured

## Validation
- `git diff --check`
- `git diff --cached --check`
- verified no `TODO(provenance)` markers in `docs/specs/sensors/superio-nuvoton-nct67xx.md`
- standard-rights PawnIO probe: `pawnio_open=0x80070005`
- elevated PawnIO probe: `pawnio_open=0x00000000`, `pawnio_load=0x00000000`, but `ioctl_find_bars=0x80070490` and `pio_outb(0x0295)=0x80070005`, so no temperature/RPM bytes were captured

## Status
Draft PR. Docs-only. `docs/specs/sensors/superio-nuvoton-nct67xx.md` remains `Draft — not implementation-ready`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sensor handoff and sensor specification docs with a clearer status snapshot, current blockers, and next steps.
  * Added more precise hardware-validation notes for the detected Nuvoton-class board, including observed IDs, base addresses, and missing data needed for readiness.
  * Expanded the Nuvoton sensor draft with concrete register and read-flow details, plus a clearer checklist for moving from draft to ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->