### PR TITLE
fix: pin cargo-deny for license checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       tauri-changed: ${{ steps.changes.outputs.tauri }}
       frontend-deps-changed: ${{ steps.changes.outputs.frontend-deps }}
       backend-deps-changed: ${{ steps.changes.outputs.backend-deps }}
+      cargo-license-config-changed: ${{ steps.changes.outputs.cargo-license-config }}
       tauri-deps-changed: ${{ steps.tauri-deps.outputs.changed }}
       actions-changed: ${{ steps.changes.outputs.actions }}
     steps:
@@ -83,6 +84,10 @@ jobs:
               - '.cargo/**'
               - '.github/actions/**'
               - '.github/scripts/**'
+            cargo-license-config:
+              - 'src-tauri/deny.toml'
+              - '.github/actions/setup-rust/**'
+              - '.github/workflows/ci.yml'
             actions:
               - '.github/workflows/**'
               - '.github/actions/**'
@@ -716,7 +721,7 @@ jobs:
 
   license-check-cargo:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.cargo-license-config-changed == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
           components: ""
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --version 0.19.4 --locked
 
       - name: Check Rust licenses
         run: cargo deny --manifest-path Cargo.toml check --config src-tauri/deny.toml licenses


### PR DESCRIPTION
## Summary

- pin the CI `cargo-deny` install to 0.19.4 with Cargo's locked dependency graph
- retain the established license-check command syntax supported by that release
- prevent the unpinned 0.20 update from blocking all Rust license matrix jobs

## Type of Change

- [x] Bug fix (`fix/` branch)

## Validation

- `cargo deny --manifest-path Cargo.toml check --config src-tauri/deny.toml licenses --help`
- `git diff --check`

## Notes

The failing command was already present on `develop`; this is a focused CI reliability repair required to unblock PR #1786.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI change detection so license verification runs when Rust license-check configuration inputs are modified.
  * Standardized the license verification tool setup by installing a pinned, lock-respecting `cargo-deny` version to improve consistency and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->