### PR TITLE
perf(dashboard): keep the doughnut gauge tween inside the update interval

### DIFF
--- a/src/components/charts/DoughnutChart.test.tsx
+++ b/src/components/charts/DoughnutChart.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DoughnutChart, gaugeAnimationDurationMs } from "./DoughnutChart";
+
+/** Hardware metrics are pushed once per second. */
+const HARDWARE_UPDATE_INTERVAL_MS = 1_000;
+
+const mocks = vi.hoisted(() => ({
+  radialBarProps: [] as Record<string, unknown>[],
+  settings: {
+    temperatureUnit: "C",
+    selectedBackgroundImg: null,
+    backgroundImgOpacity: 50,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/features/settings/hooks/useSettingsAtom", () => ({
+  useSettingsAtom: () => ({ settings: mocks.settings }),
+}));
+
+vi.mock("@/hooks/useWindowSize", () => ({
+  useWindowSize: () => ({ isBreak: () => true }),
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-container">{children}</div>
+  ),
+}));
+
+vi.mock("recharts", () => ({
+  RadialBarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="radial-bar-chart">{children}</div>
+  ),
+  RadialBar: (props: Record<string, unknown>) => {
+    mocks.radialBarProps.push(props);
+    return <div data-testid="radial-bar" />;
+  },
+  PolarGrid: () => <div />,
+  PolarRadiusAxis: () => <div />,
+  Label: () => <div />,
+}));
+
+afterEach(() => {
+  mocks.radialBarProps.length = 0;
+  cleanup();
+});
+
+describe("DoughnutChart", () => {
+  it("finishes its tween within one hardware update interval", () => {
+    render(<DoughnutChart chartValue={42} dataType="usage" />);
+
+    expect(mocks.radialBarProps).toHaveLength(1);
+    // Recharts' 1500ms default outlives the 1Hz tick, so every update restarts
+    // a tween that never settles. The gauge then never shows the current value
+    // and the WebKit compositor never idles, which is what spins up the fan on
+    // macOS (measured: WebContent 22.1% at 1500ms vs 10.3% at 300ms).
+    expect(mocks.radialBarProps[0]?.["animationDuration"]).toBeLessThan(
+      HARDWARE_UPDATE_INTERVAL_MS,
+    );
+  });
+
+  it("keeps the tween bounded across metric updates", () => {
+    const { rerender } = render(
+      <DoughnutChart chartValue={42} dataType="usage" />,
+    );
+    rerender(<DoughnutChart chartValue={57} dataType="usage" />);
+
+    expect(mocks.radialBarProps.length).toBeGreaterThan(1);
+    for (const props of mocks.radialBarProps) {
+      expect(props["animationDuration"]).toBe(gaugeAnimationDurationMs);
+    }
+  });
+
+  it("renders a placeholder instead of the gauge when no value is available", () => {
+    const { queryByTestId } = render(
+      <DoughnutChart chartValue={null} dataType="usage" />,
+    );
+
+    expect(queryByTestId("radial-bar")).toBeNull();
+    expect(mocks.radialBarProps).toHaveLength(0);
+  });
+});

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -36,6 +36,12 @@ type DoughnutChartProps =
       usagePercentage?: never;
     };
 
+/**
+ * Gauge tween length. Must stay below the 1Hz hardware update interval, and
+ * shorter still keeps the per-tick repaint cost down.
+ */
+export const gaugeAnimationDurationMs = 300;
+
 const dataType2Units = (
   dataType: Exclude<HardwareDataType, "memoryUsageValue">,
   temperatureUnit: Settings["temperatureUnit"],
@@ -136,7 +142,19 @@ export const DoughnutChart = ({
             }}
             polarRadius={isXl ? [70, 60] : [50, 42.5]}
           />
-          <RadialBar dataKey="value" background cornerRadius={10} />
+          {/*
+            Hardware metrics arrive every second. Recharts' 1500ms default
+            outlives that interval, so each tick restarts a tween that never
+            settles: the gauge never reaches the current value and the WebKit
+            compositor never goes idle. Keep the tween shorter than the update
+            interval so it completes between ticks.
+          */}
+          <RadialBar
+            dataKey="value"
+            background
+            cornerRadius={10}
+            animationDuration={gaugeAnimationDurationMs}
+          />
           <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
             <Label
               content={({ viewBox }) => {


### PR DESCRIPTION
## Summary

The dashboard renders up to six `DoughnutChart` gauges, each re-rendering on the 1 Hz hardware tick. Recharts' default `animationDuration` is **1500 ms**, which outlives that interval, so every tick restarted a tween that never settled. Two consequences:

- the gauge never reached the current value — it was permanently chasing a moving target, so the displayed arc always lagged the real metric;
- the WebKit compositor never went idle. On macOS this pinned the WebKit GPU process and audibly spun up the fan, which is how this was reported.

Shortening the tween to 300 ms lets it complete between ticks. The gauge settles on the real value, and the compositor gets to rest.

The duration is extracted as `gaugeAnimationDurationMs` so the constraint it has to satisfy — stay below the hardware update interval — is stated where the value lives.

### Measurements

macOS (Apple M4), **release build** (a dev build hides this entirely — see the note below), classic dashboard, 30 s per-process CPU averages, with A/B/A reversal:

| `animationDuration` | main | WebContent | WebKit GPU |
| --- | --- | --- | --- |
| 1500 ms (default) | 5.6 % | 20.9 % | 9.0 % |
| 1500 ms (repeat) | 6.0 % | 22.1 % | 12.6 % |
| 600 ms | 4.9 % | 17.0 % | 9.1 % |
| **300 ms (this PR)** | **3.6 %** | **10.3 %** | **3.4 %** |
| 150 ms | 2.8 % | 8.0 % | 2.6 % |
| disabled | 1.8 % | 3.4 % | 0.2 % |

Cost is **not** linear in duration: enabling the tween at all costs roughly 4.5 % WebContent regardless of its length, because each tick still repaints the SVG for as long as the tween runs. That is why 600 ms gives back most of the win while 300 ms keeps the visible transition for a small remaining delta. Disabling the animation outright was measured and rejected — the motion is worth the difference.

### Note on #1581

#1581 lists `isAnimationActive={false}` among the practices already applied. That holds for the line charts (`LineChart.tsx:186,288`) but was never true for the gauges, which is why they kept animating. This PR does not implement #1581's proposed canvas/single-path rewrite; it removes the dominant cost with one property so the larger rewrite can be scheduled on its own merits.

Manual memoization (`useMemo` / `React.memo`) was considered and deliberately left out: React Compiler is enabled in `vite.config.ts`, and #1581 already verified that memoizing the data array does not help because the upstream inputs are fresh arrays every tick.

## Related Issues

Refs #1581

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

No visual change to capture in a still image: the gauge geometry, colours, background track, corner radius and value/label rendering are untouched — only how long the arc takes to reach its new position. Rendering was verified at desktop (1280 px) and compact (900 px) widths via the E2E mock harness.

## Test Plan

- [x] Manual testing
- [x] Unit tests

`src/components/charts/DoughnutChart.test.tsx` (new) asserts the invariant rather than the literal number: the tween must finish inside the 1 Hz update interval. Verified to fail when the duration is restored to 1500 ms, so a regression is caught while a future tweak to e.g. 250 ms stays green.

The E2E/Playwright perf harness is deliberately **not** used to gate this. Headless Chromium reports `LayoutDuration` and `RecalcStyleDuration` as 0.0 % — it never composites, which is exactly where this cost lives. A 20× dashboard-vs-usage gap in the real app showed up as 2.3× there, and toggling the fix changed nothing measurable. An animation-frame-count metric was prototyped for this and discarded for the same reason.

Validation run locally: `npm run lint:ci`, `tsc && vite build`, and the full unit suite (466 tests / 71 files) all pass, plus the release-build measurements above.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved gauge animation timing for smoother, more responsive chart updates.

* **Bug Fixes**
  * Prevented gauge animations from exceeding the hardware update interval.
  * Hid the gauge when no value is available.

* **Tests**
  * Added coverage for animation timing, metric updates, and empty-value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->