### PR TITLE
perf(core): avoid redundant process refresh

### DIFF
--- a/core/src/collector/history.rs
+++ b/core/src/collector/history.rs
@@ -17,7 +17,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
-use sysinfo::{ProcessesToUpdate, System};
+use sysinfo::System;
 
 use crate::models::hardware::ProcessInfo;
 use crate::utils::rounding;
@@ -181,14 +181,13 @@ impl HistoryStore {
       .unwrap_or_default()
   }
 
-  /// Process list refreshed via sysinfo, with rolling-average CPU and
-  /// memory usage (last [`PROCESS_AVG_WINDOW`] samples) per process.
+  /// Process list from the latest collector sample, with rolling-average CPU
+  /// and memory usage (last [`PROCESS_AVG_WINDOW`] samples) per process.
   pub fn process_list(&self) -> Vec<ProcessInfo> {
-    let mut system = self.inner.system.lock().unwrap();
+    let system = self.inner.system.lock().unwrap();
     let process_cpu_histories = self.inner.process_cpu_histories.lock().unwrap();
     let process_memory_histories = self.inner.process_memory_histories.lock().unwrap();
 
-    system.refresh_processes(ProcessesToUpdate::All, true);
     let num_cores = system.cpus().len() as f32;
 
     system
@@ -197,9 +196,9 @@ impl HistoryStore {
       .map(|process| {
         let pid = process.pid();
 
-        // For freshly started processes (no history yet), fall through
-        // to the just-refreshed sysinfo sample instead of pretending the
-        // CPU usage is 0.0. Mirrors the memory branch below.
+        // For freshly started processes (no history yet), fall through to the
+        // latest sysinfo sample instead of pretending the CPU usage is 0.0.
+        // Mirrors the memory branch below.
         let core_divisor = num_cores.max(1.0);
         let fresh_cpu = || rounding::round1(process.cpu_usage() / core_divisor);
         let cpu_usage = process_cpu_histories


### PR DESCRIPTION
## Summary

- Read the Live Process Table data from the latest one-second collector sample.
- Remove the redundant `refresh_processes(ProcessesToUpdate::All, true)` call from each `get_process_list` request.
- Update the method comments to describe the collector-owned refresh path accurately.

This removes the extra all-process OS scan and its contention with the collector while preserving the existing rolling-average and IPC contracts. Process data can be up to approximately one collector interval old.

## Related Issues

Closes #1571

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable; this is a Core-only collection-path change.

## Test Plan

- [ ] Manual testing
- [x] Unit tests
  - `cargo test -p hardviz-core collector::history`
  - `cargo test -p hardviz-core`

Additional checks:

- `cargo fmt --all -- --check`
- `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Scoped linting and formatting pass
- [x] Scoped Core tests pass
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process history updates by using the latest available system sample.
  * Updated CPU fallback behavior and messaging to better reflect current system data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->