### PR TITLE
fix: detect fixes in OSV Semver ranges

### DIFF
--- a/.github/scripts/evaluate-release-vulnerabilities.mjs
+++ b/.github/scripts/evaluate-release-vulnerabilities.mjs
@@ -231,14 +231,19 @@ function hasFix(vulnerability, pkg) {
       );
       return samePackage(affectedPackage, pkg, false);
     })
-    .flatMap((affected) => list(affected.ranges).map(object))
-    .filter((range) => range.type === "ECOSYSTEM" || range.type === "SEMVER");
+    .flatMap((affected) => list(affected.ranges).map(object));
 
   // OSV confirms that the scanned version is affected, but selecting its
   // interval would require an ecosystem-specific version comparator. Report a
   // fix only for the unambiguous single-interval shape; otherwise mitigation is
   // the safe recommendation.
-  if (versionRanges.length !== 1) return false;
+  if (
+    versionRanges.length !== 1 ||
+    (versionRanges[0].type !== "ECOSYSTEM" &&
+      versionRanges[0].type !== "SEMVER")
+  ) {
+    return false;
+  }
   const events = list(versionRanges[0].events).map(object);
   return (
     events.length === 2 &&

--- a/.github/scripts/evaluate-release-vulnerabilities.mjs
+++ b/.github/scripts/evaluate-release-vulnerabilities.mjs
@@ -222,7 +222,7 @@ function preferredIdentifier(values) {
 }
 
 function hasFix(vulnerability, pkg) {
-  const ecosystemRanges = list(vulnerability.affected)
+  const versionRanges = list(vulnerability.affected)
     .map(object)
     .filter((affected) => {
       const affectedPackage = parsePackage(
@@ -232,14 +232,14 @@ function hasFix(vulnerability, pkg) {
       return samePackage(affectedPackage, pkg, false);
     })
     .flatMap((affected) => list(affected.ranges).map(object))
-    .filter((range) => range.type === "ECOSYSTEM");
+    .filter((range) => range.type === "ECOSYSTEM" || range.type === "SEMVER");
 
   // OSV confirms that the scanned version is affected, but selecting its
   // interval would require an ecosystem-specific version comparator. Report a
   // fix only for the unambiguous single-interval shape; otherwise mitigation is
   // the safe recommendation.
-  if (ecosystemRanges.length !== 1) return false;
-  const events = list(ecosystemRanges[0].events).map(object);
+  if (versionRanges.length !== 1) return false;
+  const events = list(versionRanges[0].events).map(object);
   return (
     events.length === 2 &&
     typeof events[0].introduced === "string" &&

--- a/.github/scripts/test-evaluate-release-vulnerabilities.mjs
+++ b/.github/scripts/test-evaluate-release-vulnerabilities.mjs
@@ -23,7 +23,7 @@ function affectedEntry({
   ecosystem = "npm",
   name = "runtime-package",
   fixed = "2.0.0",
-  rangeType = "ECOSYSTEM",
+  rangeType = "SEMVER",
   events,
 } = {}) {
   return {
@@ -330,6 +330,26 @@ try {
       "known_exploited",
     );
   }
+
+  assertDecision(
+    runEvaluation({
+      packages: [
+        packageResult({
+          vulnerabilities: [
+            vulnerability({
+              id: "GHSA-ecosystem-fix",
+              aliases: ["CVE-2026-12345"],
+              affected: [affectedEntry({ rangeType: "ECOSYSTEM" })],
+            }),
+          ],
+        }),
+      ],
+      kev: ["CVE-2026-12345"],
+    }),
+    1,
+    "emergency_release_candidate",
+    "known_exploited",
+  );
 
   assertDecision(
     runEvaluation({

--- a/.github/scripts/test-evaluate-release-vulnerabilities.mjs
+++ b/.github/scripts/test-evaluate-release-vulnerabilities.mjs
@@ -355,6 +355,40 @@ try {
     runEvaluation({
       packages: [
         packageResult({
+          vulnerabilities: [
+            vulnerability({
+              id: "GHSA-mixed-range-types",
+              aliases: ["CVE-2026-12345"],
+              affected: [
+                {
+                  package: { ecosystem: "npm", name: "runtime-package" },
+                  ranges: [
+                    {
+                      type: "SEMVER",
+                      events: [{ introduced: "0" }, { fixed: "2.0.0" }],
+                    },
+                    {
+                      type: "GIT",
+                      events: [{ introduced: "0" }, { fixed: "deadbeef" }],
+                    },
+                  ],
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+      kev: ["CVE-2026-12345"],
+    }),
+    1,
+    "emergency_mitigation_candidate",
+    "known_exploited",
+  );
+
+  assertDecision(
+    runEvaluation({
+      packages: [
+        packageResult({
           version: "2.5.0",
           vulnerabilities: [
             vulnerability({

--- a/docs/security/release-vulnerability-response.md
+++ b/docs/security/release-vulnerability-response.md
@@ -57,8 +57,8 @@ An emergency candidate with a fixed version is
 `emergency_release_candidate`. Without a fixed version it is
 `emergency_mitigation_candidate`, because shipping another vulnerable version
 would not resolve the risk. A fixed version is reported only when the OSV data
-contains one unambiguous Ecosystem interval ending in a fix. Multiple intervals
-and non-Ecosystem ranges conservatively require mitigation.
+contains one unambiguous Semver or Ecosystem interval ending in a fix. Multiple
+intervals and other range types conservatively require mitigation.
 
 ### CI Outcomes
 


### PR DESCRIPTION
## Summary

- recognize OSV `SEMVER` ranges when determining whether a fixed version exists
- preserve support for `ECOSYSTEM` ranges and the conservative single-interval rule
- align the release vulnerability response documentation with the accepted range types

OSV Scanner emits the affected dependency intervals used by the current release scan as `SEMVER`. The evaluator previously accepted only `ECOSYSTEM`, so it incorrectly reported `fix_available: false` even when an unambiguous fixed version was present.

## Related Issues

Follow-up to #1922.

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [x] Unit tests

Validated with:

- `node .github/scripts/test-evaluate-release-vulnerabilities.mjs`
- `npx biome check .github/scripts/evaluate-release-vulnerabilities.mjs .github/scripts/test-evaluate-release-vulnerabilities.mjs`
- `git diff --check`
- reevaluation of the latest `v1.9.2` OSV artifact, which now reports unambiguous Semver fixes as available

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability assessment for fixes described using semantic-version and ecosystem ranges.
  * Correctly identifies known-exploited vulnerabilities in ecosystem-specific ranges when determining emergency release candidates.
* **Documentation**
  * Clarified mitigation guidance for single, unambiguous semantic-version or ecosystem intervals ending in a fix.
  * Confirmed that multiple intervals and unsupported range types still require mitigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->