### PR TITLE
perf(core): target sysinfo sampling refreshes

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -90,7 +90,10 @@ used by the platform layer and Core services.
 
 Cross-platform providers:
 
-- `sysinfo_provider.rs` reads CPU and storage facts through `sysinfo`.
+- `sysinfo_provider.rs` reads CPU and storage facts through `sysinfo`. The
+  collector refreshes live CPU usage, memory, and process data on its periodic
+  loop; the provider refreshes CPU frequency on demand when CPU hardware facts
+  are requested.
 - `smartctl.rs` wraps the external `smartctl` command and parses SMART data.
 
 Windows providers:

--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -40,7 +40,17 @@ pub fn sample_temperatures() -> TemperatureSample {
 /// store's history rings.
 pub fn sample_system(store: &HistoryStore) -> Option<SystemSample> {
   let result = store.system().lock().ok().map(|mut sys| {
-    sys.refresh_all();
+    sys.refresh_cpu_usage();
+    sys.refresh_memory_specifics(sysinfo::MemoryRefreshKind::nothing().with_ram());
+    // Keep sysinfo's default task enumeration so Linux process membership
+    // remains compatible with refresh_all().
+    sys.refresh_processes_specifics(
+      sysinfo::ProcessesToUpdate::All,
+      true,
+      sysinfo::ProcessRefreshKind::nothing()
+        .with_cpu()
+        .with_memory(),
+    );
 
     let cpu_usage = calculate_average_cpu_usage(sys.cpus());
     let memory_usage =
@@ -231,6 +241,59 @@ mod tests {
     assert_eq!(
       calculate_memory_usage_percentage(16_000_000_000, 32_000_000_000),
       50.0
+    );
+  }
+
+  #[test]
+  fn sample_system_refreshes_required_system_and_process_data() {
+    let store = HistoryStore::new();
+    std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+
+    let sample = sample_system(&store).expect("system lock should be available");
+    let system = store.system().lock().unwrap();
+
+    assert_eq!(sample.cpu_usage, calculate_average_cpu_usage(system.cpus()));
+    assert_eq!(
+      sample.processors_usage,
+      system
+        .cpus()
+        .iter()
+        .map(|cpu| cpu.cpu_usage())
+        .collect::<Vec<_>>()
+    );
+    assert_eq!(
+      sample.memory_usage,
+      calculate_memory_usage_percentage(system.used_memory(), system.total_memory())
+    );
+
+    let current_pid =
+      sysinfo::get_current_pid().expect("current process should have a PID");
+    let process = system
+      .process(current_pid)
+      .expect("targeted refresh should include the current process");
+    let process_sample = sample
+      .processes
+      .iter()
+      .find(|sample| sample.pid == current_pid.as_u32())
+      .expect("system sample should include the current process");
+
+    assert!(!process_sample.name.is_empty());
+    assert_eq!(
+      process_sample.name,
+      process.name().to_string_lossy().into_owned()
+    );
+    assert_eq!(process_sample.cpu_usage, process.cpu_usage());
+    assert_eq!(process_sample.memory_kb, process.memory() as f32 / 1024.0);
+    assert_eq!(process_sample.run_time_secs, process.run_time());
+    drop(system);
+
+    assert_eq!(store.cpu_history(1), vec![sample.cpu_usage]);
+    assert_eq!(store.memory_history(1), vec![sample.memory_usage]);
+    assert!(
+      store
+        .process_list()
+        .iter()
+        .any(|process| process.pid == current_pid.as_u32() as i32)
     );
   }
 

--- a/core/src/infrastructure/providers/sysinfo_provider.rs
+++ b/core/src/infrastructure/providers/sysinfo_provider.rs
@@ -10,8 +10,12 @@ use sysinfo::{Disks, System};
 /// ## Get CPU information
 ///
 pub fn get_cpu_info(
-  system: MutexGuard<'_, System>,
+  mut system: MutexGuard<'_, System>,
 ) -> Result<models::hardware::CpuInfo, String> {
+  // The periodic collector refreshes CPU usage only. Refresh frequency at the
+  // command boundary so visible clock data stays current without adding this
+  // platform-dependent cost to every sampling tick.
+  system.refresh_cpu_frequency();
   let cpus = system.cpus();
 
   if cpus.is_empty() {

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -108,3 +108,4 @@ shared enforcement surface.
 - [Keep shared rules agent-neutral](keep-shared-rules-agent-neutral.md)
 - [Make navigation levels explicit](make-navigation-levels-explicit.md)
 - [Separate release integrity from vulnerability exposure](separate-release-integrity-from-vulnerability-exposure.md)
+- [Keep shared system refresh ownership explicit](keep-shared-system-refresh-ownership-explicit.md)

--- a/docs/agents/lessons/keep-shared-system-refresh-ownership-explicit.md
+++ b/docs/agents/lessons/keep-shared-system-refresh-ownership-explicit.md
@@ -1,0 +1,29 @@
+---
+id: LRN-20260815-keep-shared-system-refresh-ownership-explicit
+status: promoted
+cause_status: confirmed
+scope: core/src/collector, core/src/infrastructure/providers/sysinfo_provider.rs, and src-tauri/src/services/hardware_service.rs
+trigger: narrowing sysinfo refreshes or adding a consumer of HistoryStore::system
+failure_signature: replacing refresh_all with usage-only refreshes leaves the visible CPU clock at its previously cached value on platforms that update frequency dynamically
+root_cause: HistoryStore shares one sysinfo System between the periodic collector and command-backed CPU hardware information, so refresh ownership crosses those call paths
+guardrail: keep periodic refreshes limited to sampled data and refresh CPU frequency on demand in the Core provider that reads it
+canonical_refs: core/README.md, core/src/infrastructure/providers/sysinfo_provider.rs
+verification: cargo test -p hardviz-core; cargo clippy -p hardviz-core --all-targets -- -D warnings; inspect the CPU information command on platforms with dynamic frequency reporting
+evidence: "core/src/collector/history.rs, core/src/collector/sampling.rs, core/src/infrastructure/providers/sysinfo_provider.rs, src-tauri/src/services/hardware_service.rs, and GitHub Issue #1927"
+revalidate_when: sysinfo refresh semantics change, HistoryStore stops sharing System, or CPU hardware information moves to another provider
+---
+
+# Keep Shared System Refresh Ownership Explicit
+
+`HistoryStore::system()` is not private state of the periodic collector. The
+App's hardware information service passes the same `sysinfo::System` to the
+Core CPU provider, which reads cached CPU frequency in addition to identity
+facts.
+
+When narrowing the collector's refresh set, audit every consumer of the shared
+system and assign refresh cost to the path that uses each fact. CPU frequency
+belongs to the command-backed CPU information path, while usage, memory, and
+process data belong to the periodic sampler. Cross-platform tests can verify
+that required collections remain available, but dynamic frequency freshness
+still requires platform runtime evidence because CI runner hardware may expose
+a constant or unavailable value.


### PR DESCRIPTION
## Summary

Replace the 1 Hz `sysinfo::System::refresh_all()` call with targeted refreshes for the data consumed by `SystemSample` and process history:

- CPU and per-processor usage
- RAM usage
- process CPU and memory data, while preserving Linux task enumeration

CPU frequency is refreshed on demand by the Core CPU provider so hardware-info clock data remains current without charging every sampling tick. A focused regression test covers the sampled system fields, current-process data, and history updates.

## Related Issues

Closes #1927

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Performance Evidence

On macOS with sysinfo 0.39.6, a release-mode A/B benchmark alternated the broad and targeted refreshes over 20 one-second iterations after three warmups:

- about 803 processes: mean 11.102 ms to 10.127 ms (8.79% lower); median 10.538 ms to 8.486 ms
- about 1,000 processes: mean 19.899 ms to 13.047 ms; median 13.931 ms to 11.296 ms

The high-process baseline included a 102.6 ms outlier, so its mean improvement should not be generalized. Across three trials, mean and median sampling duration improved, while p95 occasionally regressed. The normal-load absolute saving was about 0.98 ms per one-second tick.

Windows and Linux runtime performance remains to be validated. The cross-platform CI matrix checks compilation and sampled-data behavior, but hosted runners cannot reliably prove dynamic CPU-frequency freshness or representative mutex contention.

## Test Plan

- [x] Manual testing
- [x] Unit tests

- `cargo test -p hardviz-core -- --test-threads=1 --nocapture`
- `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check -p hardware_visualizer --lib`
- `npm run check:agent-guidance`
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and freshness of displayed CPU usage, memory, and process information during periodic updates.
  * Ensured CPU frequency details are refreshed when CPU information is requested.

* **Documentation**
  * Clarified system metrics refresh behavior and responsibilities.
  * Added guidance for maintaining accurate shared system data updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->