### PR TITLE
fix(dev): select Tauri app as default binary

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["@shm11C3"]
 license = "MIT"
 repository = ""
 edition = "2024"
+default-run = "hardware_visualizer"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Summary

Set `default-run = "hardware_visualizer"` in the Tauri app manifest so the standard `npm run tauri:dev` command selects the application binary automatically.

Tauri dev delegates to `cargo run` without `--bin`. After the feature-gated `export_bindings` binary was added, Cargo could no longer choose between `export_bindings` and `hardware_visualizer`, causing development startup to exit before compilation.

This keeps binding export explicit while restoring the documented development command.

## Related Issues

None.

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable; this changes Cargo's development binary selection.

## Test Plan

- [x] Manual testing
  - Confirmed Cargo metadata reports `default_run=hardware_visualizer`.
  - Ran `npm run tauri:dev` without additional `--bin` arguments.
  - Confirmed the Tauri command passed the previous ambiguity point, completed the app build, and launched `target/debug/hardware_visualizer`.
- [ ] Unit tests
  - Not applicable for this manifest-only binary-selection change.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo fmt --all -- --check`)
- [x] Tests pass (manual development-startup verification)
- [x] No new build warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the default application executable for standard project run commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->