### PR TITLE
docs: Add ADR for Windows Storage Health Collection strategy

### DIFF
--- a/docs/adr/0012-native-first-windows-storage-health-collection.md
+++ b/docs/adr/0012-native-first-windows-storage-health-collection.md
@@ -1,0 +1,65 @@
+# Windows Storage Health Collection Source Priority
+
+Status: accepted
+
+## Context
+
+Storage Health can be collected from multiple sources on Windows:
+
+- DeviceIoControl
+- MSStorageDriver_FailurePredict* WMI
+- smartctl
+- Storage Management CIM
+
+Initial implementations relied on WMI with smartctl as a fallback.
+
+In a real Windows NVMe environment, however:
+
+- MSStorageDriver_FailurePredict* was unavailable for the NVMe devices.
+- smartctl was not installed.
+- Windows could still expose NVMe Health Information Log data through DeviceIoControl without elevation.
+
+Relying on smartctl as the primary source would also make basic Storage Health
+depend on installation of an external component.
+
+## Decision
+
+Prefer native Windows APIs for Storage Health when they can provide the required
+signals.
+
+Daily Storage Health collection uses:
+
+1. DeviceIoControl
+2. MSStorageDriver_FailurePredict* WMI
+3. smartctl
+4. Storage Management CIM
+
+Live Storage Health uses only DeviceIoControl.
+
+smartctl remains a fallback and capability-extension source rather than the
+primary Windows provider.
+
+## Rationale
+
+- Basic Storage Health should work on a standard Windows installation.
+- Native collection avoids spawning an external process.
+- DeviceIoControl exposes NVMe health data without elevation on supported systems.
+- smartctl remains valuable for devices or protocols not covered by the native path.
+- Provider-specific differences are normalized behind the existing Storage Health model.
+
+## Consequences
+
+- Windows-specific provider code must be maintained.
+- New smartctl capabilities should not automatically replace native collection.
+- smartctl improvements should be adopted only when they fill a concrete coverage gap.
+- Live collection may expose fewer devices than daily collection because it deliberately
+  avoids expensive fallbacks.
+
+## Rejected Alternative: Prefer smartctl
+
+Using smartctl as the primary provider would simplify some protocol-specific parsing,
+but would introduce an external runtime dependency for functionality that Windows can
+provide natively.
+
+This was rejected after observing an environment where smartctl was absent but native
+NVMe health information was available.

--- a/docs/adr/0012-native-first-windows-storage-health-collection.md
+++ b/docs/adr/0012-native-first-windows-storage-health-collection.md
@@ -34,8 +34,9 @@ Daily Storage Health collection uses:
 3. smartctl
 4. Storage Management CIM
 
-Live Storage Health uses only DeviceIoControl.
-
+Live Storage Health reads use only DeviceIoControl. Device enumeration for
+Live Storage Health uses WMI at startup and on explicit Storage Device Refresh;
+the live read path does not use WMI, smartctl, or Storage Management CIM.
 smartctl remains a fallback and capability-extension source rather than the
 primary Windows provider.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ ADR status describes decision maturity, not release status.
 - [0009 Generated App Hardware DTOs](0009-generated-app-hardware-dtos.md)
 - [0010 Grouped Navigation with Classic Fallback](0010-grouped-navigation-with-classic-fallback.md)
 - [0011 Experimental Sensor Enablement for Recognized-but-Unverified Hardware](0011-experimental-sensor-enablement.md)
+- [0012 Native-first Windows Storage Health Collection](0012-native-first-windows-storage-health-collection.md)


### PR DESCRIPTION
## Summary

Document the decision to prioritize native Windows APIs for Storage Health collection over external dependencies.

## Related Issues

<!-- Link the related Issue. New features require an Issue before opening a PR. -->
<!-- e.g., Closes #123, Fixes #456 -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests

## Checklist

- [ ] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [ ] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record describing Windows storage health collection and provider priorities.
  * Documented the use of native Windows APIs for daily and live health data collection, with fallback options for broader compatibility.
  * Recorded provider trade-offs, maintenance considerations, and the decision not to use smartctl as the primary source.
  * Added the decision record to the architecture documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->