### PR TITLE
perf(db): backport batched process stats inserts for v1.9.2

### DIFF
--- a/core/src/infrastructure/database/process_stats.rs
+++ b/core/src/infrastructure/database/process_stats.rs
@@ -2,7 +2,12 @@ use super::db;
 use crate::persistence::archive_data::ProcessStatData;
 
 pub async fn insert(processes: Vec<ProcessStatData>) -> Result<(), sqlx::Error> {
+  if processes.is_empty() {
+    return Ok(());
+  }
+
   let pool = db::get_pool().await?;
+  let mut tx = pool.begin().await?;
 
   for proc in processes {
     sqlx::query(
@@ -15,10 +20,11 @@ pub async fn insert(processes: Vec<ProcessStatData>) -> Result<(), sqlx::Error> 
     .bind(proc.memory_usage)
     .bind(proc.execution_sec)
     .bind(chrono::Utc::now())
-    .execute(&pool)
+    .execute(&mut *tx)
     .await?;
   }
 
+  tx.commit().await?;
   Ok(())
 }
 


### PR DESCRIPTION
## Summary

Backport the existing process-stat persistence optimization for the v1.9.2 maintenance release.

- batch one collection cycle of `PROCESS_STATS` inserts in a single transaction
- keep the empty-batch path free of a no-op transaction
- preserve the existing row contents and retention behavior

This is a direct `cherry-pick -x` of `73478465534dd0d53924028f95bb8e578dbb6cfb` from #1783. The branch uses `chore/` because the current `v1.9.x` branch-name workflow predates `perf/` support.

## Related Issues

- Backport of #1783
- Target release: v1.9.2

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` change kind; `chore/` branch for v1.9.x compatibility)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [ ] Manual testing
- [x] Unit tests
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p hardviz-core process_stats -- --nocapture` (3 passed)

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Focused tests pass
- [x] No new warnings or errors

## Release follow-up

Additional v1.9.2 dependency backports should be selected explicitly and added through separately reviewable commits so feature-only dependency changes from `develop` are not pulled into the maintenance branch.
