### PR TITLE
docs: define centralized live process polling ownership

### DIFF
--- a/docs/adr/0013-centralized-live-process-polling.md
+++ b/docs/adr/0013-centralized-live-process-polling.md
@@ -1,0 +1,91 @@
+# Centralized Live Process Polling
+
+Status: accepted
+
+## Context
+
+The Live Process Table is populated through the `get_process_list` Tauri
+command. The frontend stores the latest result in a shared Jotai atom, but
+`useProcessInfo` also starts an initial request and a three-second polling
+interval for every hook consumer.
+
+The default Hardware Dashboard has multiple consumers: CPU information uses the
+process count, the Live Process Table uses the full list, and the Hardware
+Report uses the process count. Sharing the atom therefore shares data but does
+not share request ownership. Mounting these consumers can create multiple
+polling loops that perform the same IPC request and write to the same atom.
+
+The process list is live, window-only data. Hardware Archive process sampling
+has a separate Core-owned lifetime and must not depend on whether the frontend
+is polling. Issue
+[#1931](https://github.com/shm11C3/HardwareVisualizer/issues/1931) owns the
+implementation scope for this decision.
+
+## Decision
+
+The frontend will have one polling coordinator for the shared live process
+resource per Jotai store.
+
+- Components consume process state without creating their own timers.
+- The first active consumer starts polling, and polling stops after the last
+  active consumer unmounts.
+- Polling pauses while the document is hidden and performs an immediate refresh
+  when the document becomes visible again.
+- Only one `get_process_list` request may be in flight. A stopped or superseded
+  request must not replace newer process state when it completes.
+- The last successful process list remains available during a transient request
+  failure. One failed polling attempt follows one shared error path.
+- The existing three-second cadence remains the initial policy. Changing the
+  cadence requires separate runtime evidence.
+
+The Live Process Table remains command-backed. The unbounded process list will
+not be added to the one-second `HardwareMonitorUpdate` event. Core continues to
+own process collection, App continues to own the typed command boundary, and
+the frontend owns polling demand and view state.
+
+The coordinator may use Jotai lifecycle support, a small feature-owned provider,
+or an equivalent local mechanism. This decision defines ownership and lifecycle
+semantics rather than prescribing one React implementation.
+
+## Rationale
+
+- Request cost should follow active frontend value instead of the number of
+  mounted consumers.
+- A single owner prevents duplicate IPC, full-list conversion, error reporting,
+  and out-of-order writes.
+- Keeping the process list out of the one-second event avoids increasing
+  window IPC payloads for consumers that only need other live metrics.
+- A feature-owned coordinator preserves the existing Core / App split without
+  adding a general-purpose data-fetching dependency.
+
+## Consequences
+
+- Multiple process-data consumers observe one refresh schedule and one shared
+  result.
+- Hidden or inactive live views no longer require process-list IPC.
+- Polling lifecycle, visibility changes, slow requests, and late responses need
+  focused frontend tests.
+- The displayed list may remain at the last successful sample during a
+  transient failure; the existing error surface still reports the failed
+  refresh.
+- Process count extraction, list ranking or capping, backend collection cadence,
+  and Hardware Archive fan-out remain separate decisions.
+
+## Rejected Alternatives
+
+### Keep polling inside every consumer hook
+
+This keeps components locally simple but makes request count depend on component
+composition. The shared atom does not deduplicate timers or IPC.
+
+### Add the full process list to HardwareMonitorUpdate
+
+The event is emitted every second and serves live metrics that do not need the
+unbounded process list. Sending the list through that path would trade duplicate
+polling for a larger high-frequency payload.
+
+### Add a general-purpose frontend query dependency
+
+The required behavior is one feature-owned polling lifecycle. A new dependency
+is not justified unless broader product requirements need its caching and
+coordination model.

--- a/docs/adr/0013-centralized-live-process-polling.md
+++ b/docs/adr/0013-centralized-live-process-polling.md
@@ -27,12 +27,22 @@ The frontend will have one polling coordinator for the shared live process
 resource per Jotai store.
 
 - Components consume process state without creating their own timers.
+- A consumer is active only while it is mounted and its `enabled` input is
+  `true`. It joins the coordinator when it mounts enabled or `enabled` changes
+  from `false` to `true`, and leaves when it unmounts or `enabled` changes from
+  `true` to `false`. Disabled consumers do not keep polling active.
 - The first active consumer starts polling, and polling stops after the last
-  active consumer unmounts.
+  active consumer leaves.
 - Polling pauses while the document is hidden and performs an immediate refresh
   when the document becomes visible again.
-- Only one `get_process_list` request may be in flight. A stopped or superseded
-  request must not replace newer process state when it completes.
+- Only one `get_process_list` request may be in flight. A periodic three-second
+  tick that occurs while a request is in flight is skipped and is not queued,
+  so steady-state polling starts at most one request every three seconds.
+- If consumer demand starts or the document becomes visible while a request
+  from an earlier inactive or hidden lifecycle is still in flight, its result
+  is ignored and those demand signals are coalesced into one immediate refresh
+  after it settles. A stopped or superseded request must not replace current
+  process state when it completes.
 - The last successful process list remains available during a transient request
   failure. One failed polling attempt follows one shared error path.
 - The existing three-second cadence remains the initial policy. Changing the
@@ -63,8 +73,8 @@ semantics rather than prescribing one React implementation.
 - Multiple process-data consumers observe one refresh schedule and one shared
   result.
 - Hidden or inactive live views no longer require process-list IPC.
-- Polling lifecycle, visibility changes, slow requests, and late responses need
-  focused frontend tests.
+- Polling lifecycle, mounted `enabled` changes, visibility changes, slow
+  requests, and late responses need focused frontend tests.
 - The displayed list may remain at the last successful sample during a
   transient failure; the existing error surface still reports the failed
   refresh.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ ADR status describes decision maturity, not release status.
 - [0010 Grouped Navigation with Classic Fallback](0010-grouped-navigation-with-classic-fallback.md)
 - [0011 Experimental Sensor Enablement for Recognized-but-Unverified Hardware](0011-experimental-sensor-enablement.md)
 - [0012 Native-first Windows Storage Health Collection](0012-native-first-windows-storage-health-collection.md)
+- [0013 Centralized Live Process Polling](0013-centralized-live-process-polling.md)


### PR DESCRIPTION
## Summary

- Record the accepted decision to centralize live process polling ownership in the frontend
- Define consumer-demand, document-visibility, single-flight, and late-response lifecycle semantics
- Keep the live process list command-backed and independent from Hardware Archive collection

## Related Issues

Relates to #1931

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable; this PR changes documentation only.

## Test Plan

- [x] `npm run check:agent-guidance`
- [x] `git diff --check origin/develop...HEAD`
- [ ] Manual testing
- [ ] Unit tests

Manual and unit tests were not run because this PR changes documentation only.

## Checklist

- [x] Self-reviewed the documentation
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

The full code lint and test suites were not run because this PR changes documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architectural decision record describing centralized live process polling.
  * Documented how polling pauses when the application is hidden and refreshes when visibility returns.
  * Documented refresh timing, request coordination, failure recovery, and preservation of the last successful result.
  * Confirmed the existing three-second polling cadence and separation from hardware monitoring and archive sampling.
  * Added the new decision record to the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->