### PR TITLE
fix(ci): prevent no-op Tauri update PRs

### DIFF
--- a/.github/scripts/check-tauri-deps-changed.ts
+++ b/.github/scripts/check-tauri-deps-changed.ts
@@ -118,7 +118,12 @@ function extractCargoLock(text: string): string {
   for (const block of text.split(/\n\s*\n/)) {
     const name = block.match(/^name = "([^"]+)"/m)?.[1];
     if (name && tauriCratePattern.test(name)) {
-      entries.push(block.trim());
+      const identity = block
+        .split("\n")
+        .filter((line) => /^(?:name|version|source|checksum) = /.test(line))
+        .sort()
+        .join("\n");
+      entries.push(identity);
     }
   }
 

--- a/.github/scripts/check-tauri-deps-changed.ts
+++ b/.github/scripts/check-tauri-deps-changed.ts
@@ -1,14 +1,15 @@
 /// <reference types="node" />
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 
 type JsonObject = Record<string, unknown>;
 type Extractor = (text: string) => string;
 
 const baseRef = process.argv[2] ?? "HEAD^";
+const headRef = process.argv[3] ?? "HEAD";
 const outputPath = process.env.GITHUB_OUTPUT;
-const tauriCratePattern = /^(tauri|tauri-build|tauri-specta|tauri-plugin-.+)$/;
+const tauriCratePattern = /^tauri(?:$|-.+)$/;
 
 const jsonSections = [
   "dependencies",
@@ -19,6 +20,10 @@ const jsonSections = [
 
 function readFileAt(ref: string, path: string): string {
   try {
+    if (ref === "--worktree") {
+      return readFileSync(path, "utf8");
+    }
+
     return execFileSync("git", ["show", `${ref}:${path}`], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -157,21 +162,32 @@ function extractCargoToml(text: string): string {
   return entries.sort().join("\n");
 }
 
-const checks: [path: string, extract: Extractor][] = [
+const npmChecks: [path: string, extract: Extractor][] = [
   ["package.json", extractPackageJson],
   ["package-lock.json", extractPackageLock],
+];
+const cargoChecks: [path: string, extract: Extractor][] = [
   ["Cargo.lock", extractCargoLock],
   ["src-tauri/Cargo.toml", extractCargoToml],
 ];
 
-const changed = checks.some(([path, extract]) => {
-  const base = extract(readFileAt(baseRef, path));
-  const head = extract(readFileAt("HEAD", path));
-  return base !== head;
-});
+function hasChanged(checks: [path: string, extract: Extractor][]): boolean {
+  return checks.some(([path, extract]) => {
+    const base = extract(readFileAt(baseRef, path));
+    const head = extract(readFileAt(headRef, path));
+    return base !== head;
+  });
+}
+
+const npmChanged = hasChanged(npmChecks);
+const cargoChanged = hasChanged(cargoChecks);
+const changed = npmChanged || cargoChanged;
 
 if (outputPath) {
-  appendFileSync(outputPath, `changed=${changed}\n`);
+  appendFileSync(
+    outputPath,
+    `changed=${changed}\nnpm_changed=${npmChanged}\ncargo_changed=${cargoChanged}\n`,
+  );
 } else {
   console.log(`changed=${changed}`);
 }

--- a/.github/scripts/test-check-tauri-deps-changed.mjs
+++ b/.github/scripts/test-check-tauri-deps-changed.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "check-tauri-deps-changed.ts",
+);
+const testRepo = mkdtempSync(join(tmpdir(), "tauri-deps-check-"));
+
+function git(...args) {
+  return execFileSync("git", args, {
+    cwd: testRepo,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function check(baseRef, headRef) {
+  const outputPath = join(testRepo, "github-output");
+  rmSync(outputPath, { force: true });
+  execFileSync(process.execPath, [scriptPath, baseRef, headRef], {
+    cwd: testRepo,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_OUTPUT: outputPath },
+  });
+  return Object.fromEntries(
+    readFileSync(outputPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => line.split("=")),
+  );
+}
+
+try {
+  git("init", "--initial-branch=main");
+  git("config", "user.name", "Tauri dependency check test");
+  git("config", "user.email", "tauri-deps-check@example.invalid");
+  mkdirSync(join(testRepo, "src-tauri"));
+
+  writeFileSync(
+    join(testRepo, "package.json"),
+    `${JSON.stringify(
+      {
+        dependencies: {
+          "@tauri-apps/api": "^2.11.0",
+          react: "19.2.0",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(testRepo, "package-lock.json"),
+    `${JSON.stringify(
+      {
+        lockfileVersion: 3,
+        packages: {
+          "": {
+            dependencies: {
+              "@tauri-apps/api": "^2.11.0",
+              react: "19.2.0",
+            },
+          },
+          "node_modules/@tauri-apps/api": { version: "2.11.0" },
+          "node_modules/react": { version: "19.2.0" },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(testRepo, "Cargo.lock"),
+    `version = 4
+
+[[package]]
+name = "tauri"
+version = "2.11.0"
+dependencies = [
+ "os_pipe",
+ "tauri-runtime",
+]
+
+[[package]]
+name = "tauri-runtime"
+version = "2.11.0"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+`,
+  );
+  writeFileSync(
+    join(testRepo, "src-tauri/Cargo.toml"),
+    `[dependencies]
+tauri = "2.11.0"
+serde = "1"
+`,
+  );
+
+  git("add", ".");
+  git("commit", "-m", "test: add baseline dependencies");
+
+  assert.deepEqual(check("HEAD", "--worktree"), {
+    changed: "false",
+    npm_changed: "false",
+    cargo_changed: "false",
+  });
+
+  const cargoLockPath = join(testRepo, "Cargo.lock");
+  writeFileSync(
+    cargoLockPath,
+    readFileSync(cargoLockPath, "utf8").replace(
+      "windows-sys 0.61.2",
+      "windows-sys 0.48.0",
+    ),
+  );
+  assert.deepEqual(
+    check("HEAD", "--worktree"),
+    {
+      changed: "false",
+      npm_changed: "false",
+      cargo_changed: "false",
+    },
+    "transitive lockfile rewrites alone must not open a Tauri update PR",
+  );
+
+  writeFileSync(
+    cargoLockPath,
+    readFileSync(cargoLockPath, "utf8").replace(
+      'name = "tauri-runtime"\nversion = "2.11.0"',
+      'name = "tauri-runtime"\nversion = "2.12.0"',
+    ),
+  );
+  assert.deepEqual(
+    check("HEAD", "--worktree"),
+    {
+      changed: "true",
+      npm_changed: "false",
+      cargo_changed: "true",
+    },
+    "a Tauri crate update must remain eligible for a PR",
+  );
+
+  git("restore", "Cargo.lock");
+  const packageLockPath = join(testRepo, "package-lock.json");
+  writeFileSync(
+    packageLockPath,
+    readFileSync(packageLockPath, "utf8").replace(
+      '"node_modules/@tauri-apps/api": {\n      "version": "2.11.0"',
+      '"node_modules/@tauri-apps/api": {\n      "version": "2.12.0"',
+    ),
+  );
+  assert.deepEqual(
+    check("HEAD", "--worktree"),
+    {
+      changed: "true",
+      npm_changed: "true",
+      cargo_changed: "false",
+    },
+    "a Tauri npm update must remain eligible for a PR",
+  );
+
+  console.log("Tauri dependency change detection tests passed.");
+} finally {
+  rmSync(testRepo, { recursive: true, force: true });
+}

--- a/.github/scripts/test-check-tauri-deps-changed.mjs
+++ b/.github/scripts/test-check-tauri-deps-changed.mjs
@@ -142,6 +142,23 @@ serde = "1"
   writeFileSync(
     cargoLockPath,
     readFileSync(cargoLockPath, "utf8").replace(
+      ' "os_pipe",',
+      ' "os_pipe 1.2.3",',
+    ),
+  );
+  assert.deepEqual(
+    check("HEAD", "--worktree"),
+    {
+      changed: "false",
+      npm_changed: "false",
+      cargo_changed: "false",
+    },
+    "dependency-list-only rewrites inside a Tauri block must be ignored",
+  );
+
+  writeFileSync(
+    cargoLockPath,
+    readFileSync(cargoLockPath, "utf8").replace(
       'name = "tauri-runtime"\nversion = "2.11.0"',
       'name = "tauri-runtime"\nversion = "2.12.0"',
     ),

--- a/.github/workflows/auto-update-tauri.yml
+++ b/.github/workflows/auto-update-tauri.yml
@@ -45,6 +45,18 @@ jobs:
       - name: Run Tauri dependency updater
         run: bash .github/scripts/tauri-updater.sh
 
+      - name: Check for effective Tauri dependency updates
+        id: tauri-deps
+        run: node .github/scripts/check-tauri-deps-changed.ts HEAD --worktree
+
+      - name: Discard npm changes without a Tauri npm update
+        if: steps.tauri-deps.outputs.npm_changed != 'true'
+        run: git restore -- package.json package-lock.json
+
+      - name: Discard Cargo changes without a Tauri crate update
+        if: steps.tauri-deps.outputs.cargo_changed != 'true'
+        run: git restore -- Cargo.lock src-tauri/Cargo.toml
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -56,7 +68,7 @@ jobs:
 
             - Updated `@tauri-apps/*` npm packages to latest
             - Updated `tauri`, `tauri-build`, and `tauri-plugin-*` Cargo crates
-            - Regenerated lockfiles
+            - Regenerated lockfiles when Tauri dependency versions changed
 
             > This workflow runs weekly (Wed 09:00 JST) and is separate from Dependabot,
             > which ignores Tauri-related packages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
           install-deps: "false"
           setup-safe-chain: "false"
 
+      - name: Test Tauri dependency change detection
+        run: node .github/scripts/test-check-tauri-deps-changed.mjs
+
       - name: Check Tauri dependency changes
         id: tauri-deps
         shell: bash


### PR DESCRIPTION
## Summary

Prevent the scheduled Tauri updater from publishing pull requests when the updater only rewrites unrelated transitive lockfile entries.

- Detect effective Tauri npm and Cargo changes independently
- Restore package or Cargo files when their Tauri dependencies did not change
- Cover the #1913-like transitive Cargo.lock rewrite with a regression test
- Run the regression test in CI change detection

## Related Issues

No linked issue. Prevents recurrence of no-op automated PRs such as #1913.

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [x] Unit tests

Commands run:

- `node .github/scripts/test-check-tauri-deps-changed.mjs`
- `env -u GITHUB_OUTPUT node .github/scripts/check-tauri-deps-changed.ts develop origin/chore/auto-tauri-update` (confirmed `changed=false`)
- `npm test` (70 files, 458 tests passed)
- `npm run lint:ci`
- `npm run check:agent-guidance`
- `actionlint .github/workflows/auto-update-tauri.yml`
- Ruby YAML parse for both changed workflows
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Tauri dependency updates across npm and Cargo packages.
  * Prevented unrelated package or lockfile changes from appearing in automated update pull requests.
  * Correctly distinguishes direct Tauri dependency changes from irrelevant and transitive lockfile updates.

* **Tests**
  * Added automated coverage for worktree detection, unchanged files, lockfile scenarios, and cleanup behavior.
  * Integrated dependency detection tests into continuous integration.

* **Documentation**
  * Clarified that lockfiles are regenerated only when Tauri dependency versions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->