### PR TITLE
chore: rename issue template contact link to match its destination

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: true
 contact_links:
-  - name: GitHub Community Support
+  - name: Questions & Discussions
     url: https://github.com/shm11C3/HardwareVisualizer/discussions
     about: Feel free to ask questions, share ideas, or drop your feedback here.
   - name: Security Vulnerability


### PR DESCRIPTION
## Summary

Renames the first `contact_links` entry in `.github/ISSUE_TEMPLATE/config.yml`
from `GitHub Community Support` to `Questions & Discussions`.

The old name came from the `config.yml` example in GitHub's documentation, where
it points at GitHub's official community forum
(`https://github.com/orgs/community/discussions`). #1337 added that example
verbatim, and #1338 repointed the URL at this repository's own Discussions but
left the name unchanged. Since then the issue chooser has advertised "GitHub
Community Support" while actually linking to this project's Discussions.

The `about` text ("Feel free to ask questions, share ideas, or drop your
feedback here.") already describes this project's own Discussions, so only the
name was out of sync. The new name also covers the non-question uses (ideas,
feedback) that the `about` text invites.

Behavior is unchanged: the link target, `blank_issues_enabled`, and the
`Security Vulnerability` entry are untouched.

## Related Issues

<!-- None; small fix, Issue optional per CONTRIBUTING.md. -->

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A - the only visible change is the link label in the issue chooser.

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Parsed the edited file to confirm it is still valid YAML and that the `&` in the
new name is read as literal text rather than a YAML anchor:

```console
$ ruby -ryaml -e 'p YAML.load_file(".github/ISSUE_TEMPLATE/config.yml")'
{"blank_issues_enabled"=>true, "contact_links"=>[{"name"=>"Questions & Discussions", "url"=>"https://github.com/shm11C3/HardwareVisualizer/discussions", ...
```

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

Lint/format and test suites were not run: the diff touches no TypeScript or Rust
source, only a GitHub issue-template config file that neither toolchain covers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the issue template contact link from “GitHub Community Support” to “Questions & Discussions” for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->