### PR TITLE
fix: pin window-vibrancy to Tauri-compatible version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,8 @@ updates:
       - dependency-name: "tauri-build"
       - dependency-name: "tauri-plugin-*"
       - dependency-name: "tauri-specta"
+      # Keep aligned with Tauri's 0.6 dependency; 0.7 duplicates macOS Objective-C symbols under release LTO.
+      - dependency-name: "window-vibrancy"
 
   - package-ecosystem: "rust-toolchain"
     directory: "/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "winapi",
- "window-vibrancy 0.7.1",
+ "window-vibrancy",
  "windows 0.62.2",
  "wmi",
 ]
@@ -5384,7 +5384,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "window-vibrancy 0.6.0",
+ "window-vibrancy",
  "windows 0.61.3",
 ]
 
@@ -6850,21 +6850,6 @@ dependencies = [
  "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
- "windows-version",
-]
-
-[[package]]
-name = "window-vibrancy"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010797bd7c40396fbc59d3105089fed0885fe267a0ef4a0a4646df54e28647f6"
-dependencies = [
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "raw-window-handle",
- "windows-sys 0.60.2",
  "windows-version",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,7 +99,7 @@ objc2 = "0.6.4"
 # `NSVisualEffectViewTagged` Objective-C class, and the release profile's LTO
 # (`lto = true`, `codegen-units = 1`) then fails the macOS link with
 # "symbol multiply defined" for `__CLASS_NSVisualEffectViewTagged` (see #1724/#1718).
-window-vibrancy = "0.7"
+window-vibrancy = "0.6"
 objc2-app-kit = { version = "0.3.2", features = [
     "NSAttributedString",
     "NSButton",


### PR DESCRIPTION
## Summary

- Pin `window-vibrancy` back to `0.6` so the app uses the same version as Tauri.
- Remove the extra `window-vibrancy 0.7.1` entry from `Cargo.lock`.
- Add a Dependabot ignore entry so this crate is not automatically bumped past Tauri's compatible version again.

Root cause: `window-vibrancy 0.7.1` introduced a second semver-incompatible copy next to Tauri's `0.6.0` dependency. On macOS release builds, LTO then hit duplicate Objective-C symbols for `NSVisualEffectViewTagged` and failed the `test-build (macos-latest)` CI job.

## Related Issues

- None

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [x] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Validation performed:

- `cargo tree -p hardware_visualizer -i window-vibrancy --locked --offline`
- `npm run tauri build -- --no-bundle`
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to avoid automatic bumps for a specific macOS-related package.
  * Adjusted a macOS compatibility setting to better match the app’s current platform requirements, helping prevent build and link issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->