### PR TITLE
perf(db): batch process_stats inserts in a single transaction

### DIFF
--- a/core/src/infrastructure/database/process_stats.rs
+++ b/core/src/infrastructure/database/process_stats.rs
@@ -2,7 +2,12 @@ use super::db;
 use crate::persistence::archive_data::ProcessStatData;
 
 pub async fn insert(processes: Vec<ProcessStatData>) -> Result<(), sqlx::Error> {
+  if processes.is_empty() {
+    return Ok(());
+  }
+
   let pool = db::get_pool().await?;
+  let mut tx = pool.begin().await?;
 
   for proc in processes {
     sqlx::query(
@@ -15,10 +20,11 @@ pub async fn insert(processes: Vec<ProcessStatData>) -> Result<(), sqlx::Error> 
     .bind(proc.memory_usage)
     .bind(proc.execution_sec)
     .bind(chrono::Utc::now())
-    .execute(&pool)
+    .execute(&mut *tx)
     .await?;
   }
 
+  tx.commit().await?;
   Ok(())
 }
 


### PR DESCRIPTION
## Summary

`process_stats::insert` executed each row directly against the connection pool, so every row in the per-tick batch (up to `PROCESS_RECORD_LIMIT * 3`) ran as its own implicit transaction — one commit/fsync per row. This wraps the batch in a single transaction and commits once, so a tick performs one fsync instead of up to ~15. Behaviour is unchanged; only the commit boundary moves.

The pattern mirrors the existing `storage_health.rs::insert_daily_records` (`pool.begin()` → execute in loop → `tx.commit()`). An early return keeps the empty-batch path free of a no-op transaction.

## Related Issues

Closes #1575

## Type of Change

- [x] Other — performance (`perf/` branch)

## Screenshots / Videos

N/A — no user-facing change.

## Test Plan

- [x] Reviewed against the existing `insert_daily_records` transaction pattern; the change is behaviour-preserving (same rows, same order, single commit).
- [ ] Unit tests — not added; happy to add a regression test if you'd like one.

> Note: linting/formatting/tests are validated by CI (`cargo tauri-fmt`, `cargo tauri-lint`, `cargo tauri-test`); I have not run them locally.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass — pending CI
- [ ] Tests pass — pending CI
- [x] No new warnings or errors expected (minimal, self-contained change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data insertion reliability by processing multiple records as a single atomic operation.
  * Prevented unnecessary work when there is nothing to save, reducing empty-operation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->