### PR TITLE
docs: preserve maintainer direction during AI review

### DIFF
--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -20,6 +20,7 @@ Separate AI review noise from useful feedback. Inspect review threads, classify 
    - Fetch inline review threads with resolved/outdated state.
    - Fetch top-level PR comments and review submissions to catch bot summaries, approvals, and nitpick-only reviews.
    - Note the author for each item. Treat Copilot, CodeRabbit, and similar bot comments as advisory until verified.
+   - Extract binding constraints from the user request, explicit maintainer corrections, and accepted canonical decisions. Use them as the classification boundary rather than treating them as advisory inputs equal to bot feedback.
 
 3. Use the best available retrieval method.
    - If GitHub connector tools are available, prefer `_list_pull_request_review_threads` for inline threads and `_fetch_pr_comments` for the merged PR timeline.
@@ -32,13 +33,15 @@ Separate AI review noise from useful feedback. Inspect review threads, classify 
    - `Should Fix`: non-blocking but clearly correct feedback that removes misleading code, unrealistic tests, stale comments, fragile behavior, or likely reviewer follow-up.
    - `Worth Fixing`: small low-risk change that improves clarity, test realism, performance in a hot path, user-visible behavior, or future maintainability.
    - `Optional`: nitpick, style preference, docstring/coverage suggestion outside project requirements, or UX improvement with fallback already implemented.
-   - `Ignore`: outdated, resolved, duplicate, incorrect after local verification, or unrelated to this PR.
+   - `Ignore`: outdated, resolved, duplicate, incorrect after local verification, unrelated to this PR, or conflicts with a binding maintainer constraint without evidence that the decision must be reopened.
 
 5. Verify before editing.
+   - Check the proposed edit against the binding constraints before judging only its local technical correctness. A plausible implementation can still be the wrong product behavior or scope.
    - Reproduce claimed CI-impacting issues locally when feasible.
    - Inspect the referenced code, not only the bot wording.
    - If a bot says "warnings-as-errors" or similar, run the relevant check before treating it as required.
    - Only mark Required if the issue is verifiable with reproduction/test evidence or deterministically verifiable from available data; if verification isn't possible, downgrade to Should Fix with a 'needs verification' tag (or Ignore if clearly stale/duplicate).
+   - If a comment conflicts with a binding constraint, preserve the constraint and report the conflict. If the comment exposes new correctness, safety, or consistency evidence, return that evidence to the maintainer instead of silently overriding the direction or implementing a compromise that weakens it.
 
 6. Decide action.
    - Treat `Required`, `Should Fix`, and `Worth Fixing` as fix targets by default. Note: fix targets assume verification feasibility has been assessed per Step 5.

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -102,6 +102,7 @@ shared enforcement surface.
 - [Separate environment failures from product regressions](separate-environment-failures.md)
 - [Verify user-visible results](verify-user-visible-results.md)
 - [Preserve clean-room specification gates](preserve-clean-room-spec-gates.md)
+- [Preserve maintainer direction during AI review](preserve-maintainer-direction-during-ai-review.md)
 - [Prevent Tauri dependency version skew](prevent-tauri-dependency-version-skew.md)
 - [Keep shared rules agent-neutral](keep-shared-rules-agent-neutral.md)
 - [Make navigation levels explicit](make-navigation-levels-explicit.md)

--- a/docs/agents/lessons/preserve-maintainer-direction-during-ai-review.md
+++ b/docs/agents/lessons/preserve-maintainer-direction-during-ai-review.md
@@ -1,0 +1,27 @@
+---
+id: LRN-20260720-preserve-maintainer-direction-during-ai-review
+status: promoted
+cause_status: confirmed
+scope: AI-generated pull request review triage and maintainer-confirmed product constraints
+trigger: an AI review proposes a change that conflicts with an explicit maintainer correction, scope boundary, or accepted decision
+failure_signature: advisory review feedback was treated as authoritative and risked reintroducing successful-reading UI metadata that the maintainer had explicitly excluded
+root_cause: review triage verified local technical plausibility without first binding classification to the maintainer-confirmed product and scope constraints
+guardrail: .agents/skills/gh-ai-review-triage/SKILL.md
+canonical_refs: .agents/skills/gh-ai-review-triage/SKILL.md
+verification: confirm the triage extracts binding constraints, classifies conflicting AI feedback as Ignore, preserves the requested direction, and escalates genuinely new correctness or safety evidence instead of silently overriding it
+evidence: "PR #1836 body and review feedback concerning successful-reading verification metadata; maintainer correction recorded in the PR implementation direction"
+revalidate_when: review authority, AI review classification, or maintainer-decision handling changes
+---
+
+# Preserve Maintainer Direction During AI Review
+
+AI review feedback is advisory. Before deciding whether a comment is a fix
+target, extract the binding product and scope constraints from the request,
+explicit maintainer corrections, and accepted decision sources. A suggestion
+that is technically plausible but reverses one of those constraints is not an
+improvement to the requested change.
+
+Classify such feedback as `Ignore` and state the conflict. If it presents new
+correctness, safety, or internal-consistency evidence, bring that evidence back
+to the maintainer rather than silently changing direction or implementing a
+compromise that weakens the confirmed constraint.


### PR DESCRIPTION
## Summary

- make AI review triage extract explicit maintainer constraints before classifying suggestions
- classify conflicting bot feedback as Ignore unless it brings new correctness, safety, or consistency evidence that must be returned to the maintainer
- record the confirmed learning and revalidation boundary separately from the product implementation in #1836

## Related Issues

Follow-up to #1836.

## Type of Change

- [ ] Bug fix (fix/ branch)
- [ ] New feature (feat/ branch)
- [ ] Refactoring (refactor/ branch)
- [ ] Performance (perf/ branch)
- [x] Documentation (docs/ branch)
- [ ] Dependencies update
- [ ] Other (chore/ branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
  - reviewed the classification flow against the PR #1836 metadata-conflict example
- [ ] Unit tests
- [x] Agent guidance validation
  - npm run check:agent-guidance
  - git diff --check

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Relevant validation passes
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI review triage guidance to prioritize explicit maintainer decisions and scope constraints.
  * Clarified when conflicting AI feedback should be ignored and when new evidence should be escalated for review.
  * Added a lesson documenting how to preserve maintainer direction during AI-assisted reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->