### PR TITLE
docs(agents): capture the identity-contract lesson from PR #1944

### DIFF
--- a/.agents/skills/verify-identity-contracts/SKILL.md
+++ b/.agents/skills/verify-identity-contracts/SKILL.md
@@ -45,8 +45,9 @@ consequence bugs, all discoverable up front by reading the producers.
 
 *Applies to every trigger, in every layer.*
 
-For every id the change consumes — including one that only a fixture supplies
-— read the *producing* Rust code and record:
+For every id the change consumes or produces — including one that only a
+fixture supplies — read the producing code (or the change itself, when it is
+the producer) and record:
 the source, the per-platform id shape, and whether any two sources share a
 namespace. When they do not, name the join key the sources actually share
 (typically the reported name) and state where the join must refuse
@@ -67,10 +68,12 @@ encode the same wrong assumption the change is about to build on.
 *Applies wherever the change supplies ids — a Rust test fixture can flatten a
 namespace exactly as an e2e one can.*
 
-A fixture may share one id across two sources only if production does. One
-that flattens a real namespace difference certifies broken joins: the classic
-GPU selector shipped non-functional on real hardware while its e2e passed,
-because `GPU_FIXTURES` used one id for both sources.
+A fixture may share one id across two sources only if production does, and
+its ids take their shapes from the contract table — `nvapi:12345` beside
+`12345` — not two arbitrary strings that merely differ. One that flattens a
+real namespace difference certifies broken joins: the classic GPU selector
+shipped non-functional on real hardware while its e2e passed, because
+`GPU_FIXTURES` used one id for both sources.
 
 ## Frontend Consumption
 
@@ -95,11 +98,12 @@ value, never in a screen parent (ADR 0010 rendering-cost rule).
 
 ## 4. Persistence And Migration
 
-*Applies when the change stores, restores, or re-namespaces an id. Skip it
-when nothing is persisted.*
+*Applies when the change stores, restores, or re-namespaces an id; skip it
+only when it does none of those.*
 
 State: which namespace is stored today, which namespace shipped versions
-stored, and what translates one to the other. The migration must run at an
+stored, and what translates one to the other. An id persisted for the first
+time has no shipped value — state that, and the translation work is done. The migration must run at an
 always-mounted boundary (an app-level hook), never inside a screen — some
 navigation layouts never mount that screen. It must fetch its own inputs,
 because a restart can land on a view that fetches nothing.

--- a/.agents/skills/verify-identity-contracts/SKILL.md
+++ b/.agents/skills/verify-identity-contracts/SKILL.md
@@ -7,22 +7,39 @@ description: Verify the id/key contract between backend producers and frontend c
 
 ## When This Fires
 
-The change consumes an entity that exists in more than one data source — a
-one-shot inventory fetch, the live monitor stream, the archive, or a persisted
-store key — or persists and restores an id across sessions.
+Any of these, whether or not the change is UI work:
+
+- an entity is read from more than one data source — a one-shot inventory
+  fetch, the live monitor stream, the archive, or a persisted store key;
+- a surface selects, attributes, or names an entity keyed by a
+  backend-produced id;
+- an id is persisted and restored across sessions;
+- a fixture, factory, or seed supplies ids for any of the above.
+
+Every step below applies to each of these triggers. Attribution UI and fixture
+work are not exempt: the contract is what makes an attribution honest, and a
+fixture is where a wrong contract gets certified as correct.
 
 The motivating failure: the `getHardwareInfo` inventory and the monitor stream
 key GPUs in different id namespaces on every platform (ADR 0016). Building a
 selector on an assumed shared namespace produced eleven review rounds of
 consequence bugs, all discoverable up front by reading the producers.
 
-## 1. Write The Contract Table Before Any UI Code
+## 1. Write The Contract Table Before Any Consuming Code
 
-For every id the change consumes, read the *producing* Rust code and record in
-the PR description or ADR: the source, the per-platform id shape, and whether
-any two sources share a namespace. When they do not, name the join key the
-sources actually share (typically the reported name) and state where the join
-must refuse (ambiguity: the key matches more than one entry on either side).
+For every id the change consumes — including one that only a fixture supplies
+— read the *producing* Rust code and record:
+the source, the per-platform id shape, and whether any two sources share a
+namespace. When they do not, name the join key the sources actually share
+(typically the reported name) and state where the join must refuse
+(ambiguity: the key matches more than one entry on either side).
+
+Record it at the smallest durable owner that fits the change, per the
+decision-preservation rule in `AGENTS.md`: a focused test or a code comment
+next to the join for an implementation-level fact, commit or PR context for a
+change-local why, and an ADR only when the contract itself is an
+architecturally significant decision. A local change that ships no PR still
+needs the reading — it does not need paperwork.
 
 Do not infer the contract from fixtures, tests, or frontend types — those can
 encode the same wrong assumption the change is about to build on.
@@ -54,6 +71,13 @@ always-mounted boundary (an app-level hook), never inside a screen — some
 navigation layouts never mount that screen. It must fetch its own inputs,
 because a restart can land on a view that fetches nothing.
 
+Migration is one-way. Cover both cases that exist: a legacy value translates
+to the current namespace, and a value already in the current namespace is left
+unchanged — including one that is simply absent this session, which is intent
+to preserve rather than a value to rewrite. Do not build or test a reverse
+translation; writing the selection back into the obsolete namespace is the
+failure, not the fallback.
+
 ## 5. Surface Parity For Resolution States
 
 List every surface that renders the value. Every state the resolution can
@@ -62,8 +86,10 @@ them; a blank on one surface reads as idle, not as missing.
 
 ## Exit Checklist
 
-- [ ] Contract table recorded, sourced from producer code
+- [ ] Contract recorded at its smallest durable owner, sourced from
+      producer code
 - [ ] Exactly one resolution owner; other consumers import it
 - [ ] Fixture ids differ across sources wherever production's do
-- [ ] Migration at an always-mounted boundary, tested in both directions
+- [ ] Migration at an always-mounted boundary; legacy values translate and
+      current values stay unchanged
 - [ ] Each resolution state asserted on each surface

--- a/.agents/skills/verify-identity-contracts/SKILL.md
+++ b/.agents/skills/verify-identity-contracts/SKILL.md
@@ -16,9 +16,14 @@ Any of these, whether or not the change is UI work:
 - an id is persisted and restored across sessions;
 - a fixture, factory, or seed supplies ids for any of the above.
 
-Every step below applies to each of these triggers. Attribution UI and fixture
-work are not exempt: the contract is what makes an attribution honest, and a
-fixture is where a wrong contract gets certified as correct.
+Step 1 applies to all of them, in any layer. Steps 2-5 describe how `src/`
+consumes a contract, so they apply when the change has frontend consumers —
+a Core or `src-tauri/` change that only produces or persists ids owes the
+contract, not a React hook.
+
+Within their scope no trigger is exempt. Attribution UI and fixture work in
+particular are covered: the contract is what makes an attribution honest, and
+a fixture is where a wrong contract gets certified as correct.
 
 The motivating failure: the `getHardwareInfo` inventory and the monitor stream
 key GPUs in different id namespaces on every platform (ADR 0016). Building a
@@ -26,6 +31,8 @@ selector on an assumed shared namespace produced eleven review rounds of
 consequence bugs, all discoverable up front by reading the producers.
 
 ## 1. Write The Contract Table Before Any Consuming Code
+
+*Applies to every trigger, in every layer.*
 
 For every id the change consumes — including one that only a fixture supplies
 — read the *producing* Rust code and record:
@@ -44,6 +51,12 @@ needs the reading — it does not need paperwork.
 Do not infer the contract from fixtures, tests, or frontend types — those can
 encode the same wrong assumption the change is about to build on.
 
+## Frontend Consumption
+
+The remaining steps apply when `src/` consumes the contract. Skip them for a
+change that only produces or persists ids in `core/` or `src-tauri/`; keep the
+fact where its layer owns it rather than moving it into the frontend.
+
 ## 2. One Resolution Rule, One Owner
 
 Grep every consumer of the shared selection atom or key. The question "which
@@ -58,10 +71,13 @@ value, never in a screen parent (ADR 0010 rendering-cost rule).
 
 ## 3. Fixtures Must Reproduce The Namespace Split
 
-An e2e or unit fixture may share one id across two sources only if production
-does. A fixture that flattens a real namespace difference certifies broken
-joins: the classic GPU selector shipped non-functional on real hardware while
-its e2e passed, because `GPU_FIXTURES` used one id for both sources.
+A fixture may share one id across two sources only if production does. One
+that flattens a real namespace difference certifies broken joins: the classic
+GPU selector shipped non-functional on real hardware while its e2e passed,
+because `GPU_FIXTURES` used one id for both sources.
+
+This one holds in any layer — a Rust test fixture can flatten a namespace just
+as an e2e one can — so apply it wherever the change supplies ids.
 
 ## 4. Persistence And Migration
 
@@ -85,6 +101,8 @@ produce — unavailable, ambiguous, not-yet-measured — must render on each of
 them; a blank on one surface reads as idle, not as missing.
 
 ## Exit Checklist
+
+Step 1 always; the rest when the change has frontend consumers.
 
 - [ ] Contract recorded at its smallest durable owner, sourced from
       producer code

--- a/.agents/skills/verify-identity-contracts/SKILL.md
+++ b/.agents/skills/verify-identity-contracts/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: verify-identity-contracts
+description: Verify the id/key contract between backend producers and frontend consumers before implementing any change that joins, selects, persists, or attributes entities keyed by backend-produced ids (GPUs, storage devices, sensors, processes). Use when adding a selector, attribution UI, persistence of a selected id, a join across two data sources, or an e2e fixture for multi-source data.
+---
+
+# Verify Identity Contracts
+
+## When This Fires
+
+The change consumes an entity that exists in more than one data source — a
+one-shot inventory fetch, the live monitor stream, the archive, or a persisted
+store key — or persists and restores an id across sessions.
+
+The motivating failure: the `getHardwareInfo` inventory and the monitor stream
+key GPUs in different id namespaces on every platform (ADR 0016). Building a
+selector on an assumed shared namespace produced eleven review rounds of
+consequence bugs, all discoverable up front by reading the producers.
+
+## 1. Write The Contract Table Before Any UI Code
+
+For every id the change consumes, read the *producing* Rust code and record in
+the PR description or ADR: the source, the per-platform id shape, and whether
+any two sources share a namespace. When they do not, name the join key the
+sources actually share (typically the reported name) and state where the join
+must refuse (ambiguity: the key matches more than one entry on either side).
+
+Do not infer the contract from fixtures, tests, or frontend types — those can
+encode the same wrong assumption the change is about to build on.
+
+## 2. One Resolution Rule, One Owner
+
+Grep every consumer of the shared selection atom or key. The question "which
+entity is effective" must be answered in exactly one place — a hook or derived
+atom — that every surface consumes. If resolution logic already exists in two
+components, centralize it in this change before adding a third. Duplicated
+resolvers are how one surface labels an entity while another surface renders a
+different entity's values.
+
+Subscriptions to per-sample atoms belong in the component that renders the
+value, never in a screen parent (ADR 0010 rendering-cost rule).
+
+## 3. Fixtures Must Reproduce The Namespace Split
+
+An e2e or unit fixture may share one id across two sources only if production
+does. A fixture that flattens a real namespace difference certifies broken
+joins: the classic GPU selector shipped non-functional on real hardware while
+its e2e passed, because `GPU_FIXTURES` used one id for both sources.
+
+## 4. Persistence And Migration
+
+State: which namespace is stored today, which namespace shipped versions
+stored, and what translates one to the other. The migration must run at an
+always-mounted boundary (an app-level hook), never inside a screen — some
+navigation layouts never mount that screen. It must fetch its own inputs,
+because a restart can land on a view that fetches nothing.
+
+## 5. Surface Parity For Resolution States
+
+List every surface that renders the value. Every state the resolution can
+produce — unavailable, ambiguous, not-yet-measured — must render on each of
+them; a blank on one surface reads as idle, not as missing.
+
+## Exit Checklist
+
+- [ ] Contract table recorded, sourced from producer code
+- [ ] Exactly one resolution owner; other consumers import it
+- [ ] Fixture ids differ across sources wherever production's do
+- [ ] Migration at an always-mounted boundary, tested in both directions
+- [ ] Each resolution state asserted on each surface

--- a/.agents/skills/verify-identity-contracts/SKILL.md
+++ b/.agents/skills/verify-identity-contracts/SKILL.md
@@ -16,14 +16,25 @@ Any of these, whether or not the change is UI work:
 - an id is persisted and restored across sessions;
 - a fixture, factory, or seed supplies ids for any of the above.
 
-Step 1 applies to all of them, in any layer. Steps 2-5 describe how `src/`
-consumes a contract, so they apply when the change has frontend consumers —
-a Core or `src-tauri/` change that only produces or persists ids owes the
-contract, not a React hook.
+Each step names the boundary it guards, and applies exactly when the change
+crosses it — no more:
 
-Within their scope no trigger is exempt. Attribution UI and fixture work in
-particular are covered: the contract is what makes an attribution honest, and
-a fixture is where a wrong contract gets certified as correct.
+| Step | Applies when |
+| --- | --- |
+| 1. Contract | always, in any layer |
+| 2. Fixture realism | the change supplies fixture, factory, or seed ids, in any layer |
+| 3. Resolution owner | `src/` derives which entity is effective |
+| 4. Persistence and migration | an id is stored, restored, or changes namespace |
+| 5. Surface parity | a surface renders a resolution state |
+
+So a Core change that only produces ids owes the contract and, if it ships a
+fixture, fixture realism — not a React hook. Attribution UI that persists
+nothing owes the contract, the resolution owner, and surface parity — not a
+migration.
+
+Within its own boundary no trigger is exempt. Attribution UI and fixture work
+are covered rather than incidental: the contract is what makes an attribution
+honest, and a fixture is where a wrong contract gets certified as correct.
 
 The motivating failure: the `getHardwareInfo` inventory and the monitor stream
 key GPUs in different id namespaces on every platform (ADR 0016). Building a
@@ -51,13 +62,26 @@ needs the reading — it does not need paperwork.
 Do not infer the contract from fixtures, tests, or frontend types — those can
 encode the same wrong assumption the change is about to build on.
 
+## 2. Fixtures Must Reproduce The Namespace Split
+
+*Applies wherever the change supplies ids — a Rust test fixture can flatten a
+namespace exactly as an e2e one can.*
+
+A fixture may share one id across two sources only if production does. One
+that flattens a real namespace difference certifies broken joins: the classic
+GPU selector shipped non-functional on real hardware while its e2e passed,
+because `GPU_FIXTURES` used one id for both sources.
+
 ## Frontend Consumption
 
-The remaining steps apply when `src/` consumes the contract. Skip them for a
-change that only produces or persists ids in `core/` or `src-tauri/`; keep the
-fact where its layer owns it rather than moving it into the frontend.
+The remaining steps describe how `src/` consumes a contract. Each applies only
+when the change crosses that step's boundary; a change that produces or
+persists ids in `core/` or `src-tauri/` keeps the fact where its layer owns it
+rather than moving it into the frontend.
 
-## 2. One Resolution Rule, One Owner
+## 3. One Resolution Rule, One Owner
+
+*Applies when the change derives which entity is effective.*
 
 Grep every consumer of the shared selection atom or key. The question "which
 entity is effective" must be answered in exactly one place — a hook or derived
@@ -69,17 +93,10 @@ different entity's values.
 Subscriptions to per-sample atoms belong in the component that renders the
 value, never in a screen parent (ADR 0010 rendering-cost rule).
 
-## 3. Fixtures Must Reproduce The Namespace Split
-
-A fixture may share one id across two sources only if production does. One
-that flattens a real namespace difference certifies broken joins: the classic
-GPU selector shipped non-functional on real hardware while its e2e passed,
-because `GPU_FIXTURES` used one id for both sources.
-
-This one holds in any layer — a Rust test fixture can flatten a namespace just
-as an e2e one can — so apply it wherever the change supplies ids.
-
 ## 4. Persistence And Migration
+
+*Applies when the change stores, restores, or re-namespaces an id. Skip it
+when nothing is persisted.*
 
 State: which namespace is stored today, which namespace shipped versions
 stored, and what translates one to the other. The migration must run at an
@@ -96,18 +113,24 @@ failure, not the fallback.
 
 ## 5. Surface Parity For Resolution States
 
+*Applies when the change renders a resolution state.*
+
 List every surface that renders the value. Every state the resolution can
 produce — unavailable, ambiguous, not-yet-measured — must render on each of
 them; a blank on one surface reads as idle, not as missing.
 
 ## Exit Checklist
 
-Step 1 always; the rest when the change has frontend consumers.
+Check the boxes whose boundary the change crosses; the first is always one of
+them.
 
 - [ ] Contract recorded at its smallest durable owner, sourced from
       producer code
-- [ ] Exactly one resolution owner; other consumers import it
 - [ ] Fixture ids differ across sources wherever production's do
+      *(supplies ids)*
+- [ ] Exactly one resolution owner; other consumers import it
+      *(derives an effective entity)*
 - [ ] Migration at an always-mounted boundary; legacy values translate and
-      current values stay unchanged
+      current values stay unchanged *(persists an id)*
 - [ ] Each resolution state asserted on each surface
+      *(renders a resolution state)*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ set of canonical sources:
 - For design-changing work, use the
   [`hardwarevisualizer-design-review`](.agents/skills/hardwarevisualizer-design-review/SKILL.md)
   skill before or alongside implementation.
+- For work that joins, selects, or persists entities keyed by
+  backend-produced ids, use the
+  [`verify-identity-contracts`](.agents/skills/verify-identity-contracts/SKILL.md)
+  skill before implementation.
 
 AI memory, chat, handoff documents, and
 [`docs/agents/lessons/`](docs/agents/lessons/) are evidence leads. Verify them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ set of canonical sources:
 - For design-changing work, use the
   [`hardwarevisualizer-design-review`](.agents/skills/hardwarevisualizer-design-review/SKILL.md)
   skill before or alongside implementation.
-- For work that joins, selects, or persists entities keyed by
-  backend-produced ids, use the
+- For work that joins, selects, attributes, persists, or supplies fixture ids
+  for entities keyed by backend-produced ids, use the
   [`verify-identity-contracts`](.agents/skills/verify-identity-contracts/SKILL.md)
   skill before implementation.
 

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -110,3 +110,4 @@ shared enforcement surface.
 - [Separate release integrity from vulnerability exposure](separate-release-integrity-from-vulnerability-exposure.md)
 - [Deliver pull requests through review](deliver-pull-requests-through-review.md)
 - [Keep shared system refresh ownership explicit](keep-shared-system-refresh-ownership-explicit.md)
+- [Read id producers before identity UI](read-id-producers-before-identity-ui.md)

--- a/docs/agents/lessons/read-id-producers-before-identity-ui.md
+++ b/docs/agents/lessons/read-id-producers-before-identity-ui.md
@@ -8,7 +8,7 @@ failure_signature: "PR #1944 needed eleven review rounds because the GPU adapter
 root_cause: the frontend id contract was inferred from fixtures and frontend types instead of read from the producing Rust code, and effective-entity resolution was duplicated per surface instead of owned in one place
 guardrail: .agents/skills/verify-identity-contracts/SKILL.md
 canonical_refs: .agents/skills/verify-identity-contracts/SKILL.md, docs/adr/0016-gpu-attribution-on-the-performance-screen.md
-verification: before identity-touching UI work, the PR records a producer-sourced contract table and names the single resolution owner; src/e2e/fixtures/hardware.ts keeps distinct inventory and live ids
+verification: "before identity-touching work, a producer-sourced contract is recorded at its smallest durable owner (focused test, join-adjacent comment, commit/PR context, or ADR) and the resolution owner is singular; src/e2e/fixtures/hardware.ts keeps distinct inventory and live ids"
 evidence: "PR #1944 review history; core/src/platform/{windows,macos,linux}/gpu.rs id producers vs core/src/infrastructure/providers GraphicInfo ids; src/e2e/fixtures/hardware.ts GPU_FIXTURES id/liveId split; src/features/hardware/gpuIdentity.ts"
 revalidate_when: "backend id namespaces are unified (issue #1948 direction) or the monitor stream starts carrying inventory ids"
 ---

--- a/docs/agents/lessons/read-id-producers-before-identity-ui.md
+++ b/docs/agents/lessons/read-id-producers-before-identity-ui.md
@@ -1,0 +1,34 @@
+---
+id: LRN-20260819-read-id-producers-before-identity-ui
+status: promoted
+cause_status: confirmed
+scope: frontend features that join, select, persist, or attribute entities keyed by backend-produced ids
+trigger: a change adds a selector, attribution UI, cross-source join, persisted id, or a fixture for multi-source data
+failure_signature: "PR #1944 needed eleven review rounds because the GPU adapter selector was built on an assumed shared id namespace; the inventory and the monitor stream key GPUs differently on every platform, and the e2e fixture used one id for both sources, so no test failed"
+root_cause: the frontend id contract was inferred from fixtures and frontend types instead of read from the producing Rust code, and effective-entity resolution was duplicated per surface instead of owned in one place
+guardrail: .agents/skills/verify-identity-contracts/SKILL.md
+canonical_refs: .agents/skills/verify-identity-contracts/SKILL.md, docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+verification: before identity-touching UI work, the PR records a producer-sourced contract table and names the single resolution owner; src/e2e/fixtures/hardware.ts keeps distinct inventory and live ids
+evidence: "PR #1944 review history; core/src/platform/{windows,macos,linux}/gpu.rs id producers vs core/src/infrastructure/providers GraphicInfo ids; src/e2e/fixtures/hardware.ts GPU_FIXTURES id/liveId split; src/features/hardware/gpuIdentity.ts"
+revalidate_when: "backend id namespaces are unified (issue #1948 direction) or the monitor stream starts carrying inventory ids"
+---
+
+# Read Id Producers Before Identity UI
+
+An identity-touching UI change is only as sound as its id contract, and the
+contract lives in the producing backend code, not in fixtures or frontend
+types. In PR #1944 thirty minutes of reading the Rust producers would have
+surfaced up front what eleven review rounds surfaced incrementally: the
+inventory and the live stream cannot be joined by id on any platform.
+
+Two practices follow, both encoded in the
+[`verify-identity-contracts`](../../../.agents/skills/verify-identity-contracts/SKILL.md)
+skill:
+
+- Record the producer-sourced contract table before writing UI code, and give
+  effective-entity resolution exactly one owner that every surface consumes.
+- Keep fixtures as split as production: a fixture sharing one id across two
+  sources certifies joins that fail on real hardware.
+
+Deterministic follow-ups (branded id types, a fixture-realism assertion, and a
+consumer allowlist for the shared selection atom) are tracked in issue #1956.


### PR DESCRIPTION
Institutionalizes the retrospective from #1944 (eleven review rounds; root cause: the GPU id contract was inferred instead of read, and resolution was duplicated per surface).

## What this adds

- **Skill `verify-identity-contracts`** — fires before any change that joins, selects, persists, or attributes entities keyed by backend-produced ids. Five steps, each mapped to a concrete failure from the #1944 review: producer-sourced contract table (the Codex P1), one resolution owner (rounds 5–8 regression chain), fixture realism (the flattened fixture that certified the broken classic selector), app-level migration (rounds 10–11), and surface parity for resolution states (rounds 8–9).
- **Lesson `LRN-20260819-read-id-producers-before-identity-ui`** — provenance and revalidation trigger (revisit when #1948 unifies namespaces), status `promoted` with the skill and ADR 0016 as canonical refs.
- **AGENTS.md pointer** next to the existing design-review skill reference.

## What this deliberately leaves out

The deterministic layer — branded `LiveGpuId`/`InventoryGpuId` types, a fixture-realism unit test, and a consumer allowlist for `selectedGpuIdAtom` — is filed as #1956 and lands after #1944 merges, since all three reference its code.

`npm run check:agent-guidance` passes (16 lessons, 6 skills, 6 rules, 16 ADRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for validating identity contracts across backend data, frontend behavior, attribution surfaces, and fixtures.
  * Clarified when verification applies to produced IDs, fixture data, persistence, migrations, and rendered resolution states.
  * Added guidance to identify backend ID sources before implementing identity-related UI behavior.
  * Added checklists covering entity ownership, ID attribution, fixture realism, first-time persistence, and one-way migrations.
  * Indexed the new identity verification lesson in the documentation library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->