### PR TITLE
Chore(deps): Bump github/codeql-action to v4.37.2 across all steps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,3 +92,11 @@ updates:
     labels:
       - "change:deps"
       - "area:github-actions"
+
+    groups:
+      # init / analyze / upload-sarif must run the same version; updating them
+      # separately fails with "Loaded a configuration file for version X, but
+      # running version Y".
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -97,6 +97,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

CodeQL Advanced fails on Dependabot PR #1847 with a configuration error, on both matrix jobs:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.37.2'
##[error]analyze post-action step failed: ...
CodeQL job status was configuration error.
```

`codeql-action/init` writes the config that `analyze` reads, so both must run the same version. Because the actions are pinned by commit SHA, Dependabot treats `init` and `analyze` as separate dependencies and bumped only `analyze`.

## Changes

- Bump `codeql-action/init` and `codeql-action/analyze` in `codeql.yml` to `e0647621c2984b5ed2f768cb892365bf2a616ad1` (v4.37.2).
- Bump `codeql-action/upload-sarif` in `scorecard.yml` to the same commit for consistency.
- Add a `codeql-action` group to the `github-actions` ecosystem in `dependabot.yml` so `github/codeql-action*` is always updated as one PR, preventing this from recurring.

The SHA was resolved from the `v4.37.2` annotated tag via the GitHub API.

## Follow-up

Dependabot PR #1847 becomes redundant and can be closed once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security scanning workflows to newer, maintained action versions.
  * Improved management of security-scanning updates by grouping related maintenance updates.
  * No changes to application functionality or the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->