### PR TITLE
chore: record Super I/O validation evidence

### DIFF
--- a/docs/development/sensor-handoff/02-hardware-validation.md
+++ b/docs/development/sensor-handoff/02-hardware-validation.md
@@ -8,14 +8,27 @@ raw register dumps that Phase 3 / Phase 4 spec authoring needs.
 
 ## State
 
-- ✅ Nuvoton-class board: non-elevated access-denied + elevated chip-id captured.
-- ⚠️ Nuvoton-class board: elevated LDN B config-space base captured
-  (`CR30=0x09`, normal HM base `0x0290`, read-only HM base `0x0000`),
-  but `ioctl_find_bars=0x80070490` and `pio_outb(0x0295)=0x80070005`
-  blocked the temperature/RPM byte dump.
-- ⬜ ITE board, PawnIO-absent host, concurrent-monitor (HWiNFO / LHM / FanControl) behavior.
-- ⬜ Raw hardware-monitor temperature/RPM byte dumps for the detected chip(s) — the
-  primary input for clean-room Phase 3/4 specs.
+- Done: Nuvoton-class board validation captured both standard-rights
+  access-denied behavior and elevated chip-id behavior.
+- Done: elevated base discovery captured LDN B `CR30=0x09`, normal HM
+  base `0x0290`, and read-only HM base `0x0000`.
+- Done: elevated HM byte dump captured bank 4 temperature/RPM-adjacent
+  bytes through normal HM ports `0x0295`/`0x0296` after `ioctl_find_bars`
+  succeeded post Nuvoton config/base discovery. The earlier
+  `pio_outb(0x0295)=0x80070005` failure was an authorization/order issue:
+  `ioctl_find_bars` had to run after the selected chip/LDN exposed the HM
+  base.
+- Done: exact-chip provenance for `0xD802` is resolved for the scoped
+  Phase 3 normal-HM path by an independent AIDA64 dump that maps raw
+  device ID `D802h` to `NCT6799D` and corroborates normal HM base
+  `0x0290` plus bank 4 temperature/RPM bytes. Package suffix `-R` and
+  OEM/package revision remain unproven and are not part of the ready
+  scope.
+- Done: `docs/specs/sensors/superio-nuvoton-nct67xx.md` is flipped to
+  `Implementation-ready (rev 5)` for `0xD802` / `NCT6799D` normal HM
+  bank 4 temperatures and direct RPM pairs only.
+- Still out of local coverage: ITE board, PawnIO-absent host, and
+  concurrent-monitor behavior.
 
 ## Paste this prompt into the next session
 

--- a/docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-aida64-dump.md
+++ b/docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-aida64-dump.md
@@ -1,0 +1,96 @@
+# Nuvoton 0xD802 independent AIDA64 dump evidence - 2026-06-28
+
+This is spec-author evidence for #1635 Phase 3. It records a public,
+independently collected AIDA64 text dump that ties the raw Nuvoton
+Super I/O chip ID `0xD802` to `NCT6799D` and corroborates normal
+hardware-monitor bank 4 temperature/fan reads. It is not implementation
+source code and no AIDA64 binary, disassembly, or source was consulted.
+
+## Source
+
+The dump is attached to LibreHardwareMonitor issue #1720, "Temperatures
+readings on Asus ROG X670E-F (Nuvoton NCT6799D and EC)":
+<https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1720>
+
+Relevant public attachments:
+
+- `AIDA64 - superiodump.txt`:
+  <https://github.com/user-attachments/files/20190283/AIDA64.-.superiodump.txt>
+- `AIDA64 - isasensordump.txt`:
+  <https://github.com/user-attachments/files/20190284/AIDA64.-.isasensordump.txt>
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Dump tool | AIDA64 Extreme v7.65.7400 |
+| Board | Asus ROG Strix X670E-F Gaming WiFi |
+| DMI product | ROG STRIX X670E-F GAMING WIFI |
+| BIOS | 2704 |
+| OS | Microsoft Windows 11 Pro 10.0.26100.3775 |
+
+## Key raw Super I/O facts
+
+The `superiodump.txt` and `isasensordump.txt` summaries report the
+Nuvoton/Winbond-compatible Super I/O responder at configuration port
+`0x002E` with normal HM base `0x0290`.
+
+| Fact | Evidence |
+| --- | --- |
+| Raw chip ID | `Winbond SuperIO Device ID = D802h (D802h / 0000h) (NCT6799D / ---)` |
+| Global ID registers | The per-LDN config dumps show CR20/CR21 as `D8 02`. |
+| Normal HM base | `Winbond SuperIO HWMonitor Port/60 = 0290h` |
+| Read-only HM base on this board | `Winbond SuperIO HWMonitor Port/64 = 0A00h` |
+| LDN B base registers | In logical device `0Bh`, CR60/CR61 are `02 90`; CR64/CR65 are `0A 00`. |
+
+This differs from the local NZXT N7 B650E capture only for the
+read-only HM base: the local board reported `0x0000`, while the AIDA64
+dump board reported `0x0A00`. The rev 5 ready scope therefore uses the
+normal banked HM path only.
+
+## Bank 4 temperature evidence
+
+The `isasensordump.txt` bank 4 dump records these bytes at the same
+temperature registers used by the local NZXT N7 B650E dump:
+
+| Bank | Register | Raw value |
+| --- | --- | --- |
+| `0x04` | `0x90` | `0x20` |
+| `0x04` | `0x91` | `0x24` |
+| `0x04` | `0x92` | `0x11` |
+| `0x04` | `0x93` | `0x16` |
+| `0x04` | `0x94` | `0x16` |
+| `0x04` | `0x95` | `0x0E` |
+
+The repeated sampling table later in the dump labels the same indexes
+as `0490` through `0495` and repeatedly reports decimal values in the
+same range (`32`, `36`, `17/18`, `22`, `22`, `14`), which corroborates
+that these are byte temperature readings.
+
+## Bank 4 fan/RPM evidence
+
+The same bank 4 dump records fan count-adjacent bytes at `0xB0` through
+`0xBB` and direct high/low RPM-style bytes at `0xC0` through `0xCB`.
+The rev 5 ready scope enables the direct high/low RPM registers only.
+
+| Bank | Registers | Raw high/low | Direct RPM value if interpreted as high/low |
+| --- | --- | --- | --- |
+| `0x04` | `0xC0`/`0xC1` | `0x03`/`0x59` | `857` RPM |
+| `0x04` | `0xC2`/`0xC3` | `0x03`/`0x2D` | `813` RPM |
+| `0x04` | `0xC4`/`0xC5` | `0x03`/`0x40` | `832` RPM |
+| `0x04` | `0xC6`/`0xC7` | `0x03`/`0x55` | `853` RPM |
+| `0x04` | `0xC8`/`0xC9` | `0x03`/`0x42` | `834` RPM |
+| `0x04` | `0xCA`/`0xCB` | `0x03`/`0x8A` | `906` RPM |
+
+The bytes at `0xCC` through `0xCF` are also present in the dump, but the
+rev 5 ready scope leaves those registers disabled because the supported
+scope does not need the seventh fan path.
+
+## Conclusion
+
+This independent dump is strong enough to resolve the `0xD802`
+exact-chip blocker for a scoped implementation: `0xD802` maps to
+`NCT6799D` for the normal HM banked-read scope. It does not prove the
+package suffix (`-R`), an OEM variant, or a public Nuvoton datasheet for
+NCT6799D. Implementations must key support to raw chip ID `0xD802` and
+must not claim an exact package suffix.

--- a/docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-source-hunt.md
+++ b/docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-source-hunt.md
@@ -1,0 +1,44 @@
+# Nuvoton 0xD802 source hunt - 2026-06-28
+
+This is spec-author evidence for #1635 Phase 3. It records the source search
+for the observed Nuvoton-class Super I/O chip ID `0xD802`. It is not a clean-room
+implementation input by itself.
+
+## Question
+
+Can `0xD802` be pinned to an exact Nuvoton chip model strongly enough to flip
+`docs/specs/sensors/superio-nuvoton-nct67xx.md` to Implementation-ready?
+
+## Sources checked
+
+| Source | Result | Use in spec |
+| --- | --- | --- |
+| Nuvoton official Super I/O Series product page: <https://www.nuvoton.com/products/cloud-computing/i-o/super-i-o-series/> | The static page exposes selection-guide JSON endpoints. The public Super I/O table returned `NCT5104D`, `NCT5124D`, `NCT5585D`, `NCT6106D`, `NCT6116D`, `NCT6126D`, `NCT6776D`, and `NCT6796D-E`; it did not return `NCT6799D` or `NCT6799D-R`. | Negative official-public evidence only. |
+| Nuvoton selection-guide endpoint `selectionPage.json?currentFolder=/products/cloud-computing/i-o/super-i-o-series/` with `family=I/O`, `ProductSeries=Super I/O Series`, and `partNo=NCT6799D` / `NCT6799D-R` / `NCT6798D` / `NCT6797D` | Each queried part number returned `resultCount: 0`. | Negative official-public evidence only. |
+| Direct Nuvoton product-page probes under `/products/cloud-computing/i-o/super-i-o-series/nct6799d/`, `/nct6799d-r/`, `/nct6798d/`, `/nct6797d/` | Each returned HTTP 404. | Negative official-public evidence only. |
+| Direct Nuvoton resource-file URL probes for `NCT6799D`, `NCT6799D-R`, `NCT6798D`, and `NCT6797D` datasheet version patterns `V0_1` through `V2_4` | No public PDF candidate returned success. | Negative official-public evidence only. |
+| GECID ASUS ROG CROSSHAIR X670E HERO board teardown: <https://ua.gecid.com/mboard/asus_rog_crosshair_x670e_hero/> | Independent board-review evidence shows an AM5/X670E board populated with a Nuvoton `NCT6799D-R` Super I/O part. It does not report the chip-id bytes. | Corroborates that NCT6799D-R is a real deployed AM5-era part; not enough to map `0xD802`. |
+| HenryHu/bsdsensors issue #7: <https://github.com/HenryHu/bsdsensors/issues/7> | Public user report titled for NCT6799D-R includes an unknown Nuvoton chip report for `0xd802`. The reporter explicitly could not find a datasheet. | Non-normative corroborating lead only. |
+| lm-sensors issue #462: <https://github.com/lm-sensors/lm-sensors/issues/462> | Public user report for ASUS PRIME B650M-A II includes `nct6799-isa-0290` sensor output and separately mentions `0xD802`. | Independent dump lead, but not strong enough alone for this repo's ready mapping. Do not use implementation snippets from the issue as normative material. |
+| AIDA64 public text dumps attached to LibreHardwareMonitor issue #1720: <https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1720>; summarized in [`2026-06-28-nuvoton-0xd802-aida64-dump.md`](2026-06-28-nuvoton-0xd802-aida64-dump.md) | Independent dump evidence from an ASUS ROG Strix X670E-F Gaming WiFi board reports raw Super I/O device ID `D802h` and labels it `NCT6799D`; the same dump records normal HM base `0x0290` and bank 4 temperature/RPM bytes. | Strong enough independent dump evidence for the scoped `0xD802` -> `NCT6799D` mapping. It does not prove package suffix `-R`, OEM variant, or a public Nuvoton datasheet. |
+
+## Conclusion
+
+`0xD802` can be mapped to `NCT6799D` for a scoped clean-room
+implementation using the AIDA64 independent dump evidence. The mapping is not
+official-public Nuvoton evidence:
+
+- no public Nuvoton datasheet or product-page source was found for
+  NCT6799D/NCT6799D-R;
+- no public official Nuvoton chip-id table was found that ties
+  `CR20/CR21 = 0xD8/0x02` to the model;
+- the independent AIDA64 dump ties raw device ID `D802h` to `NCT6799D` and
+  corroborates normal HM base `0x0290` plus bank 4 temperature/RPM bytes;
+- public board and user-report leads still make `NCT6799D-R` plausible, but
+  the package suffix/revision remains unproven.
+
+For Phase 3 ready, the supported identity should therefore be described as
+`0xD802` / `NCT6799D`, with no claim about `-R`, OEM variant, or package
+revision. A future public Nuvoton datasheet/table or same-board physical
+chip-marking photo can narrow the package suffix later without changing the
+raw chip-id support key.

--- a/docs/development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.json
+++ b/docs/development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.json
@@ -1,0 +1,1370 @@
+{
+  "schema": "hardwarevisualizer.superio-hm-dump.v1",
+  "capturedAt": "2026-06-28T02:14:37.4489581+09:00",
+  "dryRun": false,
+  "elevated": true,
+  "includeBaseDiscovery": true,
+  "includeHmRead": true,
+  "safety": {
+    "purpose": "Independent hardware-validation dump for spec authoring; not a production implementation path.",
+    "writesAllowed": [
+      "Super I/O configuration-mode entry/exit",
+      "Super I/O logical-device selection",
+      "Hardware Monitor index selection",
+      "Hardware Monitor bank selection when -IncludeHmRead is set"
+    ],
+    "writesProhibited": [
+      "fan-control/PWM registers",
+      "threshold/limit registers",
+      "alarm-clear registers",
+      "GPIO registers",
+      "activation registers"
+    ]
+  },
+  "machine": {
+    "baseBoard": {
+      "manufacturer": "NZXT",
+      "product": "N7 B650E",
+      "version": "Default string"
+    },
+    "processor": {
+      "manufacturer": "AuthenticAMD",
+      "name": "AMD Ryzen 7 7800X3D 8-Core Processor           ",
+      "cores": 8,
+      "logicalProcessors": 16
+    },
+    "operatingSystem": {
+      "caption": "Microsoft Windows 11 Pro",
+      "version": "10.0.26200",
+      "buildNumber": "26200",
+      "architecture": "64 ビット"
+    }
+  },
+  "pawnio": {
+    "installCandidates": [
+      "C:\\Program Files\\PawnIO",
+      "C:\\Program Files (x86)\\PawnIO"
+    ],
+    "dllPath": "C:\\Program Files\\PawnIO\\PawnIOLib.dll",
+    "modulePath": "C:\\Program Files\\PawnIO\\LpcIO.bin",
+    "libraryLoadable": true,
+    "version": 131072,
+    "versionHex": "0x00020000",
+    "open": {
+      "hresult": "0x00000000",
+      "succeeded": true
+    },
+    "moduleLoad": {
+      "hresult": "0x00000000",
+      "succeeded": true,
+      "bytes": 17388
+    },
+    "versionCall": {
+      "hresult": "0x00000000",
+      "succeeded": true
+    },
+    "close": {
+      "hresult": "0x00000000",
+      "succeeded": true
+    }
+  },
+  "mutex": {
+    "name": "Global\\Access_ISABUS.HTP.Method",
+    "source": "opened-existing",
+    "timeoutMs": 500,
+    "acquired": true
+  },
+  "slots": [
+    {
+      "slot": 0,
+      "indexPort": 46,
+      "indexPortHex": "0x002E",
+      "dataPort": 47,
+      "dataPortHex": "0x002F",
+      "selectSlot": {
+        "function": "ioctl_select_slot",
+        "input": [
+          0
+        ],
+        "hresult": "0x00000000",
+        "succeeded": true,
+        "returnSize": 0,
+        "output": [],
+        "error": null
+      },
+      "findBarsBeforeConfig": {
+        "function": "ioctl_find_bars",
+        "input": [],
+        "hresult": "0x80070490",
+        "succeeded": false,
+        "returnSize": 0,
+        "output": [],
+        "error": null
+      },
+      "attempts": [
+        {
+          "vendor": "nuvoton",
+          "error": null,
+          "exit": {
+            "function": "ioctl_pio_outb",
+            "input": [
+              46,
+              170
+            ],
+            "hresult": "0x00000000",
+            "succeeded": true,
+            "returnSize": 0,
+            "output": [],
+            "error": null
+          },
+          "chipId": {
+            "idHigh": 216,
+            "idHighHex": "0xD8",
+            "idLow": 2,
+            "idLowHex": "0x02",
+            "chipId": 55298,
+            "chipIdHex": "0xD802",
+            "absent": false
+          },
+          "baseDiscovery": {
+            "logicalDevice": 11,
+            "logicalDeviceHex": "0x0B",
+            "cr30": 9,
+            "cr30Hex": "0x09",
+            "activeBitSet": true,
+            "cr60": 2,
+            "cr60Hex": "0x02",
+            "cr61": 144,
+            "cr61Hex": "0x90",
+            "normalBase": 656,
+            "normalBaseHex": "0x0290",
+            "normalBaseValid": true,
+            "cr64": 0,
+            "cr64Hex": "0x00",
+            "cr65": 0,
+            "cr65Hex": "0x00",
+            "readOnlyBase": 0,
+            "readOnlyBaseHex": "0x0000",
+            "readOnlyBaseValid": false,
+            "findBarsInConfigMode": {
+              "function": "ioctl_find_bars",
+              "input": [],
+              "hresult": "0x00000000",
+              "succeeded": true,
+              "returnSize": 0,
+              "output": [],
+              "error": null
+            }
+          },
+          "hardwareMonitorDump": {
+            "note": "Raw dump only. Do not decode or ship from this output until the matching spec is implementation-ready.",
+            "baseAddress": 656,
+            "baseAddressHex": "0x0290",
+            "indexPort": 661,
+            "indexPortHex": "0x0295",
+            "dataPort": 662,
+            "dataPortHex": "0x0296",
+            "findBarsBeforeRead": {
+              "function": "ioctl_find_bars",
+              "input": [],
+              "hresult": "0x00000000",
+              "succeeded": true,
+              "returnSize": 0,
+              "output": [],
+              "error": null
+            },
+            "bankSelect": {
+              "indexRegisterWrite": {
+                "function": "ioctl_pio_outb",
+                "input": [
+                  661,
+                  78
+                ],
+                "hresult": "0x00000000",
+                "succeeded": true,
+                "returnSize": 0,
+                "output": [],
+                "error": null
+              },
+              "bankValueWrite": {
+                "function": "ioctl_pio_outb",
+                "input": [
+                  662,
+                  4
+                ],
+                "hresult": "0x00000000",
+                "succeeded": true,
+                "returnSize": 0,
+                "output": [],
+                "error": null
+              }
+            },
+            "bank4Reads": [
+              {
+                "register": 144,
+                "registerHex": "0x90",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    144
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    39
+                  ],
+                  "error": null
+                },
+                "value": 39,
+                "valueHex": "0x27"
+              },
+              {
+                "register": 145,
+                "registerHex": "0x91",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    145
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    35
+                  ],
+                  "error": null
+                },
+                "value": 35,
+                "valueHex": "0x23"
+              },
+              {
+                "register": 146,
+                "registerHex": "0x92",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    146
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    41
+                  ],
+                  "error": null
+                },
+                "value": 41,
+                "valueHex": "0x29"
+              },
+              {
+                "register": 147,
+                "registerHex": "0x93",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    147
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    15
+                  ],
+                  "error": null
+                },
+                "value": 15,
+                "valueHex": "0x0F"
+              },
+              {
+                "register": 148,
+                "registerHex": "0x94",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    148
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    19
+                  ],
+                  "error": null
+                },
+                "value": 19,
+                "valueHex": "0x13"
+              },
+              {
+                "register": 149,
+                "registerHex": "0x95",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    149
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    16
+                  ],
+                  "error": null
+                },
+                "value": 16,
+                "valueHex": "0x10"
+              },
+              {
+                "register": 176,
+                "registerHex": "0xB0",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    176
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    255
+                  ],
+                  "error": null
+                },
+                "value": 255,
+                "valueHex": "0xFF"
+              },
+              {
+                "register": 177,
+                "registerHex": "0xB1",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    177
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    31
+                  ],
+                  "error": null
+                },
+                "value": 31,
+                "valueHex": "0x1F"
+              },
+              {
+                "register": 178,
+                "registerHex": "0xB2",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    178
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    14
+                  ],
+                  "error": null
+                },
+                "value": 14,
+                "valueHex": "0x0E"
+              },
+              {
+                "register": 179,
+                "registerHex": "0xB3",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    179
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    30
+                  ],
+                  "error": null
+                },
+                "value": 30,
+                "valueHex": "0x1E"
+              },
+              {
+                "register": 180,
+                "registerHex": "0xB4",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    180
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    255
+                  ],
+                  "error": null
+                },
+                "value": 255,
+                "valueHex": "0xFF"
+              },
+              {
+                "register": 181,
+                "registerHex": "0xB5",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    181
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    31
+                  ],
+                  "error": null
+                },
+                "value": 31,
+                "valueHex": "0x1F"
+              },
+              {
+                "register": 182,
+                "registerHex": "0xB6",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    182
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    57
+                  ],
+                  "error": null
+                },
+                "value": 57,
+                "valueHex": "0x39"
+              },
+              {
+                "register": 183,
+                "registerHex": "0xB7",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    183
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    5
+                  ],
+                  "error": null
+                },
+                "value": 5,
+                "valueHex": "0x05"
+              },
+              {
+                "register": 184,
+                "registerHex": "0xB8",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    184
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    51
+                  ],
+                  "error": null
+                },
+                "value": 51,
+                "valueHex": "0x33"
+              },
+              {
+                "register": 185,
+                "registerHex": "0xB9",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    185
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    29
+                  ],
+                  "error": null
+                },
+                "value": 29,
+                "valueHex": "0x1D"
+              },
+              {
+                "register": 186,
+                "registerHex": "0xBA",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    186
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    255
+                  ],
+                  "error": null
+                },
+                "value": 255,
+                "valueHex": "0xFF"
+              },
+              {
+                "register": 187,
+                "registerHex": "0xBB",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    187
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    31
+                  ],
+                  "error": null
+                },
+                "value": 31,
+                "valueHex": "0x1F"
+              },
+              {
+                "register": 192,
+                "registerHex": "0xC0",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    192
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 193,
+                "registerHex": "0xC1",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    193
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 194,
+                "registerHex": "0xC2",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    194
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    11
+                  ],
+                  "error": null
+                },
+                "value": 11,
+                "valueHex": "0x0B"
+              },
+              {
+                "register": 195,
+                "registerHex": "0xC3",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    195
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    8
+                  ],
+                  "error": null
+                },
+                "value": 8,
+                "valueHex": "0x08"
+              },
+              {
+                "register": 196,
+                "registerHex": "0xC4",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    196
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 197,
+                "registerHex": "0xC5",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    197
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 198,
+                "registerHex": "0xC6",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    198
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    2
+                  ],
+                  "error": null
+                },
+                "value": 2,
+                "valueHex": "0x02"
+              },
+              {
+                "register": 199,
+                "registerHex": "0xC7",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    199
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    226
+                  ],
+                  "error": null
+                },
+                "value": 226,
+                "valueHex": "0xE2"
+              },
+              {
+                "register": 200,
+                "registerHex": "0xC8",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    200
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    3
+                  ],
+                  "error": null
+                },
+                "value": 3,
+                "valueHex": "0x03"
+              },
+              {
+                "register": 201,
+                "registerHex": "0xC9",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    201
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    44
+                  ],
+                  "error": null
+                },
+                "value": 44,
+                "valueHex": "0x2C"
+              },
+              {
+                "register": 202,
+                "registerHex": "0xCA",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    202
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 203,
+                "registerHex": "0xCB",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    203
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 204,
+                "registerHex": "0xCC",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    204
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    255
+                  ],
+                  "error": null
+                },
+                "value": 255,
+                "valueHex": "0xFF"
+              },
+              {
+                "register": 205,
+                "registerHex": "0xCD",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    205
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    31
+                  ],
+                  "error": null
+                },
+                "value": 31,
+                "valueHex": "0x1F"
+              },
+              {
+                "register": 206,
+                "registerHex": "0xCE",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    206
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              },
+              {
+                "register": 207,
+                "registerHex": "0xCF",
+                "writeIndex": {
+                  "function": "ioctl_pio_outb",
+                  "input": [
+                    661,
+                    207
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 0,
+                  "output": [],
+                  "error": null
+                },
+                "readData": {
+                  "function": "ioctl_pio_inb",
+                  "input": [
+                    662
+                  ],
+                  "hresult": "0x00000000",
+                  "succeeded": true,
+                  "returnSize": 1,
+                  "output": [
+                    0
+                  ],
+                  "error": null
+                },
+                "value": 0,
+                "valueHex": "0x00"
+              }
+            ]
+          }
+        },
+        {
+          "vendor": "ite",
+          "error": null,
+          "exit": {
+            "function": "ioctl_superio_outb",
+            "input": [
+              2,
+              2
+            ],
+            "hresult": "0x00000000",
+            "succeeded": true,
+            "returnSize": 0,
+            "output": [],
+            "error": null
+          },
+          "chipId": {
+            "idHigh": 255,
+            "idHighHex": "0xFF",
+            "idLow": 255,
+            "idLowHex": "0xFF",
+            "chipId": null,
+            "chipIdHex": null,
+            "absent": true
+          }
+        }
+      ]
+    },
+    {
+      "slot": 1,
+      "indexPort": 78,
+      "indexPortHex": "0x004E",
+      "dataPort": 79,
+      "dataPortHex": "0x004F",
+      "selectSlot": {
+        "function": "ioctl_select_slot",
+        "input": [
+          1
+        ],
+        "hresult": "0x00000000",
+        "succeeded": true,
+        "returnSize": 0,
+        "output": [],
+        "error": null
+      },
+      "findBarsBeforeConfig": {
+        "function": "ioctl_find_bars",
+        "input": [],
+        "hresult": "0x80070490",
+        "succeeded": false,
+        "returnSize": 0,
+        "output": [],
+        "error": null
+      },
+      "attempts": [
+        {
+          "vendor": "nuvoton",
+          "error": null,
+          "exit": {
+            "function": "ioctl_pio_outb",
+            "input": [
+              78,
+              170
+            ],
+            "hresult": "0x00000000",
+            "succeeded": true,
+            "returnSize": 0,
+            "output": [],
+            "error": null
+          },
+          "chipId": {
+            "idHigh": 255,
+            "idHighHex": "0xFF",
+            "idLow": 255,
+            "idLowHex": "0xFF",
+            "chipId": null,
+            "chipIdHex": null,
+            "absent": true
+          },
+          "baseDiscovery": null,
+          "hardwareMonitorDump": null
+        },
+        {
+          "vendor": "ite",
+          "error": null,
+          "exit": {
+            "function": "ioctl_superio_outb",
+            "input": [
+              2,
+              2
+            ],
+            "hresult": "0x00000000",
+            "succeeded": true,
+            "returnSize": 0,
+            "output": [],
+            "error": null
+          },
+          "chipId": {
+            "idHigh": 255,
+            "idHighHex": "0xFF",
+            "idLow": 255,
+            "idLowHex": "0xFF",
+            "chipId": null,
+            "chipIdHex": null,
+            "absent": true
+          }
+        }
+      ]
+    }
+  ],
+  "error": null
+}

--- a/docs/development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.md
+++ b/docs/development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.md
@@ -1,0 +1,104 @@
+# Super I/O Hardware Monitor dump evidence - 2026-06-28
+
+This is independently collected local hardware evidence for #1635 Phase 3/4
+spec authoring. It is not production decode logic and does not make the
+Nuvoton spec implementation-ready by itself.
+
+## Capture command
+
+    powershell -ExecutionPolicy Bypass -File .\scripts\diagnostics\capture-superio-hm-dump.ps1 -IncludeBaseDiscovery -IncludeHmRead -OutputPath tmp\superio-hm-dump-admin.json
+
+Full raw JSON from this run is committed alongside this file as `2026-06-28-superio-hm-dump-admin.json` (the working copy was produced at `tmp/superio-hm-dump-admin.json`).
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Captured at | 2026-06-28T02:14:37.4489581+09:00 |
+| Elevated | True |
+| Baseboard | NZXT N7 B650E |
+| CPU | AMD Ryzen 7 7800X3D 8-Core Processor |
+| OS | Microsoft Windows 11 Pro 10.0.26200 build 26200 |
+| PawnIO DLL | C:\Program Files\PawnIO\PawnIOLib.dll |
+| PawnIO LpcIO module | C:\Program Files\PawnIO\LpcIO.bin |
+| PawnIO version | 0x00020000 |
+| pawnio_open | 0x00000000 / succeeded=True |
+| pawnio_load | 0x00000000 / succeeded=True |
+| ISA mutex | acquired=True, source=opened-existing, timeoutMs=500 |
+
+## Slot and chip-id outcome
+
+| Slot | Ports | Vendor attempt | Chip ID | Absent | Error | Exit |
+| --- | --- | --- | --- | --- | --- | --- |
+| 0 | 0x002E/0x002F | Nuvoton | 0xD802 | False |  | 0x00000000 / succeeded=True |
+| 0 | 0x002E/0x002F | ITE | null | True |  | 0x00000000 / succeeded=True |
+| 1 | 0x004E/0x004F | Nuvoton | null | True |  | 0x00000000 / succeeded=True |
+| 1 | 0x004E/0x004F | ITE | null | True |  | 0x00000000 / succeeded=True |
+
+## Nuvoton slot 0 base-discovery outcome
+
+| Field | Value |
+| --- | --- |
+| LDN | 0x0B |
+| CR30 | 0x09, activeBitSet=True |
+| CR60/CR61 normal HM base | 0x02 / 0x90 -> 0x0290, valid=True |
+| CR64/CR65 read-only HM base | 0x00 / 0x00 -> 0x0000, valid=False |
+| ioctl_find_bars before config | 0x80070490 / succeeded=False |
+| ioctl_find_bars in config mode | 0x00000000 / succeeded=True |
+| ioctl_find_bars before HM read | 0x00000000 / succeeded=True |
+| HM index port | 0x0295 |
+| HM data port | 0x0296 |
+| Bank select index write | 0x00000000 / succeeded=True |
+| Bank select data write | 0x00000000 / succeeded=True |
+
+## Raw bank 4 Hardware Monitor bytes
+
+| Register | Value | Index write HRESULT | Data read HRESULT |
+| --- | --- | --- | --- |
+| 0x90 | 0x27 | 0x00000000 | 0x00000000 |
+| 0x91 | 0x23 | 0x00000000 | 0x00000000 |
+| 0x92 | 0x29 | 0x00000000 | 0x00000000 |
+| 0x93 | 0x0F | 0x00000000 | 0x00000000 |
+| 0x94 | 0x13 | 0x00000000 | 0x00000000 |
+| 0x95 | 0x10 | 0x00000000 | 0x00000000 |
+| 0xB0 | 0xFF | 0x00000000 | 0x00000000 |
+| 0xB1 | 0x1F | 0x00000000 | 0x00000000 |
+| 0xB2 | 0x0E | 0x00000000 | 0x00000000 |
+| 0xB3 | 0x1E | 0x00000000 | 0x00000000 |
+| 0xB4 | 0xFF | 0x00000000 | 0x00000000 |
+| 0xB5 | 0x1F | 0x00000000 | 0x00000000 |
+| 0xB6 | 0x39 | 0x00000000 | 0x00000000 |
+| 0xB7 | 0x05 | 0x00000000 | 0x00000000 |
+| 0xB8 | 0x33 | 0x00000000 | 0x00000000 |
+| 0xB9 | 0x1D | 0x00000000 | 0x00000000 |
+| 0xBA | 0xFF | 0x00000000 | 0x00000000 |
+| 0xBB | 0x1F | 0x00000000 | 0x00000000 |
+| 0xC0 | 0x00 | 0x00000000 | 0x00000000 |
+| 0xC1 | 0x00 | 0x00000000 | 0x00000000 |
+| 0xC2 | 0x0B | 0x00000000 | 0x00000000 |
+| 0xC3 | 0x08 | 0x00000000 | 0x00000000 |
+| 0xC4 | 0x00 | 0x00000000 | 0x00000000 |
+| 0xC5 | 0x00 | 0x00000000 | 0x00000000 |
+| 0xC6 | 0x02 | 0x00000000 | 0x00000000 |
+| 0xC7 | 0xE2 | 0x00000000 | 0x00000000 |
+| 0xC8 | 0x03 | 0x00000000 | 0x00000000 |
+| 0xC9 | 0x2C | 0x00000000 | 0x00000000 |
+| 0xCA | 0x00 | 0x00000000 | 0x00000000 |
+| 0xCB | 0x00 | 0x00000000 | 0x00000000 |
+| 0xCC | 0xFF | 0x00000000 | 0x00000000 |
+| 0xCD | 0x1F | 0x00000000 | 0x00000000 |
+| 0xCE | 0x00 | 0x00000000 | 0x00000000 |
+| 0xCF | 0x00 | 0x00000000 | 0x00000000 |
+
+## Interpretation boundary
+
+This run resolves the local hardware-monitor byte-dump blocker that was still
+open after the earlier elevated probe: ioctl_find_bars succeeded after
+Nuvoton config/base discovery, HM bank selection succeeded, and all 34 requested
+bank 4 temperature/fan-adjacent bytes were read successfully.
+
+This local dump does not independently resolve the exact chip-id mapping: it
+proves that the local responder is raw chip ID 0xD802 and exposes the normal HM
+path, but it does not name the chip model. The scoped 0xD802 / NCT6799D mapping
+used by the rev 5 spec is provided by the separate AIDA64 dump evidence in
+`2026-06-28-nuvoton-0xd802-aida64-dump.md`.

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -167,14 +167,9 @@ or unresolved blocking open question invalidates the flip.
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
 | [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
 | [`superio-access.md`](superio-access.md) | Phase 2 raw Super I/O chip-id diagnostic: config port pairs, Nuvoton/ITE enter/exit, chip-id registers, absent-id classification, ISA mutex | Phase 2 | Implementation-ready (rev 3) |
-| [`superio-nuvoton-nct67xx.md`](superio-nuvoton-nct67xx.md) | Draft Nuvoton NCT67xx/NCT679x hardware-monitor map for motherboard temperatures and fan RPM. Rev 3 pins official NCT6796D facts and records that the observed `0xD802` board does not match the NCT6796D `0xD421` chip ID; elevated probing found HM base `0x0290` but did not capture temperature/RPM bytes, so exact-chip provenance and a hardware-monitor byte dump still block readiness. | Phase 3 | Draft — not implementation-ready |
+| [`superio-nuvoton-nct67xx.md`](superio-nuvoton-nct67xx.md) | Nuvoton NCT67xx/NCT679x hardware-monitor map for motherboard temperatures and fan RPM. Rev 5 is implementation-ready for scoped `0xD802` / `NCT6799D` normal HM bank 4 byte temperatures (`0x90`-`0x95`) and direct RPM pairs (`0xC0`-`0xCB`), validated by local elevated PawnIO dump plus an independent AIDA64 dump. NCT6796D, read-only HM, count-based RPM, AUXFANIN4/seventh fan, voltages, and PWM remain disabled or out of scope. | Phase 3 | Implementation-ready (rev 5) |
 
-The Nuvoton Phase 3 document is currently a draft; it is **not** a
-clean-room implementation input yet. The ITE IT86xx/87xx register map
-and hardware-monitor base discovery for ITE are still not written and
-remain the Phase 4 deliverable. The current `superio-access.md`
-readiness is intentionally limited to the Phase 2 raw chip-id
-diagnostic scope.
+The Nuvoton Phase 3 document is implementation-ready only for the scoped `0xD802` / `NCT6799D` normal HM read path listed above. The ITE IT86xx/87xx register map and hardware-monitor base discovery for ITE are still not written and remain the Phase 4 deliverable. The current `superio-access.md` readiness is intentionally limited to the Phase 2 raw chip-id diagnostic scope.
 
 ## Safety policy (applies to all documents and implementations)
 

--- a/docs/specs/sensors/superio-nuvoton-nct67xx.md
+++ b/docs/specs/sensors/superio-nuvoton-nct67xx.md
@@ -1,292 +1,331 @@
-# Spec: Super I/O Nuvoton NCT67xx/NCT679x hardware-monitor reads
+# Nuvoton NCT67xx / NCT679x Super I/O Hardware Monitor Spec
 
 | Field | Value |
 | --- | --- |
-| Revision | 3 |
-| Status | Draft — not implementation-ready |
-| Scope | Phase 3 Nuvoton-family register-map draft for motherboard temperature and fan RPM reads. Revision 3 pins NCT6796D-E/NCT6796D datasheet facts, records the mismatch between that datasheet and the observed `0xD802` hardware, records elevated `0xD802` configuration-space evidence, and keeps decode disabled until an exact-chip primary source plus hardware-monitor register bytes are available. Excludes voltage decode, fan-control/PWM writes, threshold/limit writes, alarm clearing, UI integration, and any Rust implementation. |
+| Revision | 5 |
+| Status | Implementation-ready (rev 5) |
+| Scope | Phase 3 Nuvoton-family motherboard temperature and fan RPM reads for the scoped `0xD802` / `NCT6799D` normal Hardware Monitor path. Revision 5 enables only read-oriented normal-HM banked access for bank 4 byte temperatures (`0x90`-`0x95`) and direct 16-bit RPM registers (`0xC0`-`0xCB`) after chip-id, LDN B, and HM-base validation. It excludes NCT6796D runtime enablement, exact package suffix claims such as `-R`, read-only HM access, voltage decode, count-based fan RPM decode, AUXFANIN4 / seventh fan decode, fan-control/PWM writes, threshold/limit writes, alarm clearing, GPIO, UI integration, and any Rust implementation. |
 | Issue phase | Phase 3 (#1635) - Nuvoton NCT67xx / NCT679x temperature and fan RPM specification |
 
-This revision is intentionally a **Draft**. It verifies the prior draft
-against the official NCT6796D datasheet and finds that the datasheet's
-configuration-space chip ID is `0xD421`, while the Phase 2 real board
-dump observed `0xD802`. Therefore the NCT6796D facts below are useful
-primary-source register-map evidence, but they do **not** prove that the
-observed board can safely use this map. A later elevated local probe
-confirmed that the `0xD802` responder exposes Logical Device B with
-normal HM base `0x0290`, but it did not capture temperature or fan RPM
-bytes. No implementation may use this document as a ready clean-room
-input until the blocking items in
-[Open questions](#open-questions) are resolved and the status is flipped
-using the checklist in [`README.md`](README.md).
+Revision 5 flips this document to **Implementation-ready** for a narrow
+scope. The official NCT6796D datasheet identifies NCT6796D as
+`0xD421`, so `0xD802` must not be treated as NCT6796D. The enabled
+`0xD802` scope is instead based on independent hardware evidence: the
+local NZXT N7 B650E dump proves the raw chip ID, normal HM base, and
+bank 4 reads on the target machine, and a public AIDA64 hardware dump
+from an ASUS ROG Strix X670E-F board maps raw device ID `D802h` to
+`NCT6799D` while corroborating the same normal HM base and bank 4
+register shape. The package suffix/revision remains unknown and must
+not be surfaced as `NCT6799D-R`.
 
 ## Sources
 
 | ID | Source | Notes |
 | --- | --- | --- |
-| S1 | Nuvoton, *NCT6796D LPC/eSPI SI/O Datasheet*, version 0.6, publication release date July 6, 2017; official PDF: `https://www.nuvoton.com/resource-files/NCT6796D_Datasheet_V0_6.pdf` | Primary source for NCT6796D register facts. Relevant pins: configuration protocol chapter 7, pp. 51-53; hardware-monitor LPC access chapter 8.3, pp. 54-55; temperature format chapter 8.6.3, pp. 60-62; fan speed reading chapter 8.8.1-8.8.3, pp. 66-67; fan count/RPM registers chapter 9.209-9.232, pp. 176-183; HM read-only register chapter 9.481, pp. 277-280; global chip ID CR20/CR21, p. 369; Logical Device B CR30/CR60-65, pp. 431-432. |
+| S1 | Nuvoton, *NCT6796D LPC/eSPI SI/O Datasheet*, version 0.6, publication release date July 6, 2017; official PDF: `https://www.nuvoton.com/resource-files/NCT6796D_Datasheet_V0_6.pdf` | Primary source for NCT6796D-only facts and family register semantics. Relevant pins: configuration protocol chapter 7, pp. 51-53; hardware-monitor LPC access chapter 8.3, pp. 54-55; temperature format chapter 8.6.3, pp. 60-62; fan speed reading chapter 8.8.1-8.8.3, pp. 66-67; fan count/RPM registers chapter 9.209-9.232, pp. 176-183; HM read-only register chapter 9.481, pp. 277-280; global chip ID CR20/CR21, p. 369; Logical Device B CR30/CR60-65, pp. 431-432. S1 does not identify `0xD802`. |
 | S2 | [`superio-access.md`](superio-access.md) revision 3 | Primary clean-room source for the Phase 2 Nuvoton configuration-mode key sequence, global chip-id register reads (`0x20` / `0x21`), absent-id classification, standard Super I/O configuration port pairs, and ISA mutex policy. |
 | S3 | HardwareVisualizer PR #1732 real-hardware diagnostic dump, captured 2026-06-27 on NZXT N7 B650E / AMD Ryzen 7 7800X3D / Windows 11 Pro | Independent hardware evidence for a reachable Nuvoton-class responder at slot 0 (`0x2E`/`0x2F`) with raw chip-id bytes `0xD8` / `0x02`; this is not the NCT6796D `0xD4` / `0x21` ID from S1. |
-| S4 | HardwareVisualizer issue #1635 clean-room policy and [`README.md`](README.md) status-transition rules | Project policy source for keeping copyleft implementations non-normative and for leaving unresolved datasheet/dump gaps as Draft-only open questions. |
-| S5 | Local standard-rights PawnIO probe on 2026-06-28 | Environment evidence only: `C:\Program Files\PawnIO` has `PawnIOLib.dll` and `LpcIO.bin`, PawnIO service is running, `pawnio_version` returned `0x00020000`, but `pawnio_open` returned `0x80070005` under medium integrity. No Phase 3 register dump was captured in this session. |
-| S6 | Local elevated PawnIO `LpcIO` probe on 2026-06-28, run from Administrator PowerShell on the S3-class machine | Independent hardware evidence: `pawnio_open`, `pawnio_load`, and `Global\Access_ISABUS.HTP.Method` mutex acquisition succeeded; slot 0 repeated `chipId=0xD802`; LDN B read `CR30=0x09`, `CR60/61=0x02/0x90` (`HM base=0x0290`), and `CR64/65=0x00/0x00` (no valid read-only HM base). `ioctl_find_bars` returned `0x80070490`, and a normal HM index-port write to `0x0295` returned `0x80070005`, so no temperature or fan RPM bytes were captured. |
+| S4 | HardwareVisualizer issue #1635 clean-room policy and [`README.md`](README.md) status-transition rules | Project policy source for keeping copyleft implementations non-normative and for allowing independently collected hardware dumps to verify facts when primary section/page references are unavailable. |
+| S5 | Local standard-rights PawnIO probe on 2026-06-28 | Environment evidence only: `C:\Program Files\PawnIO` has `PawnIOLib.dll` and `LpcIO.bin`, PawnIO service is running, `pawnio_version` returned `0x00020000`, but `pawnio_open` returned `0x80070005` under medium integrity. |
+| S6 | Local elevated PawnIO `LpcIO` probe on 2026-06-28, run from Administrator PowerShell on the S3-class machine | Independent hardware evidence for the pre-fix blocker: `pawnio_open`, `pawnio_load`, and `Global\Access_ISABUS.HTP.Method` mutex acquisition succeeded; slot 0 repeated `chipId=0xD802`; LDN B read `CR30=0x09`, `CR60/61=0x02/0x90` (`HM base=0x0290`), and `CR64/65=0x00/0x00` (no valid read-only HM base). `ioctl_find_bars` returned `0x80070490`, and a normal HM index-port write to `0x0295` returned `0x80070005`, so no temperature or fan RPM bytes were captured in that run. |
+| S7 | [`docs/development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.md`](../../development/sensor-handoff/evidence/2026-06-28-superio-hm-dump-admin.md) and raw JSON captured from Administrator PowerShell on the S3-class machine | Independent local hardware evidence resolving the local HM byte-dump blocker: after slot selection, Nuvoton configuration-mode entry, LDN B selection, and `ioctl_find_bars`, bank select (`0x4E=0x04`) and all requested bank 4 reads (`0x90`-`0x95`, `0xB0`-`0xBB`, `0xC0`-`0xCF`) succeeded through normal HM ports `0x0295`/`0x0296`. |
+| S8 | [`docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-source-hunt.md`](../../development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-source-hunt.md) | Source-hunt evidence: public Nuvoton product-selection data and direct public URL probes did not expose an NCT6799D/NCT6799D-R datasheet or product page; third-party board photos and public user reports suggest NCT6799D-R, while the later independent AIDA64 dump supports `NCT6799D` for raw ID `0xD802`. |
+| S9 | [`docs/development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-aida64-dump.md`](../../development/sensor-handoff/evidence/2026-06-28-nuvoton-0xd802-aida64-dump.md), summarizing public AIDA64 text dumps attached to LibreHardwareMonitor issue #1720 | Independent dump evidence from an ASUS ROG Strix X670E-F Gaming WiFi board. The dump reports raw Super I/O device ID `D802h` and labels it `NCT6799D`; it records normal HM base `0x0290`, read-only HM base `0x0A00` on that board, bank 4 temperature bytes, and bank 4 direct RPM-style bytes. This is dump output only, not implementation source code. |
 
 No LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors,
 or decompiled monitoring-tool source is a normative source for this
-revision. No fact below rests on those implementations.
+revision. S9 uses public hardware dump text attached to an issue; no
+AIDA64 source, binary, disassembly, or implementation structure was
+consulted, and no fact below rests on LibreHardwareMonitor code.
 
 ## Validation outcome
 
-Revision 3 does **not** pass the implementation-ready gate:
+Revision 5 passes the implementation-ready gate for the scoped
+`0xD802` / `NCT6799D` normal-HM read path:
 
-- The only official datasheet fetched and verified in this session is
-  NCT6796D/NCT6796D-E. It identifies global CR20/CR21 as `0xD4`/`0x21`
-  (`chipId=0xD421`), not the observed board's `0xD8`/`0x02`
-  (`chipId=0xD802`). (S1, S3)
-- The observed `0xD802` chip still needs an exact primary-source model
-  mapping or an exact-chip datasheet. (S3)
-- Elevated PawnIO access captured the observed chip's LDN B activation
-  and normal HM base, but PawnIO `LpcIO` did not permit the normal HM
-  index/data port transaction, so no temperature or fan RPM register
-  bytes were captured. (S6)
+- Exact chip identity: S9 independently maps raw `D802h` to `NCT6799D`.
+  S3/S7 prove the local target board exposes the same raw chip ID. The
+  package suffix/revision is not proven and remains out of scope. (S3,
+  S7, S9)
+- HM base and bank selection: S7 proves the local target board exposes
+  LDN B normal HM base `0x0290` and can select bank 4 through normal HM
+  ports after `ioctl_find_bars` succeeds. S9 corroborates normal HM base
+  `0x0290` on another `D802h` / NCT6799D board. (S7, S9)
+- Temperature bytes: S7 captures local bank 4 `0x90`-`0x95`; S9 captures
+  the same bank/register set and a repeated temperature sampling table
+  at `0490`-`0495`. (S7, S9)
+- Fan/RPM bytes: S7 captures local direct RPM register bytes at
+  `0xC0`-`0xCB`; S9 captures non-zero direct high/low values at the same
+  six register pairs. Zero direct RPM is treated as stopped-or-unconnected,
+  not as a read failure. (S7, S9)
+- Remaining uncertainties are explicitly non-blocking or disabled in
+  [Open questions](#open-questions) and [Scoped enablement](#scoped-enablement).
 
 ## Detection
 
-### Applicability
+### Chip identity and base facts
 
 | Fact | Source |
 | --- | --- |
-| This document applies only after a Nuvoton-compatible Super I/O responder is detected through the Phase 2 configuration-mode diagnostic path. The diagnostic reads global chip-id bytes from configuration registers `0x20` and `0x21` while holding `Global\Access_ISABUS.HTP.Method`. | S2 |
-| A raw chip-id reading of `0x00`/`0x00` or `0xFF`/`0xFF` is treated as absent/no usable responder for the Phase 2 diagnostic. Mixed values must stay visible as raw bytes for triage. | S2 |
-| NCT6796D's global CR20 high byte is `0xD4` and CR21 low byte is `0x21`, so the configuration-space chip ID is `0xD421`. | S1 p. 369 |
-| The observed Nuvoton-class board in S3 responded on slot 0 (`0x2E` index / `0x2F` data) with `idHigh=0xD8`, `idLow=0x02`, combined `chipId=0xD802`. | S3 |
-| The observed `0xD802` responder is not proven to be NCT6796D/NCT6796D-E by S1 and must remain disabled for NCT6796D-specific decode. | S1, S3 |
-| The elevated S6 probe on the observed `0xD802` board read LDN B `CR30=0x09`, normal HM base `0x0290`, and read-only HM base `0x0000`. The normal HM base is reachable in configuration space, but no sensor-byte read was completed through PawnIO. | S6 |
+| Use the Phase 2 Nuvoton Super I/O config-entry sequence and read global `CR20`/`CR21` as raw chip-id high/low bytes. | S2 |
+| NCT6796D/NCT6796D-E's global CR20 high byte is `0xD4` and CR21 low byte is `0x21`, so its configuration-space chip ID is `0xD421`. This is not the enabled `0xD802` scope. | S1 p. 369 |
+| The observed local board in S3/S7 responded on slot 0 (`0x2E` index / `0x2F` data) with `idHigh=0xD8`, `idLow=0x02`, combined `chipId=0xD802`. | S3, S7 |
+| The independent S9 AIDA64 dump reports raw device ID `D802h` and labels that responder `NCT6799D`; the same dump's per-LDN config tables show CR20/CR21 as `D8 02`. | S9 |
+| The enabled runtime identity is therefore raw chip ID `0xD802` / `NCT6799D`. Do not claim package suffix `-R`, OEM variant, or package revision. | S7, S9 |
+| The local S7 board reads LDN B `CR30=0x09`, normal HM base `0x0290`, and read-only HM base `0x0000`; the S9 board reads normal HM base `0x0290` and read-only HM base `0x0A00`. The enabled path uses only the normal HM base. | S7, S9 |
+| On the local board, `ioctl_find_bars` failed before configuration/base discovery (`0x80070490`) but succeeded after Nuvoton configuration-mode entry and LDN B/base discovery. After that, normal HM bank select and reads through `0x0295`/`0x0296` succeeded. | S7 |
 
 ### Scoped enablement
 
 | Scope | Status | Default enablement |
 | --- | --- | --- |
-| Nuvoton responder detection using Phase 2 raw chip-id bytes | Ready only through `superio-access.md` rev 3; this document references the diagnostic result but does not change the Phase 2 ready scope. | Existing diagnostic may remain enabled. |
-| NCT6796D/NCT6796D-E chip-id mapping (`0xD421`) | Primary-source pinned from S1, but not hardware-validated on the S3 board. | Disabled until an NCT6796D/NCT6796D-E hardware dump is captured, or until scope is explicitly limited to datasheet-only support. |
-| Observed chip-id `0xD802` | Draft. Observed in S3, but exact Nuvoton model/revision is unresolved. S1 disproves treating it as NCT6796D. | Disabled. |
-| Hardware Monitor logical-device selection and base discovery | Draft. NCT6796D facts are pinned from S1; the observed `0xD802` board partially matches the LDN B/base shape with `CR30=0x09` and HM base `0x0290`, but the exact chip remains unresolved and the read-only HM base is `0x0000`. | Disabled. |
-| Temperature register reads | Draft. NCT6796D register facts are pinned from S1, but S6 did not capture hardware-monitor temperature bytes for the observed board. | Disabled. |
-| Fan tachometer / RPM reads | Draft. NCT6796D register facts are pinned from S1, but S6 did not capture hardware-monitor fan count/RPM bytes for the observed board. | Disabled. |
+| Nuvoton responder detection using Phase 2 raw chip-id bytes | Ready through `superio-access.md` rev 3; this document references the diagnostic result but does not change the Phase 2 scope. | Existing diagnostic may remain enabled. |
+| NCT6796D/NCT6796D-E chip-id mapping (`0xD421`) | Primary-source pinned from S1, but not hardware-validated on the S3 board and not needed for the rev 5 ready scope. | Disabled. |
+| `0xD802` / `NCT6799D` chip-id mapping | Ready for the normal HM read scope. S7 proves the local raw ID; S9 independently maps `D802h` to `NCT6799D`. | Enabled for the scoped Phase 3 normal-HM reads. |
+| Normal HM logical-device selection and base discovery | Ready for `0xD802`: select LDN B, read `CR30`, read `CR60/61`, validate normal HM base, then use base+`0x05`/base+`0x06`. | Enabled for `0xD802` only. |
+| Read-only HM base (`CR64/65`) | Board-variable in evidence: local S7 is `0x0000`, S9 is `0x0A00`. The ready scope does not need it. | Disabled. |
+| Bank 4 byte temperature reads `0x90`-`0x95` | Ready for `0xD802` / NCT6799D normal HM access, validated by S7 and S9. | Enabled with generic source labels. |
+| Direct 16-bit fan RPM reads `0xC0`-`0xCB` | Ready for six generic fan inputs on `0xD802` / NCT6799D normal HM access, validated by S7 and S9. | Enabled with generic fan labels. |
+| Count-based fan reads `0xB0`-`0xBB` | Captured by S7/S9 but unnecessary while direct RPM registers are available. | Disabled. |
+| AUXFANIN4 / seventh fan path `0xCC`-`0xCF` | Captured by S7/S9 but not required for the ready scope and not enough to assign a board-stable label. | Disabled. |
 
 ## Register map facts
 
 ### Configuration-space fields needed before hardware-monitor access
 
-These fields are NCT6796D facts from S1. They are not implementation-ready
-for the observed S3 hardware while the exact `0xD802` model is unresolved.
+These facts are implementation-ready only for the `0xD802` / NCT6799D
+normal-HM scope unless the row explicitly says otherwise.
 
 | Address | Name | Bits | Meaning | Units / encoding | Source |
 | --- | --- | --- | --- | --- | --- |
-| `0x20` | Chip ID high byte | `7:0` | NCT6796D high byte `0xD4`. | Raw byte | S1 p. 369 |
-| `0x21` | Chip ID low byte | `7:0` | NCT6796D low byte `0x21`. | Raw byte | S1 p. 369 |
-| `0x07` | Logical Device Number select | `7:0` | Selects which logical device's registers are accessed at indexes `0x30` and above. | Raw logical-device number | S1 pp. 51-52 |
-| `0x0B` | Logical Device B / Hardware Monitor logical device | `7:0` | Selects Logical Device B, whose CR30 enables Hardware Monitor & SB-TSI and whose CR60/61 and CR64/65 define HM base addresses. | Raw logical-device number | S1 pp. 431-432 |
-| `0x30` after LDN `0x0B` | Hardware Monitor & SB-TSI activation | bit `0` | `0` inactive, `1` active. Discovery may read this bit. This spec does not permit writing it. | Boolean active bit | S1 p. 431 |
-| `0x60` / `0x61` after LDN `0x0B` | HM base address | `15:0` | Selects the normal Hardware Monitor base address in `<0x100:0xFFE>` on a 2-byte boundary. | I/O base address | S1 p. 431 |
-| `0x64` / `0x65` after LDN `0x0B` | Read-only HM base address | `15:0` | Selects the read-only Hardware Monitor base address in `<0x100:0xFFE>` on a 2-byte boundary. | I/O base address | S1 p. 431 |
+| `0x20` | Chip ID high byte | `7:0` | `0xD8` for the enabled `0xD802` / NCT6799D scope. `0xD4` identifies NCT6796D/NCT6796D-E but that scope is disabled in rev 5. | Raw byte | S7, S9; S1 p. 369 for disabled `0xD421` |
+| `0x21` | Chip ID low byte | `7:0` | `0x02` for the enabled `0xD802` / NCT6799D scope. `0x21` identifies NCT6796D/NCT6796D-E but that scope is disabled in rev 5. | Raw byte | S7, S9; S1 p. 369 for disabled `0xD421` |
+| `0x07` | Logical Device Number select | `7:0` | Selects which logical device's registers are accessed at indexes `0x30` and above. | Raw logical-device number | S1 pp. 51-52, S2 |
+| `0x0B` | Logical Device B / Hardware Monitor logical device | `7:0` | Selects Logical Device B, whose CR30 enables Hardware Monitor & SB-TSI and whose CR60/61 and CR64/65 define HM base addresses. | Raw logical-device number | S1 pp. 431-432; S7, S9 |
+| `0x30` after LDN `0x0B` | Hardware Monitor & SB-TSI activation | bit `0` | `0` inactive, `1` active. Discovery may read this bit. This spec does not permit writing it. Higher bits are not interpreted by this revision. | Boolean active bit | S1 p. 431; S7 observed `0x09`; S9 observed `0x03` |
+| `0x60` / `0x61` after LDN `0x0B` | Normal HM base address | `15:0` | Selects the normal Hardware Monitor base address. The enabled scope requires a valid base; local and independent dumps observed `0x0290`. | I/O base address | S1 p. 431; S7, S9 |
+| `0x64` / `0x65` after LDN `0x0B` | Read-only HM base address | `15:0` | Optional read-only Hardware Monitor base. This revision records the value but does not use this path because evidence differs by board. | I/O base address | S1 p. 431; S7 observed `0x0000`; S9 observed `0x0A00` |
 
-### Hardware-monitor I/O access fields
+### Hardware-monitor access registers
 
-| Address | Name | Bits | Meaning | Units / encoding | Source |
-| --- | --- | --- | --- | --- | --- |
-| `base + 0x05` | Hardware Monitor address/index port | `7:0` | I/O port used to select a hardware-monitor internal register; standard index/data locations are usually `0x295`/`0x296`. | Port offset from discovered HM base | S1 pp. 54-55 |
-| `base + 0x06` | Hardware Monitor data port | `7:0` | I/O port used to read or write the selected hardware-monitor internal register. | Port offset from discovered HM base | S1 pp. 54-55 |
-| internal `0x4E` | Hardware Monitor bank-select register | `7:0` | Selects the bank for banked hardware-monitor internal registers. Bank writes are allowed only as read-transaction plumbing. | Bank selector | S1 p. 55 |
+For normal HM access, the enabled `0xD802` scope uses the base from
+LDN B `CR60/61` and these offsets:
 
-### Temperature sensor registers
+| Relative offset | Register | Access | Meaning | Source |
+| --- | --- | --- | --- | --- |
+| `+0x05` | HM index port | Write | Selects a Hardware Monitor register index. With base `0x0290`, this is port `0x0295`. | S1 pp. 54-55; S7, S9 |
+| `+0x06` | HM data port | Read/write for read plumbing | Reads the selected Hardware Monitor register; also receives the bank value after selecting the bank register. With base `0x0290`, this is port `0x0296`. | S1 pp. 54-55; S7, S9 |
+| HM index `0x4E` | Bank select register | Write for read plumbing | Selects the bank used by subsequent banked HM register reads. Write data value `0x04` to access bank 4. | S1 p. 176; S7, S9 |
 
-NCT6796D exposes SYSTIN, CPUTIN, AUXTIN0, AUXTIN1, AUXTIN2, AUXTIN3,
-and AUXTIN4 temperature values. The data format for those sensors is
-9-bit two's-complement with 0.5 C resolution when using the high/low
-temperature-source registers. The HM read-only table also exposes byte
-temperature readings for all seven sources. (S1 pp. 60-62, 277-280)
+Required writes in this table are read-transaction plumbing only. They
+must not be generalized to fan-control, threshold, alarm, GPIO, or
+activation writes.
 
-| Access path | Address | Name | Meaning | Units / encoding | Source |
-| --- | --- | --- | --- | --- | --- |
-| Read-only HM base | offset `0x10` | SYSTIN temperature reading | System temperature input. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x11` | CPUTIN temperature reading | CPU socket/board temperature input. Distinct from Phase 1 CPU package temperature. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x12` | AUXTIN0 temperature reading | Auxiliary temperature input 0. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x13` | AUXTIN1 temperature reading | Auxiliary temperature input 1. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x14` | AUXTIN2 temperature reading | Auxiliary temperature input 2. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x15` | AUXTIN3 temperature reading | Auxiliary temperature input 3. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Read-only HM base | offset `0x16` | AUXTIN4 temperature reading | Auxiliary temperature input 4. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 pp. 277-278 |
-| Banked HM registers | bank `0x04`, indexes `0x90`-`0x95` | SYSTIN through AUXTIN3 temperature readings | Alternate banked readings for SYSTIN, CPUTIN, and AUXTIN0-3. AUXTIN4 is not listed in this table. | Byte temperature reading; exact signedness/invalid handling still needs dump verification before enablement. | S1 p. 176 |
+### Temperature registers
+
+Bank 4 byte temperature registers are ready for the enabled `0xD802` /
+NCT6799D normal-HM scope:
+
+| Bank | Register | Generic source label | Decode | Source |
+| --- | --- | --- | --- | --- |
+| `0x04` | `0x90` | SYSTIN | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+| `0x04` | `0x91` | CPUTIN | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+| `0x04` | `0x92` | AUXTIN0 | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+| `0x04` | `0x93` | AUXTIN1 | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+| `0x04` | `0x94` | AUXTIN2 | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+| `0x04` | `0x95` | AUXTIN3 | signed 8-bit degrees C | S1 p. 176; S7, S9 |
+
+S7 captured these local raw bank 4 temperature bytes on the observed
+NZXT N7 B650E `0xD802` board:
+
+| Register | Raw value |
+| --- | --- |
+| `0x90` | `0x27` |
+| `0x91` | `0x23` |
+| `0x92` | `0x29` |
+| `0x93` | `0x0F` |
+| `0x94` | `0x13` |
+| `0x95` | `0x10` |
+
+S9 independently captured the same bank/register set on an ASUS ROG
+Strix X670E-F `D802h` / NCT6799D board:
+
+| Register | Raw value |
+| --- | --- |
+| `0x90` | `0x20` |
+| `0x91` | `0x24` |
+| `0x92` | `0x11` |
+| `0x93` | `0x16` |
+| `0x94` | `0x16` |
+| `0x95` | `0x0E` |
 
 ### Fan tachometer / RPM registers
 
-NCT6796D provides 13-bit fan count readings and 16-bit direct fan RPM
-readings. For 13-bit count reads, the datasheet requires reading the
-high byte first, then the low byte. `RPM = 1.35e6 / count`. For 16-bit
-RPM reads, the datasheet requires reading the high byte first, then the
-low byte; the combined 16-bit value is the RPM value in decimal. (S1
-p. 66)
+The rev 5 ready scope enables direct 16-bit RPM registers only. Count
+registers were captured but remain disabled because direct RPM registers
+avoid count-to-RPM conversion ambiguity and were validated on both S7
+and S9 evidence.
 
-| Fan input | 13-bit count registers | 16-bit RPM registers | Read order / conversion | Source |
-| --- | --- | --- | --- | --- |
-| SYSFANIN | bank `0x04`, high `0xB0`, low `0xB1` | bank `0x04`, high `0xC0`, low `0xC1` | Count high then low; RPM high then low. | S1 pp. 66, 176, 180 |
-| CPUFANIN | bank `0x04`, high `0xB2`, low `0xB3` | bank `0x04`, high `0xC2`, low `0xC3` | Count high then low; RPM high then low. | S1 pp. 66, 177, 180-181 |
-| AUXFANIN0 | bank `0x04`, high `0xB4`, low `0xB5` | bank `0x04`, high `0xC4`, low `0xC5` | Count high then low; RPM high then low. | S1 pp. 66, 177-178, 181 |
-| AUXFANIN1 | bank `0x04`, high `0xB6`, low `0xB7` | bank `0x04`, high `0xC6`, low `0xC7` | Count high then low; RPM high then low. | S1 pp. 66, 178, 181-182 |
-| AUXFANIN2 | bank `0x04`, high `0xB8`, low `0xB9` | bank `0x04`, high `0xC8`, low `0xC9` | Count high then low; RPM high then low. | S1 pp. 66, 178-179, 182 |
-| AUXFANIN3 | bank `0x04`, high `0xBA`, low `0xBB` | bank `0x04`, high `0xCA`, low `0xCB` | Count high then low; RPM high then low. | S1 pp. 66, 179, 182-183 |
-| AUXFANIN4 | bank `0x04`, high `0xCC`, low `0xCD` per summary table | bank `0x04`, high `0xCE`, low `0xCF` per summary table; read-only HM offsets `0x46`/`0x47` also list AUXFANIN4 RPM | Count high then low; RPM high then low. Detailed banked-register sections for `0xCC`-`0xCF` were not found in S1 text extraction, so enablement needs hardware dump confirmation. | S1 pp. 66, 279 |
+| Generic fan | Bank | Direct RPM high | Direct RPM low | Decode | Source |
+| --- | --- | --- | --- | --- | --- |
+| Fan 1 / SYSFANIN candidate | `0x04` | `0xC0` | `0xC1` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
+| Fan 2 / CPUFANIN candidate | `0x04` | `0xC2` | `0xC3` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
+| Fan 3 / AUXFANIN0 candidate | `0x04` | `0xC4` | `0xC5` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
+| Fan 4 / AUXFANIN1 candidate | `0x04` | `0xC6` | `0xC7` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
+| Fan 5 / AUXFANIN2 candidate | `0x04` | `0xC8` | `0xC9` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
+| Fan 6 / AUXFANIN3 candidate | `0x04` | `0xCA` | `0xCB` | high byte then low byte, unsigned RPM | S1 p. 66; S7, S9 |
 
-The HM read-only register table provides direct count/RPM offsets for
-the first six fan inputs and RPM offsets for AUXFANIN4:
+S7 local direct RPM bytes:
 
-| Read-only HM offset range | Meaning | Source |
+| Registers | Raw high/low | Direct RPM |
 | --- | --- | --- |
-| `0x2E`-`0x39` | SYSFANIN, CPUFANIN, AUXFANIN0, AUXFANIN1, AUXFANIN2, AUXFANIN3 count high/low readings. | S1 p. 279 |
-| `0x3A`-`0x47` | SYSFANIN, CPUFANIN, AUXFANIN0, AUXFANIN1, AUXFANIN2, AUXFANIN3, AUXFANIN4 RPM high/low readings. | S1 p. 279 |
+| `0xC0`/`0xC1` | `0x00`/`0x00` | `0` |
+| `0xC2`/`0xC3` | `0x0B`/`0x08` | `2824` |
+| `0xC4`/`0xC5` | `0x00`/`0x00` | `0` |
+| `0xC6`/`0xC7` | `0x02`/`0xE2` | `738` |
+| `0xC8`/`0xC9` | `0x03`/`0x2C` | `812` |
+| `0xCA`/`0xCB` | `0x00`/`0x00` | `0` |
 
-## Read procedure and decode
+S9 independent direct RPM bytes:
 
-### Discovery procedure (draft)
+| Registers | Raw high/low | Direct RPM |
+| --- | --- | --- |
+| `0xC0`/`0xC1` | `0x03`/`0x59` | `857` |
+| `0xC2`/`0xC3` | `0x03`/`0x2D` | `813` |
+| `0xC4`/`0xC5` | `0x03`/`0x40` | `832` |
+| `0xC6`/`0xC7` | `0x03`/`0x55` | `853` |
+| `0xC8`/`0xC9` | `0x03`/`0x42` | `834` |
+| `0xCA`/`0xCB` | `0x03`/`0x8A` | `906` |
 
-This procedure is not implementation-ready until the exact `0xD802`
-chip is identified or matching hardware is validated for NCT6796D.
+Captured but disabled fan-related registers:
+
+| Bank | Registers | Reason disabled |
+| --- | --- | --- |
+| `0x04` | `0xB0`-`0xBB` | Count-path bytes are not needed while direct RPM registers are available. |
+| `0x04` | `0xCC`-`0xCF` | AUXFANIN4 / seventh fan path is outside the rev 5 ready scope. |
+
+## Procedures
+
+### Discovery procedure
 
 1. Acquire `Global\Access_ISABUS.HTP.Method` with a bounded timeout
    before any Super I/O index/data or hardware-monitor I/O transaction.
    If the mutex cannot be acquired, abort the transaction rather than
    proceeding unlocked. (S2)
-2. Use the Phase 2 Nuvoton configuration-mode procedure to read the raw
+2. Use the Phase 2 Nuvoton configuration-mode procedure to read raw
    chip-id bytes from `0x20` / `0x21`. If the responder is absent under
    the Phase 2 absent-id rules, stop. (S2)
-3. Treat `0xD421` as NCT6796D/NCT6796D-E candidate hardware. Treat
-   `0xD802` as an unresolved Nuvoton-class responder and keep decode
-   disabled. (S1, S3)
-4. Select Logical Device B by writing `0x07` then `0x0B` in
-   configuration mode. (S1)
-5. Read CR30, CR60/61, and CR64/65. CR30 bit 0 indicates whether
-   Hardware Monitor & SB-TSI is active; CR60/61 is the normal HM base;
-   CR64/65 is the read-only HM base. (S1)
-6. Exit configuration mode using the Phase 2 Nuvoton exit sequence.
-   (S2)
-7. Cache the detected slot, chip-id bytes, optional model mapping, and
-   base addresses. Sampling paths must not re-enter configuration mode
-   on every metrics tick.
+3. Enable the rev 5 normal-HM path only when the raw chip ID is
+   `0xD802`. Label the supported chip family as `NCT6799D`; do not add
+   a `-R` suffix. Any other chip ID is outside this document's enabled
+   runtime scope. (S7, S9)
+4. Select LDN `0x0B`, read `CR30`, and require bit 0 to be set. Do not
+   write `CR30`. (S1, S7, S9)
+5. Read `CR60/61` as the normal HM base and require it to be a valid I/O
+   base in the Phase 2 / PawnIO-safe range. Record `CR64/65` if useful
+   for diagnostics, but do not use the read-only HM path in rev 5. (S7,
+   S9)
+6. Call PawnIO `ioctl_find_bars` after slot selection and LDN B/base
+   discovery, before normal HM index/data I/O. On the local board this
+   order changed `ioctl_find_bars` from `0x80070490` to success and
+   authorized normal HM port I/O. (S7)
+7. Use normal HM index port `base + 0x05` and data port `base + 0x06`.
+   Select bank 4 by writing index `0x4E`, then data `0x04`. (S1, S7,
+   S9)
+8. Read the enabled register set: temperatures `0x90`-`0x95` and direct
+   RPM pairs `0xC0`-`0xCB`. Abort the current sample on any failed index
+   write or data read; do not synthesize values from partial reads. (S7,
+   S9)
+9. Exit Nuvoton configuration mode and release the ISA mutex in all
+   paths. (S2)
 
-### Hardware-monitor register read procedure (draft)
+### Temperature decode
 
-1. Acquire `Global\Access_ISABUS.HTP.Method` for the whole
-   hardware-monitor transaction. (S2)
-2. For banked reads, write internal register `0x4E` through the normal
-   HM index/data ports to select the required bank. (S1)
-3. Write the target register address to `base + 0x05`, then read the
-   selected byte from `base + 0x06`. (S1)
-4. For 13-bit fan count and 16-bit fan RPM reads, read the high byte
-   first, then the low byte. (S1)
-5. Release the mutex after all bytes for one coherent sample have been
-   read.
-
-### Temperature decode (draft)
-
-- For high/low temperature-source registers, decode the 9-bit
-  two's-complement value as 0.5 C units. (S1 p. 60)
-- For HM read-only byte temperature offsets, do not enable decode until
-  an exact hardware dump confirms the access path and plausible source
-  labels for the board. (S1, S3, S6)
+- Decode each enabled bank 4 temperature byte as signed 8-bit degrees C.
+  Preserve the raw byte alongside the decoded value in diagnostics.
+- Use generic source labels from the register table unless a later
+  board-specific evidence file safely narrows physical labels.
 - Do not merge motherboard/board temperature inputs with Phase 1 CPU
   package temperature sources.
 
-### Fan RPM decode (draft)
+### Fan RPM decode
 
-- For 13-bit count registers, combine the high and low fields into a
-  13-bit count and calculate `RPM = 1.35e6 / count`. (S1 p. 66)
-- For 16-bit RPM registers, combine high then low bytes and interpret
-  the resulting 16-bit integer as RPM. (S1 p. 66)
-- Do not surface zero, max-count, or otherwise implausible values until
-  stopped/disconnected handling is verified by real hardware dump.
+- For enabled direct 16-bit RPM registers, combine high then low bytes
+  and interpret the resulting unsigned 16-bit integer as RPM. (S1 p. 66;
+  S7, S9)
+- A direct RPM value of `0x0000` is a valid stopped-or-unconnected raw
+  reading. Do not treat zero as a read failure and do not infer physical
+  disconnection from zero alone. (S7, S9)
+- Do not use count-path bytes at `0xB0`-`0xBB` or AUXFANIN4 / seventh fan
+  bytes at `0xCC`-`0xCF` in rev 5 implementation.
 
 ## Quirks
 
-- No model-specific quirks are implementation-ready in this revision.
-- Chip-id `0xD802` is observed on one Nuvoton-class board (S3), but S1
-  identifies NCT6796D as `0xD421`. Treat `0xD802` as a draft-only
-  applicability clue, not as a decode key.
+- `0xD802` is implementation-ready only as `NCT6799D` without a package
+  suffix claim. Public board-review and user-report leads make
+  `NCT6799D-R` plausible, but rev 5 does not prove or expose `-R`. (S8,
+  S9)
+- For the observed local board, `ioctl_find_bars` must run after Nuvoton
+  configuration/base discovery has made the HM base visible to PawnIO
+  `LpcIO`; running it before config discovery returned `0x80070490` and
+  left normal HM ports unauthorized. (S7)
+- Read-only HM base availability is board-variable in current evidence:
+  S7 observed `0x0000`, S9 observed `0x0A00`. Rev 5 does not use the
+  read-only HM path. (S7, S9)
 
 ## Safety notes
 
 - This document is read-oriented. Required writes are limited to
-  read-transaction plumbing: Nuvoton configuration-mode enter/exit
-  keys documented by S2, logical-device selection required for base
-  discovery, and hardware-monitor bank selection required for banked
-  register reads.
-- The implementation must never write fan-control registers, PWM duty
-  registers, Smart Fan policy registers, sensor source-selection
-  registers, threshold/limit registers, alarm-clear registers, GPIO
-  registers, CR30 activation bits, or any other register that can alter
-  board behavior.
-- All Super I/O and hardware-monitor index/data sequences must hold
-  `Global\Access_ISABUS.HTP.Method` for the complete multi-I/O
-  transaction. Interleaving another monitor's index write between this
-  client's index and data operations can corrupt the read. (S2)
-- Fan RPM and temperature values must be plausibility-filtered before
-  surfacing them to the metrics stream. This revision does not define
-  the exact ranges yet; implementers must wait for the readied revision.
+  read-transaction plumbing: Nuvoton configuration-mode enter/exit,
+  logical-device selection, normal HM index selection, and normal HM bank
+  selection.
+- Do not write activation, fan-control/PWM, Smart Fan, threshold, limit,
+  alarm-clear, GPIO, or vendor/OEM registers from this spec.
+- Hold the ISA mutex for the whole Super I/O / HM transaction and abort
+  rather than racing another monitor.
+- Require elevation/PawnIO access. If `pawnio_open` fails with
+  `0x80070005`, surface an unavailable/permission diagnostic rather than
+  retrying through unsafe access paths. (S5)
+- Keep all disabled scopes disabled unless a later spec revision updates
+  the scoped enablement table and records the necessary evidence.
 
 ## Open questions
 
-- Blocking for Phase 3 ready: Identify the observed `0xD802` responder
-  with a primary Nuvoton source, board documentation, or another
-  independent source. The NCT6796D datasheet fetched in this session
-  maps NCT6796D to `0xD421`, so `0xD802` must not use the NCT6796D
-  register map by assumption.
-- Blocking for Phase 3 ready: Complete a Phase 3 hardware-monitor byte
-  dump on the S3 board. S6 captured chip-id and LDN B `CR30/CR60-65`
-  under elevation, but `ioctl_find_bars` returned `0x80070490` and the
-  normal HM index-port write to `0x0295` returned `0x80070005`; the
-  remaining dump must include normal HM banked temperature/RPM bytes
-  and manual context for connected versus empty fan headers.
-- Blocking for Phase 3 ready: Confirm whether the observed chip exposes
-  the same normal HM behavior as S1 before enabling any register reads.
-  S6 observed normal HM base `0x0290` but read-only HM base `0x0000` on
-  the unresolved `0xD802` chip, so the S1 read-only HM path is not
-  hardware-validated for this board.
-- Blocking for Phase 3 ready: Define stopped, disconnected, max-count,
-  zero, and implausible fan handling from primary-source text or
-  hardware dump evidence.
-- Blocking for Phase 3 ready: Confirm AUXFANIN4 count/RPM banked
-  registers for the exact supported chip. S1's summary table lists
-  Bank 4 `0xCC`-`0xCF`, but the extracted detailed register sections
-  only reached AUXFANIN3 for the normal Bank 4 speed registers.
-- Blocking for Phase 3 ready: Decide whether a future revision will
-  support NCT6796D/NCT6796D-E only, the observed `0xD802` chip only, or
-  a broader NCT67xx/NCT679x table with per-chip scoped enablement.
+- Non-blocking for Phase 3: A public Nuvoton NCT6799D/NCT6799D-R
+  datasheet and official chip-id table remain unavailable; rev 5 is
+  scoped to independently verified raw chip ID `0xD802` / `NCT6799D` and
+  does not claim package suffix, OEM variant, or package revision.
+- Non-blocking for Phase 3: Board-specific physical header labels remain
+  unresolved; rev 5 exposes generic fan labels and preserves zero RPM as
+  stopped-or-unconnected without classifying physical connection state.
+- Non-blocking for Phase 3: NCT6796D/NCT6796D-E runtime support remains
+  disabled because no matching hardware dump was captured for chip ID
+  `0xD421` in this validation set.
+- Non-blocking for Phase 3: Read-only HM access and AUXFANIN4 / seventh
+  fan decode remain disabled; the enabled scope uses only normal HM bank
+  4 temperatures `0x90`-`0x95` and direct RPM pairs `0xC0`-`0xCB`.
 
 ## Implementation-ready transition checklist
 
-Before this document can become `Implementation-ready (rev N)`, the
-Phase 3 spec-author PR must satisfy the directory-level checklist in
-[`README.md`](README.md) and at minimum:
+Revision 5 satisfies the directory-level checklist in [`README.md`](README.md):
 
-- resolve the exact chip-id/model mapping for every enabled scope,
-- pin exact S1 or replacement primary-source section/page references
-  for every register, conversion, and procedure fact,
-- ensure no normative fact rests solely on a copyleft implementation,
-- record the exact elevated real-hardware dump(s) used for validation,
-- set scoped enablement so unsupported or unverified chip IDs remain
-  disabled by default,
-- resolve or explicitly annotate every open question according to the
-  README status-transition rules, and
-- bump the revision and status in the header and revision history.
+- no unresolved provenance marker remains in this document;
+- every enabled fact is pinned to S1/S2 or independently verified by S7
+  and S9 hardware dumps;
+- no normative fact rests solely on a copyleft implementation;
+- disabled or unverified scopes remain disabled in
+  [Scoped enablement](#scoped-enablement);
+- every remaining open question is explicitly annotated as non-blocking
+  for Phase 3; and
+- the revision, status, and revision history record the ready flip.
 
 ## Provenance text for a future clean-room implementation PR
 
-Do **not** use this text while the document is Draft. After a later
-revision is flipped to implementation-ready, the implementation PR
-should pin the ready revision and commit, for example:
+Implementation PRs should pin this ready revision and commit, for example:
 
 ```text
 Implemented from docs/specs/sensors/superio-access.md revision 3 (commit a8c167b1), limited to Super I/O configuration access and chip-id diagnostic facts.
-Implemented from docs/specs/sensors/superio-nuvoton-nct67xx.md revision <ready-revision> (commit <ready-commit>), limited to the Nuvoton scopes marked enabled in that revision.
+Implemented from docs/specs/sensors/superio-nuvoton-nct67xx.md revision 5 (commit <ready-commit>), limited to the `0xD802` / NCT6799D normal HM scopes marked enabled in that revision.
 No other external sensor documentation was used.
 ```
 
@@ -297,3 +336,5 @@ No other external sensor documentation was used.
 | 1 | 2026-06-28 | Initial Phase 3 Nuvoton-family draft; records Phase 2 diagnostic linkage, expected hardware-monitor spec shape, safety constraints, and unresolved provenance/dump requirements. |
 | 2 | 2026-06-28 | Fetched and verified the official NCT6796D V0.6 datasheet; pinned NCT6796D configuration, HM base, temperature, and fan RPM facts; recorded that S1 maps NCT6796D to `0xD421` while the observed S3 board is `0xD802`; recorded standard-rights PawnIO dump failure (`0x80070005`). Status remains Draft. |
 | 3 | 2026-06-28 | Added elevated PawnIO `LpcIO` evidence for the observed `0xD802` board: LDN B active, normal HM base `0x0290`, read-only HM base `0x0000`, and blocked HM index/data access (`ioctl_find_bars=0x80070490`, `pio_outb(0x0295)=0x80070005`). Status remains Draft. |
+| 4 | 2026-06-28 | Added successful elevated normal-HM bank 4 byte-dump evidence, recorded the `ioctl_find_bars` ordering requirement, narrowed stopped/zero-RPM handling, and documented the `0xD802` source-hunt result. Exact-chip mapping remains unresolved, so status remains Draft. |
+| 5 | 2026-06-28 | Added independent AIDA64 dump evidence mapping `0xD802` to `NCT6799D`, scoped support to normal HM bank 4 temperatures and direct RPM pairs, disabled unresolved suffix/read-only/AUXFANIN4 scopes, and flipped status to Implementation-ready. |

--- a/scripts/diagnostics/capture-superio-hm-dump.ps1
+++ b/scripts/diagnostics/capture-superio-hm-dump.ps1
@@ -1,0 +1,750 @@
+<#
+.SYNOPSIS
+Captures a clean-room Super I/O / PawnIO LpcIO diagnostic bundle.
+
+.DESCRIPTION
+This script is for #1635 hardware validation, not production sampling.
+It loads the locally installed PawnIO LpcIO module, holds the shared
+Access_ISABUS mutex, records raw chip-id bytes for both standard Super I/O
+slots, and optionally probes the Nuvoton Hardware Monitor logical-device base
+and raw Hardware Monitor bytes.
+
+The optional Hardware Monitor byte read is intentionally behind -IncludeHmRead.
+It writes only read-transaction plumbing values: configuration-mode entry/exit,
+logical-device selection, hardware-monitor index selection, and bank selection.
+It does not write fan-control, PWM, threshold, alarm, GPIO, or activation
+registers.
+
+Run from an Administrator PowerShell session for real PawnIO access:
+
+  powershell -ExecutionPolicy Bypass -File .\scripts\diagnostics\capture-superio-hm-dump.ps1 -IncludeBaseDiscovery -IncludeHmRead
+
+Use -DryRun to validate script discovery/JSON output without opening PawnIO.
+#>
+
+[CmdletBinding()]
+param(
+  [string]$OutputPath = "",
+  [string]$PawnIoRoot = "",
+  [int]$MutexTimeoutMs = 500,
+  [switch]$IncludeBaseDiscovery,
+  [switch]$IncludeHmRead,
+  [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+  $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $OutputPath = Join-Path "tmp" "superio-hm-dump-$timestamp.json"
+}
+
+function Format-HResult {
+  param([int]$Value)
+  $unsigned = [BitConverter]::ToUInt32([BitConverter]::GetBytes($Value), 0)
+  return ("0x{0:X8}" -f $unsigned)
+}
+
+function Test-HResultSucceeded {
+  param([int]$Value)
+  return $Value -ge 0
+}
+
+function Test-IsElevated {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-CimSummary {
+  param([string]$ClassName)
+  try {
+    $instance = Get-CimInstance -ClassName $ClassName | Select-Object -First 1
+    switch ($ClassName) {
+      "Win32_BaseBoard" {
+        return [ordered]@{
+          manufacturer = $instance.Manufacturer
+          product = $instance.Product
+          version = $instance.Version
+        }
+      }
+      "Win32_Processor" {
+        return [ordered]@{
+          manufacturer = $instance.Manufacturer
+          name = $instance.Name
+          cores = $instance.NumberOfCores
+          logicalProcessors = $instance.NumberOfLogicalProcessors
+        }
+      }
+      "Win32_OperatingSystem" {
+        return [ordered]@{
+          caption = $instance.Caption
+          version = $instance.Version
+          buildNumber = $instance.BuildNumber
+          architecture = $instance.OSArchitecture
+        }
+      }
+      default {
+        return [ordered]@{ name = $instance.Name }
+      }
+    }
+  } catch {
+    return [pscustomobject]@{ error = $_.Exception.Message }
+  }
+}
+
+function Convert-ByteToHex {
+  param([AllowNull()]$Value)
+  if ($null -eq $Value) {
+    return $null
+  }
+  return ("0x{0:X2}" -f ([int]$Value -band 0xFF))
+}
+
+function Convert-WordToHex {
+  param([AllowNull()]$Value)
+  if ($null -eq $Value) {
+    return $null
+  }
+  return ("0x{0:X4}" -f ([int]$Value -band 0xFFFF))
+}
+
+function Convert-CallResult {
+  param([pscustomobject]$Call)
+  if ($null -eq $Call) {
+    return $null
+  }
+
+  return [ordered]@{
+    function = $Call.function
+    input = @($Call.input)
+    hresult = $Call.hresult
+    succeeded = $Call.succeeded
+    returnSize = $Call.returnSize
+    output = @($Call.output)
+    error = $Call.error
+  }
+}
+
+function Get-PawnIoInstallCandidates {
+  $candidates = New-Object System.Collections.Generic.List[string]
+
+  if (-not [string]::IsNullOrWhiteSpace($PawnIoRoot)) {
+    $candidates.Add($PawnIoRoot)
+  }
+
+  try {
+    $reg = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO" -Name "InstallLocation" -ErrorAction Stop
+    if (-not [string]::IsNullOrWhiteSpace($reg.InstallLocation)) {
+      $candidates.Add($reg.InstallLocation)
+    }
+  } catch {
+    # Registry install location is optional; keep probing standard paths.
+  }
+
+  foreach ($name in @("ProgramFiles", "ProgramW6432", "ProgramFiles(x86)")) {
+    $root = [Environment]::GetEnvironmentVariable($name)
+    if (-not [string]::IsNullOrWhiteSpace($root)) {
+      $candidates.Add((Join-Path $root "PawnIO"))
+    }
+  }
+
+  return @($candidates | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+}
+
+function Find-FirstNamedFile {
+  param(
+    [string[]]$Roots,
+    [string[]]$Names,
+    [int]$MaxDepth = 4
+  )
+
+  foreach ($name in $Names) {
+    foreach ($root in $Roots) {
+      if (-not (Test-Path -LiteralPath $root)) {
+        continue
+      }
+
+      $direct = Join-Path $root $name
+      if (Test-Path -LiteralPath $direct -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $direct).Path
+      }
+
+      try {
+        $match = Get-ChildItem -LiteralPath $root -Recurse -File -Depth $MaxDepth -ErrorAction SilentlyContinue |
+          Where-Object { $_.Name -ieq $name } |
+          Select-Object -First 1
+        if ($null -ne $match) {
+          return $match.FullName
+        }
+      } catch {
+        # Some install subfolders may not be enumerable; keep looking.
+      }
+    }
+  }
+
+  return $null
+}
+
+Add-Type -TypeDefinition @"
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class PawnIoNative {
+  [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  private static extern IntPtr LoadLibraryW(string lpFileName);
+
+  [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi, BestFitMapping = false)]
+  private static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  public static extern bool FreeLibrary(IntPtr hModule);
+
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+  private delegate int PawnIoVersion(out UInt32 version);
+
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+  private delegate int PawnIoOpen(out IntPtr handle);
+
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+  private delegate int PawnIoLoad(IntPtr handle, byte[] blob, UIntPtr blobSize);
+
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+  private delegate int PawnIoExecute(
+    IntPtr handle,
+    [MarshalAs(UnmanagedType.LPStr)] string name,
+    UInt64[] input,
+    UIntPtr inputCells,
+    UInt64[] output,
+    UIntPtr outputCells,
+    out UIntPtr returnSize);
+
+  [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+  private delegate int PawnIoClose(IntPtr handle);
+
+  public static IntPtr LoadLibrary(string path) {
+    IntPtr library = LoadLibraryW(path);
+    if (library == IntPtr.Zero) {
+      throw new Win32Exception(Marshal.GetLastWin32Error(), "LoadLibraryW failed for " + path);
+    }
+    return library;
+  }
+
+  public static int Version(IntPtr library, out UInt32 version) {
+    return GetDelegate<PawnIoVersion>(library, "pawnio_version")(out version);
+  }
+
+  public static int Open(IntPtr library, out IntPtr handle) {
+    return GetDelegate<PawnIoOpen>(library, "pawnio_open")(out handle);
+  }
+
+  public static int Load(IntPtr library, IntPtr handle, byte[] blob) {
+    return GetDelegate<PawnIoLoad>(library, "pawnio_load")(handle, blob, (UIntPtr)blob.Length);
+  }
+
+  public static int Execute(
+    IntPtr library,
+    IntPtr handle,
+    string name,
+    UInt64[] input,
+    UInt64[] output,
+    UInt64 outputCells,
+    out UInt64 returnSize) {
+    UInt64[] safeInput = input ?? new UInt64[0];
+    UInt64[] safeOutput = output ?? new UInt64[1];
+    UIntPtr nativeReturnSize;
+    int hr = GetDelegate<PawnIoExecute>(library, "pawnio_execute")(
+      handle,
+      name,
+      safeInput,
+      (UIntPtr)safeInput.Length,
+      safeOutput,
+      (UIntPtr)outputCells,
+      out nativeReturnSize);
+    returnSize = nativeReturnSize.ToUInt64();
+    return hr;
+  }
+
+  public static int Close(IntPtr library, IntPtr handle) {
+    return GetDelegate<PawnIoClose>(library, "pawnio_close")(handle);
+  }
+
+  private static T GetDelegate<T>(IntPtr library, string name) where T : class {
+    IntPtr proc = GetProcAddress(library, name);
+    if (proc == IntPtr.Zero) {
+      throw new MissingMethodException("Missing PawnIO export: " + name);
+    }
+    return Marshal.GetDelegateForFunctionPointer(proc, typeof(T)) as T;
+  }
+}
+"@
+
+$script:PawnIoLibrary = [IntPtr]::Zero
+$script:PawnIoHandle = [IntPtr]::Zero
+
+function Invoke-PawnIo {
+  param(
+    [string]$Name,
+    [UInt64[]]$InputCells = @(),
+    [int]$OutputCells = 0
+  )
+
+  $output = New-Object UInt64[] ([Math]::Max(1, $OutputCells))
+  [UInt64]$returnSize = 0
+  try {
+    $hr = [PawnIoNative]::Execute($script:PawnIoLibrary, $script:PawnIoHandle, $Name, $InputCells, $output, ([UInt64]$OutputCells), [ref]$returnSize)
+    $succeeded = Test-HResultSucceeded $hr
+    $visibleOutput = @()
+    if ($succeeded -and $OutputCells -gt 0) {
+      $visibleOutput = @($output | Select-Object -First ([Math]::Min($OutputCells, [int]$returnSize)))
+    }
+    return [pscustomobject]@{
+      function = $Name
+      input = @($InputCells)
+      hresult = Format-HResult $hr
+      succeeded = $succeeded
+      returnSize = $returnSize
+      output = $visibleOutput
+      error = $null
+    }
+  } catch {
+    return [pscustomobject]@{
+      function = $Name
+      input = @($InputCells)
+      hresult = $null
+      succeeded = $false
+      returnSize = 0
+      output = @()
+      error = $_.Exception.Message
+    }
+  }
+}
+
+function Invoke-PawnIoRequired {
+  param(
+    [string]$Name,
+    [UInt64[]]$InputCells = @(),
+    [int]$OutputCells = 0
+  )
+  $call = Invoke-PawnIo -Name $Name -InputCells $InputCells -OutputCells $OutputCells
+  if (-not $call.succeeded) {
+    $reason = if ($call.hresult) { $call.hresult } else { $call.error }
+    throw "$Name failed: $reason"
+  }
+  return $call
+}
+
+function Read-SuperIoRegister {
+  param([byte]$Register)
+  $call = Invoke-PawnIoRequired -Name "ioctl_superio_inb" -InputCells @([UInt64]$Register) -OutputCells 1
+  return [int]$call.output[0]
+}
+
+function Write-SuperIoRegister {
+  param([byte]$Register, [byte]$Value)
+  [void](Invoke-PawnIoRequired -Name "ioctl_superio_outb" -InputCells @([UInt64]$Register, [UInt64]$Value) -OutputCells 0)
+}
+
+function Write-PortByte {
+  param([UInt16]$Port, [byte]$Value)
+  return Invoke-PawnIoRequired -Name "ioctl_pio_outb" -InputCells @([UInt64]$Port, [UInt64]$Value) -OutputCells 0
+}
+
+function Read-PortByteCall {
+  param([UInt16]$Port)
+  return Invoke-PawnIo -Name "ioctl_pio_inb" -InputCells @([UInt64]$Port) -OutputCells 1
+}
+
+function Enter-NuvotonConfig {
+  param([UInt16]$IndexPort)
+  [void](Write-PortByte -Port $IndexPort -Value 0x87)
+  [void](Write-PortByte -Port $IndexPort -Value 0x87)
+}
+
+function Exit-NuvotonConfig {
+  param([UInt16]$IndexPort)
+  return Invoke-PawnIo -Name "ioctl_pio_outb" -InputCells @([UInt64]$IndexPort, [UInt64]0xAA) -OutputCells 0
+}
+
+function Enter-IteConfig {
+  param([int]$Slot, [UInt16]$IndexPort)
+  $fourth = if ($Slot -eq 0) { 0x55 } else { 0xAA }
+  foreach ($key in @(0x87, 0x01, 0x55, $fourth)) {
+    [void](Write-PortByte -Port $IndexPort -Value ([byte]$key))
+  }
+}
+
+function Exit-IteConfig {
+  return Invoke-PawnIo -Name "ioctl_superio_outb" -InputCells @([UInt64]0x02, [UInt64]0x02) -OutputCells 0
+}
+
+function Get-ChipIdFields {
+  param([int]$High, [int]$Low)
+  $chipId = (($High -band 0xFF) -shl 8) -bor ($Low -band 0xFF)
+  $absent = (($High -eq 0x00 -and $Low -eq 0x00) -or ($High -eq 0xFF -and $Low -eq 0xFF))
+  return [ordered]@{
+    idHigh = $High
+    idHighHex = Convert-ByteToHex $High
+    idLow = $Low
+    idLowHex = Convert-ByteToHex $Low
+    chipId = if ($absent) { $null } else { $chipId }
+    chipIdHex = if ($absent) { $null } else { Convert-WordToHex $chipId }
+    absent = $absent
+  }
+}
+
+function Test-ValidIoBase {
+  param([int]$Base)
+  return $Base -ne 0x0000 -and $Base -ne 0xFFFF -and $Base -ge 0x0100 -and $Base -le 0x0FFE
+}
+
+function Read-HardwareMonitorRegister {
+  param([UInt16]$IndexPort, [UInt16]$DataPort, [byte]$Register)
+  $writeIndex = Invoke-PawnIo -Name "ioctl_pio_outb" -InputCells @([UInt64]$IndexPort, [UInt64]$Register) -OutputCells 0
+  if (-not $writeIndex.succeeded) {
+    return [ordered]@{
+      register = [int]$Register
+      registerHex = Convert-ByteToHex $Register
+      writeIndex = Convert-CallResult $writeIndex
+      readData = $null
+      value = $null
+      valueHex = $null
+    }
+  }
+
+  $readData = Read-PortByteCall -Port $DataPort
+  $value = if ($readData.succeeded -and $readData.output.Count -gt 0) { [int]$readData.output[0] } else { $null }
+  return [ordered]@{
+    register = [int]$Register
+    registerHex = Convert-ByteToHex $Register
+    writeIndex = Convert-CallResult $writeIndex
+    readData = Convert-CallResult $readData
+    value = $value
+    valueHex = Convert-ByteToHex $value
+  }
+}
+
+function Read-NuvotonHmCandidateDump {
+  param([UInt16]$BaseAddress)
+
+  $indexPort = [UInt16]($BaseAddress + 0x05)
+  $dataPort = [UInt16]($BaseAddress + 0x06)
+
+  $dump = [ordered]@{
+    note = "Raw dump only. Do not decode or ship from this output until the matching spec is implementation-ready."
+    baseAddress = [int]$BaseAddress
+    baseAddressHex = Convert-WordToHex $BaseAddress
+    indexPort = [int]$indexPort
+    indexPortHex = Convert-WordToHex $indexPort
+    dataPort = [int]$dataPort
+    dataPortHex = Convert-WordToHex $dataPort
+    findBarsBeforeRead = Convert-CallResult (Invoke-PawnIo -Name "ioctl_find_bars" -InputCells ([UInt64[]]@()) -OutputCells 0)
+    bankSelect = $null
+    bank4Reads = @()
+  }
+
+  $bankIndex = Invoke-PawnIo -Name "ioctl_pio_outb" -InputCells @([UInt64]$indexPort, [UInt64]0x4E) -OutputCells 0
+  $bankData = $null
+  if ($bankIndex.succeeded) {
+    $bankData = Invoke-PawnIo -Name "ioctl_pio_outb" -InputCells @([UInt64]$dataPort, [UInt64]0x04) -OutputCells 0
+  }
+  $dump.bankSelect = [ordered]@{
+    indexRegisterWrite = Convert-CallResult $bankIndex
+    bankValueWrite = Convert-CallResult $bankData
+  }
+
+  if ($bankIndex.succeeded -and $null -ne $bankData -and $bankData.succeeded) {
+    $registers = @(0x90,0x91,0x92,0x93,0x94,0x95,0xB0,0xB1,0xB2,0xB3,0xB4,0xB5,0xB6,0xB7,0xB8,0xB9,0xBA,0xBB,0xC0,0xC1,0xC2,0xC3,0xC4,0xC5,0xC6,0xC7,0xC8,0xC9,0xCA,0xCB,0xCC,0xCD,0xCE,0xCF)
+    $dump.bank4Reads = @($registers | ForEach-Object {
+      Read-HardwareMonitorRegister -IndexPort $indexPort -DataPort $dataPort -Register ([byte]$_)
+    })
+  }
+
+  return $dump
+}
+
+function Probe-NuvotonSlot {
+  param([int]$Slot, [UInt16]$IndexPort)
+
+  $result = [ordered]@{
+    vendor = "nuvoton"
+    error = $null
+    exit = $null
+    chipId = $null
+    baseDiscovery = $null
+    hardwareMonitorDump = $null
+  }
+
+  try {
+    Enter-NuvotonConfig -IndexPort $IndexPort
+    $high = Read-SuperIoRegister -Register 0x20
+    $low = Read-SuperIoRegister -Register 0x21
+    $result.chipId = Get-ChipIdFields -High $high -Low $low
+
+    if ($IncludeBaseDiscovery -and -not $result.chipId.absent) {
+      Write-SuperIoRegister -Register 0x07 -Value 0x0B
+      $cr30 = Read-SuperIoRegister -Register 0x30
+      $cr60 = Read-SuperIoRegister -Register 0x60
+      $cr61 = Read-SuperIoRegister -Register 0x61
+      $cr64 = Read-SuperIoRegister -Register 0x64
+      $cr65 = Read-SuperIoRegister -Register 0x65
+      $normalBase = (($cr60 -band 0xFF) -shl 8) -bor ($cr61 -band 0xFF)
+      $readOnlyBase = (($cr64 -band 0xFF) -shl 8) -bor ($cr65 -band 0xFF)
+
+      $result.baseDiscovery = [ordered]@{
+        logicalDevice = 0x0B
+        logicalDeviceHex = "0x0B"
+        cr30 = $cr30
+        cr30Hex = Convert-ByteToHex $cr30
+        activeBitSet = (($cr30 -band 0x01) -ne 0)
+        cr60 = $cr60
+        cr60Hex = Convert-ByteToHex $cr60
+        cr61 = $cr61
+        cr61Hex = Convert-ByteToHex $cr61
+        normalBase = $normalBase
+        normalBaseHex = Convert-WordToHex $normalBase
+        normalBaseValid = Test-ValidIoBase $normalBase
+        cr64 = $cr64
+        cr64Hex = Convert-ByteToHex $cr64
+        cr65 = $cr65
+        cr65Hex = Convert-ByteToHex $cr65
+        readOnlyBase = $readOnlyBase
+        readOnlyBaseHex = Convert-WordToHex $readOnlyBase
+        readOnlyBaseValid = Test-ValidIoBase $readOnlyBase
+        findBarsInConfigMode = Convert-CallResult (Invoke-PawnIo -Name "ioctl_find_bars" -InputCells ([UInt64[]]@()) -OutputCells 0)
+      }
+
+      if ($IncludeHmRead -and (Test-ValidIoBase $normalBase)) {
+        $result.hardwareMonitorDump = Read-NuvotonHmCandidateDump -BaseAddress ([UInt16]$normalBase)
+      }
+    }
+  } catch {
+    $result.error = $_.Exception.Message
+  } finally {
+    $result.exit = Convert-CallResult (Exit-NuvotonConfig -IndexPort $IndexPort)
+  }
+
+  return $result
+}
+
+function Probe-IteSlot {
+  param([int]$Slot, [UInt16]$IndexPort)
+
+  $result = [ordered]@{
+    vendor = "ite"
+    error = $null
+    exit = $null
+    chipId = $null
+  }
+
+  try {
+    Enter-IteConfig -Slot $Slot -IndexPort $IndexPort
+    $high = Read-SuperIoRegister -Register 0x20
+    $low = Read-SuperIoRegister -Register 0x21
+    $result.chipId = Get-ChipIdFields -High $high -Low $low
+  } catch {
+    $result.error = $_.Exception.Message
+  } finally {
+    $result.exit = Convert-CallResult (Exit-IteConfig)
+  }
+
+  return $result
+}
+
+function Probe-SuperIoSlots {
+  $slots = @(
+    [pscustomobject]@{ Slot = 0; IndexPort = [UInt16]0x2E; DataPort = [UInt16]0x2F },
+    [pscustomobject]@{ Slot = 1; IndexPort = [UInt16]0x4E; DataPort = [UInt16]0x4F }
+  )
+
+  return @($slots | ForEach-Object {
+    $slot = $_
+    $slotResult = [ordered]@{
+      slot = $slot.Slot
+      indexPort = [int]$slot.IndexPort
+      indexPortHex = Convert-WordToHex $slot.IndexPort
+      dataPort = [int]$slot.DataPort
+      dataPortHex = Convert-WordToHex $slot.DataPort
+      selectSlot = $null
+      findBarsBeforeConfig = $null
+      attempts = @()
+    }
+
+    $select = Invoke-PawnIo -Name "ioctl_select_slot" -InputCells ([UInt64[]]@([UInt64]$slot.Slot)) -OutputCells 0
+    $slotResult.selectSlot = Convert-CallResult $select
+    if ($select.succeeded) {
+      $slotResult.findBarsBeforeConfig = Convert-CallResult (Invoke-PawnIo -Name "ioctl_find_bars" -InputCells ([UInt64[]]@()) -OutputCells 0)
+      $slotResult.attempts = @(
+        Probe-NuvotonSlot -Slot $slot.Slot -IndexPort $slot.IndexPort
+        Probe-IteSlot -Slot $slot.Slot -IndexPort $slot.IndexPort
+      )
+    }
+
+    $slotResult
+  })
+}
+
+$installCandidates = Get-PawnIoInstallCandidates
+$dllPath = Find-FirstNamedFile -Roots $installCandidates -Names @("PawnIOLib.dll")
+$modulePath = Find-FirstNamedFile -Roots $installCandidates -Names @("LpcIO.bin", "LpcIO.amx")
+
+$result = [ordered]@{
+  schema = "hardwarevisualizer.superio-hm-dump.v1"
+  capturedAt = (Get-Date).ToString("o")
+  dryRun = [bool]$DryRun
+  elevated = Test-IsElevated
+  includeBaseDiscovery = [bool]$IncludeBaseDiscovery
+  includeHmRead = [bool]$IncludeHmRead
+  safety = [ordered]@{
+    purpose = "Independent hardware-validation dump for spec authoring; not a production implementation path."
+    writesAllowed = @(
+      "Super I/O configuration-mode entry/exit",
+      "Super I/O logical-device selection",
+      "Hardware Monitor index selection",
+      "Hardware Monitor bank selection when -IncludeHmRead is set"
+    )
+    writesProhibited = @(
+      "fan-control/PWM registers",
+      "threshold/limit registers",
+      "alarm-clear registers",
+      "GPIO registers",
+      "activation registers"
+    )
+  }
+  machine = [ordered]@{
+    baseBoard = Get-CimSummary -ClassName "Win32_BaseBoard"
+    processor = Get-CimSummary -ClassName "Win32_Processor"
+    operatingSystem = Get-CimSummary -ClassName "Win32_OperatingSystem"
+  }
+  pawnio = [ordered]@{
+    installCandidates = @($installCandidates)
+    dllPath = $dllPath
+    modulePath = $modulePath
+    libraryLoadable = $false
+    version = $null
+    versionHex = $null
+    open = $null
+    moduleLoad = $null
+  }
+  mutex = $null
+  slots = @()
+  error = $null
+}
+
+try {
+  if ($null -eq $dllPath) {
+    throw "PawnIOLib.dll was not found. Pass -PawnIoRoot if PawnIO is installed in a non-standard location."
+  }
+  if ($null -eq $modulePath) {
+    throw "LpcIO.bin or LpcIO.amx was not found. Pass -PawnIoRoot if the LpcIO module is installed in a non-standard location."
+  }
+
+  if ($DryRun) {
+    return
+  }
+
+  $script:PawnIoLibrary = [PawnIoNative]::LoadLibrary($dllPath)
+  $result.pawnio.libraryLoadable = $true
+
+  [UInt32]$version = 0
+  $versionHr = [PawnIoNative]::Version($script:PawnIoLibrary, [ref]$version)
+  $result.pawnio.versionCall = [ordered]@{
+    hresult = Format-HResult $versionHr
+    succeeded = Test-HResultSucceeded $versionHr
+  }
+  if (Test-HResultSucceeded $versionHr) {
+    $result.pawnio.version = [int64]$version
+    $result.pawnio.versionHex = ("0x{0:X8}" -f $version)
+  }
+
+  $openHr = [PawnIoNative]::Open($script:PawnIoLibrary, [ref]$script:PawnIoHandle)
+  $result.pawnio.open = [ordered]@{
+    hresult = Format-HResult $openHr
+    succeeded = (Test-HResultSucceeded $openHr) -and ($script:PawnIoHandle -ne [IntPtr]::Zero)
+  }
+  if (-not $result.pawnio.open.succeeded) {
+    throw "pawnio_open failed: $($result.pawnio.open.hresult)"
+  }
+
+  $blob = [IO.File]::ReadAllBytes($modulePath)
+  $loadHr = [PawnIoNative]::Load($script:PawnIoLibrary, $script:PawnIoHandle, $blob)
+  $result.pawnio.moduleLoad = [ordered]@{
+    hresult = Format-HResult $loadHr
+    succeeded = Test-HResultSucceeded $loadHr
+    bytes = $blob.Length
+  }
+  if (-not $result.pawnio.moduleLoad.succeeded) {
+    throw "pawnio_load failed: $($result.pawnio.moduleLoad.hresult)"
+  }
+
+  $mutexName = "Global\Access_ISABUS.HTP.Method"
+  try {
+    $mutex = [Threading.Mutex]::OpenExisting($mutexName)
+    $mutexSource = "opened-existing"
+  } catch [Threading.WaitHandleCannotBeOpenedException] {
+    $mutex = [Threading.Mutex]::new($false, $mutexName)
+    $mutexSource = "created"
+  }
+
+  $acquired = $false
+  try {
+    $acquired = $mutex.WaitOne($MutexTimeoutMs)
+    $result.mutex = [ordered]@{
+      name = $mutexName
+      source = $mutexSource
+      timeoutMs = $MutexTimeoutMs
+      acquired = $acquired
+    }
+    if (-not $acquired) {
+      throw "Timed out waiting for $mutexName"
+    }
+
+    $result.slots = Probe-SuperIoSlots
+  } finally {
+    if ($acquired) {
+      $mutex.ReleaseMutex()
+    }
+    if ($null -ne $mutex) {
+      $mutex.Dispose()
+    }
+  }
+} catch {
+  $result.error = $_.Exception.Message
+} finally {
+  if ($script:PawnIoHandle -ne [IntPtr]::Zero -and $script:PawnIoLibrary -ne [IntPtr]::Zero) {
+    try {
+      $closeHr = [PawnIoNative]::Close($script:PawnIoLibrary, $script:PawnIoHandle)
+      $result.pawnio.close = [ordered]@{
+        hresult = Format-HResult $closeHr
+        succeeded = Test-HResultSucceeded $closeHr
+      }
+    } catch {
+      $result.pawnio.close = [ordered]@{
+        hresult = $null
+        succeeded = $false
+        error = $_.Exception.Message
+      }
+    }
+  }
+  if ($script:PawnIoLibrary -ne [IntPtr]::Zero) {
+    [void][PawnIoNative]::FreeLibrary($script:PawnIoLibrary)
+  }
+
+  $outputDirectory = Split-Path -Parent $OutputPath
+  if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -LiteralPath $outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+  }
+
+  $json = ($result | ConvertTo-Json -Depth 32) -replace "`r`n", "`n"
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  [System.IO.File]::WriteAllText([System.IO.Path]::GetFullPath($OutputPath), $json + "`n", $utf8NoBom)
+  Write-Host "Wrote Super I/O diagnostic bundle to $OutputPath"
+  if (-not $result.elevated) {
+    Write-Warning "This run was not elevated. Re-run from Administrator PowerShell for real PawnIO driver access if pawnio_open failed with 0x80070005."
+  }
+  if ($IncludeHmRead) {
+    Write-Warning "-IncludeHmRead performs raw HM index/data read plumbing for validation only. Attach the JSON to the spec-author handoff; do not use it as production decode evidence until the spec is implementation-ready."
+  }
+}


### PR DESCRIPTION
﻿## Summary

- add a PowerShell diagnostic helper for clean-room Super I/O / PawnIO LpcIO hardware-validation captures
- preserve the 2026-06-28 elevated NZXT N7 B650E raw JSON evidence plus a readable evidence summary
- record the 0xD802 source-hunt and independent AIDA64 dump evidence, then flip the scoped Nuvoton 0xD802 / NCT6799D normal-HM path to `Implementation-ready (rev 5)`
- keep unsupported scopes disabled: NCT6796D runtime enablement, read-only HM, count-based RPM, AUXFANIN4/seventh fan, voltages, PWM/control, and UI integration

## Related Issues

- Related to #1635

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A — spec/evidence/tooling only.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Validation performed:

- `git diff --cached --check`
- PowerShell parser check for `scripts/diagnostics/capture-superio-hm-dump.ps1`
- diagnostic script dry-run with `-DryRun`
- standard-rights diagnostic run confirming `pawnio_open failed: 0x80070005`
- elevated Administrator run captured `tmp/superio-hm-dump-admin.json` and the committed durable copy parses as UTF-8 JSON
- durable evidence JSON confirms slot 0 Nuvoton `0xD802`, LDN B normal HM base `0x0290`, successful `ioctl_find_bars`, and 34/34 bank 4 HM byte reads

## Clean-room scope notes

This is not a Rust sensor implementation PR. It changes spec/evidence/handoff material and adds a validation helper script. The rev 5 spec explicitly scopes enablement to 0xD802 / NCT6799D normal-HM bank 4 byte temperatures and direct RPM pairs; all unresolved or control-writing paths remain disabled.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`git diff --cached --check`; no app lint needed for docs/script-only change)
- [x] Tests pass (targeted script/JSON validation above; no app unit tests needed for docs/script-only change)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics script to capture Super I/O and Hardware Monitor validation data in a structured report.
  * Added new evidence notes documenting Nuvoton chip identification and hardware-monitor readings.
* **Documentation**
  * Updated sensor documentation to mark the Nuvoton `0xD802` / `NCT6799D` normal Hardware Monitor read path as implementation-ready.
  * Clarified the validated scope and narrowed remaining open items to other hardware targets and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->