### PR TITLE
fix: enable recognized CPU sensors experimentally (v1.9.x)

### DIFF
--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -8,6 +8,10 @@
 //! Tauri `HardwareMonitorUpdate` event.
 
 use crate::collector::HistoryStore;
+#[cfg(target_os = "windows")]
+use crate::infrastructure::providers::cpu_temperature::{
+  CpuPackageTemperature, CpuPackageTemperatureError, CpuTemperatureSource,
+};
 use crate::models::{
   ExternalComponentGuidanceCandidate, GpuMetric, MetricsSnapshot, ProcessSample,
   SensorTemperature,
@@ -44,7 +48,7 @@ pub struct TemperatureSample {
 
 /// Read the latest CPU / sensor temperatures.
 ///
-/// Windows: prefer CPU package temperature from a supported PawnIO source,
+/// Windows: prefer CPU package temperature from a recognized PawnIO source,
 /// then fall back to ACPI thermal zones via the WMI sampler thread. When only
 /// ACPI is available, the headline CPU value picks a CPU-named zone when one
 /// exists, otherwise the hottest zone — see
@@ -63,10 +67,7 @@ pub fn sample_temperatures() -> TemperatureSample {
 
 #[cfg(target_os = "windows")]
 fn build_temperature_sample(
-  pawnio_cpu_temperature: Result<
-    crate::infrastructure::providers::cpu_temperature::CpuPackageTemperature,
-    String,
-  >,
+  pawnio_cpu_temperature: Result<CpuPackageTemperature, CpuPackageTemperatureError>,
   mut sensor_temperatures: Vec<SensorTemperature>,
 ) -> TemperatureSample {
   match pawnio_cpu_temperature {
@@ -74,15 +75,7 @@ fn build_temperature_sample(
       sensor_temperatures.insert(
         0,
         SensorTemperature {
-          name: match sample.source {
-            crate::infrastructure::providers::cpu_temperature::CpuTemperatureSource::IntelDtsPackageMsr => {
-              "CPU Package (PawnIO Intel DTS)"
-            }
-            crate::infrastructure::providers::cpu_temperature::CpuTemperatureSource::AmdZenSmnTctl => {
-              "CPU Package (PawnIO AMD SMN)"
-            }
-          }
-          .to_string(),
+          name: cpu_package_sensor_name(&sample).to_string(),
           temperature: sample.temperature_celsius,
         },
       );
@@ -93,22 +86,34 @@ fn build_temperature_sample(
         guidance_candidates: Vec::new(),
       }
     }
-    Err(pawnio_reason) => {
+    Err(pawnio_error) => {
+      let pawnio_reason = pawnio_error.to_string();
+      let component_failed = matches!(
+        &pawnio_error,
+        CpuPackageTemperatureError::Unavailable { .. }
+      );
       let cpu_temperature =
         crate::utils::thermal::select_cpu_temperature(&sensor_temperatures);
-      let unavailable_reason = cpu_temperature.is_none().then(|| {
-        format!("PawnIO unavailable ({pawnio_reason}); ACPI thermal zones unavailable")
+      let unavailable_reason = cpu_temperature.is_none().then(|| match &pawnio_error {
+        CpuPackageTemperatureError::Unsupported(_) => format!(
+          "PawnIO CPU package path unsupported ({pawnio_reason}); ACPI thermal zones unavailable"
+        ),
+        CpuPackageTemperatureError::Unavailable { .. } => {
+          format!("PawnIO unavailable ({pawnio_reason}); ACPI thermal zones unavailable")
+        }
+        CpuPackageTemperatureError::Internal(_) => format!(
+          "CPU temperature sampler internal error ({pawnio_reason}); ACPI thermal zones unavailable"
+        ),
       });
-      let guidance_candidates = unavailable_reason
-        .as_ref()
-        .map(|reason| {
-          vec![
-            ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
-              reason.clone(),
-            ),
-          ]
-        })
-        .unwrap_or_default();
+      let guidance_candidates = if component_failed && cpu_temperature.is_none() {
+        vec![
+          ExternalComponentGuidanceCandidate::pawnio_cpu_package_temperature(
+            pawnio_reason,
+          ),
+        ]
+      } else {
+        Vec::new()
+      };
       TemperatureSample {
         cpu_temperature,
         sensor_temperatures,
@@ -116,6 +121,14 @@ fn build_temperature_sample(
         guidance_candidates,
       }
     }
+  }
+}
+
+#[cfg(target_os = "windows")]
+fn cpu_package_sensor_name(sample: &CpuPackageTemperature) -> &'static str {
+  match sample.source {
+    CpuTemperatureSource::IntelDtsPackageMsr => "CPU Package (PawnIO Intel DTS)",
+    CpuTemperatureSource::AmdZenSmnTctl => "CPU Package (PawnIO AMD SMN)",
   }
 }
 
@@ -756,6 +769,14 @@ mod tests {
   }
 
   #[cfg(target_os = "windows")]
+  fn pawnio_failure(reason: &str) -> CpuPackageTemperatureError {
+    CpuPackageTemperatureError::Unavailable {
+      reason: reason.to_string(),
+      enablement: crate::models::SensorEnablement::Verified,
+    }
+  }
+
+  #[cfg(target_os = "windows")]
   #[test]
   fn windows_temperature_sample_prefers_pawnio_cpu_package() {
     let sample = build_temperature_sample(
@@ -782,9 +803,29 @@ mod tests {
 
   #[cfg(target_os = "windows")]
   #[test]
+  fn windows_temperature_sample_keeps_the_standard_amd_source_label() {
+    let sample = build_temperature_sample(
+      Ok(CpuPackageTemperature {
+        temperature_celsius: 63.5,
+        source: CpuTemperatureSource::AmdZenSmnTctl,
+      }),
+      Vec::new(),
+    );
+
+    assert_eq!(sample.cpu_temperature, Some(63.5));
+    assert_eq!(
+      sample.sensor_temperatures[0].name,
+      "CPU Package (PawnIO AMD SMN)"
+    );
+    assert!(sample.unavailable_reason.is_none());
+    assert!(sample.guidance_candidates.is_empty());
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
   fn windows_temperature_sample_falls_back_to_acpi_cpu_zone() {
     let sample = build_temperature_sample(
-      Err("PawnIOLib.dll not found".to_string()),
+      Err(pawnio_failure("PawnIOLib.dll not found")),
       vec![
         SensorTemperature {
           name: "TZ00".into(),
@@ -805,7 +846,7 @@ mod tests {
   #[test]
   fn windows_temperature_sample_returns_unavailable_reason_when_all_sources_fail() {
     let sample =
-      build_temperature_sample(Err("pawnio_open failed".to_string()), Vec::new());
+      build_temperature_sample(Err(pawnio_failure("pawnio_open failed")), Vec::new());
 
     assert_eq!(sample.cpu_temperature, None);
     assert_eq!(
@@ -817,8 +858,10 @@ mod tests {
   #[cfg(target_os = "windows")]
   #[test]
   fn windows_temperature_sample_returns_guidance_when_pawnio_and_acpi_fail() {
-    let sample =
-      build_temperature_sample(Err("PawnIOLib.dll not found".to_string()), Vec::new());
+    let sample = build_temperature_sample(
+      Err(pawnio_failure("PawnIOLib.dll not found")),
+      Vec::new(),
+    );
 
     assert_eq!(sample.cpu_temperature, None);
     assert_eq!(sample.guidance_candidates.len(), 1);
@@ -834,9 +877,72 @@ mod tests {
 
   #[cfg(target_os = "windows")]
   #[test]
+  fn windows_temperature_sample_identifies_an_experimental_failure() {
+    let sample = build_temperature_sample(
+      Err(CpuPackageTemperatureError::Unavailable {
+        reason: "CPU temperature decode failed".to_string(),
+        enablement: crate::models::SensorEnablement::Experimental,
+      }),
+      Vec::new(),
+    );
+
+    assert_eq!(
+      sample.unavailable_reason.as_deref(),
+      Some(
+        "PawnIO unavailable (experimental CPU package temperature attempt failed: CPU temperature decode failed); ACPI thermal zones unavailable"
+      )
+    );
+    assert_eq!(
+      sample.guidance_candidates[0].diagnostic_detail.as_deref(),
+      Some(
+        "experimental CPU package temperature attempt failed: CPU temperature decode failed"
+      )
+    );
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_suppresses_guidance_for_unsupported_cpu_path() {
+    let sample = build_temperature_sample(
+      Err(CpuPackageTemperatureError::Unsupported(
+        crate::infrastructure::providers::cpu_temperature::CpuTemperatureFallbackReason::AmdFamilyUnsupported(0x16),
+      )),
+      Vec::new(),
+    );
+
+    assert_eq!(
+      sample.unavailable_reason.as_deref(),
+      Some(
+        "PawnIO CPU package path unsupported (AMD family 0x16 is unsupported by the PawnIO RyzenSMU path); ACPI thermal zones unavailable"
+      )
+    );
+    assert!(sample.guidance_candidates.is_empty());
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
+  fn windows_temperature_sample_suppresses_guidance_for_internal_failure() {
+    let sample = build_temperature_sample(
+      Err(CpuPackageTemperatureError::Internal(
+        "CPU temperature sampler lock poisoned".to_string(),
+      )),
+      Vec::new(),
+    );
+
+    assert_eq!(
+      sample.unavailable_reason.as_deref(),
+      Some(
+        "CPU temperature sampler internal error (CPU temperature sampler lock poisoned); ACPI thermal zones unavailable"
+      )
+    );
+    assert!(sample.guidance_candidates.is_empty());
+  }
+
+  #[cfg(target_os = "windows")]
+  #[test]
   fn windows_temperature_sample_does_not_return_guidance_when_acpi_fallback_succeeds() {
     let sample = build_temperature_sample(
-      Err("PawnIOLib.dll not found".to_string()),
+      Err(pawnio_failure("PawnIOLib.dll not found")),
       vec![SensorTemperature {
         name: "CPUZ".into(),
         temperature: 51.0,

--- a/core/src/infrastructure/providers/windows/cpu_temperature.rs
+++ b/core/src/infrastructure/providers/windows/cpu_temperature.rs
@@ -10,6 +10,7 @@ use super::pawn_io::{
   ACCESS_PCI_MUTEX, NamedMutex, PawnIoClient, PawnIoDiscovery, PawnIoInitError,
   PawnIoModule,
 };
+use crate::models::SensorEnablement;
 use crate::{log_debug, log_warn};
 
 const PAWNIO_MUTEX_TIMEOUT: Duration = Duration::from_millis(50);
@@ -40,12 +41,6 @@ pub struct IntelThermalCapabilities {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AmdFamilyEnablement {
-  pub recognized_by_pawnio_module: bool,
-  pub enabled_by_spec: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CpuTemperatureSource {
   IntelDtsPackageMsr,
   AmdZenSmnTctl,
@@ -56,7 +51,6 @@ pub enum CpuTemperatureFallbackReason {
   UnsupportedCpuVendor(String),
   IntelDtsUnavailable,
   IntelPackageThermalUnavailable,
-  AmdFamilyDisabled(u32),
   AmdFamilyUnsupported(u32),
 }
 
@@ -70,15 +64,38 @@ impl fmt::Display for CpuTemperatureFallbackReason {
       Self::IntelPackageThermalUnavailable => {
         write!(f, "Intel package thermal management unavailable")
       }
-      Self::AmdFamilyDisabled(family) => {
-        write!(f, "AMD family 0x{family:x} is disabled by the ready spec")
-      }
       Self::AmdFamilyUnsupported(family) => {
         write!(
           f,
-          "AMD family 0x{family:x} is unsupported by the ready spec"
+          "AMD family 0x{family:x} is unsupported by the PawnIO RyzenSMU path"
         )
       }
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CpuPackageTemperatureError {
+  Unsupported(CpuTemperatureFallbackReason),
+  Unavailable {
+    reason: String,
+    enablement: SensorEnablement,
+  },
+  Internal(String),
+}
+
+impl fmt::Display for CpuPackageTemperatureError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Unsupported(reason) => fmt::Display::fmt(reason, f),
+      Self::Unavailable {
+        reason,
+        enablement: SensorEnablement::Experimental,
+      } => write!(
+        f,
+        "experimental CPU package temperature attempt failed: {reason}"
+      ),
+      Self::Unavailable { reason, .. } | Self::Internal(reason) => f.write_str(reason),
     }
   }
 }
@@ -87,22 +104,14 @@ impl fmt::Display for CpuTemperatureFallbackReason {
 pub(crate) struct CpuTemperatureCandidate {
   pub(crate) source: CpuTemperatureSource,
   pub(crate) module: PawnIoModule,
+  pub(crate) enablement: SensorEnablement,
 }
 
-pub fn amd_family_enablement(family: u32) -> AmdFamilyEnablement {
+pub fn amd_family_enablement(family: u32) -> SensorEnablement {
   match family {
-    0x17 | 0x19 => AmdFamilyEnablement {
-      recognized_by_pawnio_module: true,
-      enabled_by_spec: true,
-    },
-    0x1a => AmdFamilyEnablement {
-      recognized_by_pawnio_module: true,
-      enabled_by_spec: false,
-    },
-    _ => AmdFamilyEnablement {
-      recognized_by_pawnio_module: false,
-      enabled_by_spec: false,
-    },
+    0x17 | 0x19 => SensorEnablement::Verified,
+    0x1a => SensorEnablement::Experimental,
+    _ => SensorEnablement::Unsupported,
   }
 }
 
@@ -125,21 +134,22 @@ pub(crate) fn select_cpu_temperature_candidate(
       Ok(CpuTemperatureCandidate {
         source: CpuTemperatureSource::IntelDtsPackageMsr,
         module: PawnIoModule::IntelMsr,
+        enablement: SensorEnablement::Verified,
       })
     }
     CpuVendor::Amd => {
       let enablement = amd_family_enablement(cpu.family);
-      if enablement.enabled_by_spec {
-        Ok(CpuTemperatureCandidate {
-          source: CpuTemperatureSource::AmdZenSmnTctl,
-          module: PawnIoModule::RyzenSmu,
-        })
-      } else if enablement.recognized_by_pawnio_module {
-        Err(CpuTemperatureFallbackReason::AmdFamilyDisabled(cpu.family))
-      } else {
-        Err(CpuTemperatureFallbackReason::AmdFamilyUnsupported(
-          cpu.family,
-        ))
+      match enablement {
+        SensorEnablement::Verified | SensorEnablement::Experimental => {
+          Ok(CpuTemperatureCandidate {
+            source: CpuTemperatureSource::AmdZenSmnTctl,
+            module: PawnIoModule::RyzenSmu,
+            enablement,
+          })
+        }
+        SensorEnablement::Unsupported => Err(
+          CpuTemperatureFallbackReason::AmdFamilyUnsupported(cpu.family),
+        ),
       }
     }
     CpuVendor::Other => Err(CpuTemperatureFallbackReason::UnsupportedCpuVendor(
@@ -152,9 +162,10 @@ pub(crate) fn select_cpu_temperature_candidate(
 pub struct CpuTemperatureDiagnostics {
   pub cpu: CpuIdentity,
   pub intel_capabilities: Option<IntelThermalCapabilities>,
-  pub amd_enablement: Option<AmdFamilyEnablement>,
+  pub amd_enablement: Option<SensorEnablement>,
   pub pawnio: PawnIoDiscovery,
   pub selected_source: Option<CpuTemperatureSource>,
+  pub selected_enablement: Option<SensorEnablement>,
   pub fallback_reason: Option<String>,
 }
 
@@ -168,22 +179,26 @@ enum ActiveCpuTemperatureSource {
   Intel {
     client: PawnIoClient,
     target_celsius: u32,
+    enablement: SensorEnablement,
   },
   Amd {
     client: PawnIoClient,
     tctl_offset_celsius: f32,
+    enablement: SensorEnablement,
   },
 }
 
 struct CpuTemperatureSampler {
   diagnostics: CpuTemperatureDiagnostics,
   active: Option<ActiveCpuTemperatureSource>,
+  inactive_error: Option<CpuPackageTemperatureError>,
   sample_failure_logged: bool,
 }
 
 static CPU_TEMPERATURE_SAMPLER: OnceLock<Mutex<CpuTemperatureSampler>> = OnceLock::new();
 
-pub fn sample_cpu_package_temperature() -> Result<CpuPackageTemperature, String> {
+pub fn sample_cpu_package_temperature()
+-> Result<CpuPackageTemperature, CpuPackageTemperatureError> {
   let sampler = CPU_TEMPERATURE_SAMPLER.get_or_init(|| {
     let sampler = CpuTemperatureSampler::new();
     log_debug!(
@@ -196,7 +211,11 @@ pub fn sample_cpu_package_temperature() -> Result<CpuPackageTemperature, String>
 
   sampler
     .lock()
-    .map_err(|_| "CPU temperature sampler lock poisoned".to_string())?
+    .map_err(|_| {
+      CpuPackageTemperatureError::Internal(
+        "CPU temperature sampler lock poisoned".to_string(),
+      )
+    })?
     .sample()
 }
 
@@ -225,6 +244,7 @@ impl CpuTemperatureDiagnostics {
       amd_enablement: None,
       pawnio: PawnIoDiscovery::unavailable("sampler unavailable"),
       selected_source: None,
+      selected_enablement: None,
       fallback_reason: Some(reason.into()),
     }
   }
@@ -242,7 +262,7 @@ impl CpuTemperatureSampler {
     let candidate = match select_cpu_temperature_candidate(&cpu, intel_capabilities) {
       Ok(candidate) => candidate,
       Err(reason) => {
-        let reason = reason.to_string();
+        let fallback_reason = reason.to_string();
         let mut pawnio = PawnIoDiscovery::probe_install();
         if pawnio.fallback_reason.is_none() {
           pawnio.fallback_reason =
@@ -255,9 +275,11 @@ impl CpuTemperatureSampler {
             amd_enablement,
             pawnio,
             selected_source: None,
-            fallback_reason: Some(reason),
+            selected_enablement: None,
+            fallback_reason: Some(fallback_reason),
           },
           active: None,
+          inactive_error: Some(CpuPackageTemperatureError::Unsupported(reason)),
           sample_failure_logged: false,
         };
       }
@@ -271,31 +293,47 @@ impl CpuTemperatureSampler {
           amd_enablement,
           pawnio,
           selected_source: Some(candidate.source),
+          selected_enablement: Some(candidate.enablement),
           fallback_reason: None,
         },
         active: Some(active),
+        inactive_error: None,
         sample_failure_logged: false,
       },
-      Err(error) => Self {
-        diagnostics: CpuTemperatureDiagnostics {
-          cpu,
-          intel_capabilities,
-          amd_enablement,
-          pawnio: *error.discovery,
-          selected_source: None,
-          fallback_reason: Some(error.reason),
-        },
-        active: None,
-        sample_failure_logged: false,
-      },
+      Err(error) => {
+        let PawnIoInitError { discovery, reason } = error;
+        Self {
+          diagnostics: CpuTemperatureDiagnostics {
+            cpu,
+            intel_capabilities,
+            amd_enablement,
+            pawnio: *discovery,
+            selected_source: None,
+            selected_enablement: Some(candidate.enablement),
+            fallback_reason: Some(reason.clone()),
+          },
+          active: None,
+          inactive_error: Some(CpuPackageTemperatureError::Unavailable {
+            reason,
+            enablement: candidate.enablement,
+          }),
+          sample_failure_logged: false,
+        }
+      }
     }
   }
 
-  fn sample(&mut self) -> Result<CpuPackageTemperature, String> {
+  fn sample(&mut self) -> Result<CpuPackageTemperature, CpuPackageTemperatureError> {
+    let enablement = self
+      .active
+      .as_ref()
+      .map(ActiveCpuTemperatureSource::enablement)
+      .unwrap_or(SensorEnablement::Verified);
     let result = match self.active.as_mut() {
       Some(ActiveCpuTemperatureSource::Intel {
         client,
         target_celsius,
+        enablement: _,
       }) => client
         .read_msr(IA32_PACKAGE_THERM_STATUS)
         .and_then(|status| {
@@ -305,10 +343,12 @@ impl CpuTemperatureSampler {
         .map(|temperature| CpuPackageTemperature {
           temperature_celsius: temperature,
           source: CpuTemperatureSource::IntelDtsPackageMsr,
-        }),
+        })
+        .map_err(|reason| CpuPackageTemperatureError::Unavailable { reason, enablement }),
       Some(ActiveCpuTemperatureSource::Amd {
         client,
         tctl_offset_celsius,
+        enablement: _,
       }) => match NamedMutex::acquire(ACCESS_PCI_MUTEX, PAWNIO_MUTEX_TIMEOUT) {
         Ok(_mutex) => client
           .read_smu_register(AMD_THM_TCON_CUR_TMP)
@@ -321,14 +361,13 @@ impl CpuTemperatureSampler {
             source: CpuTemperatureSource::AmdZenSmnTctl,
           }),
         Err(reason) => Err(reason),
-      },
-      None => Err(
-        self
-          .diagnostics
-          .fallback_reason
-          .clone()
-          .unwrap_or_else(|| "CPU package temperature unavailable".to_string()),
-      ),
+      }
+      .map_err(|reason| CpuPackageTemperatureError::Unavailable { reason, enablement }),
+      None => Err(self.inactive_error.clone().unwrap_or_else(|| {
+        CpuPackageTemperatureError::Internal(
+          "CPU package temperature unavailable".to_string(),
+        )
+      })),
     };
 
     if let Err(reason) = &result
@@ -338,7 +377,7 @@ impl CpuTemperatureSampler {
       log_warn!(
         "cpu_temperature_sample_failed",
         "windows::cpu_temperature::CpuTemperatureSampler::sample",
-        Some(reason.clone())
+        Some(reason.to_string())
       );
     }
 
@@ -347,6 +386,12 @@ impl CpuTemperatureSampler {
 }
 
 impl ActiveCpuTemperatureSource {
+  const fn enablement(&self) -> SensorEnablement {
+    match self {
+      Self::Intel { enablement, .. } | Self::Amd { enablement, .. } => *enablement,
+    }
+  }
+
   fn open(
     cpu: &CpuIdentity,
     candidate: &CpuTemperatureCandidate,
@@ -378,11 +423,13 @@ impl ActiveCpuTemperatureSource {
         Self::Intel {
           client,
           target_celsius,
+          enablement: candidate.enablement,
         }
       }
       CpuTemperatureSource::AmdZenSmnTctl => Self::Amd {
         client,
         tctl_offset_celsius: amd_tctl_offset_celsius(&cpu.brand),
+        enablement: candidate.enablement,
       },
     };
 
@@ -600,32 +647,14 @@ mod tests {
   }
 
   #[test]
-  fn amd_family_17h_and_19h_are_enabled() {
-    assert_eq!(
-      amd_family_enablement(0x17),
-      AmdFamilyEnablement {
-        recognized_by_pawnio_module: true,
-        enabled_by_spec: true
-      }
-    );
-    assert_eq!(
-      amd_family_enablement(0x19),
-      AmdFamilyEnablement {
-        recognized_by_pawnio_module: true,
-        enabled_by_spec: true
-      }
-    );
+  fn amd_family_17h_and_19h_are_verified() {
+    assert_eq!(amd_family_enablement(0x17), SensorEnablement::Verified);
+    assert_eq!(amd_family_enablement(0x19), SensorEnablement::Verified);
   }
 
   #[test]
-  fn amd_family_1ah_is_recognized_but_disabled() {
-    assert_eq!(
-      amd_family_enablement(0x1a),
-      AmdFamilyEnablement {
-        recognized_by_pawnio_module: true,
-        enabled_by_spec: false
-      }
-    );
+  fn amd_family_1ah_is_experimental() {
+    assert_eq!(amd_family_enablement(0x1a), SensorEnablement::Experimental);
   }
 
   #[test]
@@ -642,6 +671,7 @@ mod tests {
       Ok(CpuTemperatureCandidate {
         source: CpuTemperatureSource::IntelDtsPackageMsr,
         module: PawnIoModule::IntelMsr,
+        enablement: SensorEnablement::Verified,
       })
     );
 
@@ -658,23 +688,47 @@ mod tests {
   }
 
   #[test]
-  fn amd_candidate_accepts_only_enabled_families() {
+  fn amd_candidate_classifies_verified_experimental_and_unsupported_families() {
     assert_eq!(
       select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x19), None),
       Ok(CpuTemperatureCandidate {
         source: CpuTemperatureSource::AmdZenSmnTctl,
         module: PawnIoModule::RyzenSmu,
+        enablement: SensorEnablement::Verified,
       })
     );
 
     assert_eq!(
       select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x1a), None),
-      Err(CpuTemperatureFallbackReason::AmdFamilyDisabled(0x1a))
+      Ok(CpuTemperatureCandidate {
+        source: CpuTemperatureSource::AmdZenSmnTctl,
+        module: PawnIoModule::RyzenSmu,
+        enablement: SensorEnablement::Experimental,
+      })
     );
     assert_eq!(
       select_cpu_temperature_candidate(&cpu(CpuVendor::Amd, "AuthenticAMD", 0x16), None),
       Err(CpuTemperatureFallbackReason::AmdFamilyUnsupported(0x16))
     );
+  }
+
+  #[test]
+  fn experimental_failure_is_identified_only_in_the_error() {
+    let error = CpuPackageTemperatureError::Unavailable {
+      reason: "CPU temperature decode failed".to_string(),
+      enablement: SensorEnablement::Experimental,
+    };
+
+    assert_eq!(
+      error.to_string(),
+      "experimental CPU package temperature attempt failed: CPU temperature decode failed"
+    );
+
+    let verified_error = CpuPackageTemperatureError::Unavailable {
+      reason: "CPU temperature decode failed".to_string(),
+      enablement: SensorEnablement::Verified,
+    };
+    assert_eq!(verified_error.to_string(), "CPU temperature decode failed");
   }
 
   #[test]

--- a/core/src/models/metrics.rs
+++ b/core/src/models/metrics.rs
@@ -14,6 +14,19 @@ pub struct GpuMetric {
   pub gpu_cooler_level: Option<u32>,
 }
 
+/// Runtime enablement decision for a native sensor path.
+///
+/// Prefer `Experimental` when an existing read-only access path recognizes the
+/// hardware and an existing plausibility-gated decode can be attempted safely.
+/// Use `Unsupported` when attempting the path would require guessing hardware
+/// facts such as an address, register map, or chip selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SensorEnablement {
+  Verified,
+  Experimental,
+  Unsupported,
+}
+
 /// One named temperature sensor reading (e.g. an ACPI thermal zone),
 /// always in raw °C.
 ///

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -8,4 +8,6 @@ pub use external_component_guidance::{
   ExternalComponent, ExternalComponentGuidanceCandidate, ExternalComponentReasonKind,
   ExternalComponentUsage, SmartInfoCollectionOutcome,
 };
-pub use metrics::{GpuMetric, MetricsSnapshot, ProcessSample, SensorTemperature};
+pub use metrics::{
+  GpuMetric, MetricsSnapshot, ProcessSample, SensorEnablement, SensorTemperature,
+};

--- a/docs/adr/0011-experimental-sensor-enablement.md
+++ b/docs/adr/0011-experimental-sensor-enablement.md
@@ -1,0 +1,128 @@
+# Experimental Sensor Enablement for Recognized-but-Unverified Hardware
+
+Status: accepted
+
+We will prefer best-effort experimental enablement for hardware that the current
+safe access path already recognizes, even when the register behavior has not yet
+been fully verified against a primary hardware specification. The goal is to
+increase the number of devices that can produce useful local readings and then
+use user reports, diagnostics, and later primary-source or hardware-dump
+verification to improve quality.
+
+The concrete trigger is issue #1824: AMD Family 1Ah / Zen 5 (Ryzen 7 9800X3D)
+is recognized by the PawnIO `RyzenSMU` module, but HardwareVisualizer previously
+hard-disabled it with `AMD family 0x1a is disabled by the ready spec`. Under this
+policy, that family is attempted as an **experimental** CPU package temperature
+source instead of being blocked only because the Family 1Ah THM facts are not yet
+verified.
+
+## Decision
+
+For native sensor collection, the implementation distinguishes three states:
+
+1. **Verified** — the hardware/register path is covered by the implementation-
+   ready spec. The verified hardware matrix is maintained in the relevant
+   sensor specification rather than exposed as routine UI state.
+2. **Experimental** — the access module or OS path already recognizes the device
+   or family, and HardwareVisualizer has a plausible read-only decode to attempt,
+   but the exact hardware facts are not yet fully verified. The app may collect
+   and display a successful reading through the existing presentation contract;
+   success is not labeled or otherwise classified as experimental on screen.
+3. **Unsupported** — the access module/path does not recognize the hardware, or
+   attempting a read would require guessing an address, chip selection, register
+   map, mutation, or behavior not already described by the current repository
+   inputs. This remains disabled.
+
+Enablement confidence is independent from sensor availability. A successfully
+collected experimental value is still available; `Experimental` describes the
+policy for attempting the hardware/register path, not a status attached to each
+successful sample.
+
+The sensor specifications are the canonical record of which hardware is
+Verified, Experimental, or Unsupported. Runtime code may mirror the minimum
+classification needed to select a safe path and to describe an actual failure,
+but the App event DTO and routine frontend readings do not carry verification
+metadata. If collection from an Experimental path fails and an existing
+diagnostic or guidance surface exposes that failure, the failure text may state
+that the attempted path was experimental.
+
+Lack of complete primary-source verification is not, by itself, a reason to
+disable a reading. When the device is recognized and the existing read-only
+decode can be applied without inventing hardware facts, `Experimental` is the
+default. This policy applies across vendors; it is not an AMD-only exception.
+
+For AMD CPU package temperature, this means:
+
+- Family 17h and 19h remain **Verified** for the current `RyzenSMU` SMN
+  `0x00059800` Tctl path.
+- Family 1Ah / Zen 5 becomes **Experimental** when using the same read-only
+  `RyzenSMU` path and existing plausibility-gated decode.
+- Families not accepted by `RyzenSMU` remain **Unsupported**.
+
+For the other current paths:
+
+- Intel CPU package temperature has no family/model allowlist. A CPU that
+  advertises the architectural DTS and package-thermal-management capability
+  bits uses the existing Intel MSR path as **Verified**; the capability bits are
+  existence gates, not verification allowlists.
+- ACPI thermal zones are **Verified** OS/firmware API readings when they pass the
+  existing plausibility filter.
+- Nuvoton NCT6799D motherboard readings remain **Verified**. Other Super I/O
+  chips remain **Unsupported** until an implementation-ready chip profile exists,
+  because reusing a register map based only on a similar chip ID would guess
+  hardware facts.
+- Vendor and OS API providers that already attempt capabilities at runtime do not
+  gain coverage from a family allowlist change; their existing success/failure
+  contracts remain in place.
+
+## Guardrails
+
+This policy changes runtime enablement, not clean-room provenance:
+
+- Do not consult prohibited monitoring implementations. Implementation still uses
+  only `docs/specs/sensors/**`, this repository, and allowed platform/API docs.
+- Do not add new register addresses, decode fields, chip selection logic, writes,
+  fan control, limit changes, or power-state changes merely to widen coverage.
+- Keep access read-only and preserve the existing mutex and optional-component
+  rules.
+- Keep plausibility gates. For CPU temperature, reject all-zero reads and values
+  outside the accepted range rather than publishing them as experimental.
+- Keep successful readings on the existing data and presentation contracts; do
+  not add verification metadata, badges, or source-label suffixes to routine UI.
+- When an Experimental attempt actually fails and that failure is surfaced,
+  identify the attempted path as experimental in the diagnostic detail. Do not
+  show an experimental label merely because collection succeeded.
+- Do not show PawnIO installation/permission guidance when the only issue is
+  that a source is experimental or unverified. Guidance remains for actual
+  missing, permission, load, or runtime failures after an attempted source and
+  all useful fallbacks are insufficient.
+- Experimental support should graduate to Verified only through a later spec
+  update backed by a primary source or maintainer-accepted hardware dump.
+
+## Implementation
+
+The implementation makes the following vertical change:
+
+1. Core owns the internal `SensorEnablement` (`Verified`, `Experimental`,
+   `Unsupported`) policy model used to select a safe path and contextualize
+   failures.
+2. Successful Core readings, App event DTOs, generated bindings, and frontend
+   state keep their existing shapes. Verification metadata is not propagated
+   with successful samples and the Dashboard receives no new label or badge.
+3. AMD Family `0x1A` selects the existing AMD SMN source as `Experimental`;
+   families `0x17` and `0x19` remain `Verified`, and families rejected by the
+   `RyzenSMU` module remain `Unsupported`.
+4. Intel remains capability-driven rather than family/model-gated.
+5. A failed Experimental attempt carries that context in the existing Core
+   diagnostic detail. Optional-component guidance still requires an actual
+   missing, permission, load, read, or decode failure plus insufficient
+   fallback data.
+6. Existing plausibility checks, read-only access, mutexes, fallback behavior,
+   and optional-component guidance rules remain unchanged.
+7. Focused regression tests cover candidate classification, unchanged success
+   labels, experimental failure wording, and guidance suppression.
+
+The Windows-only providers still require a Windows runner or machine for final
+runtime proof. Per-CCD temperatures, SMU PM-table metrics, new Zen 5 register
+facts, installer bundling, and unverified Super I/O register maps remain out of
+scope.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,3 +16,4 @@ implementation guidance belongs in the architecture documents.
 - [0006 Live Storage Health on Demand](0006-live-storage-health-on-demand.md)
 - [0007 Elevated Startup Mode](0007-elevated-startup-mode.md)
 - [0008 Selected Storage Device Overrides Focus Alarm](0008-selected-storage-device-overrides-focus.md)
+- [0011 Experimental Sensor Enablement](0011-experimental-sensor-enablement.md)

--- a/docs/architecture/windows-sensor-external-components.md
+++ b/docs/architecture/windows-sensor-external-components.md
@@ -17,8 +17,7 @@ Required components:
 - `PawnIOLib.dll`, loaded dynamically from the existing installation.
 - One CPU-specific PawnIO module blob:
   - Intel package temperature path: `IntelMSR.amx` or `IntelMSR.bin`.
-  - AMD Family 17h / 19h package temperature path: `RyzenSMU.amx` or
-    `RyzenSMU.bin`.
+  - AMD package temperature path: `RyzenSMU.amx` or `RyzenSMU.bin`.
 
 The CPU-specific module blob is not installed by the PawnIO runtime itself.
 Users must download a release asset from
@@ -65,12 +64,17 @@ include:
 
 ## Scope Boundaries
 
-The Phase 1 implementation only uses read-only CPU package temperature paths:
+The Phase 1 implementation uses read-only CPU package temperature paths:
 
 - Intel: `MSR_TEMPERATURE_TARGET` and `IA32_PACKAGE_THERM_STATUS` through
   `IntelMSR`.
-- AMD: SMN `0x00059800` through `RyzenSMU`, enabled only for Family 17h and
-  Family 19h.
+- AMD: SMN `0x00059800` through `RyzenSMU`. Family 17h and 19h are verified;
+  other families the `RyzenSMU` module recognizes (e.g. Family 1Ah / Zen 5) are
+  enabled best-effort as experimental paths with the same plausibility gate.
+  Successful values keep the existing Core sample, App event, and Dashboard
+  presentation contracts. Verification status is maintained in the sensor
+  specification; only a surfaced failure from an experimental attempt carries
+  that context (see ADR 0011).
 
 The following are not covered by this runtime checklist or by the Phase 1
 implementation:
@@ -78,7 +82,9 @@ implementation:
 - Installing PawnIO.
 - Bundling `PawnIOLib.dll` or module blobs.
 - Driver installer integration or bootstrapper work.
-- AMD Family 1Ah / Zen 5 enablement.
+- AMD Family 1Ah / Zen 5 *verified* enablement (it is enabled experimentally in
+  the current implementation; verification against a primary source is still
+  future work).
 - AMD per-CCD temperatures or SMU PM-table metrics.
 - Threadripper / EPYC multi-die-specific behavior.
 - Super I/O, fan RPM, voltage, and motherboard sensors.

--- a/docs/specs/sensors/README.md
+++ b/docs/specs/sensors/README.md
@@ -165,7 +165,7 @@ or unresolved blocking open question invalidates the flip.
 | --- | --- | --- | --- |
 | [`pawnio-interface.md`](pawnio-interface.md) | PawnIO driver/library API, module IOCTL contracts, mutex conventions, blob distribution (signed `.bin`), elevation requirement, licensing facts | Phase 1 | Implementation-ready (rev 4) |
 | [`cpu-intel-dts-msr.md`](cpu-intel-dts-msr.md) | Intel digital thermal sensor via MSRs (package/core temperature) | Phase 1 | Implementation-ready (rev 2) |
-| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 3) |
+| [`cpu-amd-zen-smn.md`](cpu-amd-zen-smn.md) | AMD Zen Tctl/Tdie via SMN thermal controller | Phase 1 | Implementation-ready (rev 4) |
 | [`superio-access.md`](superio-access.md) | Generic Super I/O configuration access, chip detection, ISA mutex | Phases 2–4 (mechanism) | Draft — not implementation-ready |
 
 Per-chip Super I/O register maps (Nuvoton NCT67xx, ITE IT86xx/87xx) are

--- a/docs/specs/sensors/cpu-amd-zen-smn.md
+++ b/docs/specs/sensors/cpu-amd-zen-smn.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 | --- | --- |
-| Revision | 3 |
-| Status | Implementation-ready (rev 3) |
-| Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2) and Family 19h (Zen 3/Zen 4) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Family 1Ah (Zen 5) is recognized but disabled by default pending verification (see Detection). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
+| Revision | 4 |
+| Status | Implementation-ready (rev 4) |
+| Scope | Package control temperature (Tctl) and die temperature (Tdie) on AMD Family 17h (Zen/Zen+/Zen 2) and Family 19h (Zen 3/Zen 4) processors, read from the SMU thermal controller (THM) over the System Management Network (SMN). Family 1Ah (Zen 5) is recognized and enabled best-effort as experimental pending verification (see Detection and ADR 0011). Excludes: per-CCD temperatures, SMU PM-table metrics, pre-Zen (Family 15h/16h) thermal registers. |
 | Issue phase | Phase 1 (#1635) |
 
 ## Sources
@@ -28,15 +28,21 @@
 | Effective family = `BaseFamily + ExtendedFamily` (CPUID leaf 1; extended family is added when base family is `0xF`) | AMD CPUID convention |
 | The PawnIO `RyzenSMU` module accepts families `0x17`, `0x19`, `0x1A` and rejects other vendors/families with an error status, providing a second layer of gating | S5 |
 
-"Recognized by the PawnIO module" and "enabled by this project" are
-separate decisions. This spec enables a family only once its THM
-register facts are verified against a primary source:
+"Recognized by the PawnIO module", "verified by this spec", and
+"enabled by this project" are separate decisions. A family is marked
+**Verified** only once its THM register facts are verified against a
+primary source. Per ADR 0011, a family that the `RyzenSMU` module
+recognizes but this spec has not yet verified is still enabled
+best-effort as an **experimental** path (reusing the verified decode and
+plausibility gate) rather than disabled. Successful readings use the normal
+presentation contract; if an attempted experimental path fails and the failure
+is surfaced, the diagnostic may identify it as experimental:
 
 | Family | Status | Default enablement |
 | --- | --- | --- |
 | `0x17` | Layout and ranges verified against the directly pinned AMD OSRR 56255 Rev 3.03 §4.2.1, p. 243 (S2) and the AMD register header (S6) | Enabled |
 | `0x19` | Register, address, and Tctl description verified against PPR 55898 Vol 2 §10.3 (S1) | Enabled |
-| `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Disabled until PPR/OSRR or hardware-dump verification |
+| `0x1A` | Recognized by the PawnIO module (S5) but not yet verified by this spec | Enabled best-effort as **experimental** and plausibility-gated per ADR 0011; successful UI readings use the normal source label; graduates to verified once THM facts are pinned |
 
 ## Register map (facts)
 
@@ -64,8 +70,10 @@ Notes:
   than the fields above, i.e. including 18:16) as **Reserved** on the
   CPU THM; the `TJ_SEL` fields named in the GPU-IP header (S6) are
   therefore not part of this spec's decode — see Open questions.
-  Family 1Ah is not yet verified by this spec and stays disabled by
-  default — see Detection and Open questions.
+  Family 1Ah is not yet verified by this spec; per ADR 0011 it is enabled
+  best-effort as an experimental path (reusing this verified decode and
+  plausibility gate) rather than disabled — see
+  Detection and Open questions.
 - SMN is reached through an index/data register pair in the host
   bridge PCI configuration space; the PawnIO module performs that
   access, and the **client must hold `Global\Access_PCI`** around
@@ -146,10 +154,11 @@ non-normative):
   not part of the Ready decode path; revisit only if Phase 2 dumps
   show readings explained by it (then a spec revision may adopt it as
   a future extension).
-- Non-blocking for Phase 1: family 1Ah stays disabled by default via
-  the Detection enablement table. Confirm `THM_TCON_CUR_TMP`
-  address/layout from an AMD PPR/OSRR when available, or validate
-  against a Phase 2 register dump, before enabling it.
+- Non-blocking for Phase 1: family 1Ah is enabled best-effort as an
+  experimental path via the Detection enablement table (ADR 0011),
+  not verified. Confirm `THM_TCON_CUR_TMP` address/layout from an AMD
+  PPR/OSRR when available, or validate against a Phase 2 register dump,
+  to graduate it from experimental to verified.
 - Non-blocking for Phase 1: the reported value is the package control
   temperature that drives cooling policy regardless of die-selection
   details, and Phase 1 targets single-die consumer parts. Whether
@@ -163,3 +172,4 @@ non-normative):
 | 1 | 2026-06-10 | Initial version |
 | 2 | 2026-06-11 | Provenance pinned: PPR 55898 Vol 2 §10.3 (p. 2-179), AMD OSRR 17h §4.2.1, AMD MIT register header, SB-TSI scaling corroboration. Added `CUR_TEMP_TJ_SEL` field and decode rule. Corrected `Access_PCI` ownership to caller-held. Open questions resolved or annotated non-blocking. Status → Implementation-ready. |
 | 3 | 2026-06-11 | OSRR 56255 Rev 3.03 §4.2.1 (p. 243) fetched and pinned directly (GitHub mirror of the AMD PDF), replacing the FreeBSD-carried quote as the Family 17h primary; S8 demoted to non-normative corroboration. `TJ_SEL` removed from the register map and decode path (the CPU OSRR marks bits 18:0 Reserved) and recorded as a non-blocking open question. Fixed the contradictory zero-offset wording in the Tctl-offset table. Status remains Implementation-ready. |
+| 4 | 2026-07-20 | Runtime enablement policy updated per ADR 0011: Family 1Ah remains unverified by this spec but is no longer hard-disabled by default; it is enabled best-effort as an experimental, plausibility-gated reading until THM facts are verified by a primary source or accepted hardware dump. No new register facts were added. Status remains Implementation-ready. |


### PR DESCRIPTION
## Summary

- backport the CPU sensor enablement policy and fix from #1836 to the v1.9.x sampling architecture
- enable AMD Family 1Ah through the existing read-only RyzenSMU decode and plausibility gate as Experimental
- keep Intel CPU package temperature capability-driven without adding a family/model allowlist
- preserve the existing successful-reading App/frontend contract; no badge, verification metadata, or source-label suffix is added
- identify Experimental only when an attempted path fails, and suppress PawnIO guidance for unsupported or internal failures

## Related Issues

Backports #1836
Relates to #1824

## Type of Change

- [x] Bug fix (fix/ branch)
- [ ] New feature (feat/ branch)
- [ ] Refactoring (refactor/ branch)
- [ ] Documentation (docs/ branch)
- [ ] Dependencies update
- [ ] Other (chore/ branch)

## Clean-room provenance

Implemented from docs/specs/sensors/pawnio-interface.md revision 4 (commit 7a6f179275905cfb0297c6f24392942e1723ceaa).
Implemented from docs/specs/sensors/cpu-intel-dts-msr.md revision 2 (commit 7a6f179275905cfb0297c6f24392942e1723ceaa).
Implemented from docs/specs/sensors/cpu-amd-zen-smn.md revision 4 (commit 7a6f179275905cfb0297c6f24392942e1723ceaa).
No other external sensor documentation was used.

### Implementer attestation

- [x] This implementation references only docs/specs/sensors/** at the revisions pinned above and this repository.
- [x] Every spec document pinned above carries Status: Implementation-ready (rev N) at the pinned revision and has no unresolved TODO(provenance) markers.
- [x] I did not consult LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors, or any decompiled monitoring tool while writing this implementation.
- [x] Register access remains read-only; no new address, decode field, write, or mutation path is introduced, and the existing mutex convention is preserved.

### Reviewer attestation

Reviewers: copy the checklist below into your approval review comment, with both boxes checked.

- [ ] I reviewed this implementation only against docs/specs/sensors/**, this repository, and the pinned spec revision.
- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor, Linux kernel, lm-sensors, or decompiled monitoring tools while reviewing this implementation.

## Screenshots / Videos

Not applicable. Successful sensor display behavior is unchanged.

## Test Plan

- [ ] Manual testing
- [x] Unit tests
  - cargo test -p hardviz-core: 234 unit + 2 integration passed
- [x] Static validation
  - cargo fmt --all --check
  - cargo clippy -p hardviz-core --all-targets -- -D warnings
  - diff and clean-room spec gate checks
- [ ] Windows CI/runtime validation
  - the provider/spec blobs match #1836, whose windows-latest Core lint and tests passed
  - local cross-target checking stopped before project code because the macOS environment lacks the Windows C/SDK header assert.h required by ring; this PR relies on the Windows CI job for the v1.9.x integration proof

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Native Core tests pass
- [x] No new warnings or errors in completed checks
