### PR TITLE
perf(frontend): centralize live process polling ownership

### DIFF
--- a/src/features/hardware/hooks/useProcessInfo.test.ts
+++ b/src/features/hardware/hooks/useProcessInfo.test.ts
@@ -1,11 +1,8 @@
-// src/features/hardware/hooks/useProcessInfo.test.ts
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { Provider } from "jotai";
-import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { createElement, type PropsWithChildren, StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-/**
- * Mock setup
- */
 const errorMock = vi.fn();
 vi.mock("@/hooks/useTauriDialog", () => ({
   useTauriDialog: () => ({
@@ -19,26 +16,60 @@ vi.mock("@/rspc/bindings", () => ({
   },
 }));
 
-/**
- * Import hook to test
- */
 import { useProcessInfo } from "@/features/hardware/hooks/useProcessInfo";
-import { commands } from "@/rspc/bindings";
+import { commands, type ProcessInfo } from "@/rspc/bindings";
 
-/**
- * Test execution
- */
+const getProcessListMock = vi.mocked(commands.getProcessList);
+
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+};
+
+const setDocumentVisibility = (hidden: boolean) => {
+  setDocumentHidden(hidden);
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+const flushMicrotasks = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+const StrictProvider = ({ children }: PropsWithChildren) =>
+  createElement(StrictMode, null, createElement(Provider, null, children));
+
 describe("useProcessInfo", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    setDocumentHidden(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    setDocumentHidden(false);
   });
 
   it("returns process list on successful fetch", async () => {
     const processData = [
-      { pid: 1, name: "process1", cpuUsage: 10, memoryUsage: 200 },
-      { pid: 2, name: "process2", cpuUsage: 5, memoryUsage: 100 },
+      { pid: 1, name: "process1", cpuUsage: "10", memoryUsage: "200" },
+      { pid: 2, name: "process2", cpuUsage: "5", memoryUsage: "100" },
     ];
-    (commands.getProcessList as Mock).mockResolvedValue(processData);
+    getProcessListMock.mockResolvedValue(processData);
 
     const { result } = renderHook(() => useProcessInfo(), {
       wrapper: Provider,
@@ -50,7 +81,7 @@ describe("useProcessInfo", () => {
   });
 
   it("starts with empty array before fetch resolves", () => {
-    (commands.getProcessList as Mock).mockReturnValue(new Promise(() => {}));
+    getProcessListMock.mockReturnValue(new Promise(() => {}));
 
     const { result } = renderHook(() => useProcessInfo(), {
       wrapper: Provider,
@@ -59,98 +90,234 @@ describe("useProcessInfo", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("does not fetch or subscribe to shared process state when disabled", () => {
+  it("does not fetch or subscribe to shared process state when disabled", async () => {
     const { result } = renderHook(() => useProcessInfo({ enabled: false }), {
       wrapper: Provider,
     });
 
+    await flushMicrotasks();
+
     expect(result.current).toEqual([]);
-    expect(commands.getProcessList).not.toHaveBeenCalled();
+    expect(getProcessListMock).not.toHaveBeenCalled();
   });
 
-  it("calls error() and console.error on fetch failure", async () => {
-    const errorMsg = "Failed to fetch processes";
-    (commands.getProcessList as Mock).mockRejectedValue(errorMsg);
+  it("shares one initial request and polling schedule across consumers", async () => {
+    getProcessListMock.mockResolvedValue([]);
+    vi.useFakeTimers();
 
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
+    renderHook(
+      () => {
+        const first = useProcessInfo();
+        const second = useProcessInfo();
+        return [first, second];
+      },
+      { wrapper: StrictProvider },
+    );
+
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers and removes demand when enabled changes", async () => {
+    getProcessListMock.mockResolvedValue([]);
+    vi.useFakeTimers();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useProcessInfo({ enabled }),
+      {
+        initialProps: { enabled: true },
+        wrapper: Provider,
+      },
+    );
+
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    vi.advanceTimersByTime(9000);
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true });
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps polling while another consumer remains active", async () => {
+    getProcessListMock.mockResolvedValue([]);
+    vi.useFakeTimers();
+
+    const { rerender } = renderHook(
+      ({ secondEnabled }) => {
+        useProcessInfo();
+        useProcessInfo({ enabled: secondEnabled });
+      },
+      {
+        initialProps: { secondEnabled: true },
+        wrapper: Provider,
+      },
+    );
+
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    rerender({ secondEnabled: false });
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("pauses while hidden and refreshes immediately when visible", async () => {
+    getProcessListMock.mockResolvedValue([]);
+    vi.useFakeTimers();
+
+    renderHook(() => useProcessInfo(), {
+      wrapper: Provider,
+    });
+
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    act(() => setDocumentVisibility(true));
+    vi.advanceTimersByTime(9000);
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    act(() => setDocumentVisibility(false));
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips periodic ticks while a request is in flight", async () => {
+    const slowRequest = deferred<ProcessInfo[]>();
+    getProcessListMock
+      .mockReturnValueOnce(slowRequest.promise)
+      .mockResolvedValue([]);
+    vi.useFakeTimers();
+
+    renderHook(() => useProcessInfo(), {
+      wrapper: Provider,
+    });
+
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(9000);
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    slowRequest.resolve([]);
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces resumed demand and ignores a stale response", async () => {
+    const staleRequest = deferred<ProcessInfo[]>();
+    const resumedRequest = deferred<ProcessInfo[]>();
+    const staleData = [
+      { pid: 1, name: "stale", cpuUsage: "10", memoryUsage: "100" },
+    ];
+    const currentData = [
+      { pid: 2, name: "current", cpuUsage: "20", memoryUsage: "200" },
+    ];
+    getProcessListMock
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockReturnValueOnce(resumedRequest.promise);
 
     const { result } = renderHook(() => useProcessInfo(), {
       wrapper: Provider,
     });
 
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setDocumentVisibility(true);
+      setDocumentVisibility(false);
+      setDocumentVisibility(false);
+    });
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
+
+    staleRequest.resolve(staleData);
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual([]);
+
+    resumedRequest.resolve(currentData);
     await waitFor(() => {
-      expect(errorMock).toHaveBeenCalledWith(errorMsg);
+      expect(result.current).toEqual(currentData);
+    });
+    expect(getProcessListMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves the last successful result and reports one shared error", async () => {
+    const processData = [
+      { pid: 1, name: "process1", cpuUsage: "10", memoryUsage: "200" },
+    ];
+    const pollingError = "Failed to fetch processes";
+    getProcessListMock
+      .mockResolvedValueOnce(processData)
+      .mockRejectedValueOnce(pollingError);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { result } = renderHook(
+      () => {
+        useProcessInfo();
+        return useProcessInfo();
+      },
+      { wrapper: Provider },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(processData);
     });
 
-    expect(result.current).toEqual([]);
+    act(() => setDocumentVisibility(true));
+    act(() => setDocumentVisibility(false));
+
+    await waitFor(() => {
+      expect(errorMock).toHaveBeenCalledWith(pollingError);
+    });
+
+    expect(result.current).toEqual(processData);
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to fetch processes:",
-      errorMsg,
+      pollingError,
     );
-    consoleErrorSpy.mockRestore();
   });
 
-  it("refetches processes via setInterval every 3000ms", async () => {
-    const firstBatch = [
-      { pid: 1, name: "proc1", cpuUsage: 10, memoryUsage: 100 },
-    ];
-    const secondBatch = [
-      { pid: 2, name: "proc2", cpuUsage: 20, memoryUsage: 200 },
-    ];
+  it("stops polling after the final consumer unmounts", async () => {
+    getProcessListMock.mockResolvedValue([]);
+    vi.useFakeTimers();
 
-    (commands.getProcessList as Mock)
-      .mockResolvedValueOnce(firstBatch)
-      .mockResolvedValueOnce(secondBatch);
+    const { unmount } = renderHook(() => useProcessInfo(), {
+      wrapper: Provider,
+    });
 
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+    await flushMicrotasks();
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
 
-    try {
-      const { result } = renderHook(() => useProcessInfo(), {
-        wrapper: Provider,
-      });
+    unmount();
+    vi.advanceTimersByTime(9000);
 
-      // Wait for initial fetch
-      await waitFor(() => {
-        expect(result.current).toEqual(firstBatch);
-      });
-
-      // Advance timer by 3000ms to trigger the interval callback
-      vi.advanceTimersByTime(3000);
-
-      await waitFor(() => {
-        expect(result.current).toEqual(secondBatch);
-      });
-
-      expect(commands.getProcessList).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("clears interval on unmount (no further fetches)", async () => {
-    (commands.getProcessList as Mock).mockResolvedValue([]);
-
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
-    try {
-      const { unmount } = renderHook(() => useProcessInfo(), {
-        wrapper: Provider,
-      });
-
-      await waitFor(() => {
-        expect(commands.getProcessList).toHaveBeenCalledTimes(1);
-      });
-
-      unmount();
-
-      // Advance 9 seconds - no further calls expected after unmount
-      vi.advanceTimersByTime(9000);
-
-      expect(commands.getProcessList).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(getProcessListMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/hardware/hooks/useProcessInfo.ts
+++ b/src/features/hardware/hooks/useProcessInfo.ts
@@ -1,10 +1,157 @@
-import { atom, useAtomValue, useSetAtom } from "jotai";
-import { useEffect } from "react";
+import { atom, useAtomValue, useStore } from "jotai";
+import { useEffect, useRef } from "react";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { commands, type ProcessInfo } from "@/rspc/bindings";
 
+const PROCESS_POLL_INTERVAL_MS = 3000;
 const processesAtom = atom<ProcessInfo[]>([]);
 const disabledProcessesAtom = atom<ProcessInfo[]>([]);
+
+type ErrorReporter = (pollingError: unknown) => void;
+type Store = ReturnType<typeof useStore>;
+
+class ProcessPollingCoordinator {
+  private readonly consumers = new Map<symbol, ErrorReporter>();
+  private intervalId: ReturnType<typeof setInterval> | undefined;
+  private requestInFlight = false;
+  private pendingDemandRefresh = false;
+  private demandRefreshScheduled = false;
+  private generation = 0;
+
+  constructor(private readonly store: Store) {}
+
+  subscribe(reportError: ErrorReporter) {
+    const consumerId = Symbol("process-polling-consumer");
+    const isFirstConsumer = this.consumers.size === 0;
+    this.consumers.set(consumerId, reportError);
+
+    if (isFirstConsumer) {
+      document.addEventListener(
+        "visibilitychange",
+        this.handleVisibilityChange,
+      );
+      if (!document.hidden) {
+        this.startInterval();
+        this.scheduleDemandRefresh();
+      }
+    }
+
+    return () => {
+      if (!this.consumers.delete(consumerId) || this.consumers.size > 0) {
+        return;
+      }
+
+      document.removeEventListener(
+        "visibilitychange",
+        this.handleVisibilityChange,
+      );
+      this.pause();
+    };
+  }
+
+  private readonly handleVisibilityChange = () => {
+    if (document.hidden) {
+      this.pause();
+      return;
+    }
+
+    if (this.consumers.size > 0) {
+      this.startInterval();
+      this.scheduleDemandRefresh();
+    }
+  };
+
+  private startInterval() {
+    if (this.intervalId !== undefined) {
+      return;
+    }
+
+    this.intervalId = setInterval(() => {
+      void this.refreshProcesses("periodic");
+    }, PROCESS_POLL_INTERVAL_MS);
+  }
+
+  private pause() {
+    this.generation += 1;
+    this.pendingDemandRefresh = false;
+
+    if (this.intervalId !== undefined) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
+  }
+
+  private scheduleDemandRefresh() {
+    if (this.demandRefreshScheduled) {
+      return;
+    }
+
+    this.demandRefreshScheduled = true;
+    // One microtask of deferral collapses rapid subscribe/unsubscribe cycles
+    // (StrictMode remounts, visibility flaps) into a single request.
+    void Promise.resolve().then(() => {
+      this.demandRefreshScheduled = false;
+      if (this.hasVisibleDemand()) {
+        void this.refreshProcesses("demand");
+      }
+    });
+  }
+
+  private async refreshProcesses(trigger: "demand" | "periodic") {
+    if (!this.hasVisibleDemand()) {
+      return;
+    }
+
+    if (this.requestInFlight) {
+      if (trigger === "demand") {
+        this.pendingDemandRefresh = true;
+      }
+      return;
+    }
+
+    this.requestInFlight = true;
+    const requestGeneration = this.generation;
+
+    try {
+      const processesData = await commands.getProcessList();
+      if (this.isCurrentRequest(requestGeneration)) {
+        this.store.set(processesAtom, processesData);
+      }
+    } catch (pollingError) {
+      if (this.isCurrentRequest(requestGeneration)) {
+        // All reporters open the same shared dialog; any surviving one works.
+        this.consumers.values().next().value?.(pollingError);
+        console.error("Failed to fetch processes:", pollingError);
+      }
+    } finally {
+      this.requestInFlight = false;
+
+      if (this.pendingDemandRefresh) {
+        this.pendingDemandRefresh = false;
+        this.scheduleDemandRefresh();
+      }
+    }
+  }
+
+  private hasVisibleDemand() {
+    return this.consumers.size > 0 && !document.hidden;
+  }
+
+  private isCurrentRequest(requestGeneration: number) {
+    return requestGeneration === this.generation && this.hasVisibleDemand();
+  }
+}
+
+const coordinators = new WeakMap<Store, ProcessPollingCoordinator>();
+
+const getCoordinator = (store: Store) => {
+  let coordinator = coordinators.get(store);
+  if (!coordinator) {
+    coordinator = new ProcessPollingCoordinator(store);
+    coordinators.set(store, coordinator);
+  }
+  return coordinator;
+};
 
 export const useProcessInfo = ({
   enabled = true,
@@ -12,33 +159,25 @@ export const useProcessInfo = ({
   enabled?: boolean;
 } = {}) => {
   const { error } = useTauriDialog();
+  const errorRef = useRef(error);
+  const store = useStore();
   const processes = useAtomValue(
     enabled ? processesAtom : disabledProcessesAtom,
   );
-  const setAtom = useSetAtom(processesAtom);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `error` and `setAtom` are stable functions
+  useEffect(() => {
+    errorRef.current = error;
+  }, [error]);
+
   useEffect(() => {
     if (!enabled) {
       return;
     }
 
-    const fetchProcesses = async () => {
-      try {
-        const processesData = await commands.getProcessList();
-        setAtom(processesData);
-      } catch (err) {
-        error(err as string);
-        console.error("Failed to fetch processes:", err);
-      }
-    };
-
-    fetchProcesses();
-
-    const interval = setInterval(fetchProcesses, 3000);
-
-    return () => clearInterval(interval);
-  }, [enabled]);
+    return getCoordinator(store).subscribe((pollingError) => {
+      errorRef.current(pollingError as string);
+    });
+  }, [store, enabled]);
 
   return processes;
 };


### PR DESCRIPTION
## Summary

`useProcessInfo` shared its **state** through a Jotai atom, but not the **request lifecycle**: every hook consumer started its own initial request and three-second `setInterval`. The default dashboard mounts several consumers (CPU card process count, Live Process Table, hardware report export; the CPU detail screen adds a fourth), so the same `get_process_list` IPC could run as several concurrent polling loops writing to one atom.

This implements the lifecycle decided in [ADR 0013](docs/adr/0013-centralized-live-process-polling.md): one `ProcessPollingCoordinator` per Jotai store (`WeakMap<Store, Coordinator>`), with consumers registering demand while mounted and enabled.

- The first active consumer starts polling; the last one leaving stops it.
- Polling pauses while the document is hidden and refreshes immediately on becoming visible.
- Single-flight: a periodic tick during a slow request is skipped, not queued; demand signals are coalesced through one microtask so StrictMode double-mounts and visibility flaps still produce exactly one request (the app renders under `React.StrictMode`, so this path is real, and is asserted by a StrictMode-wrapped test).
- A generation counter keeps responses from a stopped or superseded lifecycle from overwriting current state.
- A transient failure preserves the last successful list and reports through one shared error path (one dialog per failed attempt, instead of one per consumer).

### Design notes

The ADR allows "Jotai lifecycle support, a small feature-owned provider, or an equivalent local mechanism". `atom.onMount` was considered as the built-in way to get first-subscriber/last-unsubscriber semantics; it was set aside because the error surface belongs to `useTauriDialog`, which needs the React i18n context for dialog titles — an `onMount` closure has no clean access to it, and routing errors through an atom would fan the dialog out to every consumer. The explicit coordinator keeps the established error boundary; the irreducible parts (visibility, single-flight, generation) would be the same size in either shape.

Acceptance criteria from the issue map to tests as follows: shared initial request/schedule (`shares one initial request and polling schedule across consumers`), enabled transitions (`registers and removes demand when enabled changes`, `keeps polling while another consumer remains active`), stop on last unmount (`stops polling after the final consumer unmounts`), visibility pause/resume (`pauses while hidden and refreshes immediately when visible`), no overlapping requests (`skips periodic ticks while a request is in flight`), stale-response rejection and demand coalescing (`coalesces resumed demand and ignores a stale response`), single error path with preserved data (`preserves the last successful result and reports one shared error`).

The test mocks now type `ProcessInfo` correctly (`cpuUsage`/`memoryUsage` are strings in the generated bindings; the old mocks used numbers).

## Related Issues

Closes #1931 (design record: ADR 0013, merged in #1932)

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

No visual change: the Live Process Table, CPU card process count, and report export read the same atom as before, on the same three-second cadence. The change is request-lifecycle-only.

## Test Plan

- [x] Manual testing
- [x] Unit tests

`useProcessInfo.test.ts` is rewritten against the coordinator contract — 11 cases covering shared scheduling, enabled transitions, visibility changes, slow requests, out-of-order responses, and cleanup, including one suite wrapped in `StrictMode` to pin the double-mount behavior.

Validation run locally: `npm run lint:ci`, `tsc && vite build`, and the full unit suite (466 tests / 71 files) all pass.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved hardware process monitoring by coordinating polling across shared consumers.
  * Reduced redundant requests and prevented overlapping refresh operations.

* **Reliability**
  * Polling now pauses when the page is hidden and resumes when visible.
  * Stale responses are safely ignored, and shared errors are reported consistently.
  * Monitoring starts and stops automatically based on active consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->