### PR TITLE
ci: reduce dependency update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
       time: "08:30"
       timezone: "Asia/Tokyo"
     cooldown:

--- a/.github/workflows/auto-update-licenses.yml
+++ b/.github/workflows/auto-update-licenses.yml
@@ -1,8 +1,9 @@
-name: "Auto Update Licenses Weekly"
+name: "Auto Update Licenses Twice Monthly"
 
 on:
   schedule:
-    - cron: "0 3 * * 5"
+    # Twice monthly on the 9th and 23rd at 12:00 JST (03:00 UTC)
+    - cron: "0 3 9,23 * *"
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/auto-update-npm.yml
+++ b/.github/workflows/auto-update-npm.yml
@@ -5,8 +5,8 @@ name: Auto update npm lockfile
 on:
   workflow_dispatch:
   schedule:
-    # Every Monday 09:15 JST (00:15 UTC)
-    - cron: "15 0 * * 1"
+    # Twice monthly on the 1st and 15th at 09:15 JST (00:15 UTC)
+    - cron: "15 0 1,15 * *"
 
 permissions: read-all
 

--- a/.github/workflows/auto-update-safe-chain.yml
+++ b/.github/workflows/auto-update-safe-chain.yml
@@ -3,8 +3,8 @@ name: Auto update safe-chain version
 on:
   workflow_dispatch:
   schedule:
-    # Every Monday 09:30 JST (00:30 UTC)
-    - cron: "30 0 * * 1"
+    # Twice monthly on the 1st and 15th at 09:30 JST (00:30 UTC)
+    - cron: "30 0 1,15 * *"
 
 permissions: read-all
 
@@ -95,7 +95,7 @@ jobs:
             This PR was created automatically.
 
             - Updates pinned safe-chain version in `.github/actions/setup-safe-chain/action.yml`
-            - Schedule: weekly
+            - Schedule: twice monthly (1st and 15th, 09:30 JST)
           branch: chore/auto-safe-chain-bump
           add-paths: |
             .github/actions/setup-safe-chain/action.yml

--- a/.github/workflows/auto-update-tauri.yml
+++ b/.github/workflows/auto-update-tauri.yml
@@ -3,8 +3,8 @@ name: Auto update Tauri dependencies
 on:
   workflow_dispatch:
   schedule:
-    # Every Wednesday 09:00 JST (00:00 UTC)
-    - cron: "0 0 * * 3"
+    # Twice monthly on the 8th and 22nd at 09:00 JST (00:00 UTC)
+    - cron: "0 0 8,22 * *"
 
 permissions: read-all
 
@@ -58,7 +58,7 @@ jobs:
             - Updated `tauri`, `tauri-build`, and `tauri-plugin-*` Cargo crates
             - Regenerated lockfiles
 
-            > This workflow runs weekly (Wed 09:00 JST) and is separate from Dependabot,
+            > This workflow runs twice monthly (8th and 22nd, 09:00 JST) and is separate from Dependabot,
             > which ignores Tauri-related packages.
           branch: chore/auto-tauri-update
           delete-branch: true


### PR DESCRIPTION
## Summary

- Run npm Dependabot weekly on Tuesday instead of daily.
- Run the npm lockfile and safe-chain updaters on the 1st and 15th of each month.
- Run the Tauri updater on the 8th and 22nd, then refresh license notices on the 9th and 23rd.
- Keep manual dispatch available and leave the daily OSV vulnerability scan unchanged.

This reduces automated dependency-maintenance PR churn while preserving regular updates and daily vulnerability detection.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Validated the changed workflows with `actionlint`
- [x] Parsed the Dependabot and workflow YAML files
- [x] Verified the configured cron expressions and npm Dependabot schedule
- [x] Ran `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Relevant linting and formatting checks pass
- [x] Relevant tests pass
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update checks to run on a twice-monthly schedule.
  * Updated license, npm, Safe Chain, and Tauri maintenance workflows with their new run dates and times.
  * Updated generated pull request descriptions to reflect the revised maintenance schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->