### PR TITLE
feat(performance): identify and select the GPU behind the live readings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ _Avoid_: Performance Layout Preset, Detailed preset, Custom preset, Insights tab
 The always-mounted live header of the Panels view: one hue-coded CPU, RAM, and GPU instrument combining a doughnut gauge, a short-window sparkline, and platform-dependent secondary readings.
 _Avoid_: Current Values panel, metric cards, gauge row
 
+**Selected GPU**:
+The adapter whose live readings the Performance Screen shows, chosen explicitly by the user and kept while that adapter is still detected, even when it reports nothing.
+_Avoid_: active GPU, primary GPU, current graphics card, GPU tab
+
 **System Specifications Screen**:
 The grouped-navigation destination that presents available hardware configuration, platform facts, capability-dependent observations, and Hardware Report access as one surface.
 _Avoid_: System Specifications Tab, Grouped Dashboard, Hardware Category Screen, standalone CPU screen, standalone GPU screen, System screen

--- a/docs/adr/0014-performance-views-and-specification-sheet.md
+++ b/docs/adr/0014-performance-views-and-specification-sheet.md
@@ -9,6 +9,8 @@ Dashboard destination. [ADR 0015](0015-performance-and-system-specifications-des
 promoted them to peer sidebar destinations. Every presentation decision below
 still applies; read "Performance Tab" and "System Specifications tab" as the
 Performance Screen and the System Specifications Screen.
+[ADR 0016](0016-gpu-attribution-on-the-performance-screen.md) adds adapter
+identity and selection to this decision's GPU instrument.
 
 The first implementation shipped four Performance Layout Presets (Compact,
 Monitor, Detailed, Custom) and reused the Hardware Dashboard card grid for the

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -62,8 +62,13 @@ surface and read back through the name by the one surface that needs the
 inventory.
 
 The classic card is reachable before the first sample, when no live id exists
-yet, so a selection made there starts as an inventory id and is reconciled to
-the live id as soon as the stream names that adapter. Committing an id that
+yet, so a selection made there starts as an inventory id. So do the selections
+already on disk from shipped versions, whose classic card wrote inventory ids
+into the same store key. Both are translated to the live id as soon as the
+stream names that adapter, and the translation lives in
+`useSelectedGpuPersistence` — mounted for the whole app — rather than in a GPU
+screen, because grouped navigation never mounts the classic card and the
+stored choice would otherwise stay inert forever. Committing an id that
 cannot address readings is what would otherwise leave the card's highlight and
 the graphs describing different adapters.
 
@@ -103,7 +108,11 @@ level down.
 "This adapter is not reporting live readings" may only be stated once some
 adapter has reported and this one still has not, in any of the four maps.
 Empty maps at startup mean the first sample has not arrived, and claiming
-unavailability there would turn a timing gap into a hardware conclusion. The
+unavailability there would turn a timing gap into a hardware conclusion. A
+detected adapter counts as evidence that sampling happened: a machine whose
+only GPU reports its name and no values at all leaves every value map empty
+permanently, and waiting for one of them would suppress the explanation for
+exactly the user who needs it. The
 note is additive rather than a replacement: it appears alongside whatever the
 adapter did report, never in place of it.
 

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -52,9 +52,14 @@ silent — the exact misattribution this decision exists to prevent. The
 inventory's surface is the System Specifications sheet, which lists every
 detected adapter as a static fact and attributes no readings.
 
-Where the two sides do have to meet — the VRAM total that labels a live VRAM
-reading — they meet on the name, which both sources report, the same join the
-classic Hardware Dashboard already uses.
+Where the two sides do have to meet, they meet on the name, which both sources
+report — and only while that name picks out exactly one entry on each side.
+There are two such places: the VRAM total that labels a live VRAM reading, and
+the classic Hardware Dashboard, which holds inventory entries but shares
+`selectedGpuIdAtom` with Performance. `findInventoryGpu` and `toLiveGpuId` are
+that join, so the shared selection is written in the live namespace by every
+surface and read back through the name by the one surface that needs the
+inventory.
 
 "Every detected adapter is represented" therefore means every adapter the
 monitor stream reported. An adapter that names itself and reports no values is
@@ -151,6 +156,7 @@ selection; it follows the choice made in Panels.
 - Changing GPU collection providers, archive semantics, or the Insights GPU
   view.
 - Adding selection or live readings to the System Specifications sheet.
-- Changing the classic Hardware Dashboard GPU card, whose own selector writes
-  inventory ids into the same atom and therefore does not resolve against the
-  live maps. That mismatch predates this decision and is tracked separately.
+- Redesigning the classic Hardware Dashboard GPU card. Its selection is
+  reconciled with the shared atom here, because making a second adapter
+  selectable on Performance would otherwise let the classic card pair one
+  adapter's name with another's readings, but nothing else about it changes.

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -36,16 +36,30 @@ selection pointing at an adapter that no longer exists is discarded, because
 there is no longer anything to honor.
 
 An adapter list is therefore needed, not just the live maps. It is the union of
-the adapters the one-shot hardware fetch detected and any id that appears only
-in a live map, so a reading is never rendered without an owner and a detected
-adapter is never unreachable.
+the adapters the one-shot hardware fetch detected and any id that appears in
+any live map, so a reading is never rendered without an owner and a detected
+adapter is never unreachable. An id the static fetch has not returned — because
+it is slow, or because it failed — is named from the temperature or fan map,
+which carry the platform's own name for each adapter; only an id no source
+names at all is shown as itself.
+
+## All four live maps, or none of the conclusions
+
+Usage, temperature, fan speed, and dedicated memory are populated
+independently: an adapter can report a fan speed and no usage. Every question
+of the form "did this adapter report anything" therefore has to consult all
+four. Consulting a subset turns a partially reporting adapter into a silent
+one, which is the same misattribution this decision exists to prevent, one
+level down.
 
 ## Not measured yet is not unavailable
 
 "This adapter is not reporting live readings" may only be stated once some
-adapter has reported and this one still has not. Empty maps at startup mean the
-first sample has not arrived, and claiming unavailability there would turn a
-timing gap into a hardware conclusion.
+adapter has reported and this one still has not, in any of the four maps.
+Empty maps at startup mean the first sample has not arrived, and claiming
+unavailability there would turn a timing gap into a hardware conclusion. The
+note is additive rather than a replacement: it appears alongside whatever the
+adapter did report, never in place of it.
 
 ## Adapter labels
 
@@ -61,7 +75,9 @@ falls back to the full name.
 ## Placement
 
 The selector sits in the GPU instrument's header, where the readings it governs
-are. A single-adapter machine gets the name alone, because naming is the whole
+are. It is a labelled group of toggle buttons, not a tablist: there is no
+tabpanel, no roving tabindex, and no arrow-key contract, so announcing tabs
+would promise a keyboard model the control does not implement. A single-adapter machine gets the name alone, because naming is the whole
 job when there is no choice to make. Compact names its adapter in the footer
 rather than in the GPU row: the row's tracks are sized for the mini monitor's
 small corner window and cannot hold a device name. Compact does not offer
@@ -87,6 +103,11 @@ selection; it follows the choice made in Panels.
   is only available on hover or to assistive technology.
 - Compact fetches the static hardware facts itself, adding one one-shot IPC
   call to a view that previously needed none.
+- The unavailable state only covers an adapter that has never reported. The
+  live maps are append-only, so an adapter that reports and then goes silent
+  keeps its last value on screen; distinguishing a stale reading from a current
+  one needs per-sample presence tracking in the event listener, which this
+  decision does not add.
 
 ### Non-goals
 

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -68,9 +68,8 @@ into the same store key. Both are translated to the live id as soon as the
 stream names that adapter, and the translation lives in
 `useSelectedGpuPersistence` — mounted for the whole app — rather than in a GPU
 screen, because grouped navigation never mounts the classic card and the
-stored choice would otherwise stay inert forever. Committing an id that
-cannot address readings is what would otherwise leave the card's highlight and
-the graphs describing different adapters.
+stored choice would stay inert forever. An id that cannot address readings is
+what leaves the card's highlight and the graphs describing different adapters.
 
 Where the join is ambiguous, the caller refuses rather than falls back: the
 classic card claims no adapter identity for a selection it cannot resolve,
@@ -112,9 +111,10 @@ unavailability there would turn a timing gap into a hardware conclusion. A
 detected adapter counts as evidence that sampling happened: a machine whose
 only GPU reports its name and no values at all leaves every value map empty
 permanently, and waiting for one of them would suppress the explanation for
-exactly the user who needs it. The
-note is additive rather than a replacement: it appears alongside whatever the
-adapter did report, never in place of it.
+exactly the user who needs it.
+
+The note is additive rather than a replacement: it appears alongside whatever
+the adapter did report, never in place of it.
 
 ## Adapter labels
 

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -71,6 +71,18 @@ enumeration order and the stream's are different enumerations.
 monitor stream reported. An adapter that names itself and reports no values is
 still listed and still selectable; that is what the unavailable state is for.
 
+The derived atoms the classic Usage screen, the classic dashboard, and the
+Monitor graph read (`graphicUsageHistoryAtom`, `gpuUsageSourceAtom`,
+`gpuDedicatedMemoryKbAtom`) resolve the selection through the same rule. They
+previously fell back to the first adapter whenever the selected key was
+missing, which would have let Monitor name one adapter in its toolbar and
+graph another underneath it.
+
+The subscription that answers these questions lives in the component that
+renders the answer, never in a screen's parent: the underlying atoms are
+rewritten on every sample, so subscribing higher up would rerender unrelated
+panels once a second and break the ADR 0010 rendering-cost rule.
+
 ## All four live maps, or none of the conclusions
 
 Usage, temperature, fan speed, and dedicated memory are populated

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -25,8 +25,8 @@ The effective GPU resolves in this order:
 
 1. An explicit selection, while that adapter is still detected — whether or not
    it is currently reporting anything.
-2. Otherwise the first adapter that reports usage, then the first that reports
-   a temperature.
+2. Otherwise the first adapter that reports usage, then temperature, then fan
+   speed, then dedicated memory.
 
 The first rule is the decision. The earlier resolver dropped a selection the
 moment its adapter stopped appearing in the usage map, which silently replaced
@@ -35,13 +35,30 @@ Honoring the selection and reporting nothing is the honest answer; only a
 selection pointing at an adapter that no longer exists is discarded, because
 there is no longer anything to honor.
 
-An adapter list is therefore needed, not just the live maps. It is the union of
-the adapters the one-shot hardware fetch detected and any id that appears in
-any live map, so a reading is never rendered without an owner and a detected
-adapter is never unreachable. An id the static fetch has not returned — because
-it is slow, or because it failed — is named from the temperature or fan map,
-which carry the platform's own name for each adapter; only an id no source
-names at all is shown as itself.
+## The inventory is not a source of adapter identity
+
+The `getHardwareInfo` inventory and the monitor stream key their GPUs in
+different namespaces on every platform. Windows NVIDIA reports the raw NVAPI id
+as `GraphicInfo.id` but samples as `nvapi:<id>`; macOS pairs
+`0x<registry_id>` with `iokit:<name>`; Linux pairs `card<n>` with the PCI BDF.
+The two id spaces are disjoint, so they cannot be joined, unioned, or looked up
+across.
+
+The adapter list is therefore built from the live side alone: every id the
+stream reported, named by the `gpuName` each sample carries, plus any id that
+only a value map knows about. Unioning with the inventory would render one
+physical GPU as two adapters, one of which reports nothing and is then declared
+silent — the exact misattribution this decision exists to prevent. The
+inventory's surface is the System Specifications sheet, which lists every
+detected adapter as a static fact and attributes no readings.
+
+Where the two sides do have to meet — the VRAM total that labels a live VRAM
+reading — they meet on the name, which both sources report, the same join the
+classic Hardware Dashboard already uses.
+
+"Every detected adapter is represented" therefore means every adapter the
+monitor stream reported. An adapter that names itself and reports no values is
+still listed and still selectable; that is what the unavailable state is for.
 
 ## All four live maps, or none of the conclusions
 
@@ -77,8 +94,10 @@ falls back to the full name.
 The selector sits in the GPU instrument's header, where the readings it governs
 are. It is a labelled group of toggle buttons, not a tablist: there is no
 tabpanel, no roving tabindex, and no arrow-key contract, so announcing tabs
-would promise a keyboard model the control does not implement. A single-adapter machine gets the name alone, because naming is the whole
-job when there is no choice to make. Compact names its adapter in the footer
+would promise a keyboard model the control does not implement.
+
+A single-adapter machine gets the name alone, because naming is the whole job
+when there is no choice to make. Compact names its adapter in the footer
 rather than in the GPU row: the row's tracks are sized for the mini monitor's
 small corner window and cannot hold a device name. Compact does not offer
 selection; it follows the choice made in Panels.
@@ -91,9 +110,12 @@ selection; it follows the choice made in Panels.
 - Every detected adapter is reachable without leaving grouped navigation.
 - A user who selects a silent adapter is told it is silent instead of being
   shown another adapter's numbers.
-- The selection is one piece of state (`selectedGpuIdAtom`, persisted by
-  `useSelectedGpuPersistence`), so Performance, Compact, and the classic
-  Hardware Dashboard agree and the choice survives restarts.
+- The selection is one piece of state (`selectedGpuIdAtom`), so Performance and
+  Compact always agree on which adapter they describe.
+- `useSelectedGpuPersistence` restores the stored id as-is instead of
+  validating it against the inventory, which it could never match. A selection
+  made for an adapter that is absent at the next launch is kept on disk rather
+  than overwritten, so it applies again when the adapter returns.
 
 ### Negative
 
@@ -101,8 +123,9 @@ selection; it follows the choice made in Panels.
   no device to name.
 - Long adapter names still truncate inside a three-column strip; the full name
   is only available on hover or to assistive technology.
-- Compact fetches the static hardware facts itself, adding one one-shot IPC
-  call to a view that previously needed none.
+- A GPU that the inventory lists but the monitor stream never reports does not
+  appear on Performance at all. It is still on the System Specifications sheet,
+  but Performance cannot name a device it has no reading from.
 - The unavailable state only covers an adapter that has never reported. The
   live maps are append-only, so an adapter that reports and then goes silent
   keeps its last value on screen; distinguishing a stale reading from a current
@@ -114,4 +137,6 @@ selection; it follows the choice made in Panels.
 - Changing GPU collection providers, archive semantics, or the Insights GPU
   view.
 - Adding selection or live readings to the System Specifications sheet.
-- Changing the classic Hardware Dashboard GPU card.
+- Changing the classic Hardware Dashboard GPU card, whose own selector writes
+  inventory ids into the same atom and therefore does not resolve against the
+  live maps. That mismatch predates this decision and is tracked separately.

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -1,0 +1,96 @@
+# GPU Attribution on the Performance Screen
+
+Status: accepted
+
+Refines [ADR 0014](0014-performance-views-and-specification-sheet.md) and
+[ADR 0015](0015-performance-and-system-specifications-destinations.md).
+
+ADR 0014 moved every live GPU reading onto the Performance Screen and left the
+System Specifications sheet as static facts. That split left the Instrument
+Strip and the Compact strip showing GPU usage, temperature, VRAM, and fan
+speed without saying which adapter produced them, and grouped navigation
+carried no way to change adapters at all — the only selection control in the
+app was the classic Hardware Dashboard GPU card. On a machine with a discrete
+and an integrated GPU, a grouped-navigation user could neither tell which
+adapter the numbers described nor reach the other one.
+
+Attribution belongs on the surface that makes the claim. The Performance
+Screen names the adapter behind its GPU readings and owns the selection; the
+specifications sheet stays an inventory of every detected adapter with no
+selected state, because it shows nothing that could be attributed.
+
+## Selection beats availability
+
+The effective GPU resolves in this order:
+
+1. An explicit selection, while that adapter is still detected — whether or not
+   it is currently reporting anything.
+2. Otherwise the first adapter that reports usage, then the first that reports
+   a temperature.
+
+The first rule is the decision. The earlier resolver dropped a selection the
+moment its adapter stopped appearing in the usage map, which silently replaced
+the user's chosen adapter with another adapter's numbers under the same label.
+Honoring the selection and reporting nothing is the honest answer; only a
+selection pointing at an adapter that no longer exists is discarded, because
+there is no longer anything to honor.
+
+An adapter list is therefore needed, not just the live maps. It is the union of
+the adapters the one-shot hardware fetch detected and any id that appears only
+in a live map, so a reading is never rendered without an owner and a detected
+adapter is never unreachable.
+
+## Not measured yet is not unavailable
+
+"This adapter is not reporting live readings" may only be stated once some
+adapter has reported and this one still has not. Empty maps at startup mean the
+first sample has not arrived, and claiming unavailability there would turn a
+timing gap into a hardware conclusion.
+
+## Adapter labels
+
+Controls carry a shortened label and keep the full platform name as the
+accessible name and tooltip. Shortening removes only what cannot distinguish
+one adapter from another: trademark marks, a leading vendor word, and a run of
+leading words every detected adapter repeats. The last rule matters because the
+shared part is exactly what a narrow card keeps while truncating the model
+away — "GeForce RTX 4080" and "GeForce RTX 4060" would otherwise both render as
+"GeForce RTX 40…". If shortening would make two labels identical, every label
+falls back to the full name.
+
+## Placement
+
+The selector sits in the GPU instrument's header, where the readings it governs
+are. A single-adapter machine gets the name alone, because naming is the whole
+job when there is no choice to make. Compact names its adapter in the footer
+rather than in the GPU row: the row's tracks are sized for the mini monitor's
+small corner window and cannot hold a device name. Compact does not offer
+selection; it follows the choice made in Panels.
+
+## Consequences
+
+### Positive
+
+- Every GPU number on the Performance Screen states the device it came from.
+- Every detected adapter is reachable without leaving grouped navigation.
+- A user who selects a silent adapter is told it is silent instead of being
+  shown another adapter's numbers.
+- The selection is one piece of state (`selectedGpuIdAtom`, persisted by
+  `useSelectedGpuPersistence`), so Performance, Compact, and the classic
+  Hardware Dashboard agree and the choice survives restarts.
+
+### Negative
+
+- The GPU instrument header is denser than the CPU and RAM headers, which have
+  no device to name.
+- Long adapter names still truncate inside a three-column strip; the full name
+  is only available on hover or to assistive technology.
+- Compact fetches the static hardware facts itself, adding one one-shot IPC
+  call to a view that previously needed none.
+
+### Non-goals
+
+- Changing GPU collection providers, archive semantics, or the Insights GPU
+  view.
+- Adding selection or live readings to the System Specifications sheet.
+- Changing the classic Hardware Dashboard GPU card.

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -68,7 +68,10 @@ into the same store key. Both are translated to the live id as soon as the
 stream names that adapter, and the translation lives in
 `useSelectedGpuPersistence` — mounted for the whole app — rather than in a GPU
 screen, because grouped navigation never mounts the classic card and the
-stored choice would stay inert forever. An id that cannot address readings is
+stored choice would stay inert forever. The migration fetches the inventory
+itself when an id needs translating, since a restart can land on a view
+(Monitor, Compact) that never fetches it; it waits for the first sample
+before deciding, because until then every id looks unresolved. An id that cannot address readings is
 what leaves the card's highlight and the graphs describing different adapters.
 
 Where the join is ambiguous, the caller refuses rather than falls back: the

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -61,6 +61,12 @@ that join, so the shared selection is written in the live namespace by every
 surface and read back through the name by the one surface that needs the
 inventory.
 
+The classic card is reachable before the first sample, when no live id exists
+yet, so a selection made there starts as an inventory id and is reconciled to
+the live id as soon as the stream names that adapter. Committing an id that
+cannot address readings is what would otherwise leave the card's highlight and
+the graphs describing different adapters.
+
 Where the join is ambiguous, the caller refuses rather than falls back: the
 classic card claims no adapter identity for a selection it cannot resolve,
 instead of labelling one adapter's readings with another's name. Pairing the
@@ -167,10 +173,11 @@ selection; it follows the choice made in Panels.
   appear on Performance at all. It is still on the System Specifications sheet,
   but Performance cannot name a device it has no reading from.
 - The unavailable state only covers an adapter that has never reported. The
-  live maps are append-only, so an adapter that reports and then goes silent
-  keeps its last value on screen; distinguishing a stale reading from a current
-  one needs per-sample presence tracking in the event listener, which this
-  decision does not add.
+  live maps, including the name map, are append-only, so an adapter that
+  reports and then goes silent keeps its last value on screen and stays in the
+  selector for the rest of the session. Distinguishing a stale reading from a
+  current one, and an unplugged adapter from a skipped sample, needs per-sample
+  presence tracking in the event listener, which this decision does not add.
 
 ### Non-goals
 

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -96,8 +96,10 @@ announced exactly when the raw name cannot tell the cards apart.
 
 A duplicated name also disqualifies the name as a join key. The VRAM total,
 the one place the inventory and the live side have to meet, is dropped rather
-than guessed when two adapters share a name: showing a live reading against
-the wrong card's capacity is worse than showing no denominator.
+than guessed when the name is ambiguous on *either* side: two live adapters
+sharing it, or two inventory entries sharing it while only one reports.
+Showing a live reading against the wrong card's capacity is worse than showing
+no denominator.
 
 ## Placement
 

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -61,6 +61,12 @@ that join, so the shared selection is written in the live namespace by every
 surface and read back through the name by the one surface that needs the
 inventory.
 
+Where the join is ambiguous, the caller refuses rather than falls back: the
+classic card claims no adapter identity for a selection it cannot resolve,
+instead of labelling one adapter's readings with another's name. Pairing the
+two sides by position would look plausible and is a guess — the inventory's
+enumeration order and the stream's are different enumerations.
+
 "Every detected adapter is represented" therefore means every adapter the
 monitor stream reported. An adapter that names itself and reports no values is
 still listed and still selectable; that is what the unavailable state is for.
@@ -114,7 +120,10 @@ tabpanel, no roving tabindex, and no arrow-key contract, so announcing tabs
 would promise a keyboard model the control does not implement.
 
 A single-adapter machine gets the name alone, because naming is the whole job
-when there is no choice to make. Compact names its adapter in the footer
+when there is no choice to make. Monitor carries the same control in its
+toolbar whenever the GPU is among the graph's display targets: it mounts only
+the graph, so there is nowhere else for the adapter behind the GPU series to
+be named. Compact names its adapter in the footer
 rather than in the GPU row: the row's tracks are sized for the mini monitor's
 small corner window and cannot hold a device name. Compact does not offer
 selection; it follows the choice made in Panels.

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -86,8 +86,18 @@ one adapter from another: trademark marks, a leading vendor word, and a run of
 leading words every detected adapter repeats. The last rule matters because the
 shared part is exactly what a narrow card keeps while truncating the model
 away — "GeForce RTX 4080" and "GeForce RTX 4060" would otherwise both render as
-"GeForce RTX 40…". If shortening would make two labels identical, every label
-falls back to the full name.
+"GeForce RTX 40…".
+
+Labels are then made unique, because two controls that read identically are
+not a choice. Adapters the platform reports under one name — two identical
+cards — get an ordinal; if labels still collide, every label falls back to the
+full name. The accessible name follows the same rule, so the ordinal is
+announced exactly when the raw name cannot tell the cards apart.
+
+A duplicated name also disqualifies the name as a join key. The VRAM total,
+the one place the inventory and the live side have to meet, is dropped rather
+than guessed when two adapters share a name: showing a live reading against
+the wrong card's capacity is worse than showing no denominator.
 
 ## Placement
 
@@ -123,6 +133,8 @@ selection; it follows the choice made in Panels.
   no device to name.
 - Long adapter names still truncate inside a three-column strip; the full name
   is only available on hover or to assistive technology.
+- Two identical cards lose their VRAM denominator, because the only join
+  available cannot say which card is which.
 - A GPU that the inventory lists but the monitor stream never reports does not
   appear on Performance at all. It is still on the System Specifications sheet,
   but Performance cannot name a device it has no reading from.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ ADR status describes decision maturity, not release status.
 - [0013 Centralized Live Process Polling](0013-centralized-live-process-polling.md)
 - [0014 Performance Views and the Specification Sheet](0014-performance-views-and-specification-sheet.md)
 - [0015 Performance and System Specifications as Sidebar Destinations](0015-performance-and-system-specifications-destinations.md)
+- [0016 GPU Attribution on the Performance Screen](0016-gpu-attribution-on-the-performance-screen.md)

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -19,11 +19,20 @@ test.describe("dashboard captures", () => {
     await gotoApp(page, { path: "/?navigationLayout=classic" });
     await seedHardwareHistory(page);
 
+    const gpuCard = page.getByTestId("dashboard-gpu-readings");
+    const readingsBefore = await gpuCard.innerText();
+
     const secondaryGpuTab = page.getByRole("tab", {
       name: GPU_FIXTURES[1].name,
     });
     await secondaryGpuTab.click();
     await expect(secondaryGpuTab).toHaveAttribute("aria-selected", "true");
+
+    // The pressed state is not the point: the card has to actually describe
+    // the other adapter. The selection is shared with Performance and is
+    // written in the live id namespace, so a card that resolved it by id
+    // alone would keep rendering the first adapter's readings here.
+    await expect.poll(async () => gpuCard.innerText()).not.toBe(readingsBefore);
 
     await saveCapture(page, "dashboard-gpu-secondary");
   });

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -121,6 +121,13 @@ test.describe("Grouped navigation destinations", () => {
     const primary = page.getByRole("button", { name: "HV Fixture GPU 8GB" });
     const secondary = page.getByRole("button", { name: "HV Fixture iGPU" });
 
+    // Exactly one control per physical adapter. The fixture's inventory ids
+    // and live ids differ on purpose, so a join across the two namespaces
+    // would show four controls here, two of them permanently silent.
+    await expect(
+      page.getByTestId("performance-gpu-selector").getByRole("button"),
+    ).toHaveCount(2);
+
     // Both adapters are reachable and the readings say which one they are.
     await expect(primary).toHaveAttribute("aria-pressed", "true");
     await expect(secondary).toHaveAttribute("aria-pressed", "false");

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -118,16 +118,16 @@ test.describe("Grouped navigation destinations", () => {
     await seedHardwareHistory(page);
 
     const gpuInstrument = page.getByTestId("performance-metric-gpu");
-    const primary = page.getByRole("tab", { name: "HV Fixture GPU 8GB" });
-    const secondary = page.getByRole("tab", { name: "HV Fixture iGPU" });
+    const primary = page.getByRole("button", { name: "HV Fixture GPU 8GB" });
+    const secondary = page.getByRole("button", { name: "HV Fixture iGPU" });
 
     // Both adapters are reachable and the readings say which one they are.
-    await expect(primary).toHaveAttribute("aria-selected", "true");
-    await expect(secondary).toHaveAttribute("aria-selected", "false");
+    await expect(primary).toHaveAttribute("aria-pressed", "true");
+    await expect(secondary).toHaveAttribute("aria-pressed", "false");
     await expect(gpuInstrument).toContainText("VRAM 4.0/8 GB");
 
     await secondary.click();
-    await expect(secondary).toHaveAttribute("aria-selected", "true");
+    await expect(secondary).toHaveAttribute("aria-pressed", "true");
     await expect(gpuInstrument).toContainText("VRAM 1.0/2 GB");
     await expect(gpuInstrument).not.toContainText("VRAM 4.0/8 GB");
 
@@ -137,8 +137,8 @@ test.describe("Grouped navigation destinations", () => {
     await navigateTo(page, "systemSpecifications");
     await navigateTo(page, "performance");
     await expect(
-      page.getByRole("tab", { name: "HV Fixture iGPU" }),
-    ).toHaveAttribute("aria-selected", "true");
+      page.getByRole("button", { name: "HV Fixture iGPU" }),
+    ).toHaveAttribute("aria-pressed", "true");
 
     // ...and the Compact strip reports the same adapter rather than its own.
     await page.getByRole("tab", { name: "Compact" }).click();

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -147,6 +147,16 @@ test.describe("Grouped navigation destinations", () => {
       page.getByRole("button", { name: "HV Fixture iGPU" }),
     ).toHaveAttribute("aria-pressed", "true");
 
+    // Monitor mounts only the graph, so the selector is its sole attribution.
+    await page.getByRole("tab", { name: "Monitor" }).click();
+    await expect(page.getByTestId("performance-usage-graphs")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "HV Fixture iGPU" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await saveCapture(page, "performance-gpu-selector-monitor");
+
+    await page.getByRole("tab", { name: "Panels" }).click();
+
     // ...and the Compact strip reports the same adapter rather than its own.
     await page.getByRole("tab", { name: "Compact" }).click();
     // The label drops the words both fixture adapters share, so a narrow strip

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -111,6 +111,45 @@ test.describe("Grouped navigation destinations", () => {
     await saveCapture(page, "performance-monitor-desktop");
   });
 
+  test("attributes the GPU readings to a named adapter the user can change", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+
+    const gpuInstrument = page.getByTestId("performance-metric-gpu");
+    const primary = page.getByRole("tab", { name: "HV Fixture GPU 8GB" });
+    const secondary = page.getByRole("tab", { name: "HV Fixture iGPU" });
+
+    // Both adapters are reachable and the readings say which one they are.
+    await expect(primary).toHaveAttribute("aria-selected", "true");
+    await expect(secondary).toHaveAttribute("aria-selected", "false");
+    await expect(gpuInstrument).toContainText("VRAM 4.0/8 GB");
+
+    await secondary.click();
+    await expect(secondary).toHaveAttribute("aria-selected", "true");
+    await expect(gpuInstrument).toContainText("VRAM 1.0/2 GB");
+    await expect(gpuInstrument).not.toContainText("VRAM 4.0/8 GB");
+
+    await saveCapture(page, "performance-gpu-selector-desktop");
+
+    // The choice is explicit user intent, so it outlives leaving the screen.
+    await navigateTo(page, "systemSpecifications");
+    await navigateTo(page, "performance");
+    await expect(
+      page.getByRole("tab", { name: "HV Fixture iGPU" }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    // ...and the Compact strip reports the same adapter rather than its own.
+    await page.getByRole("tab", { name: "Compact" }).click();
+    // The label drops the words both fixture adapters share, so a narrow strip
+    // keeps the part that tells them apart.
+    const strip = page.getByTestId("performance-compact-strip");
+    await expect(strip).toContainText("GPU: iGPU");
+    await expect(strip).not.toContainText("GPU 8GB");
+    await saveCapture(page, "performance-gpu-selector-compact");
+  });
+
   test("persists panel visibility edited in the panels view", async ({
     page,
   }) => {

--- a/src/e2e/fixtures/hardware.ts
+++ b/src/e2e/fixtures/hardware.ts
@@ -7,14 +7,23 @@ import type {
 } from "@/rspc/bindings";
 
 /**
- * GPU ids must match between `sysInfoFixture.gpus[].id` and the
- * `hardware-monitor-update` payloads (`gpus[].gpuId`) — the dashboard joins
- * them to resolve the selected GPU. Two GPUs are provided so the GPU selector
- * tablist renders and can be driven via accessible selectors.
+ * The inventory id and the live sampling id are deliberately different, as
+ * they are on every real platform: Windows NVIDIA pairs `<nvapi id>` with
+ * `nvapi:<id>`, macOS pairs `0x<registry_id>` with `iokit:<name>`, Linux
+ * pairs `card<n>` with the PCI BDF. A fixture that used one id for both would
+ * let id-based joins across the two sources pass here and fail on hardware.
+ * The name is what the two sources actually share.
+ *
+ * Two GPUs are provided so the adapter selector renders and can be driven via
+ * accessible selectors.
  */
 export const GPU_FIXTURES = [
-  { id: "e2e-gpu-0", name: "HV Fixture GPU 8GB" },
-  { id: "e2e-gpu-1", name: "HV Fixture iGPU" },
+  {
+    id: "e2e-gpu-inventory-0",
+    liveId: "e2e-gpu-0",
+    name: "HV Fixture GPU 8GB",
+  },
+  { id: "e2e-gpu-inventory-1", liveId: "e2e-gpu-1", name: "HV Fixture iGPU" },
 ] as const;
 
 export const sysInfoFixture: SysInfo = {
@@ -209,7 +218,7 @@ export const buildHardwareUpdateSeries = (
     memoryUsage: round1(62 + 6 * Math.sin(i / 6 + 1)),
     gpus: [
       {
-        gpuId: GPU_FIXTURES[0].id,
+        gpuId: GPU_FIXTURES[0].liveId,
         gpuName: GPU_FIXTURES[0].name,
         gpuUsage: round1(55 + 35 * Math.sin(i / 3 + 2)),
         gpuTemperature: round1(58 + 6 * Math.sin(i / 5)),
@@ -218,7 +227,7 @@ export const buildHardwareUpdateSeries = (
         gpuCoolerLevel: 42,
       },
       {
-        gpuId: GPU_FIXTURES[1].id,
+        gpuId: GPU_FIXTURES[1].liveId,
         gpuName: GPU_FIXTURES[1].name,
         gpuUsage: round1(20 + 10 * Math.sin(i / 4 + 1)),
         gpuTemperature: round1(45 + 4 * Math.sin(i / 5 + 1)),

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -162,24 +162,6 @@ export const GPUInfo = () => {
       : (findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? null);
   const hasMultipleGpus = gpus.length > 1;
 
-  // A selection made from the inventory before the first sample arrived can
-  // only be an inventory id, which addresses no readings. Adopt the live id
-  // for the same adapter as soon as the stream names exactly one, so the
-  // highlight here and the graphs elsewhere stop describing different cards.
-  useEffect(() => {
-    if (selectedGpuId == null || gpuNames[selectedGpuId] != null) {
-      return;
-    }
-    const stillInventory = gpus.find((gpu) => gpu.id === selectedGpuId);
-    if (stillInventory == null) {
-      return;
-    }
-    const liveId = toLiveGpuId(stillInventory, gpuNames);
-    if (liveId !== selectedGpuId) {
-      setSelectedGpuId(liveId);
-    }
-  }, [selectedGpuId, gpus, gpuNames, setSelectedGpuId]);
-
   const getTargetInfo = (data: NameValues) => {
     if (!targetGpu || data.length === 0) return undefined;
     // Prefer an exact name match for the currently selected GPU.

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -25,11 +25,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { minOpacity } from "@/consts/style";
+import { findInventoryGpu, toLiveGpuId } from "@/features/hardware/gpuIdentity";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
+  gpuNamesAtom,
   gpuTempAtom,
   gpuUsageSourceAtom,
   graphicUsageHistoryAtom,
@@ -142,10 +144,16 @@ export const GPUInfo = () => {
   const { isBreak } = useWindowSize();
   const [showGpuUsageSource] = useTauriStore("showGpuUsageSource", false);
   const [gpuDedicatedMemoryKbMap] = useAtom(gpuDedicatedMemoryKbMapAtom);
+  const [gpuNames] = useAtom(gpuNamesAtom);
   const os = useMemo(() => platform(), []);
 
   const gpus = hardwareInfo.gpus ?? [];
-  const targetGpu = gpus.find((g) => g.id === selectedGpuId) ?? gpus[0] ?? null;
+  // The shared selection is written in the live namespace by the Performance
+  // selector and by the event listener's auto-selection, so resolving it by
+  // id alone would silently land on the first inventory entry and pair its
+  // name and badge with another adapter's readings.
+  const targetGpu =
+    findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? gpus[0] ?? null;
   const hasMultipleGpus = gpus.length > 1;
 
   const getTargetInfo = (data: NameValues) => {
@@ -182,7 +190,9 @@ export const GPUInfo = () => {
                       role="tab"
                       aria-selected={isSelected}
                       aria-label={gpu.name}
-                      onClick={() => setSelectedGpuId(gpu.id)}
+                      onClick={() =>
+                        setSelectedGpuId(toLiveGpuId(gpu, gpuNames))
+                      }
                       className={cn(
                         "min-w-7 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
                         isSelected
@@ -200,7 +210,7 @@ export const GPUInfo = () => {
           </div>
         </TooltipProvider>
       )}
-      <div className="relative">
+      <div className="relative" data-testid="dashboard-gpu-readings">
         <div
           className={cn(
             "flex justify-around",

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -162,6 +162,24 @@ export const GPUInfo = () => {
       : (findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? null);
   const hasMultipleGpus = gpus.length > 1;
 
+  // A selection made from the inventory before the first sample arrived can
+  // only be an inventory id, which addresses no readings. Adopt the live id
+  // for the same adapter as soon as the stream names exactly one, so the
+  // highlight here and the graphs elsewhere stop describing different cards.
+  useEffect(() => {
+    if (selectedGpuId == null || gpuNames[selectedGpuId] != null) {
+      return;
+    }
+    const stillInventory = gpus.find((gpu) => gpu.id === selectedGpuId);
+    if (stillInventory == null) {
+      return;
+    }
+    const liveId = toLiveGpuId(stillInventory, gpuNames);
+    if (liveId !== selectedGpuId) {
+      setSelectedGpuId(liveId);
+    }
+  }, [selectedGpuId, gpus, gpuNames, setSelectedGpuId]);
+
   const getTargetInfo = (data: NameValues) => {
     if (!targetGpu || data.length === 0) return undefined;
     // Prefer an exact name match for the currently selected GPU.

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -152,8 +152,14 @@ export const GPUInfo = () => {
   // selector and by the event listener's auto-selection, so resolving it by
   // id alone would silently land on the first inventory entry and pair its
   // name and badge with another adapter's readings.
+  // With nothing selected yet, the first entry is the honest default. With a
+  // selection that cannot be resolved — two identically named cards, so the
+  // only available join is ambiguous — the card claims no identity at all
+  // rather than labelling one adapter's readings with another's name.
   const targetGpu =
-    findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? gpus[0] ?? null;
+    selectedGpuId == null
+      ? (gpus[0] ?? null)
+      : (findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? null);
   const hasMultipleGpus = gpus.length > 1;
 
   const getTargetInfo = (data: NameValues) => {

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -293,6 +293,26 @@ describe("findInventoryGpu", () => {
     ).toBeUndefined();
   });
 
+  it("refuses rather than pairing by position when both sides have twins", () => {
+    // Positional pairing would look plausible and be a guess: the inventory's
+    // enumeration order and the stream's are different enumerations.
+    const twins = [
+      { id: "inv-a", name: "NVIDIA GeForce RTX 4090" },
+      { id: "inv-b", name: "NVIDIA GeForce RTX 4090" },
+    ];
+
+    expect(
+      findInventoryGpu(
+        twins,
+        {
+          "nvapi:1": "NVIDIA GeForce RTX 4090",
+          "nvapi:2": "NVIDIA GeForce RTX 4090",
+        },
+        "nvapi:2",
+      ),
+    ).toBeUndefined();
+  });
+
   it("has nothing to resolve without a selection", () => {
     expect(findInventoryGpu(inventory, {}, null)).toBeUndefined();
   });

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -329,6 +329,13 @@ describe("toLiveGpuId", () => {
     expect(toLiveGpuId(inventory[1], {})).toBe("67890");
   });
 
+  it("keeps the inventory id before any sample names an adapter", () => {
+    // The classic card is available before the first monitor sample. The id
+    // it returns here cannot address readings, so the card reconciles it once
+    // the stream names the adapter.
+    expect(toLiveGpuId(inventory[1], {})).toBe("67890");
+  });
+
   it("keeps the inventory id when the name is ambiguous", () => {
     expect(
       toLiveGpuId(

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  findInventoryGpu,
   type GpuLiveMaps,
   getEffectiveGpuId,
   hasNoLiveGpuReadings,
   listGpuAdapters,
+  toLiveGpuId,
 } from "./gpuIdentity";
+
+const inventory = [
+  { id: "12345", name: "NVIDIA GeForce RTX 4080" },
+  { id: "67890", name: "Intel UHD Graphics 770" },
+];
 
 /** The live name map, as the event listener builds it from each sample. */
 const names = (...pairs: [string, string][]) => Object.fromEntries(pairs);
@@ -250,5 +257,67 @@ describe("hasNoLiveGpuReadings", () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("findInventoryGpu", () => {
+  it("resolves a live id to its inventory entry through the shared name", () => {
+    // Selecting the second adapter on Performance writes a live id. Resolving
+    // it by id alone would land on the first inventory entry and pair its
+    // name with the second adapter's readings.
+    expect(
+      findInventoryGpu(
+        inventory,
+        { "pci:0:2:0": "Intel UHD Graphics 770" },
+        "pci:0:2:0",
+      ),
+    ).toEqual(inventory[1]);
+  });
+
+  it("still accepts an id the inventory itself uses", () => {
+    expect(findInventoryGpu(inventory, {}, "67890")).toEqual(inventory[1]);
+  });
+
+  it("refuses the join when the name picks out more than one entry", () => {
+    const twins = [
+      { id: "a", name: "NVIDIA GeForce RTX 4090" },
+      { id: "b", name: "NVIDIA GeForce RTX 4090" },
+    ];
+
+    expect(
+      findInventoryGpu(
+        twins,
+        { "nvapi:1": "NVIDIA GeForce RTX 4090" },
+        "nvapi:1",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("has nothing to resolve without a selection", () => {
+    expect(findInventoryGpu(inventory, {}, null)).toBeUndefined();
+  });
+});
+
+describe("toLiveGpuId", () => {
+  it("writes the shared selection in the namespace readings are keyed by", () => {
+    expect(
+      toLiveGpuId(inventory[1], { "pci:0:2:0": "Intel UHD Graphics 770" }),
+    ).toBe("pci:0:2:0");
+  });
+
+  it("keeps the inventory id when no live adapter reports that name", () => {
+    expect(toLiveGpuId(inventory[1], {})).toBe("67890");
+  });
+
+  it("keeps the inventory id when the name is ambiguous", () => {
+    expect(
+      toLiveGpuId(
+        { id: "a", name: "NVIDIA GeForce RTX 4090" },
+        {
+          "nvapi:1": "NVIDIA GeForce RTX 4090",
+          "nvapi:2": "NVIDIA GeForce RTX 4090",
+        },
+      ),
+    ).toBe("a");
   });
 });

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -260,6 +260,21 @@ describe("hasNoLiveGpuReadings", () => {
   });
 });
 
+describe("hasNoLiveGpuReadings with an all-null sample", () => {
+  it("explains a lone adapter that reports only its own name", () => {
+    // An Intel GPU whose PDH usage query fails: the sample arrives, the name
+    // is recorded, and all four value maps stay empty forever. Treating that
+    // as "not measured yet" would blank the explanation permanently.
+    expect(
+      hasNoLiveGpuReadings("pdh:UHD Graphics", live({}), ["pdh:UHD Graphics"]),
+    ).toBe(true);
+  });
+
+  it("still says nothing before any adapter is detected", () => {
+    expect(hasNoLiveGpuReadings("pdh:UHD Graphics", live({}), [])).toBe(false);
+  });
+});
+
 describe("findInventoryGpu", () => {
   it("resolves a live id to its inventory entry through the shared name", () => {
     // Selecting the second adapter on Performance writes a live id. Resolving

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -182,6 +182,58 @@ export const listGpuAdapters = (
 };
 
 /**
+ * The inventory entry a selection describes.
+ *
+ * `selectedGpuIdAtom` is shared by every GPU surface, but the inventory and
+ * the monitor stream use different id namespaces (see `gpuNamesAtom`), so a
+ * live id — which is what the Performance selector and the event listener's
+ * auto-selection both write — never matches an inventory id directly. Joining
+ * on the name both sources report is what keeps the classic card from pairing
+ * one adapter's name with another adapter's readings.
+ *
+ * The join is refused when the name picks out more than one entry; the caller
+ * then falls back rather than guessing.
+ */
+export const findInventoryGpu = <T extends { id: string; name: string }>(
+  gpus: readonly T[],
+  gpuNames: Record<string, string>,
+  selectedGpuId: string | null,
+): T | undefined => {
+  if (selectedGpuId == null) {
+    return undefined;
+  }
+
+  const byId = gpus.find((gpu) => gpu.id === selectedGpuId);
+  if (byId != null) {
+    return byId;
+  }
+
+  const liveName = gpuNames[selectedGpuId];
+  if (liveName == null) {
+    return undefined;
+  }
+
+  const matches = gpus.filter((gpu) => gpu.name === liveName);
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+/**
+ * The live id that names the same adapter as an inventory entry, so a surface
+ * holding inventory entries can write the shared selection in the namespace
+ * every reading is keyed by. Falls back to the inventory id when no live
+ * adapter reports that name, or when more than one does.
+ */
+export const toLiveGpuId = (
+  gpu: { id: string; name: string },
+  gpuNames: Record<string, string>,
+): string => {
+  const matches = Object.entries(gpuNames).filter(
+    ([, name]) => name === gpu.name,
+  );
+  return matches.length === 1 ? matches[0][0] : gpu.id;
+};
+
+/**
  * The GPU both Performance views agree on.
  *
  * An explicit selection wins while the adapter is still detected, even when it

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -267,19 +267,28 @@ export const getEffectiveGpuId = (
  * Whether the screen may state that an adapter has no live readings.
  *
  * Empty maps before the first sample mean "not measured yet", so the claim is
- * only allowed once some adapter has reported and this one still has not — in
- * any of the maps, since a fan speed alone is still a live reading.
+ * only allowed once sampling has actually happened and this adapter still has
+ * no value — in any of the maps, since a fan speed alone is still a live
+ * reading.
+ *
+ * A detected adapter is itself proof that a sample arrived: a machine whose
+ * only GPU reports its name and nothing else leaves every value map empty
+ * forever, and treating that as "not measured yet" would suppress the
+ * explanation for exactly the user who most needs it.
  */
 export const hasNoLiveGpuReadings = (
   gpuId: string | undefined,
   live: GpuLiveMaps,
+  detectedGpuIds: readonly string[] = [],
 ) => {
   if (gpuId == null) {
     return false;
   }
 
   const maps = liveMapsInOrder(live);
-  const anyAdapterReported = maps.some((map) => Object.keys(map).length > 0);
+  const sampled =
+    detectedGpuIds.length > 0 ||
+    maps.some((map) => Object.keys(map).length > 0);
 
-  return anyAdapterReported && !maps.some((map) => Object.hasOwn(map, gpuId));
+  return sampled && !maps.some((map) => Object.hasOwn(map, gpuId));
 };

--- a/src/features/hardware/hooks/useGpuAdapters.ts
+++ b/src/features/hardware/hooks/useGpuAdapters.ts
@@ -50,18 +50,18 @@ export const useGpuAdapters = () => {
     () => listGpuAdapters(gpuNames, live),
     [gpuNames, live],
   );
-  const effectiveGpuId = getEffectiveGpuId(
-    selectedGpuId,
-    live,
-    adapters.map((adapter) => adapter.id),
+  const detectedGpuIds = useMemo(
+    () => adapters.map((adapter) => adapter.id),
+    [adapters],
   );
+  const effectiveGpuId = getEffectiveGpuId(selectedGpuId, live, detectedGpuIds);
 
   return {
     live,
     adapters,
     effectiveGpuId,
     effectiveAdapter: adapters.find((adapter) => adapter.id === effectiveGpuId),
-    hasNoReadings: hasNoLiveGpuReadings(effectiveGpuId, live),
+    hasNoReadings: hasNoLiveGpuReadings(effectiveGpuId, live, detectedGpuIds),
     selectGpu: setSelectedGpuId,
   };
 };

--- a/src/features/hardware/hooks/useGpuAdapters.ts
+++ b/src/features/hardware/hooks/useGpuAdapters.ts
@@ -1,0 +1,67 @@
+import { useAtom, useAtomValue } from "jotai";
+import { useMemo } from "react";
+import {
+  type GpuLiveMaps,
+  getEffectiveGpuId,
+  hasNoLiveGpuReadings,
+  listGpuAdapters,
+} from "@/features/hardware/gpuIdentity";
+import {
+  gpuDedicatedMemoryKbMapAtom,
+  gpuFanSpeedMapAtom,
+  gpuNamesAtom,
+  gpuTempMapAtom,
+  gpuUsageHistoriesAtom,
+  selectedGpuIdAtom,
+} from "@/features/hardware/store/chart";
+
+/**
+ * The one place the GPU surfaces agree on which adapter they are describing.
+ *
+ * Every view that renders a GPU reading needs the same three answers — which
+ * adapters exist, which one is effective, and whether it is reporting — and
+ * they have to be the same answers, or two views would attribute the same
+ * numbers to different devices.
+ */
+export const useGpuAdapters = () => {
+  const gpuUsageHistories = useAtomValue(gpuUsageHistoriesAtom);
+  const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
+  const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
+  const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
+  const gpuNames = useAtomValue(gpuNamesAtom);
+  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
+
+  const live = useMemo<GpuLiveMaps>(
+    () => ({
+      usageHistories: gpuUsageHistories,
+      temperatures: gpuTemperatureMap,
+      fanSpeeds: gpuFanSpeedMap,
+      dedicatedMemoryKb: gpuDedicatedMemoryKbMap,
+    }),
+    [
+      gpuUsageHistories,
+      gpuTemperatureMap,
+      gpuFanSpeedMap,
+      gpuDedicatedMemoryKbMap,
+    ],
+  );
+
+  const adapters = useMemo(
+    () => listGpuAdapters(gpuNames, live),
+    [gpuNames, live],
+  );
+  const effectiveGpuId = getEffectiveGpuId(
+    selectedGpuId,
+    live,
+    adapters.map((adapter) => adapter.id),
+  );
+
+  return {
+    live,
+    adapters,
+    effectiveGpuId,
+    effectiveAdapter: adapters.find((adapter) => adapter.id === effectiveGpuId),
+    hasNoReadings: hasNoLiveGpuReadings(effectiveGpuId, live),
+    selectGpu: setSelectedGpuId,
+  };
+};

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -11,6 +11,7 @@ import {
   gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedAtom,
   gpuFanSpeedMapAtom,
+  gpuNamesAtom,
   gpuTempAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
@@ -887,6 +888,45 @@ describe("useHardwareEventListener", () => {
         { name: "GPU A", value: 40 },
         { name: "GPU B", value: 65 },
       ]);
+    });
+
+    it("tracks the reported name for every GPU, whatever it reports", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [names] = useAtom(gpuNamesAtom);
+          return names;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() =>
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:12345",
+                gpuName: "NVIDIA GeForce RTX 4080",
+              }),
+              // Reports nothing but its own identity: the Performance screen
+              // still has to be able to name and select it.
+              makeGpu({
+                gpuId: "pci:0:2:0",
+                gpuName: "Intel UHD Graphics 770",
+                gpuUsage: null,
+                gpuTemperature: null,
+                gpuCoolerLevel: null,
+                gpuDedicatedMemoryUsageKb: null,
+              }),
+            ],
+          }),
+        ),
+      );
+
+      expect(result.current).toEqual({
+        "nvapi:12345": "NVIDIA GeForce RTX 4080",
+        "pci:0:2:0": "Intel UHD Graphics 770",
+      });
     });
 
     it("tracks usage sources for all GPUs", () => {

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -929,6 +929,40 @@ describe("useHardwareEventListener", () => {
       });
     });
 
+    it("keeps a known adapter's name when a sample omits it", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [names] = useAtom(gpuNamesAtom);
+          return names;
+        },
+        { wrapper: Provider },
+      );
+
+      act(() => {
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0", gpuName: "GeForce RTX 4080" }),
+              makeGpu({ gpuId: "pci:0:2:0", gpuName: "UHD Graphics 770" }),
+            ],
+          }),
+        );
+        // A provider hiccup drops one adapter from a single sample. A name is
+        // identity, not a reading, so it must not vanish with it.
+        emit(
+          makePayload({
+            gpus: [makeGpu({ gpuId: "nvapi:0", gpuName: "GeForce RTX 4080" })],
+          }),
+        );
+      });
+
+      expect(result.current).toEqual({
+        "nvapi:0": "GeForce RTX 4080",
+        "pci:0:2:0": "UHD Graphics 770",
+      });
+    });
+
     it("tracks usage sources for all GPUs", () => {
       const { result } = renderHook(
         () => {

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -6,6 +6,7 @@ import {
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedMapAtom,
+  gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   gpuUsageSourcesAtom,
@@ -35,6 +36,7 @@ export const useHardwareEventListener = () => {
   const setGpuHistories = useSetAtom(gpuUsageHistoriesAtom);
   const setProcessorsHistory = useSetAtom(processorsUsageHistoryAtom);
   const setGpuTempMap = useSetAtom(gpuTempMapAtom);
+  const setGpuNames = useSetAtom(gpuNamesAtom);
   const setGpuSources = useSetAtom(gpuUsageSourcesAtom);
   const setGpuMemoryMap = useSetAtom(gpuDedicatedMemoryKbMapAtom);
   const setGpuFanSpeedMap = useSetAtom(gpuFanSpeedMapAtom);
@@ -105,6 +107,13 @@ export const useHardwareEventListener = () => {
         ),
       );
 
+      // Names from all GPUs. Every sample carries one, and it is the only way
+      // to name an adapter: live ids and the inventory's ids do not share a
+      // namespace on any platform (see `gpuNamesAtom`).
+      setGpuNames(
+        Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuName])),
+      );
+
       // Usage sources from all GPUs
       setGpuSources(
         Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuSource])),
@@ -154,6 +163,7 @@ export const useHardwareEventListener = () => {
       setGpuHistories,
       setGpuTempMap,
       setProcessorsHistory,
+      setGpuNames,
       setGpuSources,
       setGpuMemoryMap,
       setGpuFanSpeedMap,

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -110,9 +110,14 @@ export const useHardwareEventListener = () => {
       // Names from all GPUs. Every sample carries one, and it is the only way
       // to name an adapter: live ids and the inventory's ids do not share a
       // namespace on any platform (see `gpuNamesAtom`).
-      setGpuNames(
-        Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuName])),
-      );
+      // Merged, not replaced: a name is an identity, not a reading. A
+      // provider that drops one adapter from a single sample must not erase
+      // the only record that the adapter exists, or the Performance selector
+      // would jump to another GPU on a transient hiccup.
+      setGpuNames((prev) => ({
+        ...prev,
+        ...Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuName])),
+      }));
 
       // Usage sources from all GPUs
       setGpuSources(

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   setStored: vi.fn(),
   isPending: false,
   gpus: null as { id: string; name: string }[] | null,
+  init: vi.fn(),
 }));
 
 vi.mock("@/hooks/useTauriStore", () => ({
@@ -22,7 +23,7 @@ vi.mock("@/hooks/useTauriStore", () => ({
 vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
   useHardwareInfoAtom: () => ({
     hardwareInfo: { gpus: mocks.gpus },
-    init: vi.fn(),
+    init: mocks.init,
   }),
 }));
 
@@ -43,6 +44,7 @@ describe("useSelectedGpuPersistence", () => {
     mocks.isPending = false;
     mocks.setStored.mockClear();
     mocks.gpus = null;
+    mocks.init.mockClear();
   });
 
   it("restores the persisted GPU selection on mount", () => {
@@ -120,6 +122,32 @@ describe("useSelectedGpuPersistence", () => {
 
     expect(result.current.selected).toBe("nvapi:absent");
     expect(mocks.setStored).not.toHaveBeenCalled();
+  });
+
+  it("fetches the inventory itself when a stored id cannot be resolved", () => {
+    // A restart into Monitor or Compact mounts nothing that fetches the
+    // inventory, and the migration cannot read what nothing has fetched.
+    mocks.storeValue = "67890";
+    mocks.gpus = null;
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() =>
+      result.current.setNames({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+    );
+
+    expect(mocks.init).toHaveBeenCalled();
+  });
+
+  it("does not fetch the inventory while the stored id resolves live", () => {
+    mocks.storeValue = "pci:0:2:0";
+    mocks.gpus = null;
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() =>
+      result.current.setNames({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+    );
+
+    expect(mocks.init).not.toHaveBeenCalled();
   });
 
   it("waits for the store to load before hydrating", () => {

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import { Provider, useAtom } from "jotai";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
+import { useSelectedGpuPersistence } from "./useSelectedGpuPersistence";
+
+const mocks = vi.hoisted(() => ({
+  storeValue: null as string | null,
+  setStored: vi.fn(),
+  isPending: false,
+}));
+
+vi.mock("@/hooks/useTauriStore", () => ({
+  useTauriStore: () => [mocks.storeValue, mocks.setStored, mocks.isPending],
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider>{children}</Provider>
+);
+
+const useHarness = () => {
+  useSelectedGpuPersistence();
+  const [selected, setSelected] = useAtom(selectedGpuIdAtom);
+  return { selected, setSelected };
+};
+
+describe("useSelectedGpuPersistence", () => {
+  beforeEach(() => {
+    mocks.storeValue = null;
+    mocks.isPending = false;
+    mocks.setStored.mockClear();
+  });
+
+  it("restores the persisted GPU selection on mount", () => {
+    mocks.storeValue = "nvapi:12345";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+
+    expect(result.current.selected).toBe("nvapi:12345");
+  });
+
+  it("does not write the pre-hydration value back over the restored one", () => {
+    // The write-back effect runs in the same commit as hydration, where the
+    // atom still holds null. Persisting there would erase the preference the
+    // hydration effect had just restored.
+    mocks.storeValue = "nvapi:12345";
+
+    renderHook(() => useHarness(), { wrapper });
+
+    expect(mocks.setStored).not.toHaveBeenCalled();
+  });
+
+  it("persists an explicit change", () => {
+    mocks.storeValue = "nvapi:12345";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() => result.current.setSelected("pci:0:2:0"));
+
+    expect(mocks.setStored).toHaveBeenCalledWith("pci:0:2:0");
+  });
+
+  it("restores a selection the current session cannot resolve, rather than discarding it", () => {
+    // An adapter that is absent this launch — an unplugged eGPU. The stored
+    // intent has to survive so it applies again when the adapter returns;
+    // resolving it for display is `getEffectiveGpuId`'s job, not this hook's.
+    mocks.storeValue = "nvapi:absent";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+
+    expect(result.current.selected).toBe("nvapi:absent");
+    expect(mocks.setStored).not.toHaveBeenCalled();
+  });
+
+  it("waits for the store to load before hydrating", () => {
+    mocks.isPending = true;
+    mocks.storeValue = "nvapi:12345";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+
+    expect(result.current.selected).toBeNull();
+    expect(mocks.setStored).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
@@ -2,17 +2,28 @@ import { act, renderHook } from "@testing-library/react";
 import { Provider, useAtom } from "jotai";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
+import {
+  gpuNamesAtom,
+  selectedGpuIdAtom,
+} from "@/features/hardware/store/chart";
 import { useSelectedGpuPersistence } from "./useSelectedGpuPersistence";
 
 const mocks = vi.hoisted(() => ({
   storeValue: null as string | null,
   setStored: vi.fn(),
   isPending: false,
+  gpus: null as { id: string; name: string }[] | null,
 }));
 
 vi.mock("@/hooks/useTauriStore", () => ({
   useTauriStore: () => [mocks.storeValue, mocks.setStored, mocks.isPending],
+}));
+
+vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
+  useHardwareInfoAtom: () => ({
+    hardwareInfo: { gpus: mocks.gpus },
+    init: vi.fn(),
+  }),
 }));
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -22,7 +33,8 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 const useHarness = () => {
   useSelectedGpuPersistence();
   const [selected, setSelected] = useAtom(selectedGpuIdAtom);
-  return { selected, setSelected };
+  const [, setNames] = useAtom(gpuNamesAtom);
+  return { selected, setSelected, setNames };
 };
 
 describe("useSelectedGpuPersistence", () => {
@@ -30,6 +42,7 @@ describe("useSelectedGpuPersistence", () => {
     mocks.storeValue = null;
     mocks.isPending = false;
     mocks.setStored.mockClear();
+    mocks.gpus = null;
   });
 
   it("restores the persisted GPU selection on mount", () => {
@@ -67,6 +80,43 @@ describe("useSelectedGpuPersistence", () => {
     mocks.storeValue = "nvapi:absent";
 
     const { result } = renderHook(() => useHarness(), { wrapper });
+
+    expect(result.current.selected).toBe("nvapi:absent");
+    expect(mocks.setStored).not.toHaveBeenCalled();
+  });
+
+  it("migrates an inventory id stored by the pre-change classic card", () => {
+    // Shipped versions wrote GraphicInfo.id here. Grouped navigation never
+    // mounts the classic card, so translating it anywhere but app level would
+    // leave the choice inert for the life of the installation.
+    mocks.storeValue = "67890";
+    mocks.gpus = [
+      { id: "12345", name: "NVIDIA GeForce RTX 4080" },
+      { id: "67890", name: "Intel UHD Graphics 770" },
+    ];
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    expect(result.current.selected).toBe("67890");
+
+    act(() =>
+      result.current.setNames({
+        "nvapi:1": "NVIDIA GeForce RTX 4080",
+        "pci:0:2:0": "Intel UHD Graphics 770",
+      }),
+    );
+
+    expect(result.current.selected).toBe("pci:0:2:0");
+    expect(mocks.setStored).toHaveBeenLastCalledWith("pci:0:2:0");
+  });
+
+  it("leaves a live id that is simply absent this session alone", () => {
+    mocks.storeValue = "nvapi:absent";
+    mocks.gpus = [{ id: "12345", name: "NVIDIA GeForce RTX 4080" }];
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() =>
+      result.current.setNames({ "nvapi:1": "NVIDIA GeForce RTX 4080" }),
+    );
 
     expect(result.current.selected).toBe("nvapi:absent");
     expect(mocks.setStored).not.toHaveBeenCalled();

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toLiveGpuId } from "@/features/hardware/gpuIdentity";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
@@ -36,6 +36,7 @@ export const useSelectedGpuPersistence = () => {
   // `selectedGpuId` is still the pre-hydration value — so it would persist
   // that stale value straight over the preference just restored.
   const [hydrated, setHydrated] = useState(false);
+  const inventoryRequestedRef = useRef(false);
   const gpuNames = useAtomValue(gpuNamesAtom);
   const { hardwareInfo, init } = useHardwareInfoAtom();
 
@@ -71,9 +72,14 @@ export const useSelectedGpuPersistence = () => {
     // A restart can land on a view that never fetches the inventory (Monitor,
     // Compact), and the migration cannot read what nothing has fetched. Only
     // an unresolved id triggers the fetch, so steady-state startups where the
-    // stored id is already live cost no extra IPC.
+    // stored id is already live cost no extra IPC. The ref keeps the request
+    // single-shot: `init` is a new function every render, so it re-triggers
+    // this effect while the fetch is still in flight.
     if (hardwareInfo.gpus == null) {
-      void init();
+      if (!inventoryRequestedRef.current) {
+        inventoryRequestedRef.current = true;
+        void init();
+      }
       return;
     }
 
@@ -86,7 +92,12 @@ export const useSelectedGpuPersistence = () => {
     if (liveId !== selectedGpuId) {
       setSelectedGpuId(liveId);
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: `init` is
-    // recreated every render; depending on it would refetch in a loop.
-  }, [hydrated, selectedGpuId, gpuNames, hardwareInfo.gpus, setSelectedGpuId]);
+  }, [
+    hydrated,
+    selectedGpuId,
+    gpuNames,
+    hardwareInfo.gpus,
+    setSelectedGpuId,
+    init,
+  ]);
 };

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,6 +1,11 @@
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
-import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
+import { toLiveGpuId } from "@/features/hardware/gpuIdentity";
+import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
+import {
+  gpuNamesAtom,
+  selectedGpuIdAtom,
+} from "@/features/hardware/store/chart";
 import { useTauriStore } from "@/hooks/useTauriStore";
 
 const STORE_KEY = "selectedGpuId";
@@ -31,6 +36,8 @@ export const useSelectedGpuPersistence = () => {
   // `selectedGpuId` is still the pre-hydration value — so it would persist
   // that stale value straight over the preference just restored.
   const [hydrated, setHydrated] = useState(false);
+  const gpuNames = useAtomValue(gpuNamesAtom);
+  const { hardwareInfo } = useHardwareInfoAtom();
 
   useEffect(() => {
     if (isPending || hydrated) return;
@@ -47,4 +54,24 @@ export const useSelectedGpuPersistence = () => {
     if (selectedGpuId === storedId) return;
     setStoredId(selectedGpuId);
   }, [hydrated, selectedGpuId, storedId, setStoredId]);
+
+  // Selections written before this hook existed — and any made in the classic
+  // card before the first sample — are inventory ids, which address no
+  // readings. Translating them here rather than inside a GPU screen matters:
+  // grouped navigation never mounts the classic card, so a stored choice would
+  // otherwise stay inert for the whole life of the installation.
+  useEffect(() => {
+    if (!hydrated || selectedGpuId == null) return;
+    if (gpuNames[selectedGpuId] != null) return;
+
+    const inventoryEntry = hardwareInfo.gpus?.find(
+      (gpu) => gpu.id === selectedGpuId,
+    );
+    if (inventoryEntry == null) return;
+
+    const liveId = toLiveGpuId(inventoryEntry, gpuNames);
+    if (liveId !== selectedGpuId) {
+      setSelectedGpuId(liveId);
+    }
+  }, [hydrated, selectedGpuId, gpuNames, hardwareInfo.gpus, setSelectedGpuId]);
 };

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -37,7 +37,7 @@ export const useSelectedGpuPersistence = () => {
   // that stale value straight over the preference just restored.
   const [hydrated, setHydrated] = useState(false);
   const gpuNames = useAtomValue(gpuNamesAtom);
-  const { hardwareInfo } = useHardwareInfoAtom();
+  const { hardwareInfo, init } = useHardwareInfoAtom();
 
   useEffect(() => {
     if (isPending || hydrated) return;
@@ -62,9 +62,22 @@ export const useSelectedGpuPersistence = () => {
   // otherwise stay inert for the whole life of the installation.
   useEffect(() => {
     if (!hydrated || selectedGpuId == null) return;
+    // Before the first sample every id looks unresolved; there is nothing to
+    // decide yet, so wait rather than fetch an inventory that may never be
+    // needed.
+    if (Object.keys(gpuNames).length === 0) return;
     if (gpuNames[selectedGpuId] != null) return;
 
-    const inventoryEntry = hardwareInfo.gpus?.find(
+    // A restart can land on a view that never fetches the inventory (Monitor,
+    // Compact), and the migration cannot read what nothing has fetched. Only
+    // an unresolved id triggers the fetch, so steady-state startups where the
+    // stored id is already live cost no extra IPC.
+    if (hardwareInfo.gpus == null) {
+      void init();
+      return;
+    }
+
+    const inventoryEntry = hardwareInfo.gpus.find(
       (gpu) => gpu.id === selectedGpuId,
     );
     if (inventoryEntry == null) return;
@@ -73,5 +86,7 @@ export const useSelectedGpuPersistence = () => {
     if (liveId !== selectedGpuId) {
       setSelectedGpuId(liveId);
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: `init` is
+    // recreated every render; depending on it would refetch in a loop.
   }, [hydrated, selectedGpuId, gpuNames, hardwareInfo.gpus, setSelectedGpuId]);
 };

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,5 +1,5 @@
 import { useAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
 import { useTauriStore } from "@/hooks/useTauriStore";
 
@@ -26,21 +26,25 @@ export const useSelectedGpuPersistence = () => {
     null,
   );
   const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
-  const hydratedRef = useRef(false);
+  // State, not a ref: a ref flipped inside the hydration effect is already
+  // true when the write-back effect runs later in the *same* commit, where
+  // `selectedGpuId` is still the pre-hydration value — so it would persist
+  // that stale value straight over the preference just restored.
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    if (isPending || hydratedRef.current) return;
+    if (isPending || hydrated) return;
     if (storedId != null) {
       // Explicit intent outranks the event listener's auto-selection of the
       // first reporting adapter, whichever of the two lands first.
       setSelectedGpuId(storedId);
     }
-    hydratedRef.current = true;
-  }, [isPending, storedId, setSelectedGpuId]);
+    setHydrated(true);
+  }, [isPending, hydrated, storedId, setSelectedGpuId]);
 
   useEffect(() => {
-    if (!hydratedRef.current) return;
+    if (!hydrated) return;
     if (selectedGpuId === storedId) return;
     setStoredId(selectedGpuId);
-  }, [selectedGpuId, storedId, setStoredId]);
+  }, [hydrated, selectedGpuId, storedId, setStoredId]);
 };

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,15 +1,24 @@
 import { useAtom } from "jotai";
 import { useEffect, useRef } from "react";
-import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import { selectedGpuIdAtom } from "@/features/hardware/store/chart";
 import { useTauriStore } from "@/hooks/useTauriStore";
 
 const STORE_KEY = "selectedGpuId";
 
 /**
- * Persist the currently selected GPU id via Tauri Store so it survives
- * app restarts. Stored values referencing GPUs that no longer exist are
- * ignored so the event listener's auto-selection of the first GPU wins.
+ * Persist the currently selected GPU id via Tauri Store so it survives app
+ * restarts.
+ *
+ * The stored id is restored as-is rather than validated against the
+ * `getHardwareInfo` inventory: the inventory keys GPUs in a different
+ * namespace than the monitor stream the selection comes from (see
+ * `gpuNamesAtom`), so validating there would reject every valid id. It also
+ * discarded the user's intent permanently the first time they launched
+ * without that adapter, which DP-06 forbids.
+ *
+ * A stored id that no longer matches any reporting adapter costs nothing:
+ * `getEffectiveGpuId` falls back at display time, and the intent stays on
+ * disk so it applies again when the adapter comes back.
  */
 export const useSelectedGpuPersistence = () => {
   const [storedId, setStoredId, isPending] = useTauriStore<string | null>(
@@ -17,18 +26,17 @@ export const useSelectedGpuPersistence = () => {
     null,
   );
   const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
-  const { hardwareInfo } = useHardwareInfoAtom();
   const hydratedRef = useRef(false);
 
   useEffect(() => {
     if (isPending || hydratedRef.current) return;
-    const gpus = hardwareInfo.gpus ?? [];
-    if (gpus.length === 0) return;
-    if (storedId && gpus.some((g) => g.id === storedId)) {
+    if (storedId != null) {
+      // Explicit intent outranks the event listener's auto-selection of the
+      // first reporting adapter, whichever of the two lands first.
       setSelectedGpuId(storedId);
     }
     hydratedRef.current = true;
-  }, [isPending, storedId, hardwareInfo.gpus, setSelectedGpuId]);
+  }, [isPending, storedId, setSelectedGpuId]);
 
   useEffect(() => {
     if (!hydratedRef.current) return;

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -25,7 +25,28 @@ const state = vi.hoisted(() => ({
   } as PerformanceCustomLayout,
   chartRenders: { cpu: 0, memory: 0, gpu: 0 },
   processRenders: 0,
+  gpus: null as
+    | null
+    | {
+        id: string;
+        name: string;
+        vendorName: string;
+        clock: number;
+        memorySize: string;
+        memorySizeDedicated: string;
+        coreCount: string | null;
+      }[],
 }));
+
+const gpuFixture = (id: string, name: string) => ({
+  id,
+  name,
+  vendorName: "Vendor",
+  clock: 2100,
+  memorySize: "8 GB",
+  memorySizeDedicated: "8 GB",
+  coreCount: null,
+});
 
 const settings = vi.hoisted(() => ({
   graphFitToWindow: false,
@@ -65,7 +86,7 @@ vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
     hardwareInfo: {
       cpu: null,
       memory: null,
-      gpus: null,
+      gpus: state.gpus,
       storage: [],
       motherboard: null,
     },
@@ -141,6 +162,7 @@ describe("Performance", () => {
     };
     state.chartRenders = { cpu: 0, memory: 0, gpu: 0 };
     state.processRenders = 0;
+    state.gpus = null;
   });
 
   afterEach(cleanup);
@@ -257,13 +279,15 @@ describe("Performance", () => {
 
   it("uses one effective GPU for history and temperature fallbacks", () => {
     const store = createStore();
-    store.set(selectedGpuIdAtom, "stale-gpu");
+    // A selection left over from an adapter that is no longer detected: it
+    // appears in no live map and in no detected list, so it cannot be honored.
+    store.set(selectedGpuIdAtom, "removed-gpu");
     store.set(gpuUsageHistoriesAtom, {
       "gpu-1": [25],
     });
     store.set(gpuTempMapAtom, {
       "gpu-1": { name: "GPU 1", value: 45 },
-      "stale-gpu": { name: "Stale GPU", value: 67 },
+      "gpu-2": { name: "GPU 2", value: 67 },
     });
 
     render(
@@ -276,6 +300,122 @@ describe("Performance", () => {
     expect(gpuMetric).toHaveTextContent("25%");
     expect(gpuMetric).toHaveTextContent("45°C");
     expect(gpuMetric).not.toHaveTextContent("67°C");
+  });
+
+  it("names the adapter behind the GPU readings without offering a choice there is none of", () => {
+    const store = createStore();
+    state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [42] });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("performance-gpu-adapter")).toHaveTextContent(
+      "GeForce RTX 4080",
+    );
+    expect(screen.queryByTestId("performance-gpu-selector")).toBeNull();
+  });
+
+  it("moves every GPU reading to the adapter the user picks", () => {
+    const store = createStore();
+    state.gpus = [
+      gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
+      gpuFixture("gpu-2", "Intel UHD Graphics 770"),
+    ];
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
+    store.set(gpuTempMapAtom, {
+      "gpu-1": { name: "GPU 1", value: 45 },
+      "gpu-2": { name: "GPU 2", value: 67 },
+    });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const gpuMetric = screen.getByTestId("performance-metric-gpu");
+    expect(gpuMetric).toHaveTextContent("25%");
+    expect(gpuMetric).toHaveTextContent("45°C");
+
+    act(() => {
+      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }).click();
+    });
+
+    expect(store.get(selectedGpuIdAtom)).toBe("gpu-2");
+    expect(gpuMetric).toHaveTextContent("50%");
+    expect(gpuMetric).toHaveTextContent("67°C");
+    expect(gpuMetric).not.toHaveTextContent("45°C");
+    expect(
+      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps a silent adapter selected and says so instead of borrowing readings", () => {
+    const store = createStore();
+    state.gpus = [
+      gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
+      gpuFixture("gpu-2", "Intel UHD Graphics 770"),
+    ];
+    store.set(selectedGpuIdAtom, "gpu-2");
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
+    store.set(gpuTempMapAtom, { "gpu-1": { name: "GPU 1", value: 45 } });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const gpuMetric = screen.getByTestId("performance-metric-gpu");
+    expect(gpuMetric).toHaveTextContent("pages.performance.gpuNoLiveReadings");
+    expect(gpuMetric).not.toHaveTextContent("25%");
+    expect(gpuMetric).not.toHaveTextContent("45°C");
+    // The rest of the adapter's information stays reachable.
+    expect(
+      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("does not call an adapter unavailable before the first sample arrives", () => {
+    const store = createStore();
+    state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("performance-metric-gpu")).not.toHaveTextContent(
+      "pages.performance.gpuNoLiveReadings",
+    );
+  });
+
+  it("carries the selected adapter into the Compact strip", () => {
+    const store = createStore();
+    state.view = "compact";
+    state.gpus = [
+      gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
+      gpuFixture("gpu-2", "Intel UHD Graphics 770"),
+    ];
+    store.set(selectedGpuIdAtom, "gpu-2");
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const strip = screen.getByTestId("performance-compact-strip");
+    expect(strip).toHaveTextContent("UHD Graphics 770");
+    expect(screen.getByTestId("performance-compact-row-gpu")).toHaveTextContent(
+      "50%",
+    );
   });
 
   it("keeps the two-column request collapsible to one column", () => {

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -191,6 +191,27 @@ describe("Performance", () => {
     expect(state.processRenders).toBe(1);
   });
 
+  it("keeps a GPU tick out of the panels that do not show GPU data", () => {
+    // The GPU atoms are rewritten on every sample. A subscription in the
+    // Performance parent would rerender the whole screen once a second.
+    const store = createStore();
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const before = { ...state.chartRenders, process: state.processRenders };
+
+    act(() => store.set(gpuUsageHistoriesAtom, { "gpu-1": [25, 40] }));
+
+    expect(state.processRenders).toBe(before.process);
+    expect(state.chartRenders.cpu).toBe(before.cpu);
+    expect(state.chartRenders.memory).toBe(before.memory);
+  });
+
   it("mounts only the dense strip in Compact", () => {
     state.view = "compact";
 

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -64,7 +64,10 @@ const settings = vi.hoisted(() => ({
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    // Interpolated values are appended so tests can assert on what the string
+    // actually carries, not just which key was reached.
+    t: (key: string, params?: Record<string, unknown>) =>
+      params == null ? key : `${key} ${Object.values(params).join(" ")}`,
   }),
 }));
 
@@ -342,7 +345,7 @@ describe("Performance", () => {
     expect(gpuMetric).toHaveTextContent("45°C");
 
     act(() => {
-      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }).click();
+      screen.getByRole("button", { name: "Intel UHD Graphics 770" }).click();
     });
 
     expect(store.get(selectedGpuIdAtom)).toBe("gpu-2");
@@ -350,8 +353,8 @@ describe("Performance", () => {
     expect(gpuMetric).toHaveTextContent("67°C");
     expect(gpuMetric).not.toHaveTextContent("45°C");
     expect(
-      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }),
-    ).toHaveAttribute("aria-selected", "true");
+      screen.getByRole("button", { name: "Intel UHD Graphics 770" }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("keeps a silent adapter selected and says so instead of borrowing readings", () => {
@@ -376,8 +379,8 @@ describe("Performance", () => {
     expect(gpuMetric).not.toHaveTextContent("45°C");
     // The rest of the adapter's information stays reachable.
     expect(
-      screen.getByRole("tab", { name: "Intel UHD Graphics 770" }),
-    ).toHaveAttribute("aria-selected", "true");
+      screen.getByRole("button", { name: "Intel UHD Graphics 770" }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("does not call an adapter unavailable before the first sample arrives", () => {
@@ -412,7 +415,9 @@ describe("Performance", () => {
     );
 
     const strip = screen.getByTestId("performance-compact-strip");
-    expect(strip).toHaveTextContent("UHD Graphics 770");
+    expect(strip).toHaveTextContent(
+      "pages.performance.compactGpuAdapter UHD Graphics 770",
+    );
     expect(screen.getByTestId("performance-compact-row-gpu")).toHaveTextContent(
       "50%",
     );
@@ -443,7 +448,7 @@ describe("Performance", () => {
     expect(screen.getByTestId("performance-hidden-panels")).toBeVisible();
     expect(
       screen.getAllByRole("button", {
-        name: "pages.performance.showPanel",
+        name: /^pages\.performance\.showPanel/,
       }),
     ).toHaveLength(2);
   });

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -474,6 +474,28 @@ describe("Performance", () => {
     );
   });
 
+  it("says why a Compact row is dashed when its adapter is silent", () => {
+    const store = createStore();
+    state.view = "compact";
+    store.set(selectedGpuIdAtom, "gpu-2");
+    store.set(gpuNamesAtom, {
+      "gpu-1": "NVIDIA GeForce RTX 4080",
+      "gpu-2": "Intel UHD Graphics 770",
+    });
+    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const strip = screen.getByTestId("performance-compact-strip");
+    expect(strip).toHaveTextContent("pages.performance.gpuNoLiveReadings");
+    // And it is still the selected adapter's row, not the reporting one's.
+    expect(strip).not.toHaveTextContent("25%");
+  });
+
   it("carries the selected adapter into the Compact strip", () => {
     const store = createStore();
     state.view = "compact";

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -3,6 +3,7 @@ import { createStore, Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cpuUsageHistoryAtom,
+  gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
@@ -308,6 +309,7 @@ describe("Performance", () => {
   it("names the adapter behind the GPU readings without offering a choice there is none of", () => {
     const store = createStore();
     state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
+    store.set(gpuNamesAtom, { "gpu-1": "NVIDIA GeForce RTX 4080" });
     store.set(gpuUsageHistoriesAtom, { "gpu-1": [42] });
 
     render(
@@ -328,6 +330,10 @@ describe("Performance", () => {
       gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
+    store.set(gpuNamesAtom, {
+      "gpu-1": "NVIDIA GeForce RTX 4080",
+      "gpu-2": "Intel UHD Graphics 770",
+    });
     store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
     store.set(gpuTempMapAtom, {
       "gpu-1": { name: "GPU 1", value: 45 },
@@ -364,6 +370,11 @@ describe("Performance", () => {
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
     store.set(selectedGpuIdAtom, "gpu-2");
+    // gpu-2 named itself in the stream but reported no values at all.
+    store.set(gpuNamesAtom, {
+      "gpu-1": "NVIDIA GeForce RTX 4080",
+      "gpu-2": "Intel UHD Graphics 770",
+    });
     store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
     store.set(gpuTempMapAtom, { "gpu-1": { name: "GPU 1", value: 45 } });
 
@@ -386,6 +397,7 @@ describe("Performance", () => {
   it("does not call an adapter unavailable before the first sample arrives", () => {
     const store = createStore();
     state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
+    store.set(gpuNamesAtom, { "gpu-1": "NVIDIA GeForce RTX 4080" });
 
     render(
       <Provider store={store}>
@@ -406,6 +418,10 @@ describe("Performance", () => {
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
     store.set(selectedGpuIdAtom, "gpu-2");
+    store.set(gpuNamesAtom, {
+      "gpu-1": "NVIDIA GeForce RTX 4080",
+      "gpu-2": "Intel UHD Graphics 770",
+    });
     store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
 
     render(

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -3,6 +3,7 @@ import { createStore, Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cpuUsageHistoryAtom,
+  gpuDedicatedMemoryKbMapAtom,
   gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
@@ -322,6 +323,48 @@ describe("Performance", () => {
       "GeForce RTX 4080",
     );
     expect(screen.queryByTestId("performance-gpu-selector")).toBeNull();
+  });
+
+  it("drops the VRAM total when the inventory name cannot pick out one card", () => {
+    const store = createStore();
+    // Two identical cards in the inventory, only one of them reporting. The
+    // live side looks unambiguous, but the name still cannot say which
+    // capacity belongs to the reading.
+    state.gpus = [
+      gpuFixture("inventory-a", "NVIDIA GeForce RTX 4090"),
+      gpuFixture("inventory-b", "NVIDIA GeForce RTX 4090"),
+    ];
+    store.set(gpuNamesAtom, { "nvapi:1": "NVIDIA GeForce RTX 4090" });
+    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [40] });
+    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4 * 1024 * 1024 });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const gpuMetric = screen.getByTestId("performance-metric-gpu");
+    expect(gpuMetric).toHaveTextContent("VRAM 4.0 GB");
+    expect(gpuMetric).not.toHaveTextContent("VRAM 4.0/8 GB");
+  });
+
+  it("keeps the VRAM total when exactly one inventory entry matches", () => {
+    const store = createStore();
+    state.gpus = [gpuFixture("inventory-a", "NVIDIA GeForce RTX 4090")];
+    store.set(gpuNamesAtom, { "nvapi:1": "NVIDIA GeForce RTX 4090" });
+    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [40] });
+    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4 * 1024 * 1024 });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("performance-metric-gpu")).toHaveTextContent(
+      "VRAM 4.0/8 GB",
+    );
   });
 
   it("moves every GPU reading to the adapter the user picks", () => {

--- a/src/features/hardware/performance/Performance.tsx
+++ b/src/features/hardware/performance/Performance.tsx
@@ -10,9 +10,12 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { BurnInShift } from "@/components/shared/BurnInShift";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import { UsageGraphPanel } from "@/features/hardware/usage/Usage";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
 import { CompactStrip } from "./components/CompactStrip";
+import { GpuAdapterSelector } from "./components/GpuAdapterSelector";
 import { InstrumentStrip } from "./components/InstrumentStrip";
 import { PanelColumnsSelector } from "./components/PanelColumnsSelector";
 import { PanelGrid } from "./components/PanelGrid";
@@ -40,7 +43,13 @@ export const Performance = ({
     isPending,
   } = usePerformanceLayout();
   const [editing, setEditing] = useState(false);
+  const { settings } = useSettingsAtom();
+  const { adapters, effectiveGpuId, selectGpu } = useGpuAdapters();
   const isMonitor = view === "monitor";
+  // Monitor is only the graph, so the adapter behind its GPU series has
+  // nowhere else to be named. The Instrument Strip that normally carries this
+  // is not mounted here.
+  const showsGpuSeries = settings.displayTargets.includes("gpu");
   const isCompactFullScreen = view === "compact" && compactExpanded;
 
   useEffect(() => {
@@ -103,6 +112,13 @@ export const Performance = ({
               <ArrowsOutSimpleIcon size={15} />
               {t("pages.performance.expandCompact")}
             </button>
+          )}
+          {isMonitor && showsGpuSeries && (
+            <GpuAdapterSelector
+              adapters={adapters}
+              selectedId={effectiveGpuId}
+              onSelect={selectGpu}
+            />
           )}
           {view === "panels" && (
             <PanelColumnsSelector

--- a/src/features/hardware/performance/Performance.tsx
+++ b/src/features/hardware/performance/Performance.tsx
@@ -10,13 +10,11 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { BurnInShift } from "@/components/shared/BurnInShift";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import { UsageGraphPanel } from "@/features/hardware/usage/Usage";
-import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
 import { CompactStrip } from "./components/CompactStrip";
-import { GpuAdapterSelector } from "./components/GpuAdapterSelector";
 import { InstrumentStrip } from "./components/InstrumentStrip";
+import { MonitorGpuSelector } from "./components/MonitorGpuSelector";
 import { PanelColumnsSelector } from "./components/PanelColumnsSelector";
 import { PanelGrid } from "./components/PanelGrid";
 import { PerformanceViewSwitcher } from "./components/PerformanceViewSwitcher";
@@ -43,13 +41,7 @@ export const Performance = ({
     isPending,
   } = usePerformanceLayout();
   const [editing, setEditing] = useState(false);
-  const { settings } = useSettingsAtom();
-  const { adapters, effectiveGpuId, selectGpu } = useGpuAdapters();
   const isMonitor = view === "monitor";
-  // Monitor is only the graph, so the adapter behind its GPU series has
-  // nowhere else to be named. The Instrument Strip that normally carries this
-  // is not mounted here.
-  const showsGpuSeries = settings.displayTargets.includes("gpu");
   const isCompactFullScreen = view === "compact" && compactExpanded;
 
   useEffect(() => {
@@ -113,13 +105,10 @@ export const Performance = ({
               {t("pages.performance.expandCompact")}
             </button>
           )}
-          {isMonitor && showsGpuSeries && (
-            <GpuAdapterSelector
-              adapters={adapters}
-              selectedId={effectiveGpuId}
-              onSelect={selectGpu}
-            />
-          )}
+          {/* Monitor is only the graph, so the adapter behind its GPU series
+              has nowhere else to be named: the Instrument Strip that normally
+              carries that is not mounted here. */}
+          {isMonitor && <MonitorGpuSelector />}
           {view === "panels" && (
             <PanelColumnsSelector
               columns={columns}

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -224,9 +224,13 @@ export const CompactStrip = ({
               name: activeGpuAdapter.label,
             }),
             // The visible text is shortened to fit a corner window; the full
-            // name is still announced and still available on hover.
+            // name is still announced and still available on hover. Where two
+            // identical cards share that name it says nothing, so the
+            // ordinal-bearing label is what gets announced instead.
             fullText: t("pages.performance.compactGpuAdapter", {
-              name: activeGpuAdapter.name,
+              name: activeGpuAdapter.isNameAmbiguous
+                ? activeGpuAdapter.label
+                : activeGpuAdapter.name,
             }),
           },
         ]

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -1,21 +1,11 @@
 import { useAtomValue } from "jotai";
-import { type CSSProperties, memo, useMemo } from "react";
+import { type CSSProperties, memo } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  type GpuLiveMaps,
-  getEffectiveGpuId,
-  listGpuAdapters,
-} from "@/features/hardware/gpuIdentity";
+import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
-  gpuDedicatedMemoryKbMapAtom,
-  gpuFanSpeedMapAtom,
-  gpuNamesAtom,
-  gpuTempMapAtom,
-  gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
-  selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
@@ -139,40 +129,12 @@ export const CompactStrip = ({
   const { settings } = useSettingsAtom();
   const cpuHistory = useAtomValue(cpuUsageHistoryAtom);
   const memoryHistory = useAtomValue(memoryUsageHistoryAtom);
-  const gpuUsageHistories = useAtomValue(gpuUsageHistoriesAtom);
   const cpuTemperatures = useAtomValue(cpuTempAtom);
-  const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
-  const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
-  const gpuNames = useAtomValue(gpuNamesAtom);
-  const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
-  const selectedGpuId = useAtomValue(selectedGpuIdAtom);
-
-  const gpuLive = useMemo<GpuLiveMaps>(
-    () => ({
-      usageHistories: gpuUsageHistories,
-      temperatures: gpuTemperatureMap,
-      fanSpeeds: gpuFanSpeedMap,
-      dedicatedMemoryKb: gpuDedicatedMemoryKbMap,
-    }),
-    [
-      gpuUsageHistories,
-      gpuTemperatureMap,
-      gpuFanSpeedMap,
-      gpuDedicatedMemoryKbMap,
-    ],
-  );
-  const gpuAdapters = useMemo(
-    () => listGpuAdapters(gpuNames, gpuLive),
-    [gpuNames, gpuLive],
-  );
-  const effectiveGpuId = getEffectiveGpuId(
-    selectedGpuId,
-    gpuLive,
-    gpuAdapters.map((adapter) => adapter.id),
-  );
-  const activeGpuAdapter = gpuAdapters.find(
-    (adapter) => adapter.id === effectiveGpuId,
-  );
+  const {
+    live: gpuLive,
+    effectiveGpuId,
+    effectiveAdapter: activeGpuAdapter,
+  } = useGpuAdapters();
 
   const rows: CompactMetricRow[] = [
     {
@@ -197,9 +159,9 @@ export const CompactStrip = ({
             id: "gpu",
             label: t("pages.performance.metrics.gpu"),
             color: toCssColor(settings.lineGraphColor.gpu),
-            history: gpuUsageHistories[effectiveGpuId] ?? [],
+            history: gpuLive.usageHistories[effectiveGpuId] ?? [],
             detail: formatTemperature(
-              gpuTemperatureMap[effectiveGpuId]?.value,
+              gpuLive.temperatures[effectiveGpuId]?.value,
               settings.temperatureUnit,
             ),
           },

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -2,6 +2,11 @@ import { useAtomValue } from "jotai";
 import { type CSSProperties, memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  type GpuLiveMaps,
+  getEffectiveGpuId,
+  listGpuAdapters,
+} from "@/features/hardware/gpuIdentity";
+import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
@@ -14,11 +19,6 @@ import {
 } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
-import {
-  type GpuLiveMaps,
-  getEffectiveGpuId,
-  listGpuAdapters,
-} from "../gpuIdentity";
 import { formatTemperature, toCssColor } from "./InstrumentStrip";
 import { Sparkline } from "./Sparkline";
 

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -134,6 +134,7 @@ export const CompactStrip = ({
     live: gpuLive,
     effectiveGpuId,
     effectiveAdapter: activeGpuAdapter,
+    hasNoReadings: gpuHasNoReadings,
   } = useGpuAdapters();
 
   const rows: CompactMetricRow[] = [
@@ -177,26 +178,32 @@ export const CompactStrip = ({
   // The GPU row carries one adapter's numbers, so the strip says which one.
   // It goes in the footer rather than the row: the row's tracks are sized for
   // the mini monitor's small corner window and cannot hold a device name.
-  const footerItems: CompactFooterItem[] =
-    activeGpuAdapter != null
-      ? [
-          {
-            id: "gpu-adapter",
-            text: t("pages.performance.compactGpuAdapter", {
-              name: activeGpuAdapter.label,
-            }),
-            // The visible text is shortened to fit a corner window; the full
-            // name is still announced and still available on hover. Where two
-            // identical cards share that name it says nothing, so the
-            // ordinal-bearing label is what gets announced instead.
-            fullText: t("pages.performance.compactGpuAdapter", {
-              name: activeGpuAdapter.isNameAmbiguous
-                ? activeGpuAdapter.label
-                : activeGpuAdapter.name,
-            }),
-          },
-        ]
-      : [];
+  const footerItems: CompactFooterItem[] = [];
+  if (activeGpuAdapter != null) {
+    footerItems.push({
+      id: "gpu-adapter",
+      text: t("pages.performance.compactGpuAdapter", {
+        name: activeGpuAdapter.label,
+      }),
+      // The visible text is shortened to fit a corner window; the full
+      // name is still announced and still available on hover. Where two
+      // identical cards share that name it says nothing, so the
+      // ordinal-bearing label is what gets announced instead.
+      fullText: t("pages.performance.compactGpuAdapter", {
+        name: activeGpuAdapter.isNameAmbiguous
+          ? activeGpuAdapter.label
+          : activeGpuAdapter.name,
+      }),
+    });
+  }
+  // A dash in the row means "no number". Only the footer can say whether that
+  // is because the adapter is silent or because nothing has been measured yet.
+  if (gpuHasNoReadings) {
+    footerItems.push({
+      id: "gpu-unavailable",
+      text: t("pages.performance.gpuNoLiveReadings"),
+    });
+  }
 
   return (
     <section

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai";
-import { type CSSProperties, memo } from "react";
+import { type CSSProperties, memo, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
@@ -11,11 +12,8 @@ import {
 } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
-import {
-  formatTemperature,
-  getEffectiveGpuId,
-  toCssColor,
-} from "./InstrumentStrip";
+import { getEffectiveGpuId, listGpuAdapters } from "../gpuIdentity";
+import { formatTemperature, toCssColor } from "./InstrumentStrip";
 import { Sparkline } from "./Sparkline";
 
 /**
@@ -129,11 +127,34 @@ export const CompactStrip = ({
   const cpuTemperatures = useAtomValue(cpuTempAtom);
   const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
   const selectedGpuId = useAtomValue(selectedGpuIdAtom);
+  const { hardwareInfo, init } = useHardwareInfoAtom();
 
+  // The strip names its GPU row's adapter, and Compact is the only thing
+  // mounted in this view, so it has to fetch the static facts itself.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: one-time static-fact fetch
+  useEffect(() => {
+    if (hardwareInfo.gpus == null) {
+      void init();
+    }
+  }, []);
+
+  const gpuAdapters = useMemo(
+    () =>
+      listGpuAdapters(
+        hardwareInfo.gpus,
+        gpuTemperatureMap,
+        Object.keys(gpuUsageHistories),
+      ),
+    [hardwareInfo.gpus, gpuTemperatureMap, gpuUsageHistories],
+  );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,
     gpuUsageHistories,
     gpuTemperatureMap,
+    gpuAdapters.map((adapter) => adapter.id),
+  );
+  const activeGpuAdapter = gpuAdapters.find(
+    (adapter) => adapter.id === effectiveGpuId,
   );
 
   const rows: CompactMetricRow[] = [
@@ -173,7 +194,14 @@ export const CompactStrip = ({
   // strip once the backend collects them; they join `rows` / `footerItems`
   // without further layout changes. Storage capacity deliberately stays out:
   // it is a specification fact, not a live reading (see ADR 0014).
-  const footerItems: string[] = [];
+  //
+  // The GPU row carries one adapter's numbers, so the strip says which one.
+  // It goes in the footer rather than the row: the row's tracks are sized for
+  // the mini monitor's small corner window and cannot hold a device name.
+  const footerItems: string[] =
+    activeGpuAdapter != null
+      ? [`${t("pages.performance.metrics.gpu")}: ${activeGpuAdapter.label}`]
+      : [];
 
   return (
     <section

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -1,12 +1,12 @@
 import { useAtomValue } from "jotai";
-import { type CSSProperties, memo, useEffect, useMemo } from "react";
+import { type CSSProperties, memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedMapAtom,
+  gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
@@ -133,18 +133,9 @@ export const CompactStrip = ({
   const cpuTemperatures = useAtomValue(cpuTempAtom);
   const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
   const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
+  const gpuNames = useAtomValue(gpuNamesAtom);
   const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
   const selectedGpuId = useAtomValue(selectedGpuIdAtom);
-  const { hardwareInfo, init } = useHardwareInfoAtom();
-
-  // The strip names its GPU row's adapter, and Compact is the only thing
-  // mounted in this view, so it has to fetch the static facts itself.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: one-time static-fact fetch
-  useEffect(() => {
-    if (hardwareInfo.gpus == null) {
-      void init();
-    }
-  }, []);
 
   const gpuLive = useMemo<GpuLiveMaps>(
     () => ({
@@ -161,8 +152,8 @@ export const CompactStrip = ({
     ],
   );
   const gpuAdapters = useMemo(
-    () => listGpuAdapters(hardwareInfo.gpus, gpuLive),
-    [hardwareInfo.gpus, gpuLive],
+    () => listGpuAdapters(gpuNames, gpuLive),
+    [gpuNames, gpuLive],
   );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -27,6 +27,16 @@ import { Sparkline } from "./Sparkline";
  * so metrics that are not collected yet (disk activity, network throughput)
  * become new builders here instead of new layout work.
  */
+/**
+ * One footer entry. `fullText` carries the unshortened form for assistive
+ * technology and hover when the visible text had to be abbreviated.
+ */
+export type CompactFooterItem = {
+  id: string;
+  text: string;
+  fullText?: string | undefined;
+};
+
 export type CompactMetricRow = {
   id: string;
   label: string;
@@ -205,12 +215,20 @@ export const CompactStrip = ({
   // The GPU row carries one adapter's numbers, so the strip says which one.
   // It goes in the footer rather than the row: the row's tracks are sized for
   // the mini monitor's small corner window and cannot hold a device name.
-  const footerItems: string[] =
+  const footerItems: CompactFooterItem[] =
     activeGpuAdapter != null
       ? [
-          t("pages.performance.compactGpuAdapter", {
-            name: activeGpuAdapter.label,
-          }),
+          {
+            id: "gpu-adapter",
+            text: t("pages.performance.compactGpuAdapter", {
+              name: activeGpuAdapter.label,
+            }),
+            // The visible text is shortened to fit a corner window; the full
+            // name is still announced and still available on hover.
+            fullText: t("pages.performance.compactGpuAdapter", {
+              name: activeGpuAdapter.name,
+            }),
+          },
         ]
       : [];
 
@@ -231,7 +249,16 @@ export const CompactStrip = ({
       {footerItems.length > 0 && (
         <div className="flex gap-4 border-border/60 border-t py-2 font-mono text-[11px] text-muted-foreground tabular-nums">
           {footerItems.map((item) => (
-            <span key={item}>{item}</span>
+            <span key={item.id} title={item.fullText ?? item.text}>
+              {item.fullText == null || item.fullText === item.text ? (
+                item.text
+              ) : (
+                <>
+                  <span aria-hidden="true">{item.text}</span>
+                  <span className="sr-only">{item.fullText}</span>
+                </>
+              )}
+            </span>
           ))}
         </div>
       )}

--- a/src/features/hardware/performance/components/CompactStrip.tsx
+++ b/src/features/hardware/performance/components/CompactStrip.tsx
@@ -5,6 +5,8 @@ import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAt
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
+  gpuDedicatedMemoryKbMapAtom,
+  gpuFanSpeedMapAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
@@ -12,7 +14,11 @@ import {
 } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { cn } from "@/lib/utils";
-import { getEffectiveGpuId, listGpuAdapters } from "../gpuIdentity";
+import {
+  type GpuLiveMaps,
+  getEffectiveGpuId,
+  listGpuAdapters,
+} from "../gpuIdentity";
 import { formatTemperature, toCssColor } from "./InstrumentStrip";
 import { Sparkline } from "./Sparkline";
 
@@ -126,6 +132,8 @@ export const CompactStrip = ({
   const gpuUsageHistories = useAtomValue(gpuUsageHistoriesAtom);
   const cpuTemperatures = useAtomValue(cpuTempAtom);
   const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
+  const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
+  const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
   const selectedGpuId = useAtomValue(selectedGpuIdAtom);
   const { hardwareInfo, init } = useHardwareInfoAtom();
 
@@ -138,19 +146,27 @@ export const CompactStrip = ({
     }
   }, []);
 
+  const gpuLive = useMemo<GpuLiveMaps>(
+    () => ({
+      usageHistories: gpuUsageHistories,
+      temperatures: gpuTemperatureMap,
+      fanSpeeds: gpuFanSpeedMap,
+      dedicatedMemoryKb: gpuDedicatedMemoryKbMap,
+    }),
+    [
+      gpuUsageHistories,
+      gpuTemperatureMap,
+      gpuFanSpeedMap,
+      gpuDedicatedMemoryKbMap,
+    ],
+  );
   const gpuAdapters = useMemo(
-    () =>
-      listGpuAdapters(
-        hardwareInfo.gpus,
-        gpuTemperatureMap,
-        Object.keys(gpuUsageHistories),
-      ),
-    [hardwareInfo.gpus, gpuTemperatureMap, gpuUsageHistories],
+    () => listGpuAdapters(hardwareInfo.gpus, gpuLive),
+    [hardwareInfo.gpus, gpuLive],
   );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,
-    gpuUsageHistories,
-    gpuTemperatureMap,
+    gpuLive,
     gpuAdapters.map((adapter) => adapter.id),
   );
   const activeGpuAdapter = gpuAdapters.find(
@@ -200,7 +216,11 @@ export const CompactStrip = ({
   // the mini monitor's small corner window and cannot hold a device name.
   const footerItems: string[] =
     activeGpuAdapter != null
-      ? [`${t("pages.performance.metrics.gpu")}: ${activeGpuAdapter.label}`]
+      ? [
+          t("pages.performance.compactGpuAdapter", {
+            name: activeGpuAdapter.label,
+          }),
+        ]
       : [];
 
   return (

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -39,7 +39,10 @@ export const GpuAdapterSelector = ({
         title={adapter.name}
         data-testid="performance-gpu-adapter"
       >
-        {adapter.label}
+        {/* The visible text is shortened to fit the card; the full name is
+            still read out, since a title alone is not an accessible name. */}
+        <span aria-hidden="true">{adapter.label}</span>
+        <span className="sr-only">{adapter.name}</span>
       </p>
     );
   }

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -45,20 +45,24 @@ export const GpuAdapterSelector = ({
   }
 
   return (
-    <div
-      role="tablist"
-      aria-label={t("pages.performance.gpuSelector")}
-      className={cn("flex min-w-0 justify-end gap-1", className)}
+    // A labelled group of toggles rather than a tablist: there is no tabpanel,
+    // no roving tabindex, and no arrow-key contract here, so announcing these
+    // as tabs would promise a keyboard model the control does not implement.
+    <fieldset
+      className={cn(
+        "m-0 flex min-w-0 justify-end gap-1 border-0 p-0",
+        className,
+      )}
       data-testid="performance-gpu-selector"
     >
+      <legend className="sr-only">{t("pages.performance.gpuSelector")}</legend>
       {adapters.map((adapter) => {
         const isSelected = adapter.id === selectedId;
         return (
           <button
             key={adapter.id}
             type="button"
-            role="tab"
-            aria-selected={isSelected}
+            aria-pressed={isSelected}
             // The visible label is shortened to fit the card, so the full name
             // the platform reported is what assistive technology announces.
             aria-label={adapter.name}
@@ -75,6 +79,6 @@ export const GpuAdapterSelector = ({
           </button>
         );
       })}
-    </div>
+    </fieldset>
   );
 };

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -3,6 +3,13 @@ import { cn } from "@/lib/utils";
 import type { GpuAdapter } from "../gpuIdentity";
 
 /**
+ * The full name, except where two identical cards report the same one — then
+ * the label, which carries the ordinal that tells them apart.
+ */
+const accessibleName = (adapter: GpuAdapter) =>
+  adapter.isNameAmbiguous ? adapter.label : adapter.name;
+
+/**
  * States which adapter the GPU instrument's readings belong to, and lets the
  * user pick another one when the machine has more than one.
  *
@@ -36,13 +43,13 @@ export const GpuAdapterSelector = ({
           "min-w-0 truncate text-muted-foreground text-xs",
           className,
         )}
-        title={adapter.name}
+        title={accessibleName(adapter)}
         data-testid="performance-gpu-adapter"
       >
         {/* The visible text is shortened to fit the card; the full name is
             still read out, since a title alone is not an accessible name. */}
         <span aria-hidden="true">{adapter.label}</span>
-        <span className="sr-only">{adapter.name}</span>
+        <span className="sr-only">{accessibleName(adapter)}</span>
       </p>
     );
   }
@@ -66,10 +73,12 @@ export const GpuAdapterSelector = ({
             key={adapter.id}
             type="button"
             aria-pressed={isSelected}
-            // The visible label is shortened to fit the card, so the full name
-            // the platform reported is what assistive technology announces.
-            aria-label={adapter.name}
-            title={adapter.name}
+            // The visible label is shortened to fit the card, so the full
+            // name is what assistive technology announces — carrying the
+            // ordinal when the platform reports the same name twice, since
+            // the raw name alone would not say which card this is.
+            aria-label={accessibleName(adapter)}
+            title={accessibleName(adapter)}
             onClick={() => onSelect(adapter.id)}
             className={cn(
               "min-w-0 max-w-28 truncate rounded-md border px-1.5 py-0.5 text-[11px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
+import type { GpuAdapter } from "@/features/hardware/gpuIdentity";
 import { cn } from "@/lib/utils";
-import type { GpuAdapter } from "../gpuIdentity";
 
 /**
  * The full name, except where two identical cards report the same one — then

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import type { GpuAdapter } from "../gpuIdentity";
+
+/**
+ * States which adapter the GPU instrument's readings belong to, and lets the
+ * user pick another one when the machine has more than one.
+ *
+ * A single adapter needs no control — naming it is the whole job — so the
+ * switcher only appears once there is a choice to make. The visible text is
+ * the short label while the accessible name and tooltip keep the full name
+ * the platform reported.
+ */
+export const GpuAdapterSelector = ({
+  adapters,
+  selectedId,
+  onSelect,
+  className,
+}: {
+  adapters: GpuAdapter[];
+  selectedId: string | undefined;
+  onSelect: (gpuId: string) => void;
+  className?: string;
+}) => {
+  const { t } = useTranslation();
+
+  if (adapters.length === 0) {
+    return null;
+  }
+
+  if (adapters.length === 1) {
+    const [adapter] = adapters;
+    return (
+      <p
+        className={cn(
+          "min-w-0 truncate text-muted-foreground text-xs",
+          className,
+        )}
+        title={adapter.name}
+        data-testid="performance-gpu-adapter"
+      >
+        {adapter.label}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t("pages.performance.gpuSelector")}
+      className={cn("flex min-w-0 justify-end gap-1", className)}
+      data-testid="performance-gpu-selector"
+    >
+      {adapters.map((adapter) => {
+        const isSelected = adapter.id === selectedId;
+        return (
+          <button
+            key={adapter.id}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            // The visible label is shortened to fit the card, so the full name
+            // the platform reported is what assistive technology announces.
+            aria-label={adapter.name}
+            title={adapter.name}
+            onClick={() => onSelect(adapter.id)}
+            className={cn(
+              "min-w-0 max-w-28 truncate rounded-md border px-1.5 py-0.5 text-[11px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              isSelected
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border/70 bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {adapter.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -1,5 +1,5 @@
 import { CpuIcon, GraphicsCardIcon, MemoryIcon } from "@phosphor-icons/react";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import {
   type CSSProperties,
   memo,
@@ -24,23 +24,16 @@ import {
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { cn } from "@/lib/utils";
+import {
+  getEffectiveGpuId,
+  hasNoLiveGpuReadings,
+  listGpuAdapters,
+} from "../gpuIdentity";
+import { GpuAdapterSelector } from "./GpuAdapterSelector";
 import { Sparkline } from "./Sparkline";
 
 export const toCssColor = (value: string) =>
   value.startsWith("rgb(") ? value : `rgb(${value})`;
-
-/**
- * The GPU both Performance views agree on: the explicit selection while it is
- * still reporting usage, otherwise the first GPU that reports anything.
- */
-export const getEffectiveGpuId = (
-  selectedGpuId: string | null,
-  gpuUsageHistories: Record<string, (number | null)[]>,
-  gpuTemperatureMap: Record<string, { name: string; value: number }>,
-) =>
-  selectedGpuId != null && Object.hasOwn(gpuUsageHistories, selectedGpuId)
-    ? selectedGpuId
-    : (Object.keys(gpuUsageHistories)[0] ?? Object.keys(gpuTemperatureMap)[0]);
 
 export const formatTemperature = (
   value: number | null | undefined,
@@ -63,6 +56,8 @@ const MetricInstrument = memo(
     history,
     color,
     badge,
+    identity,
+    note,
     substats,
     gauges,
     icon,
@@ -73,6 +68,10 @@ const MetricInstrument = memo(
     history: (number | null)[];
     color: string;
     badge?: string | undefined;
+    /** Names the physical device the readings came from, e.g. the GPU adapter. */
+    identity?: ReactNode;
+    /** Stated instead of substats when the device reports nothing. */
+    note?: string | undefined;
     substats: Substat[];
     /** Classic Hardware Dashboard card icon, colored per metric hue. */
     icon: ReactNode;
@@ -90,9 +89,9 @@ const MetricInstrument = memo(
         className="absolute inset-x-0 top-0 h-0.5 bg-[var(--metric-color)]"
         aria-hidden="true"
       />
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2">
         {icon}
-        <p className="font-semibold text-muted-foreground text-xs uppercase tracking-[0.18em]">
+        <p className="shrink-0 font-semibold text-muted-foreground text-xs uppercase tracking-[0.18em]">
           {label}
         </p>
         {badge != null && (
@@ -100,6 +99,7 @@ const MetricInstrument = memo(
             {badge}
           </p>
         )}
+        {identity != null && <div className="ml-auto min-w-0">{identity}</div>}
       </div>
       {/* Two side-by-side doughnuts must fit a one-third-width card, so the
           xl row stays below the classic 200px dashboard height. */}
@@ -114,12 +114,16 @@ const MetricInstrument = memo(
       <div className="mt-2 text-muted-foreground">
         <Sparkline values={history} color={color} />
       </div>
-      {substats.length > 0 && (
-        <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[11px] text-muted-foreground tabular-nums">
-          {substats.map((substat) => (
-            <span key={substat.key}>{substat.text}</span>
-          ))}
-        </div>
+      {note != null ? (
+        <p className="mt-1.5 text-[11px] text-muted-foreground">{note}</p>
+      ) : (
+        substats.length > 0 && (
+          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[11px] text-muted-foreground tabular-nums">
+            {substats.map((substat) => (
+              <span key={substat.key}>{substat.text}</span>
+            ))}
+          </div>
+        )
       )}
     </article>
   ),
@@ -141,7 +145,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
   const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
   const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
   const processorsUsageHistory = useAtomValue(processorsUsageHistoryAtom);
-  const selectedGpuId = useAtomValue(selectedGpuIdAtom);
+  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
   const { settings } = useSettingsAtom();
   const { hardwareInfo, init } = useHardwareInfoAtom();
   const { isBreak } = useWindowSize();
@@ -155,8 +159,23 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     void init();
   }, []);
 
+  const gpuAdapters = useMemo(
+    () =>
+      listGpuAdapters(
+        hardwareInfo.gpus,
+        gpuTemperatureMap,
+        Object.keys(gpuUsageHistories),
+      ),
+    [hardwareInfo.gpus, gpuTemperatureMap, gpuUsageHistories],
+  );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,
+    gpuUsageHistories,
+    gpuTemperatureMap,
+    gpuAdapters.map((adapter) => adapter.id),
+  );
+  const gpuHasNoReadings = hasNoLiveGpuReadings(
+    effectiveGpuId,
     gpuUsageHistories,
     gpuTemperatureMap,
   );
@@ -331,6 +350,18 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
         history={gpuHistory}
         color={toCssColor(settings.lineGraphColor.gpu)}
         substats={gpuSubstats}
+        note={
+          gpuHasNoReadings
+            ? t("pages.performance.gpuNoLiveReadings")
+            : undefined
+        }
+        identity={
+          <GpuAdapterSelector
+            adapters={gpuAdapters}
+            selectedId={effectiveGpuId}
+            onSelect={setSelectedGpuId}
+          />
+        }
         icon={
           <GraphicsCardIcon
             size={22}

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -25,6 +25,7 @@ import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { cn } from "@/lib/utils";
 import {
+  type GpuLiveMaps,
   getEffectiveGpuId,
   hasNoLiveGpuReadings,
   listGpuAdapters,
@@ -70,7 +71,7 @@ const MetricInstrument = memo(
     badge?: string | undefined;
     /** Names the physical device the readings came from, e.g. the GPU adapter. */
     identity?: ReactNode;
-    /** Stated instead of substats when the device reports nothing. */
+    /** Added below the substats when the device reports nothing. */
     note?: string | undefined;
     substats: Substat[];
     /** Classic Hardware Dashboard card icon, colored per metric hue. */
@@ -114,16 +115,17 @@ const MetricInstrument = memo(
       <div className="mt-2 text-muted-foreground">
         <Sparkline values={history} color={color} />
       </div>
-      {note != null ? (
+      {substats.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[11px] text-muted-foreground tabular-nums">
+          {substats.map((substat) => (
+            <span key={substat.key}>{substat.text}</span>
+          ))}
+        </div>
+      )}
+      {/* Additive, never a replacement: the note says what is missing, so it
+          must not take the place of whatever the device did report. */}
+      {note != null && (
         <p className="mt-1.5 text-[11px] text-muted-foreground">{note}</p>
-      ) : (
-        substats.length > 0 && (
-          <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[11px] text-muted-foreground tabular-nums">
-            {substats.map((substat) => (
-              <span key={substat.key}>{substat.text}</span>
-            ))}
-          </div>
-        )
       )}
     </article>
   ),
@@ -159,26 +161,30 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     void init();
   }, []);
 
+  const gpuLive = useMemo<GpuLiveMaps>(
+    () => ({
+      usageHistories: gpuUsageHistories,
+      temperatures: gpuTemperatureMap,
+      fanSpeeds: gpuFanSpeedMap,
+      dedicatedMemoryKb: gpuDedicatedMemoryKbMap,
+    }),
+    [
+      gpuUsageHistories,
+      gpuTemperatureMap,
+      gpuFanSpeedMap,
+      gpuDedicatedMemoryKbMap,
+    ],
+  );
   const gpuAdapters = useMemo(
-    () =>
-      listGpuAdapters(
-        hardwareInfo.gpus,
-        gpuTemperatureMap,
-        Object.keys(gpuUsageHistories),
-      ),
-    [hardwareInfo.gpus, gpuTemperatureMap, gpuUsageHistories],
+    () => listGpuAdapters(hardwareInfo.gpus, gpuLive),
+    [hardwareInfo.gpus, gpuLive],
   );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,
-    gpuUsageHistories,
-    gpuTemperatureMap,
+    gpuLive,
     gpuAdapters.map((adapter) => adapter.id),
   );
-  const gpuHasNoReadings = hasNoLiveGpuReadings(
-    effectiveGpuId,
-    gpuUsageHistories,
-    gpuTemperatureMap,
-  );
+  const gpuHasNoReadings = hasNoLiveGpuReadings(effectiveGpuId, gpuLive);
   const gpuHistory =
     effectiveGpuId != null ? (gpuUsageHistories[effectiveGpuId] ?? []) : [];
   const gpuTemperature =

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -9,6 +9,12 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { DoughnutChart } from "@/components/charts/DoughnutChart";
+import {
+  type GpuLiveMaps,
+  getEffectiveGpuId,
+  hasNoLiveGpuReadings,
+  listGpuAdapters,
+} from "@/features/hardware/gpuIdentity";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
@@ -25,12 +31,6 @@ import {
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { cn } from "@/lib/utils";
-import {
-  type GpuLiveMaps,
-  getEffectiveGpuId,
-  hasNoLiveGpuReadings,
-  listGpuAdapters,
-} from "../gpuIdentity";
 import { GpuAdapterSelector } from "./GpuAdapterSelector";
 import { Sparkline } from "./Sparkline";
 

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -186,9 +186,9 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     gpuLive,
     gpuAdapters.map((adapter) => adapter.id),
   );
-  const effectiveGpuName = gpuAdapters.find(
+  const effectiveGpuAdapter = gpuAdapters.find(
     (adapter) => adapter.id === effectiveGpuId,
-  )?.name;
+  );
   const gpuHasNoReadings = hasNoLiveGpuReadings(effectiveGpuId, gpuLive);
   const gpuHistory =
     effectiveGpuId != null ? (gpuUsageHistories[effectiveGpuId] ?? []) : [];
@@ -262,10 +262,15 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
       if (usedKb != null) {
         // Matched by name, not id: the inventory and the live samples use
         // different id namespaces (see `gpuNamesAtom`), so an id lookup here
-        // always misses and silently drops the total.
-        const totalLabel = hardwareInfo.gpus?.find(
-          (gpu) => gpu.name === effectiveGpuName,
-        )?.memorySizeDedicated;
+        // always misses and silently drops the total. Two identical cards
+        // make the name ambiguous, and a total attributed to the wrong one
+        // of them is worse than no total, so the denominator is dropped.
+        const totalLabel =
+          effectiveGpuAdapter != null && !effectiveGpuAdapter.isNameAmbiguous
+            ? hardwareInfo.gpus?.find(
+                (gpu) => gpu.name === effectiveGpuAdapter.name,
+              )?.memorySizeDedicated
+            : undefined;
         const usedGb = (usedKb / 1024 / 1024).toFixed(1);
         substats.push({
           key: "vram",
@@ -291,7 +296,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     return substats;
   }, [
     effectiveGpuId,
-    effectiveGpuName,
+    effectiveGpuAdapter,
     gpuDedicatedMemoryKbMap,
     gpuFanSpeedMap,
     hardwareInfo.gpus,

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -15,6 +15,7 @@ import {
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
   gpuFanSpeedMapAtom,
+  gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
@@ -145,6 +146,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
   const cpuTemperatures = useAtomValue(cpuTempAtom);
   const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
   const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
+  const gpuNames = useAtomValue(gpuNamesAtom);
   const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
   const processorsUsageHistory = useAtomValue(processorsUsageHistoryAtom);
   const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
@@ -176,14 +178,17 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     ],
   );
   const gpuAdapters = useMemo(
-    () => listGpuAdapters(hardwareInfo.gpus, gpuLive),
-    [hardwareInfo.gpus, gpuLive],
+    () => listGpuAdapters(gpuNames, gpuLive),
+    [gpuNames, gpuLive],
   );
   const effectiveGpuId = getEffectiveGpuId(
     selectedGpuId,
     gpuLive,
     gpuAdapters.map((adapter) => adapter.id),
   );
+  const effectiveGpuName = gpuAdapters.find(
+    (adapter) => adapter.id === effectiveGpuId,
+  )?.name;
   const gpuHasNoReadings = hasNoLiveGpuReadings(effectiveGpuId, gpuLive);
   const gpuHistory =
     effectiveGpuId != null ? (gpuUsageHistories[effectiveGpuId] ?? []) : [];
@@ -255,8 +260,11 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     if (effectiveGpuId != null) {
       const usedKb = gpuDedicatedMemoryKbMap[effectiveGpuId];
       if (usedKb != null) {
+        // Matched by name, not id: the inventory and the live samples use
+        // different id namespaces (see `gpuNamesAtom`), so an id lookup here
+        // always misses and silently drops the total.
         const totalLabel = hardwareInfo.gpus?.find(
-          (gpu) => gpu.id === effectiveGpuId,
+          (gpu) => gpu.name === effectiveGpuName,
         )?.memorySizeDedicated;
         const usedGb = (usedKb / 1024 / 1024).toFixed(1);
         substats.push({
@@ -283,6 +291,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     return substats;
   }, [
     effectiveGpuId,
+    effectiveGpuName,
     gpuDedicatedMemoryKbMap,
     gpuFanSpeedMap,
     hardwareInfo.gpus,

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -265,11 +265,20 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
         // always misses and silently drops the total. Two identical cards
         // make the name ambiguous, and a total attributed to the wrong one
         // of them is worse than no total, so the denominator is dropped.
-        const totalLabel =
-          effectiveGpuAdapter != null && !effectiveGpuAdapter.isNameAmbiguous
-            ? hardwareInfo.gpus?.find(
+        // Both sides have to be unambiguous, not just the live one: the
+        // inventory can hold two identically named cards while only one of
+        // them reports, and `.find()` would then pick a capacity at random.
+        const inventoryMatches =
+          effectiveGpuAdapter == null
+            ? []
+            : (hardwareInfo.gpus?.filter(
                 (gpu) => gpu.name === effectiveGpuAdapter.name,
-              )?.memorySizeDedicated
+              ) ?? []);
+        const totalLabel =
+          effectiveGpuAdapter != null &&
+          !effectiveGpuAdapter.isNameAmbiguous &&
+          inventoryMatches.length === 1
+            ? inventoryMatches[0].memorySizeDedicated
             : undefined;
         const usedGb = (usedKb / 1024 / 1024).toFixed(1);
         substats.push({

--- a/src/features/hardware/performance/components/InstrumentStrip.tsx
+++ b/src/features/hardware/performance/components/InstrumentStrip.tsx
@@ -1,5 +1,5 @@
 import { CpuIcon, GraphicsCardIcon, MemoryIcon } from "@phosphor-icons/react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtomValue } from "jotai";
 import {
   type CSSProperties,
   memo,
@@ -9,24 +9,15 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { DoughnutChart } from "@/components/charts/DoughnutChart";
-import {
-  type GpuLiveMaps,
-  getEffectiveGpuId,
-  hasNoLiveGpuReadings,
-  listGpuAdapters,
-} from "@/features/hardware/gpuIdentity";
+import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
-  gpuDedicatedMemoryKbMapAtom,
-  gpuFanSpeedMapAtom,
-  gpuNamesAtom,
   gpuTempMapAtom,
   gpuUsageHistoriesAtom,
   memoryUsageHistoryAtom,
   processorsUsageHistoryAtom,
-  selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { useWindowSize } from "@/hooks/useWindowSize";
@@ -145,11 +136,15 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
   const gpuUsageHistories = useAtomValue(gpuUsageHistoriesAtom);
   const cpuTemperatures = useAtomValue(cpuTempAtom);
   const gpuTemperatureMap = useAtomValue(gpuTempMapAtom);
-  const gpuFanSpeedMap = useAtomValue(gpuFanSpeedMapAtom);
-  const gpuNames = useAtomValue(gpuNamesAtom);
-  const gpuDedicatedMemoryKbMap = useAtomValue(gpuDedicatedMemoryKbMapAtom);
   const processorsUsageHistory = useAtomValue(processorsUsageHistoryAtom);
-  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
+  const {
+    adapters: gpuAdapters,
+    effectiveGpuId,
+    effectiveAdapter: effectiveGpuAdapter,
+    live: gpuLive,
+    hasNoReadings: gpuHasNoReadings,
+    selectGpu: setSelectedGpuId,
+  } = useGpuAdapters();
   const { settings } = useSettingsAtom();
   const { hardwareInfo, init } = useHardwareInfoAtom();
   const { isBreak } = useWindowSize();
@@ -163,33 +158,6 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
     void init();
   }, []);
 
-  const gpuLive = useMemo<GpuLiveMaps>(
-    () => ({
-      usageHistories: gpuUsageHistories,
-      temperatures: gpuTemperatureMap,
-      fanSpeeds: gpuFanSpeedMap,
-      dedicatedMemoryKb: gpuDedicatedMemoryKbMap,
-    }),
-    [
-      gpuUsageHistories,
-      gpuTemperatureMap,
-      gpuFanSpeedMap,
-      gpuDedicatedMemoryKbMap,
-    ],
-  );
-  const gpuAdapters = useMemo(
-    () => listGpuAdapters(gpuNames, gpuLive),
-    [gpuNames, gpuLive],
-  );
-  const effectiveGpuId = getEffectiveGpuId(
-    selectedGpuId,
-    gpuLive,
-    gpuAdapters.map((adapter) => adapter.id),
-  );
-  const effectiveGpuAdapter = gpuAdapters.find(
-    (adapter) => adapter.id === effectiveGpuId,
-  );
-  const gpuHasNoReadings = hasNoLiveGpuReadings(effectiveGpuId, gpuLive);
   const gpuHistory =
     effectiveGpuId != null ? (gpuUsageHistories[effectiveGpuId] ?? []) : [];
   const gpuTemperature =
@@ -258,7 +226,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
   const gpuSubstats = useMemo<Substat[]>(() => {
     const substats: Substat[] = [];
     if (effectiveGpuId != null) {
-      const usedKb = gpuDedicatedMemoryKbMap[effectiveGpuId];
+      const usedKb = gpuLive.dedicatedMemoryKb[effectiveGpuId];
       if (usedKb != null) {
         // Matched by name, not id: the inventory and the live samples use
         // different id namespaces (see `gpuNamesAtom`), so an id lookup here
@@ -290,7 +258,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
         });
       }
 
-      const fan = gpuFanSpeedMap[effectiveGpuId];
+      const fan = gpuLive.fanSpeeds[effectiveGpuId];
       if (fan != null) {
         substats.push({
           key: "fan",
@@ -303,14 +271,7 @@ export const InstrumentStrip = ({ className }: { className?: string }) => {
       }
     }
     return substats;
-  }, [
-    effectiveGpuId,
-    effectiveGpuAdapter,
-    gpuDedicatedMemoryKbMap,
-    gpuFanSpeedMap,
-    hardwareInfo.gpus,
-    t,
-  ]);
+  }, [effectiveGpuId, effectiveGpuAdapter, gpuLive, hardwareInfo.gpus, t]);
 
   const currentMemoryUsage = memoryHistory.at(-1) ?? null;
 

--- a/src/features/hardware/performance/components/MonitorGpuSelector.tsx
+++ b/src/features/hardware/performance/components/MonitorGpuSelector.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { GpuAdapterSelector } from "./GpuAdapterSelector";
@@ -11,8 +12,10 @@ import { GpuAdapterSelector } from "./GpuAdapterSelector";
  * where the value is rendered.
  */
 export const MonitorGpuSelector = () => {
+  const { t } = useTranslation();
   const { settings } = useSettingsAtom();
-  const { adapters, effectiveGpuId, selectGpu } = useGpuAdapters();
+  const { adapters, effectiveGpuId, selectGpu, hasNoReadings } =
+    useGpuAdapters();
 
   // Naming the adapter behind a series the user has turned off is noise.
   if (!settings.displayTargets.includes("gpu")) {
@@ -20,10 +23,22 @@ export const MonitorGpuSelector = () => {
   }
 
   return (
-    <GpuAdapterSelector
-      adapters={adapters}
-      selectedId={effectiveGpuId}
-      onSelect={selectGpu}
-    />
+    <div className="flex min-w-0 items-center gap-2">
+      {/* Monitor is only the graph, so a blank series is the sole evidence the
+          user gets. Say why it is blank rather than letting it read as idle. */}
+      {hasNoReadings && (
+        <p
+          className="min-w-0 truncate text-muted-foreground text-xs"
+          data-testid="performance-monitor-gpu-unavailable"
+        >
+          {t("pages.performance.gpuNoLiveReadings")}
+        </p>
+      )}
+      <GpuAdapterSelector
+        adapters={adapters}
+        selectedId={effectiveGpuId}
+        onSelect={selectGpu}
+      />
+    </div>
   );
 };

--- a/src/features/hardware/performance/components/MonitorGpuSelector.tsx
+++ b/src/features/hardware/performance/components/MonitorGpuSelector.tsx
@@ -1,0 +1,29 @@
+import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import { GpuAdapterSelector } from "./GpuAdapterSelector";
+
+/**
+ * Monitor's adapter attribution, kept in its own component.
+ *
+ * `useGpuAdapters` subscribes to atoms the event listener rewrites on every
+ * sample, so calling it from the Performance parent would rerender the whole
+ * screen — panels, toolbar, and all — once a second. The subscription belongs
+ * where the value is rendered.
+ */
+export const MonitorGpuSelector = () => {
+  const { settings } = useSettingsAtom();
+  const { adapters, effectiveGpuId, selectGpu } = useGpuAdapters();
+
+  // Naming the adapter behind a series the user has turned off is noise.
+  if (!settings.displayTargets.includes("gpu")) {
+    return null;
+  }
+
+  return (
+    <GpuAdapterSelector
+      adapters={adapters}
+      selectedId={effectiveGpuId}
+      onSelect={selectGpu}
+    />
+  );
+};

--- a/src/features/hardware/performance/gpuIdentity.test.ts
+++ b/src/features/hardware/performance/gpuIdentity.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import type { GraphicInfo } from "@/rspc/bindings";
 import {
   type GpuLiveMaps,
   getEffectiveGpuId,
@@ -7,15 +6,8 @@ import {
   listGpuAdapters,
 } from "./gpuIdentity";
 
-const gpu = (id: string, name: string): GraphicInfo => ({
-  id,
-  name,
-  vendorName: "Vendor",
-  clock: 0,
-  memorySize: "8 GB",
-  memorySizeDedicated: "8 GB",
-  coreCount: null,
-});
+/** The live name map, as the event listener builds it from each sample. */
+const names = (...pairs: [string, string][]) => Object.fromEntries(pairs);
 
 const live = (maps: Partial<GpuLiveMaps> = {}): GpuLiveMaps => ({
   usageHistories: {},
@@ -26,63 +18,68 @@ const live = (maps: Partial<GpuLiveMaps> = {}): GpuLiveMaps => ({
 });
 
 describe("listGpuAdapters", () => {
-  it("represents every detected adapter even when only one reports values", () => {
+  it("lists one adapter per live id, never unioned with the inventory namespace", () => {
+    // Windows NVIDIA: the inventory reports "12345", sampling reports
+    // "nvapi:12345". Unioning them would render one card as two adapters and
+    // declare the inventory half silent.
     const adapters = listGpuAdapters(
-      [gpu("gpu-1", "NVIDIA GeForce RTX 4080"), gpu("gpu-2", "Intel UHD 770")],
-      live({ usageHistories: { "gpu-1": [20] } }),
-    );
-
-    expect(adapters.map((adapter) => adapter.id)).toEqual(["gpu-1", "gpu-2"]);
-  });
-
-  it("keeps an adapter that only exists in the live maps, so no reading is ownerless", () => {
-    const adapters = listGpuAdapters(
-      [gpu("gpu-1", "Radeon 780M")],
-      live({ temperatures: { "gpu-9": { name: "Late GPU", value: 40 } } }),
-    );
-
-    expect(adapters).toEqual([
-      { id: "gpu-1", name: "Radeon 780M", label: "Radeon 780M" },
-      { id: "gpu-9", name: "Late GPU", label: "Late GPU" },
-    ]);
-  });
-
-  it("names an adapter from the fan map when the static fetch has not answered", () => {
-    // The static fetch can be slow or fail outright; the sensor maps carry the
-    // platform's own name, so an id never has to be shown raw when one exists.
-    const adapters = listGpuAdapters(
-      null,
-      live({
-        usageHistories: { "GPU-{8ee6}": [30] },
-        fanSpeeds: { "GPU-{8ee6}": { name: "Radeon RX 7900 XT", value: 55 } },
-      }),
+      names(["nvapi:12345", "NVIDIA GeForce RTX 4080"]),
+      live({ usageHistories: { "nvapi:12345": [30] } }),
     );
 
     expect(adapters).toEqual([
       {
-        id: "GPU-{8ee6}",
-        name: "Radeon RX 7900 XT",
-        label: "Radeon RX 7900 XT",
+        id: "nvapi:12345",
+        name: "NVIDIA GeForce RTX 4080",
+        label: "GeForce RTX 4080",
       },
     ]);
   });
 
-  it("falls back to the id only when no map names the adapter at all", () => {
+  it("covers every live map, so a fan-only adapter is still listed", () => {
     const adapters = listGpuAdapters(
-      null,
-      live({ usageHistories: { "GPU-{8ee6}": [30] } }),
+      names(["pci:1:0:0", "Radeon RX 7900 XT"]),
+      live({
+        usageHistories: { "nvapi:1": [30] },
+        fanSpeeds: { "pci:1:0:0": { name: "Radeon RX 7900 XT", value: 55 } },
+      }),
     );
 
-    expect(adapters[0].label).toBe("GPU-{8ee6}");
+    // Named adapters come first in payload order, then any id that only a
+    // value map knows about.
+    expect(adapters.map((adapter) => adapter.id)).toEqual([
+      "pci:1:0:0",
+      "nvapi:1",
+    ]);
+  });
+
+  it("names an adapter from the sensor map when the name map has not caught up", () => {
+    const adapters = listGpuAdapters(
+      {},
+      live({
+        temperatures: { "iokit:M3": { name: "Apple M3 Max", value: 51 } },
+      }),
+    );
+
+    expect(adapters[0].name).toBe("Apple M3 Max");
+  });
+
+  it("falls back to the id only when no source names the adapter", () => {
+    const adapters = listGpuAdapters(
+      {},
+      live({ usageHistories: { "pdh:Unknown": [30] } }),
+    );
+
+    expect(adapters[0].label).toBe("pdh:Unknown");
   });
 
   it("drops the vendor word that every adapter of a brand repeats", () => {
     const adapters = listGpuAdapters(
-      [
-        gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
-        gpu("gpu-2", "Intel(R) UHD Graphics 770"),
-      ],
-      live(),
+      names(
+        ["gpu-1", "NVIDIA GeForce RTX 4080"],
+        ["gpu-2", "Intel(R) UHD Graphics 770"],
+      ),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -93,8 +90,8 @@ describe("listGpuAdapters", () => {
 
   it("falls back to full names rather than showing two identical labels", () => {
     const adapters = listGpuAdapters(
-      [gpu("gpu-1", "NVIDIA RTX A2000"), gpu("gpu-2", "AMD RTX A2000")],
-      live(),
+      names(["gpu-1", "NVIDIA RTX A2000"], ["gpu-2", "AMD RTX A2000"]),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -107,11 +104,11 @@ describe("listGpuAdapters", () => {
     // Two identical cards: shortening cannot tell them apart, so it must not
     // pretend to by showing the same short label twice.
     const adapters = listGpuAdapters(
-      [
-        gpu("gpu-1", "NVIDIA GeForce RTX 4090"),
-        gpu("gpu-2", "NVIDIA GeForce RTX 4090"),
-      ],
-      live(),
+      names(
+        ["gpu-1", "NVIDIA GeForce RTX 4090"],
+        ["gpu-2", "NVIDIA GeForce RTX 4090"],
+      ),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -122,11 +119,11 @@ describe("listGpuAdapters", () => {
 
   it("drops the leading words two adapters share, since a narrow card truncates the rest away", () => {
     const adapters = listGpuAdapters(
-      [
-        gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
-        gpu("gpu-2", "NVIDIA GeForce RTX 4060"),
-      ],
-      live(),
+      names(
+        ["gpu-1", "NVIDIA GeForce RTX 4080"],
+        ["gpu-2", "NVIDIA GeForce RTX 4060"],
+      ),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual(["4080", "4060"]);
@@ -136,8 +133,8 @@ describe("listGpuAdapters", () => {
 
   it("never consumes a whole name when one adapter's name prefixes another's", () => {
     const adapters = listGpuAdapters(
-      [gpu("gpu-1", "Radeon Graphics"), gpu("gpu-2", "Radeon Graphics Pro")],
-      live(),
+      names(["gpu-1", "Radeon Graphics"], ["gpu-2", "Radeon Graphics Pro"]),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -147,9 +144,12 @@ describe("listGpuAdapters", () => {
   });
 
   it("keeps a name that is nothing but a vendor word", () => {
-    expect(listGpuAdapters([gpu("gpu-1", "Apple")], live())[0].label).toBe(
-      "Apple",
+    const adapters = listGpuAdapters(
+      names(["gpu-1", "Apple"]),
+      live({ usageHistories: { "gpu-1": [20] } }),
     );
+
+    expect(adapters[0].label).toBe("Apple");
   });
 });
 

--- a/src/features/hardware/performance/gpuIdentity.test.ts
+++ b/src/features/hardware/performance/gpuIdentity.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { GraphicInfo } from "@/rspc/bindings";
+import {
+  getEffectiveGpuId,
+  hasNoLiveGpuReadings,
+  listGpuAdapters,
+} from "./gpuIdentity";
+
+const gpu = (id: string, name: string): GraphicInfo => ({
+  id,
+  name,
+  vendorName: "Vendor",
+  clock: 0,
+  memorySize: "8 GB",
+  memorySizeDedicated: "8 GB",
+  coreCount: null,
+});
+
+describe("listGpuAdapters", () => {
+  it("represents every detected adapter even when only one reports values", () => {
+    const adapters = listGpuAdapters(
+      [gpu("gpu-1", "NVIDIA GeForce RTX 4080"), gpu("gpu-2", "Intel UHD 770")],
+      {},
+      ["gpu-1"],
+    );
+
+    expect(adapters.map((adapter) => adapter.id)).toEqual(["gpu-1", "gpu-2"]);
+  });
+
+  it("keeps an adapter that only exists in the live maps, so no reading is ownerless", () => {
+    const adapters = listGpuAdapters([gpu("gpu-1", "Radeon 780M")], {
+      "gpu-9": { name: "Late GPU" },
+    });
+
+    expect(adapters).toEqual([
+      { id: "gpu-1", name: "Radeon 780M", label: "Radeon 780M" },
+      { id: "gpu-9", name: "Late GPU", label: "Late GPU" },
+    ]);
+  });
+
+  it("drops the vendor word that every adapter of a brand repeats", () => {
+    const adapters = listGpuAdapters(
+      [
+        gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
+        gpu("gpu-2", "Intel(R) UHD Graphics 770"),
+      ],
+      {},
+      [],
+    );
+
+    expect(adapters.map((adapter) => adapter.label)).toEqual([
+      "GeForce RTX 4080",
+      "UHD Graphics 770",
+    ]);
+  });
+
+  it("falls back to full names rather than showing two identical labels", () => {
+    const adapters = listGpuAdapters(
+      [gpu("gpu-1", "NVIDIA RTX A2000"), gpu("gpu-2", "AMD RTX A2000")],
+      {},
+      [],
+    );
+
+    expect(adapters.map((adapter) => adapter.label)).toEqual([
+      "NVIDIA RTX A2000",
+      "AMD RTX A2000",
+    ]);
+  });
+
+  it("drops the leading words two adapters share, since a narrow card truncates the rest away", () => {
+    const adapters = listGpuAdapters(
+      [
+        gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
+        gpu("gpu-2", "NVIDIA GeForce RTX 4060"),
+      ],
+      {},
+      [],
+    );
+
+    expect(adapters.map((adapter) => adapter.label)).toEqual(["4080", "4060"]);
+    // The full name is still what the control reports for a tooltip.
+    expect(adapters[0].name).toBe("NVIDIA GeForce RTX 4080");
+  });
+
+  it("never consumes a whole name when one adapter's name prefixes another's", () => {
+    const adapters = listGpuAdapters(
+      [gpu("gpu-1", "Radeon Graphics"), gpu("gpu-2", "Radeon Graphics Pro")],
+      {},
+      [],
+    );
+
+    expect(adapters.map((adapter) => adapter.label)).toEqual([
+      "Graphics",
+      "Graphics Pro",
+    ]);
+  });
+
+  it("keeps a name that is nothing but a vendor word", () => {
+    expect(listGpuAdapters([gpu("gpu-1", "Apple")], {}, [])[0].label).toBe(
+      "Apple",
+    );
+  });
+});
+
+describe("getEffectiveGpuId", () => {
+  it("keeps an explicit selection that reports nothing yet", () => {
+    expect(
+      getEffectiveGpuId("gpu-2", { "gpu-1": [20] }, {}, ["gpu-1", "gpu-2"]),
+    ).toBe("gpu-2");
+  });
+
+  it("drops a selection whose adapter is gone instead of showing nothing", () => {
+    expect(getEffectiveGpuId("removed", { "gpu-1": [20] }, {}, ["gpu-1"])).toBe(
+      "gpu-1",
+    );
+  });
+
+  it("falls back to a temperature-only adapter when no usage is reported", () => {
+    expect(
+      getEffectiveGpuId(null, {}, { "gpu-1": { name: "GPU 1", value: 40 } }),
+    ).toBe("gpu-1");
+  });
+});
+
+describe("hasNoLiveGpuReadings", () => {
+  it("stays silent before the first sample, which is 'not yet' rather than 'unavailable'", () => {
+    expect(hasNoLiveGpuReadings("gpu-2", {}, {})).toBe(false);
+  });
+
+  it("reports an adapter that stayed silent while another one answered", () => {
+    expect(hasNoLiveGpuReadings("gpu-2", { "gpu-1": [20] }, {})).toBe(true);
+  });
+
+  it("counts a temperature-only adapter as reporting", () => {
+    expect(
+      hasNoLiveGpuReadings(
+        "gpu-2",
+        { "gpu-1": [20] },
+        { "gpu-2": { name: "GPU 2", value: 51 } },
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/features/hardware/performance/gpuIdentity.test.ts
+++ b/src/features/hardware/performance/gpuIdentity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { GraphicInfo } from "@/rspc/bindings";
 import {
+  type GpuLiveMaps,
   getEffectiveGpuId,
   hasNoLiveGpuReadings,
   listGpuAdapters,
@@ -16,26 +17,63 @@ const gpu = (id: string, name: string): GraphicInfo => ({
   coreCount: null,
 });
 
+const live = (maps: Partial<GpuLiveMaps> = {}): GpuLiveMaps => ({
+  usageHistories: {},
+  temperatures: {},
+  fanSpeeds: {},
+  dedicatedMemoryKb: {},
+  ...maps,
+});
+
 describe("listGpuAdapters", () => {
   it("represents every detected adapter even when only one reports values", () => {
     const adapters = listGpuAdapters(
       [gpu("gpu-1", "NVIDIA GeForce RTX 4080"), gpu("gpu-2", "Intel UHD 770")],
-      {},
-      ["gpu-1"],
+      live({ usageHistories: { "gpu-1": [20] } }),
     );
 
     expect(adapters.map((adapter) => adapter.id)).toEqual(["gpu-1", "gpu-2"]);
   });
 
   it("keeps an adapter that only exists in the live maps, so no reading is ownerless", () => {
-    const adapters = listGpuAdapters([gpu("gpu-1", "Radeon 780M")], {
-      "gpu-9": { name: "Late GPU" },
-    });
+    const adapters = listGpuAdapters(
+      [gpu("gpu-1", "Radeon 780M")],
+      live({ temperatures: { "gpu-9": { name: "Late GPU", value: 40 } } }),
+    );
 
     expect(adapters).toEqual([
       { id: "gpu-1", name: "Radeon 780M", label: "Radeon 780M" },
       { id: "gpu-9", name: "Late GPU", label: "Late GPU" },
     ]);
+  });
+
+  it("names an adapter from the fan map when the static fetch has not answered", () => {
+    // The static fetch can be slow or fail outright; the sensor maps carry the
+    // platform's own name, so an id never has to be shown raw when one exists.
+    const adapters = listGpuAdapters(
+      null,
+      live({
+        usageHistories: { "GPU-{8ee6}": [30] },
+        fanSpeeds: { "GPU-{8ee6}": { name: "Radeon RX 7900 XT", value: 55 } },
+      }),
+    );
+
+    expect(adapters).toEqual([
+      {
+        id: "GPU-{8ee6}",
+        name: "Radeon RX 7900 XT",
+        label: "Radeon RX 7900 XT",
+      },
+    ]);
+  });
+
+  it("falls back to the id only when no map names the adapter at all", () => {
+    const adapters = listGpuAdapters(
+      null,
+      live({ usageHistories: { "GPU-{8ee6}": [30] } }),
+    );
+
+    expect(adapters[0].label).toBe("GPU-{8ee6}");
   });
 
   it("drops the vendor word that every adapter of a brand repeats", () => {
@@ -44,8 +82,7 @@ describe("listGpuAdapters", () => {
         gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
         gpu("gpu-2", "Intel(R) UHD Graphics 770"),
       ],
-      {},
-      [],
+      live(),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -57,13 +94,29 @@ describe("listGpuAdapters", () => {
   it("falls back to full names rather than showing two identical labels", () => {
     const adapters = listGpuAdapters(
       [gpu("gpu-1", "NVIDIA RTX A2000"), gpu("gpu-2", "AMD RTX A2000")],
-      {},
-      [],
+      live(),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
       "NVIDIA RTX A2000",
       "AMD RTX A2000",
+    ]);
+  });
+
+  it("keeps full names when trimming the shared prefix would collide", () => {
+    // Two identical cards: shortening cannot tell them apart, so it must not
+    // pretend to by showing the same short label twice.
+    const adapters = listGpuAdapters(
+      [
+        gpu("gpu-1", "NVIDIA GeForce RTX 4090"),
+        gpu("gpu-2", "NVIDIA GeForce RTX 4090"),
+      ],
+      live(),
+    );
+
+    expect(adapters.map((adapter) => adapter.label)).toEqual([
+      "NVIDIA GeForce RTX 4090",
+      "NVIDIA GeForce RTX 4090",
     ]);
   });
 
@@ -73,8 +126,7 @@ describe("listGpuAdapters", () => {
         gpu("gpu-1", "NVIDIA GeForce RTX 4080"),
         gpu("gpu-2", "NVIDIA GeForce RTX 4060"),
       ],
-      {},
-      [],
+      live(),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual(["4080", "4060"]);
@@ -85,8 +137,7 @@ describe("listGpuAdapters", () => {
   it("never consumes a whole name when one adapter's name prefixes another's", () => {
     const adapters = listGpuAdapters(
       [gpu("gpu-1", "Radeon Graphics"), gpu("gpu-2", "Radeon Graphics Pro")],
-      {},
-      [],
+      live(),
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
@@ -96,7 +147,7 @@ describe("listGpuAdapters", () => {
   });
 
   it("keeps a name that is nothing but a vendor word", () => {
-    expect(listGpuAdapters([gpu("gpu-1", "Apple")], {}, [])[0].label).toBe(
+    expect(listGpuAdapters([gpu("gpu-1", "Apple")], live())[0].label).toBe(
       "Apple",
     );
   });
@@ -105,38 +156,83 @@ describe("listGpuAdapters", () => {
 describe("getEffectiveGpuId", () => {
   it("keeps an explicit selection that reports nothing yet", () => {
     expect(
-      getEffectiveGpuId("gpu-2", { "gpu-1": [20] }, {}, ["gpu-1", "gpu-2"]),
+      getEffectiveGpuId("gpu-2", live({ usageHistories: { "gpu-1": [20] } }), [
+        "gpu-1",
+        "gpu-2",
+      ]),
     ).toBe("gpu-2");
   });
 
   it("drops a selection whose adapter is gone instead of showing nothing", () => {
-    expect(getEffectiveGpuId("removed", { "gpu-1": [20] }, {}, ["gpu-1"])).toBe(
-      "gpu-1",
-    );
+    expect(
+      getEffectiveGpuId(
+        "removed",
+        live({ usageHistories: { "gpu-1": [20] } }),
+        ["gpu-1"],
+      ),
+    ).toBe("gpu-1");
   });
 
-  it("falls back to a temperature-only adapter when no usage is reported", () => {
+  it("falls back through every map, so a fan-only adapter is still reachable", () => {
     expect(
-      getEffectiveGpuId(null, {}, { "gpu-1": { name: "GPU 1", value: 40 } }),
+      getEffectiveGpuId(
+        null,
+        live({ fanSpeeds: { "gpu-1": { name: "GPU 1", value: 55 } } }),
+      ),
     ).toBe("gpu-1");
+  });
+
+  it("has no effective GPU before anything reports", () => {
+    expect(getEffectiveGpuId(null, live())).toBeUndefined();
   });
 });
 
 describe("hasNoLiveGpuReadings", () => {
   it("stays silent before the first sample, which is 'not yet' rather than 'unavailable'", () => {
-    expect(hasNoLiveGpuReadings("gpu-2", {}, {})).toBe(false);
+    expect(hasNoLiveGpuReadings("gpu-2", live())).toBe(false);
   });
 
   it("reports an adapter that stayed silent while another one answered", () => {
-    expect(hasNoLiveGpuReadings("gpu-2", { "gpu-1": [20] }, {})).toBe(true);
+    expect(
+      hasNoLiveGpuReadings(
+        "gpu-2",
+        live({ usageHistories: { "gpu-1": [20] } }),
+      ),
+    ).toBe(true);
   });
 
   it("counts a temperature-only adapter as reporting", () => {
     expect(
       hasNoLiveGpuReadings(
         "gpu-2",
-        { "gpu-1": [20] },
-        { "gpu-2": { name: "GPU 2", value: 51 } },
+        live({
+          usageHistories: { "gpu-1": [20] },
+          temperatures: { "gpu-2": { name: "GPU 2", value: 51 } },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("counts a fan-only adapter as reporting, so its fan speed is not called absent", () => {
+    expect(
+      hasNoLiveGpuReadings(
+        "gpu-2",
+        live({
+          usageHistories: { "gpu-1": [20] },
+          fanSpeeds: { "gpu-2": { name: "GPU 2", value: 40 } },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("counts a VRAM-only adapter as reporting", () => {
+    expect(
+      hasNoLiveGpuReadings(
+        "gpu-2",
+        live({
+          usageHistories: { "gpu-1": [20] },
+          dedicatedMemoryKb: { "gpu-2": 1_048_576 },
+        }),
       ),
     ).toBe(false);
   });

--- a/src/features/hardware/performance/gpuIdentity.test.ts
+++ b/src/features/hardware/performance/gpuIdentity.test.ts
@@ -32,6 +32,7 @@ describe("listGpuAdapters", () => {
         id: "nvapi:12345",
         name: "NVIDIA GeForce RTX 4080",
         label: "GeForce RTX 4080",
+        isNameAmbiguous: false,
       },
     ]);
   });
@@ -100,9 +101,9 @@ describe("listGpuAdapters", () => {
     ]);
   });
 
-  it("keeps full names when trimming the shared prefix would collide", () => {
-    // Two identical cards: shortening cannot tell them apart, so it must not
-    // pretend to by showing the same short label twice.
+  it("adds an ordinal when the platform reports the same name twice", () => {
+    // Two identical cards. Neither shortening nor the full name can tell them
+    // apart, and two controls that read identically are not a choice.
     const adapters = listGpuAdapters(
       names(
         ["gpu-1", "NVIDIA GeForce RTX 4090"],
@@ -112,9 +113,23 @@ describe("listGpuAdapters", () => {
     );
 
     expect(adapters.map((adapter) => adapter.label)).toEqual([
-      "NVIDIA GeForce RTX 4090",
-      "NVIDIA GeForce RTX 4090",
+      "GeForce RTX 4090 #1",
+      "GeForce RTX 4090 #2",
     ]);
+    // Anything that keys on the name has to refuse it here.
+    expect(adapters.every((adapter) => adapter.isNameAmbiguous)).toBe(true);
+  });
+
+  it("leaves distinct adapters unmarked, so name joins stay allowed", () => {
+    const adapters = listGpuAdapters(
+      names(
+        ["gpu-1", "NVIDIA GeForce RTX 4080"],
+        ["gpu-2", "Intel UHD Graphics 770"],
+      ),
+      live({ usageHistories: { "gpu-1": [20], "gpu-2": [5] } }),
+    );
+
+    expect(adapters.every((adapter) => adapter.isNameAmbiguous)).toBe(false);
   });
 
   it("drops the leading words two adapters share, since a narrow card truncates the rest away", () => {

--- a/src/features/hardware/performance/gpuIdentity.ts
+++ b/src/features/hardware/performance/gpuIdentity.ts
@@ -1,0 +1,165 @@
+import type { GraphicInfo } from "@/rspc/bindings";
+
+/**
+ * One adapter as the Performance screens need it: the stable id every live
+ * value is keyed by, the name the platform reported, and a short label for
+ * controls that cannot fit the full name.
+ */
+export type GpuAdapter = {
+  id: string;
+  name: string;
+  label: string;
+};
+
+/**
+ * Vendor words that every adapter of a given brand repeats, so they carry no
+ * information in a control that exists to tell two adapters apart. Anything
+ * else in the name is kept: shortening must not invent a distinction or drop
+ * the part the user recognizes the card by.
+ */
+const VENDOR_PREFIX =
+  /^(nvidia|advanced micro devices,?\s*inc\.?|amd|intel(?: corporation)?|apple)\s+/i;
+
+const shortenGpuName = (name: string) => {
+  const cleaned = name
+    .replace(/\((?:r|tm)\)/gi, "")
+    .replace(/[®™]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  const withoutVendor = cleaned.replace(VENDOR_PREFIX, "").trim();
+
+  if (withoutVendor.length > 0) {
+    return withoutVendor;
+  }
+  return cleaned.length > 0 ? cleaned : name;
+};
+
+/**
+ * Drop a leading run of words every adapter repeats.
+ *
+ * A switcher exists to tell two adapters apart, and a shared prefix is both
+ * the part that cannot do that and the part a narrow card keeps while
+ * truncating away the model: "GeForce RTX 4080" and "GeForce RTX 4060" become
+ * "GeForce RTX 40…" twice. The full name stays on the control's tooltip.
+ */
+const dropSharedPrefixWords = (labels: string[]) => {
+  if (labels.length < 2) {
+    return labels;
+  }
+
+  const wordLists = labels.map((label) => label.split(" "));
+  const shortest = Math.min(...wordLists.map((words) => words.length));
+  let shared = 0;
+  while (
+    // Never consume a whole name: at least one word has to survive.
+    shared < shortest - 1 &&
+    wordLists.every(
+      (words) =>
+        words[shared].toLowerCase() === wordLists[0][shared].toLowerCase(),
+    )
+  ) {
+    shared += 1;
+  }
+
+  if (shared === 0) {
+    return labels;
+  }
+
+  const trimmed = wordLists.map((words) => words.slice(shared).join(" "));
+  return new Set(trimmed).size === trimmed.length ? trimmed : labels;
+};
+
+/**
+ * Every adapter the Performance screens can attribute a reading to: the ones
+ * the one-shot hardware fetch detected, plus any id that only ever shows up in
+ * the live maps. The second part matters because a reading rendered without an
+ * owner is exactly the misattribution this list exists to prevent.
+ *
+ * Labels are shortened only while they stay unique; when two adapters shorten
+ * to the same string every label falls back to the full name rather than
+ * showing two controls that read identically.
+ */
+export const listGpuAdapters = (
+  gpus: GraphicInfo[] | null | undefined,
+  liveNamesById: Record<string, { name: string }>,
+  liveIds: readonly string[] = [],
+): GpuAdapter[] => {
+  const named = new Map<string, string>();
+
+  for (const gpu of gpus ?? []) {
+    named.set(gpu.id, gpu.name);
+  }
+  for (const id of liveIds) {
+    if (!named.has(id)) {
+      named.set(id, liveNamesById[id]?.name ?? id);
+    }
+  }
+  for (const [id, value] of Object.entries(liveNamesById)) {
+    if (!named.has(id)) {
+      named.set(id, value.name);
+    }
+  }
+
+  const entries = [...named.entries()];
+  const labels = dropSharedPrefixWords(
+    entries.map(([, name]) => shortenGpuName(name)),
+  );
+  const isUnique = new Set(labels).size === labels.length;
+
+  return entries.map(([id, name], index) => ({
+    id,
+    name,
+    label: isUnique ? labels[index] : name,
+  }));
+};
+
+/**
+ * The GPU both Performance views agree on.
+ *
+ * An explicit selection wins while the adapter is still detected, even when it
+ * reports nothing: the honest answer there is "this adapter has no readings",
+ * not another adapter's numbers. Only a selection pointing at an adapter that
+ * no longer exists falls back to the first GPU that reports anything.
+ */
+export const getEffectiveGpuId = (
+  selectedGpuId: string | null,
+  gpuUsageHistories: Record<string, (number | null)[]>,
+  gpuTemperatureMap: Record<string, { name: string; value: number }>,
+  detectedGpuIds: readonly string[] = [],
+) => {
+  if (
+    selectedGpuId != null &&
+    (Object.hasOwn(gpuUsageHistories, selectedGpuId) ||
+      detectedGpuIds.includes(selectedGpuId))
+  ) {
+    return selectedGpuId;
+  }
+
+  return Object.keys(gpuUsageHistories)[0] ?? Object.keys(gpuTemperatureMap)[0];
+};
+
+/**
+ * Whether the screen may state that an adapter has no live readings.
+ *
+ * Empty maps before the first sample mean "not measured yet", so the claim is
+ * only allowed once some adapter has reported and this one still has not.
+ */
+export const hasNoLiveGpuReadings = (
+  gpuId: string | undefined,
+  gpuUsageHistories: Record<string, (number | null)[]>,
+  gpuTemperatureMap: Record<string, { name: string; value: number }>,
+) => {
+  if (gpuId == null) {
+    return false;
+  }
+
+  const anyAdapterReported =
+    Object.keys(gpuUsageHistories).length > 0 ||
+    Object.keys(gpuTemperatureMap).length > 0;
+
+  return (
+    anyAdapterReported &&
+    !Object.hasOwn(gpuUsageHistories, gpuId) &&
+    !Object.hasOwn(gpuTemperatureMap, gpuId)
+  );
+};

--- a/src/features/hardware/performance/gpuIdentity.ts
+++ b/src/features/hardware/performance/gpuIdentity.ts
@@ -1,5 +1,3 @@
-import type { GraphicInfo } from "@/rspc/bindings";
-
 /**
  * One adapter as the Performance screens need it: the stable id every live
  * value is keyed by, the name the platform reported, and a short label for
@@ -92,39 +90,46 @@ const dropSharedPrefixWords = (labels: string[]) => {
 };
 
 /**
- * Every adapter the Performance screens can attribute a reading to: the ones
- * the one-shot hardware fetch detected, plus any id that only shows up in the
- * live maps. The second part matters because a reading rendered without an
- * owner is exactly the misattribution this list exists to prevent.
+ * Every adapter the Performance screens can attribute a reading to.
  *
- * Labels are shortened only while they stay unique; when two adapters shorten
- * to the same string every label falls back to the full name rather than
- * showing two controls that read identically.
+ * The list is built from the live maps alone, never unioned with the
+ * `getHardwareInfo` inventory: the two key their GPUs in different namespaces
+ * on every platform (see `gpuNamesAtom`), so unioning by id renders one
+ * physical GPU as two adapters — one of which reports nothing and is then
+ * declared silent. The inventory's job is the System Specifications sheet;
+ * this list's job is attribution, and only ids that carry readings can be
+ * attributed to.
+ *
+ * Names come from the sample that carried the reading. Labels are shortened
+ * only while they stay unique; when two adapters shorten to the same string
+ * every label falls back to the full name rather than showing two controls
+ * that read identically.
  */
 export const listGpuAdapters = (
-  gpus: GraphicInfo[] | null | undefined,
+  gpuNames: Record<string, string>,
   live: GpuLiveMaps,
 ): GpuAdapter[] => {
   const named = new Map<string, string>();
 
-  for (const gpu of gpus ?? []) {
-    named.set(gpu.id, gpu.name);
-  }
-
-  // The sensor maps carry the platform's own name for each adapter, so they
-  // can identify an id the static fetch has not returned (or never will,
-  // when it failed). Only an id no map names at all falls back to the id.
-  for (const map of [live.temperatures, live.fanSpeeds]) {
-    for (const [id, value] of Object.entries(map)) {
-      if (!named.has(id)) {
-        named.set(id, value.name);
-      }
-    }
+  // Every adapter the stream named, in payload order — including one that
+  // named itself and reported nothing else, which is the case the unavailable
+  // state exists for.
+  for (const [id, name] of Object.entries(gpuNames)) {
+    named.set(id, name);
   }
   for (const map of liveMapsInOrder(live)) {
     for (const id of Object.keys(map)) {
       if (!named.has(id)) {
         named.set(id, id);
+      }
+    }
+  }
+  // The sensor maps carry a name too, so they can still identify an adapter
+  // if the name map has not caught up with them.
+  for (const map of [live.temperatures, live.fanSpeeds]) {
+    for (const [id, value] of Object.entries(map)) {
+      if (named.get(id) === id) {
+        named.set(id, value.name);
       }
     }
   }

--- a/src/features/hardware/performance/gpuIdentity.ts
+++ b/src/features/hardware/performance/gpuIdentity.ts
@@ -5,8 +5,16 @@
  */
 export type GpuAdapter = {
   id: string;
+  /** The raw platform name. Two identical cards report the same one. */
   name: string;
+  /** Always unique across the list, so a control can never be ambiguous. */
   label: string;
+  /**
+   * Whether another adapter reports the same `name`. Any join that keys on
+   * the name — the inventory's VRAM total, for one — has to refuse when this
+   * is true, because the name cannot pick out one of the two.
+   */
+  isNameAmbiguous: boolean;
 };
 
 /**
@@ -135,15 +143,41 @@ export const listGpuAdapters = (
   }
 
   const entries = [...named.entries()];
-  const labels = dropSharedPrefixWords(
+  const shortened = dropSharedPrefixWords(
     entries.map(([, name]) => shortenGpuName(name)),
   );
-  const isUnique = new Set(labels).size === labels.length;
+  const nameCounts = new Map<string, number>();
+  for (const [, name] of entries) {
+    nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+  }
+
+  // An ordinal for the adapters the platform reports under one name — two
+  // identical cards — then, only if labels still collide, the full names.
+  // A control the user cannot tell from its neighbour is not a choice.
+  const withOrdinals = (bases: string[]) => {
+    const seen = new Map<string, number>();
+    return bases.map((base, index) => {
+      const name = entries[index][1];
+      if ((nameCounts.get(name) ?? 0) < 2) {
+        return base;
+      }
+      const ordinal = (seen.get(name) ?? 0) + 1;
+      seen.set(name, ordinal);
+      return `${base} #${ordinal}`;
+    });
+  };
+
+  const shortLabels = withOrdinals(shortened);
+  const labels =
+    new Set(shortLabels).size === shortLabels.length
+      ? shortLabels
+      : withOrdinals(entries.map(([, name]) => name));
 
   return entries.map(([id, name], index) => ({
     id,
     name,
-    label: isUnique ? labels[index] : name,
+    label: labels[index],
+    isNameAmbiguous: (nameCounts.get(name) ?? 0) > 1,
   }));
 };
 

--- a/src/features/hardware/performance/gpuIdentity.ts
+++ b/src/features/hardware/performance/gpuIdentity.ts
@@ -12,6 +12,28 @@ export type GpuAdapter = {
 };
 
 /**
+ * The live per-GPU maps, together.
+ *
+ * They are populated independently — an adapter can report a fan speed with no
+ * usage, or VRAM with no temperature — so anything that asks "did this adapter
+ * report" has to ask all four. Asking a subset is what turns a partially
+ * reporting adapter into a silent one.
+ */
+export type GpuLiveMaps = {
+  usageHistories: Record<string, (number | null)[]>;
+  temperatures: Record<string, { name: string; value: number }>;
+  fanSpeeds: Record<string, { name: string; value: number }>;
+  dedicatedMemoryKb: Record<string, number | null>;
+};
+
+const liveMapsInOrder = (live: GpuLiveMaps) => [
+  live.usageHistories,
+  live.temperatures,
+  live.fanSpeeds,
+  live.dedicatedMemoryKb,
+];
+
+/**
  * Vendor words that every adapter of a given brand repeats, so they carry no
  * information in a control that exists to tell two adapters apart. Anything
  * else in the name is kept: shortening must not invent a distinction or drop
@@ -71,8 +93,8 @@ const dropSharedPrefixWords = (labels: string[]) => {
 
 /**
  * Every adapter the Performance screens can attribute a reading to: the ones
- * the one-shot hardware fetch detected, plus any id that only ever shows up in
- * the live maps. The second part matters because a reading rendered without an
+ * the one-shot hardware fetch detected, plus any id that only shows up in the
+ * live maps. The second part matters because a reading rendered without an
  * owner is exactly the misattribution this list exists to prevent.
  *
  * Labels are shortened only while they stay unique; when two adapters shorten
@@ -81,22 +103,29 @@ const dropSharedPrefixWords = (labels: string[]) => {
  */
 export const listGpuAdapters = (
   gpus: GraphicInfo[] | null | undefined,
-  liveNamesById: Record<string, { name: string }>,
-  liveIds: readonly string[] = [],
+  live: GpuLiveMaps,
 ): GpuAdapter[] => {
   const named = new Map<string, string>();
 
   for (const gpu of gpus ?? []) {
     named.set(gpu.id, gpu.name);
   }
-  for (const id of liveIds) {
-    if (!named.has(id)) {
-      named.set(id, liveNamesById[id]?.name ?? id);
+
+  // The sensor maps carry the platform's own name for each adapter, so they
+  // can identify an id the static fetch has not returned (or never will,
+  // when it failed). Only an id no map names at all falls back to the id.
+  for (const map of [live.temperatures, live.fanSpeeds]) {
+    for (const [id, value] of Object.entries(map)) {
+      if (!named.has(id)) {
+        named.set(id, value.name);
+      }
     }
   }
-  for (const [id, value] of Object.entries(liveNamesById)) {
-    if (!named.has(id)) {
-      named.set(id, value.name);
+  for (const map of liveMapsInOrder(live)) {
+    for (const id of Object.keys(map)) {
+      if (!named.has(id)) {
+        named.set(id, id);
+      }
     }
   }
 
@@ -123,43 +152,43 @@ export const listGpuAdapters = (
  */
 export const getEffectiveGpuId = (
   selectedGpuId: string | null,
-  gpuUsageHistories: Record<string, (number | null)[]>,
-  gpuTemperatureMap: Record<string, { name: string; value: number }>,
+  live: GpuLiveMaps,
   detectedGpuIds: readonly string[] = [],
 ) => {
   if (
     selectedGpuId != null &&
-    (Object.hasOwn(gpuUsageHistories, selectedGpuId) ||
-      detectedGpuIds.includes(selectedGpuId))
+    (detectedGpuIds.includes(selectedGpuId) ||
+      liveMapsInOrder(live).some((map) => Object.hasOwn(map, selectedGpuId)))
   ) {
     return selectedGpuId;
   }
 
-  return Object.keys(gpuUsageHistories)[0] ?? Object.keys(gpuTemperatureMap)[0];
+  for (const map of liveMapsInOrder(live)) {
+    const [first] = Object.keys(map);
+    if (first != null) {
+      return first;
+    }
+  }
+  return undefined;
 };
 
 /**
  * Whether the screen may state that an adapter has no live readings.
  *
  * Empty maps before the first sample mean "not measured yet", so the claim is
- * only allowed once some adapter has reported and this one still has not.
+ * only allowed once some adapter has reported and this one still has not — in
+ * any of the maps, since a fan speed alone is still a live reading.
  */
 export const hasNoLiveGpuReadings = (
   gpuId: string | undefined,
-  gpuUsageHistories: Record<string, (number | null)[]>,
-  gpuTemperatureMap: Record<string, { name: string; value: number }>,
+  live: GpuLiveMaps,
 ) => {
   if (gpuId == null) {
     return false;
   }
 
-  const anyAdapterReported =
-    Object.keys(gpuUsageHistories).length > 0 ||
-    Object.keys(gpuTemperatureMap).length > 0;
+  const maps = liveMapsInOrder(live);
+  const anyAdapterReported = maps.some((map) => Object.keys(map).length > 0);
 
-  return (
-    anyAdapterReported &&
-    !Object.hasOwn(gpuUsageHistories, gpuId) &&
-    !Object.hasOwn(gpuTemperatureMap, gpuId)
-  );
+  return anyAdapterReported && !maps.some((map) => Object.hasOwn(map, gpuId));
 };

--- a/src/features/hardware/store/chart.test.ts
+++ b/src/features/hardware/store/chart.test.ts
@@ -1,0 +1,70 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+import {
+  gpuDedicatedMemoryKbAtom,
+  gpuDedicatedMemoryKbMapAtom,
+  gpuNamesAtom,
+  gpuTempMapAtom,
+  gpuUsageHistoriesAtom,
+  gpuUsageSourceAtom,
+  gpuUsageSourcesAtom,
+  graphicUsageHistoryAtom,
+  selectedGpuIdAtom,
+} from "./chart";
+
+/**
+ * These atoms feed the classic Usage screen, the classic dashboard, and the
+ * Monitor graph — surfaces that name an adapter elsewhere on the page. If they
+ * resolved a selection differently from the GPU selectors, the page would
+ * label one adapter and graph another.
+ */
+describe("derived GPU atoms", () => {
+  const withSelection = (selected: string) => {
+    const store = createStore();
+    store.set(selectedGpuIdAtom, selected);
+    store.set(gpuNamesAtom, {
+      "nvapi:1": "GeForce RTX 4080",
+      "pci:0:2:0": "UHD Graphics 770",
+    });
+    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [70] });
+    store.set(gpuUsageSourcesAtom, { "nvapi:1": "NVAPI" });
+    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4096 });
+    store.set(gpuTempMapAtom, {
+      "pci:0:2:0": { name: "UHD Graphics 770", value: 48 },
+    });
+    return store;
+  };
+
+  it("reports nothing for a selected adapter that has no usage of its own", () => {
+    // The iGPU reports a temperature but no usage. Falling back to the first
+    // history would graph the discrete card under the integrated one's name.
+    const store = withSelection("pci:0:2:0");
+
+    expect(store.get(graphicUsageHistoryAtom)).toEqual([]);
+    expect(store.get(gpuUsageSourceAtom)).toBeNull();
+    expect(store.get(gpuDedicatedMemoryKbAtom)).toBeNull();
+  });
+
+  it("resolves a selection that does report", () => {
+    const store = withSelection("nvapi:1");
+
+    expect(store.get(graphicUsageHistoryAtom)).toEqual([70]);
+    expect(store.get(gpuUsageSourceAtom)).toBe("NVAPI");
+    expect(store.get(gpuDedicatedMemoryKbAtom)).toBe(4096);
+  });
+
+  it("falls back to the first reporting adapter when the selection is gone", () => {
+    const store = withSelection("removed-gpu");
+
+    expect(store.get(graphicUsageHistoryAtom)).toEqual([70]);
+    expect(store.get(gpuUsageSourceAtom)).toBe("NVAPI");
+  });
+
+  it("has nothing to report before the first sample", () => {
+    const store = createStore();
+
+    expect(store.get(graphicUsageHistoryAtom)).toEqual([]);
+    expect(store.get(gpuUsageSourceAtom)).toBeNull();
+    expect(store.get(gpuDedicatedMemoryKbAtom)).toBeNull();
+  });
+});

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { getEffectiveGpuId } from "@/features/hardware/gpuIdentity";
 import type {
   MotherboardFanSpeedValues,
   MotherboardTemperatureValues,
@@ -79,29 +80,45 @@ export const gpuFanSpeedAtom = atom<NameValues>((get) =>
 
 // ── Derived atoms for backward compatibility ──
 
-/** Resolves to the selected (or first) GPU's usage history */
+/**
+ * The adapter every derived atom below describes.
+ *
+ * It has to be the same answer the GPU selectors show, or a surface would
+ * label one adapter and render another's numbers. In particular an explicit
+ * selection that reports no usage resolves to itself, so the consumers below
+ * return nothing rather than borrowing the first adapter's values.
+ */
+const effectiveGpuIdAtom = atom<string | undefined>((get) =>
+  getEffectiveGpuId(
+    get(selectedGpuIdAtom),
+    {
+      usageHistories: get(gpuUsageHistoriesAtom),
+      temperatures: get(gpuTempMapAtom),
+      fanSpeeds: get(gpuFanSpeedMapAtom),
+      dedicatedMemoryKb: get(gpuDedicatedMemoryKbMapAtom),
+    },
+    Object.keys(get(gpuNamesAtom)),
+  ),
+);
+
+/** Resolves to the effective GPU's usage history */
 export const graphicUsageHistoryAtom = atom<(number | null)[]>((get) => {
-  const selected = get(selectedGpuIdAtom);
-  const histories = get(gpuUsageHistoriesAtom);
-  if (selected && histories[selected]) return histories[selected];
-  const keys = Object.keys(histories);
-  return keys.length > 0 ? histories[keys[0]] : [];
+  const effective = get(effectiveGpuIdAtom);
+  return effective != null ? (get(gpuUsageHistoriesAtom)[effective] ?? []) : [];
 });
 
-/** Resolves to the selected (or first) GPU's usage source */
+/** Resolves to the effective GPU's usage source */
 export const gpuUsageSourceAtom = atom<string | null>((get) => {
-  const selected = get(selectedGpuIdAtom);
-  const sources = get(gpuUsageSourcesAtom);
-  if (selected && selected in sources) return sources[selected];
-  const keys = Object.keys(sources);
-  return keys.length > 0 ? (sources[keys[0]] ?? null) : null;
+  const effective = get(effectiveGpuIdAtom);
+  return effective != null
+    ? (get(gpuUsageSourcesAtom)[effective] ?? null)
+    : null;
 });
 
-/** Resolves to the selected (or first) GPU's dedicated memory (KB) */
+/** Resolves to the effective GPU's dedicated memory (KB) */
 export const gpuDedicatedMemoryKbAtom = atom<number | null>((get) => {
-  const selected = get(selectedGpuIdAtom);
-  const map = get(gpuDedicatedMemoryKbMapAtom);
-  if (selected && selected in map) return map[selected];
-  const keys = Object.keys(map);
-  return keys.length > 0 ? (map[keys[0]] ?? null) : null;
+  const effective = get(effectiveGpuIdAtom);
+  return effective != null
+    ? (get(gpuDedicatedMemoryKbMapAtom)[effective] ?? null)
+    : null;
 });

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -16,6 +16,18 @@ export const gpuUsageHistoriesAtom = atom<Record<string, (number | null)[]>>(
   {},
 );
 
+/**
+ * Per-GPU name keyed by the live sampling id.
+ *
+ * The monitor stream and the one-shot `getHardwareInfo` inventory key their
+ * GPUs in different namespaces on every platform — Windows NVIDIA reports the
+ * raw NVAPI id as `GraphicInfo.id` but samples as `nvapi:<id>`, macOS pairs
+ * `0x<registry_id>` with `iokit:<name>`, Linux pairs `card<n>` with the PCI
+ * BDF. So a live id cannot be resolved against the inventory, and every
+ * sample carries its own name for exactly that reason.
+ */
+export const gpuNamesAtom = atom<Record<string, string>>({});
+
 /** Currently selected GPU ID for dashboard/usage view */
 export const selectedGpuIdAtom = atom<string | null>(null);
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -292,6 +292,8 @@
       "currentValues": "Current values",
       "perCoreUnavailable": "Per-core usage is not available on this system.",
       "motherboardSensorsUnavailable": "No motherboard sensors detected on this system.",
+      "gpuSelector": "Select GPU",
+      "gpuNoLiveReadings": "This adapter is not reporting live readings.",
       "metrics": {
         "cpu": "CPU",
         "memory": "RAM",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -294,6 +294,7 @@
       "motherboardSensorsUnavailable": "No motherboard sensors detected on this system.",
       "gpuSelector": "Select GPU",
       "gpuNoLiveReadings": "This adapter is not reporting live readings.",
+      "compactGpuAdapter": "GPU: {{name}}",
       "metrics": {
         "cpu": "CPU",
         "memory": "RAM",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -294,6 +294,7 @@
       "motherboardSensorsUnavailable": "このシステムではマザーボードセンサーを検出できません。",
       "gpuSelector": "GPU を選択",
       "gpuNoLiveReadings": "このアダプタはライブ値を報告していません。",
+      "compactGpuAdapter": "GPU: {{name}}",
       "metrics": {
         "cpu": "CPU",
         "memory": "メモリ",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -292,6 +292,8 @@
       "currentValues": "現在値",
       "perCoreUnavailable": "このシステムではコア別使用率を利用できません。",
       "motherboardSensorsUnavailable": "このシステムではマザーボードセンサーを検出できません。",
+      "gpuSelector": "GPU を選択",
+      "gpuNoLiveReadings": "このアダプタはライブ値を報告していません。",
       "metrics": {
         "cpu": "CPU",
         "memory": "メモリ",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -282,6 +282,8 @@
       "currentValues": "Текущие значения",
       "perCoreUnavailable": "Загрузка по ядрам недоступна в этой системе.",
       "motherboardSensorsUnavailable": "Датчики материнской платы не обнаружены в этой системе.",
+      "gpuSelector": "Выберите ГП",
+      "gpuNoLiveReadings": "Этот адаптер не передаёт текущие показания.",
       "metrics": {
         "cpu": "ЦП",
         "memory": "Память",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -284,6 +284,7 @@
       "motherboardSensorsUnavailable": "Датчики материнской платы не обнаружены в этой системе.",
       "gpuSelector": "Выберите ГП",
       "gpuNoLiveReadings": "Этот адаптер не передаёт текущие показания.",
+      "compactGpuAdapter": "ГП: {{name}}",
       "metrics": {
         "cpu": "ЦП",
         "memory": "Память",


### PR DESCRIPTION
Closes #1806.

## Problem

ADR 0014 moved every live GPU reading onto the Performance Screen. It never said which adapter produced them, and grouped navigation had no GPU selection control at all — `setSelectedGpuId` was called in exactly one place, the classic Hardware Dashboard `GPUInfo` card. A user with a discrete and an integrated GPU could neither tell which adapter the numbers described nor reach the other one.

The issue was filed while both surfaces were tabs in one Grouped Dashboard destination and assumed the specifications tab carried live readings. It was rescoped to the Performance Screen before implementation ([comment](https://github.com/shm11C3/HardwareVisualizer/issues/1806#issuecomment-5308182464)); the criteria #1942 already met were moved to an `Already delivered` section rather than redone.

## Change

- **The GPU instrument names its adapter.** One adapter: the name alone. More than one: a named switcher writing `selectedGpuIdAtom`, which `useSelectedGpuPersistence` already persists.
- **Explicit selection beats data availability.** The resolver used to drop a selection the moment its adapter left the usage map, silently substituting another adapter's numbers under the same label. It now honors the selection while the adapter is still detected and reports nothing when it reports nothing. Only a selection pointing at an adapter that no longer exists falls back (DP-06).
- **"Not measured yet" is not "unavailable."** The no-readings note is withheld until some adapter has reported, and it is additive — it never takes the place of what the adapter did report (DP-02).
- **Every live map counts.** Usage, temperature, fan speed, and dedicated memory are populated independently, so all four are consulted before calling an adapter silent. They travel together as `GpuLiveMaps`.
- **Compact names its adapter** in the footer; the row tracks are sized for the mini monitor's small corner window and cannot hold a device name. Compact follows the choice made in Panels and offers no selection of its own.
- **Labels drop only what cannot distinguish adapters** — trademark marks, a leading vendor word, and a leading run of words every adapter repeats. That last rule is what keeps "GeForce RTX 4080" and "GeForce RTX 4060" from both rendering as `GeForce RTX 40…` in a three-column strip. If shortening would make two labels identical, all fall back to full names. The full name stays as the accessible name and tooltip.

The selector is a labelled group of toggle buttons rather than a tablist: there is no tabpanel, roving tabindex, or arrow-key contract to back that role up.

## Decision record

New [ADR 0016](docs/adr/0016-gpu-attribution-on-the-performance-screen.md), refining ADR 0014/0015. `CONTEXT.md` gains **Selected GPU**. The System Specifications sheet is untouched — ADR 0014 keeps it static facts, so it has no reading to attribute and no selected state.

## Verification

- 510 unit tests pass, including 21 new ones across `gpuIdentity.test.ts` and `Performance.test.tsx`: silent-adapter selection is kept and non-borrowing is asserted positively *and* negatively; the removed-adapter fallback, the pre-first-sample silence, fan-only and VRAM-only adapters, label collisions, and the cross-view carry are each pinned.
- 20 e2e pass, including a new multi-GPU case: both adapters reachable, switching moves the VRAM reading from `4.0/8 GB` to `1.0/2 GB`, the choice survives navigating away to System Specifications and back, and Compact reports the same adapter. Captures `performance-gpu-selector-desktop` and `performance-gpu-selector-compact`.
- Rendered layouts inspected at 1280 / 820 / 520 px. `tsc --noEmit`, `biome check`, and `check:agent-guidance` clean.

## Review note

A Fable review of the first commit found that the honesty check was itself dishonest — it consulted only two of the four live maps, so a fan-only adapter was declared silent *and* had its real fan/VRAM readings hidden by the note that replaced the substats. That is the second commit, along with the raw-LUID naming path, the ARIA role, and the hard-coded footer separator.

## Known limitation (not introduced here)

The live maps are append-only in `useHardwareEventListener`, so an adapter that reports and then goes silent keeps its last value on screen. The unavailable state only covers an adapter that has never reported. Recorded in ADR 0016's consequences; distinguishing stale from current needs per-sample presence tracking in the event listener and is filed separately as #1945. A second review finding, #1946, covers a Selected GPU being discarded after one launch without that adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPU adapter selection to Performance, Monitor, Dashboard, and Compact views.
  - Preserves the selected adapter across navigation and application restarts.
  - Displays adapter names with accessible labels, tooltips, and localized text.
  - Indicates when an adapter is detected but has no live readings.
  - Keeps GPU usage, temperature, fan, and VRAM readings aligned with the selected adapter.

- **Bug Fixes**
  - Improved GPU identification when inventory and live monitoring identifiers differ.
  - Prevented ambiguous adapter names from showing incorrect readings.

- **Documentation**
  - Documented GPU attribution and adapter-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->