### PR TITLE
ci: pin cargo-deny for license checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
           components: ""
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --version 0.19.4 --locked
 
       - name: Check Rust licenses
         run: cargo deny --manifest-path Cargo.toml check --config src-tauri/deny.toml licenses


### PR DESCRIPTION
## Summary

- pin the CI `cargo-deny` install to 0.19.4 with Cargo's locked dependency graph
- retain the established license-check command syntax supported by that release
- prevent the unpinned 0.20 update from blocking all Rust license matrix jobs

## Type of Change

- [x] CI/CD (`ci/` branch)

## Validation

- `cargo deny --manifest-path Cargo.toml check --config src-tauri/deny.toml licenses --help`
- `git diff --check`

## Notes

The failing command was already present on `develop`; this is a focused CI reliability repair required to unblock PR #1786.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the license-checking tool to a specific version for more consistent automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->