### PR TITLE
feat(quality): make GPU id namespaces a compile-time contract

### DIFF
--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -48,8 +48,8 @@ and where stored intent is restored, so writing an inventory id into the
 shared selection or indexing a live map with one is a type error rather than a
 review finding. Two tests back the types up deterministically: the e2e fixture
 must keep its inventory and live ids distinct the way every platform does, and
-`selectedGpuIdAtom` may only be imported by an allowlisted set of resolution
-owners.
+`selectedGpuIdAtom` may only be reached by an allowlisted set of resolution
+owners — by named or namespace import alike.
 
 The adapter list is therefore built from the live side alone: every id the
 stream reported, named by the `gpuName` each sample carries, plus any id that

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -46,7 +46,10 @@ across. The frontend enforces this at compile time: live ids carry the branded
 `LiveGpuId` type, minted only where samples enter (`useHardwareEventListener`)
 and where stored intent is restored, so writing an inventory id into the
 shared selection or indexing a live map with one is a type error rather than a
-review finding. Two tests back the types up deterministically: the e2e fixture
+review finding. Live maps are built through `liveGpuRecord`, because
+`Object.fromEntries` returns a `string`-indexed object that TypeScript accepts
+for a branded record — indexing is checked by the brand alone, construction
+needed the gate. Two tests back the types up deterministically: the e2e fixture
 must keep its inventory and live ids distinct the way every platform does, and
 `selectedGpuIdAtom` may only be reached by an allowlisted set of resolution
 owners — by named or namespace import alike.

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -42,7 +42,14 @@ different namespaces on every platform. Windows NVIDIA reports the raw NVAPI id
 as `GraphicInfo.id` but samples as `nvapi:<id>`; macOS pairs
 `0x<registry_id>` with `iokit:<name>`; Linux pairs `card<n>` with the PCI BDF.
 The two id spaces are disjoint, so they cannot be joined, unioned, or looked up
-across.
+across. The frontend enforces this at compile time: live ids carry the branded
+`LiveGpuId` type, minted only where samples enter (`useHardwareEventListener`)
+and where stored intent is restored, so writing an inventory id into the
+shared selection or indexing a live map with one is a type error rather than a
+review finding. Two tests back the types up deterministically: the e2e fixture
+must keep its inventory and live ids distinct the way every platform does, and
+`selectedGpuIdAtom` may only be imported by an allowlisted set of resolution
+owners.
 
 The adapter list is therefore built from the live side alone: every id the
 stream reported, named by the `gpuName` each sample carries, plus any id that

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -46,7 +46,9 @@ across. The frontend enforces this at compile time: live ids carry the branded
 `LiveGpuId` type, minted only where samples enter (`useHardwareEventListener`)
 and where stored intent is restored, so writing an inventory id into the
 shared selection or indexing a live map with one is a type error rather than a
-review finding. Live maps are built through `liveGpuRecord`, because
+review finding. The minting
+sites are the monitor payload, the restored stored intent, and the classic
+card's `toLiveGpuId` write. Live maps are built through `liveGpuRecord`, because
 `Object.fromEntries` returns a `string`-indexed object that TypeScript accepts
 for a branded record — indexing is checked by the brand alone, construction
 needed the gate. Two tests back the types up deterministically: the e2e fixture

--- a/src/e2e/fixtures/hardware.test.ts
+++ b/src/e2e/fixtures/hardware.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { GPU_FIXTURES } from "./hardware";
+
+/**
+ * A fixture may share one id across two sources only if production does — and
+ * no platform does: the inventory and the monitor stream key GPUs in
+ * different namespaces everywhere (ADR 0016). A fixture that flattens that
+ * split certifies cross-namespace joins that fail on real hardware; the
+ * classic GPU selector shipped non-functional exactly this way while its e2e
+ * passed.
+ */
+describe("GPU fixture id namespaces", () => {
+  it("keeps the inventory id and the live id distinct, as every platform does", () => {
+    for (const gpu of GPU_FIXTURES) {
+      expect(gpu.id).not.toBe(gpu.liveId);
+    }
+  });
+
+  it("keeps ids unique within each namespace", () => {
+    const inventoryIds: string[] = GPU_FIXTURES.map((gpu) => gpu.id);
+    const liveIds: string[] = GPU_FIXTURES.map((gpu) => gpu.liveId);
+    expect(new Set(inventoryIds).size).toBe(inventoryIds.length);
+    expect(new Set(liveIds).size).toBe(liveIds.length);
+    // The namespaces must not overlap either: an id that exists on both
+    // sides would let an id-based join succeed by accident in tests.
+    expect(inventoryIds.filter((id) => liveIds.includes(id))).toEqual([]);
+  });
+});

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -265,7 +265,11 @@ export const GPUInfo = () => {
               </div>
             )}
             {(() => {
-              const dedicatedMemoryKb = gpuDedicatedMemoryKbMap[gpu.id] ?? null;
+              // gpu.id is an inventory id; the map is keyed by live ids. The
+              // branded types surfaced this: the old direct index could never
+              // match, so this row always showed the total without usage.
+              const dedicatedMemoryKb =
+                gpuDedicatedMemoryKbMap[toLiveGpuId(gpu, gpuNames)] ?? null;
               const hasMemorySize = gpu.memorySize !== "N/A";
               const hasMemoryUsage = dedicatedMemoryKb != null;
               const formattedMemoryUsage = hasMemoryUsage

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -268,8 +268,16 @@ export const GPUInfo = () => {
               // gpu.id is an inventory id; the map is keyed by live ids. The
               // branded types surfaced this: the old direct index could never
               // match, so this row always showed the total without usage.
-              const dedicatedMemoryKb =
-                gpuDedicatedMemoryKbMap[toLiveGpuId(gpu, gpuNames)] ?? null;
+              //
+              // The name join has to be unique on BOTH sides. `toLiveGpuId`
+              // only checks the live side, so two identically named inventory
+              // rows would each resolve to the one reporting adapter and show
+              // its usage twice (ADR 0016).
+              const inventoryTwin =
+                gpus.filter((entry) => entry.name === gpu.name).length > 1;
+              const dedicatedMemoryKb = inventoryTwin
+                ? null
+                : (gpuDedicatedMemoryKbMap[toLiveGpuId(gpu, gpuNames)] ?? null);
               const hasMemorySize = gpu.memorySize !== "N/A";
               const hasMemoryUsage = dedicatedMemoryKb != null;
               const formattedMemoryUsage = hasMemoryUsage

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  asLiveGpuId,
   findInventoryGpu,
   type GpuLiveMaps,
   getEffectiveGpuId,
   hasNoLiveGpuReadings,
+  type LiveGpuId,
   listGpuAdapters,
   toLiveGpuId,
 } from "./gpuIdentity";
@@ -14,15 +16,33 @@ const inventory = [
 ];
 
 /** The live name map, as the event listener builds it from each sample. */
-const names = (...pairs: [string, string][]) => Object.fromEntries(pairs);
+const names = (...pairs: [string, string][]) =>
+  Object.fromEntries(
+    pairs.map(([id, name]) => [asLiveGpuId(id), name]),
+  ) as Record<LiveGpuId, string>;
 
-const live = (maps: Partial<GpuLiveMaps> = {}): GpuLiveMaps => ({
-  usageHistories: {},
-  temperatures: {},
-  fanSpeeds: {},
-  dedicatedMemoryKb: {},
-  ...maps,
-});
+/** Test seeds mint ids the way the event listener does. */
+const id = asLiveGpuId;
+
+/**
+ * Seeds take plain string keys and mint them here, the same way the event
+ * listener mints ids at the payload boundary.
+ */
+const live = (
+  maps: {
+    usageHistories?: Record<string, (number | null)[]>;
+    temperatures?: Record<string, { name: string; value: number }>;
+    fanSpeeds?: Record<string, { name: string; value: number }>;
+    dedicatedMemoryKb?: Record<string, number | null>;
+  } = {},
+): GpuLiveMaps =>
+  ({
+    usageHistories: {},
+    temperatures: {},
+    fanSpeeds: {},
+    dedicatedMemoryKb: {},
+    ...maps,
+  }) as GpuLiveMaps;
 
 describe("listGpuAdapters", () => {
   it("lists one adapter per live id, never unioned with the inventory namespace", () => {
@@ -178,19 +198,20 @@ describe("listGpuAdapters", () => {
 describe("getEffectiveGpuId", () => {
   it("keeps an explicit selection that reports nothing yet", () => {
     expect(
-      getEffectiveGpuId("gpu-2", live({ usageHistories: { "gpu-1": [20] } }), [
-        "gpu-1",
-        "gpu-2",
-      ]),
+      getEffectiveGpuId(
+        id("gpu-2"),
+        live({ usageHistories: { "gpu-1": [20] } }),
+        [id("gpu-1"), id("gpu-2")],
+      ),
     ).toBe("gpu-2");
   });
 
   it("drops a selection whose adapter is gone instead of showing nothing", () => {
     expect(
       getEffectiveGpuId(
-        "removed",
+        id("removed"),
         live({ usageHistories: { "gpu-1": [20] } }),
-        ["gpu-1"],
+        [id("gpu-1")],
       ),
     ).toBe("gpu-1");
   });
@@ -211,13 +232,13 @@ describe("getEffectiveGpuId", () => {
 
 describe("hasNoLiveGpuReadings", () => {
   it("stays silent before the first sample, which is 'not yet' rather than 'unavailable'", () => {
-    expect(hasNoLiveGpuReadings("gpu-2", live())).toBe(false);
+    expect(hasNoLiveGpuReadings(id("gpu-2"), live())).toBe(false);
   });
 
   it("reports an adapter that stayed silent while another one answered", () => {
     expect(
       hasNoLiveGpuReadings(
-        "gpu-2",
+        id("gpu-2"),
         live({ usageHistories: { "gpu-1": [20] } }),
       ),
     ).toBe(true);
@@ -226,7 +247,7 @@ describe("hasNoLiveGpuReadings", () => {
   it("counts a temperature-only adapter as reporting", () => {
     expect(
       hasNoLiveGpuReadings(
-        "gpu-2",
+        id("gpu-2"),
         live({
           usageHistories: { "gpu-1": [20] },
           temperatures: { "gpu-2": { name: "GPU 2", value: 51 } },
@@ -238,7 +259,7 @@ describe("hasNoLiveGpuReadings", () => {
   it("counts a fan-only adapter as reporting, so its fan speed is not called absent", () => {
     expect(
       hasNoLiveGpuReadings(
-        "gpu-2",
+        id("gpu-2"),
         live({
           usageHistories: { "gpu-1": [20] },
           fanSpeeds: { "gpu-2": { name: "GPU 2", value: 40 } },
@@ -250,7 +271,7 @@ describe("hasNoLiveGpuReadings", () => {
   it("counts a VRAM-only adapter as reporting", () => {
     expect(
       hasNoLiveGpuReadings(
-        "gpu-2",
+        id("gpu-2"),
         live({
           usageHistories: { "gpu-1": [20] },
           dedicatedMemoryKb: { "gpu-2": 1_048_576 },
@@ -266,12 +287,16 @@ describe("hasNoLiveGpuReadings with an all-null sample", () => {
     // is recorded, and all four value maps stay empty forever. Treating that
     // as "not measured yet" would blank the explanation permanently.
     expect(
-      hasNoLiveGpuReadings("pdh:UHD Graphics", live({}), ["pdh:UHD Graphics"]),
+      hasNoLiveGpuReadings(id("pdh:UHD Graphics"), live({}), [
+        id("pdh:UHD Graphics"),
+      ]),
     ).toBe(true);
   });
 
   it("still says nothing before any adapter is detected", () => {
-    expect(hasNoLiveGpuReadings("pdh:UHD Graphics", live({}), [])).toBe(false);
+    expect(hasNoLiveGpuReadings(id("pdh:UHD Graphics"), live({}), [])).toBe(
+      false,
+    );
   });
 });
 
@@ -283,14 +308,14 @@ describe("findInventoryGpu", () => {
     expect(
       findInventoryGpu(
         inventory,
-        { "pci:0:2:0": "Intel UHD Graphics 770" },
-        "pci:0:2:0",
+        names(["pci:0:2:0", "Intel UHD Graphics 770"]),
+        id("pci:0:2:0"),
       ),
     ).toEqual(inventory[1]);
   });
 
   it("still accepts an id the inventory itself uses", () => {
-    expect(findInventoryGpu(inventory, {}, "67890")).toEqual(inventory[1]);
+    expect(findInventoryGpu(inventory, {}, id("67890"))).toEqual(inventory[1]);
   });
 
   it("refuses the join when the name picks out more than one entry", () => {
@@ -302,8 +327,8 @@ describe("findInventoryGpu", () => {
     expect(
       findInventoryGpu(
         twins,
-        { "nvapi:1": "NVIDIA GeForce RTX 4090" },
-        "nvapi:1",
+        names(["nvapi:1", "NVIDIA GeForce RTX 4090"]),
+        id("nvapi:1"),
       ),
     ).toBeUndefined();
   });
@@ -319,11 +344,11 @@ describe("findInventoryGpu", () => {
     expect(
       findInventoryGpu(
         twins,
-        {
-          "nvapi:1": "NVIDIA GeForce RTX 4090",
-          "nvapi:2": "NVIDIA GeForce RTX 4090",
-        },
-        "nvapi:2",
+        names(
+          ["nvapi:1", "NVIDIA GeForce RTX 4090"],
+          ["nvapi:2", "NVIDIA GeForce RTX 4090"],
+        ),
+        id("nvapi:2"),
       ),
     ).toBeUndefined();
   });
@@ -336,7 +361,7 @@ describe("findInventoryGpu", () => {
 describe("toLiveGpuId", () => {
   it("writes the shared selection in the namespace readings are keyed by", () => {
     expect(
-      toLiveGpuId(inventory[1], { "pci:0:2:0": "Intel UHD Graphics 770" }),
+      toLiveGpuId(inventory[1], names(["pci:0:2:0", "Intel UHD Graphics 770"])),
     ).toBe("pci:0:2:0");
   });
 
@@ -355,10 +380,10 @@ describe("toLiveGpuId", () => {
     expect(
       toLiveGpuId(
         { id: "a", name: "NVIDIA GeForce RTX 4090" },
-        {
-          "nvapi:1": "NVIDIA GeForce RTX 4090",
-          "nvapi:2": "NVIDIA GeForce RTX 4090",
-        },
+        names(
+          ["nvapi:1", "NVIDIA GeForce RTX 4090"],
+          ["nvapi:2", "NVIDIA GeForce RTX 4090"],
+        ),
       ),
     ).toBe("a");
   });

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -1,10 +1,32 @@
+declare const liveGpuIdBrand: unique symbol;
+
+/**
+ * An id from the monitor stream — the namespace every live map and the
+ * shared selection are keyed by.
+ *
+ * The inventory (`GraphicInfo.id`) uses a different namespace on every
+ * platform (see ADR 0016), so it is deliberately NOT this type: the compiler
+ * rejects writing an inventory id into the selection or indexing a live map
+ * with one — the bug class behind most of PR #1944's review rounds.
+ */
+export type LiveGpuId = string & { readonly [liveGpuIdBrand]: true };
+
+/**
+ * Mint a `LiveGpuId`. Only namespace boundaries may call this: the monitor
+ * payload (`useHardwareEventListener`), the persisted selection
+ * (`useSelectedGpuPersistence`), test seeds, and the joins in this module.
+ * Casting an inventory id defeats the type — resolve through `toLiveGpuId`
+ * instead.
+ */
+export const asLiveGpuId = (id: string): LiveGpuId => id as LiveGpuId;
+
 /**
  * One adapter as the Performance screens need it: the stable id every live
  * value is keyed by, the name the platform reported, and a short label for
  * controls that cannot fit the full name.
  */
 export type GpuAdapter = {
-  id: string;
+  id: LiveGpuId;
   /** The raw platform name. Two identical cards report the same one. */
   name: string;
   /** Always unique across the list, so a control can never be ambiguous. */
@@ -26,11 +48,17 @@ export type GpuAdapter = {
  * reporting adapter into a silent one.
  */
 export type GpuLiveMaps = {
-  usageHistories: Record<string, (number | null)[]>;
-  temperatures: Record<string, { name: string; value: number }>;
-  fanSpeeds: Record<string, { name: string; value: number }>;
-  dedicatedMemoryKb: Record<string, number | null>;
+  usageHistories: Record<LiveGpuId, (number | null)[]>;
+  temperatures: Record<LiveGpuId, { name: string; value: number }>;
+  fanSpeeds: Record<LiveGpuId, { name: string; value: number }>;
+  dedicatedMemoryKb: Record<LiveGpuId, number | null>;
 };
+
+/** `Object.keys` erases the brand; these two restate what the maps guarantee. */
+const liveKeys = (map: Record<LiveGpuId, unknown>) =>
+  Object.keys(map) as LiveGpuId[];
+const liveEntries = <T>(map: Record<LiveGpuId, T>) =>
+  Object.entries(map) as [LiveGpuId, T][];
 
 const liveMapsInOrder = (live: GpuLiveMaps) => [
   live.usageHistories,
@@ -114,19 +142,19 @@ const dropSharedPrefixWords = (labels: string[]) => {
  * that read identically.
  */
 export const listGpuAdapters = (
-  gpuNames: Record<string, string>,
+  gpuNames: Record<LiveGpuId, string>,
   live: GpuLiveMaps,
 ): GpuAdapter[] => {
-  const named = new Map<string, string>();
+  const named = new Map<LiveGpuId, string>();
 
   // Every adapter the stream named, in payload order — including one that
   // named itself and reported nothing else, which is the case the unavailable
   // state exists for.
-  for (const [id, name] of Object.entries(gpuNames)) {
+  for (const [id, name] of liveEntries(gpuNames)) {
     named.set(id, name);
   }
   for (const map of liveMapsInOrder(live)) {
-    for (const id of Object.keys(map)) {
+    for (const id of liveKeys(map)) {
       if (!named.has(id)) {
         named.set(id, id);
       }
@@ -135,7 +163,7 @@ export const listGpuAdapters = (
   // The sensor maps carry a name too, so they can still identify an adapter
   // if the name map has not caught up with them.
   for (const map of [live.temperatures, live.fanSpeeds]) {
-    for (const [id, value] of Object.entries(map)) {
+    for (const [id, value] of liveEntries(map)) {
       if (named.get(id) === id) {
         named.set(id, value.name);
       }
@@ -196,8 +224,8 @@ export const listGpuAdapters = (
  */
 export const findInventoryGpu = <T extends { id: string; name: string }>(
   gpus: readonly T[],
-  gpuNames: Record<string, string>,
-  selectedGpuId: string | null,
+  gpuNames: Record<LiveGpuId, string>,
+  selectedGpuId: LiveGpuId | null,
 ): T | undefined => {
   if (selectedGpuId == null) {
     return undefined;
@@ -225,12 +253,13 @@ export const findInventoryGpu = <T extends { id: string; name: string }>(
  */
 export const toLiveGpuId = (
   gpu: { id: string; name: string },
-  gpuNames: Record<string, string>,
-): string => {
-  const matches = Object.entries(gpuNames).filter(
-    ([, name]) => name === gpu.name,
-  );
-  return matches.length === 1 ? matches[0][0] : gpu.id;
+  gpuNames: Record<LiveGpuId, string>,
+): LiveGpuId => {
+  const matches = liveEntries(gpuNames).filter(([, name]) => name === gpu.name);
+  // The fallback deliberately mints the inventory id as intent: it addresses
+  // no readings yet, but the app-level migration re-resolves it once the
+  // stream names the adapter, and discarding the click would be worse.
+  return matches.length === 1 ? matches[0][0] : asLiveGpuId(gpu.id);
 };
 
 /**
@@ -242,10 +271,10 @@ export const toLiveGpuId = (
  * no longer exists falls back to the first GPU that reports anything.
  */
 export const getEffectiveGpuId = (
-  selectedGpuId: string | null,
+  selectedGpuId: LiveGpuId | null,
   live: GpuLiveMaps,
-  detectedGpuIds: readonly string[] = [],
-) => {
+  detectedGpuIds: readonly LiveGpuId[] = [],
+): LiveGpuId | undefined => {
   if (
     selectedGpuId != null &&
     (detectedGpuIds.includes(selectedGpuId) ||
@@ -255,7 +284,7 @@ export const getEffectiveGpuId = (
   }
 
   for (const map of liveMapsInOrder(live)) {
-    const [first] = Object.keys(map);
+    const [first] = liveKeys(map);
     if (first != null) {
       return first;
     }
@@ -277,9 +306,9 @@ export const getEffectiveGpuId = (
  * explanation for exactly the user who most needs it.
  */
 export const hasNoLiveGpuReadings = (
-  gpuId: string | undefined,
+  gpuId: LiveGpuId | undefined,
   live: GpuLiveMaps,
-  detectedGpuIds: readonly string[] = [],
+  detectedGpuIds: readonly LiveGpuId[] = [],
 ) => {
   if (gpuId == null) {
     return false;
@@ -287,8 +316,7 @@ export const hasNoLiveGpuReadings = (
 
   const maps = liveMapsInOrder(live);
   const sampled =
-    detectedGpuIds.length > 0 ||
-    maps.some((map) => Object.keys(map).length > 0);
+    detectedGpuIds.length > 0 || maps.some((map) => liveKeys(map).length > 0);
 
   return sampled && !maps.some((map) => Object.hasOwn(map, gpuId));
 };

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -21,6 +21,19 @@ export type LiveGpuId = string & { readonly [liveGpuIdBrand]: true };
 export const asLiveGpuId = (id: string): LiveGpuId => id as LiveGpuId;
 
 /**
+ * Build a live-keyed map from entries whose keys are already minted.
+ *
+ * `Object.fromEntries` returns a `string`-indexed object, and TypeScript
+ * accepts that for a `Record<LiveGpuId, T>` — so constructing a live map
+ * wholesale would otherwise bypass the brand entirely and let an
+ * inventory-keyed dictionary into the atoms. Indexing is checked; only
+ * construction needed this gate.
+ */
+export const liveGpuRecord = <T>(
+  entries: readonly (readonly [LiveGpuId, T])[],
+): Record<LiveGpuId, T> => Object.fromEntries(entries) as Record<LiveGpuId, T>;
+
+/**
  * One adapter as the Performance screens need it: the stable id every live
  * value is keyed by, the name the platform reported, and a short label for
  * controls that cannot fit the full name.

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -33,17 +33,30 @@ const sources = import.meta.glob("/src/**/*.{ts,tsx}", {
 const ATOM = /\bselectedGpuIdAtom\b/;
 
 /**
- * Blank out comments and literals so only code remains.
+ * Blank out comments, strings, templates, and regex literals so only code
+ * remains.
  *
- * Written as a scanner rather than a pair of regexes: stripping `//` to the
- * end of the line silently eats a real reference that follows a URL on the
- * same line, which turns this guard into a bypass instead of a check. The
- * TypeScript 7 parser lives behind `unstable/` entry points, so depending on
- * it here would trade one fragility for another.
+ * A lexer over JavaScript's five literal token classes, because anything less
+ * has a bypass: a `//` inside a URL string eats the rest of the line, a quote
+ * inside a regex swallows the rest of the file, and blanking a whole template
+ * hides a real reference inside its `${}`. The classes are finite, so this is
+ * written once and pinned by tests rather than patched per counterexample.
+ * Whether `/` starts a regex or is division uses the standard lexer
+ * heuristic: a regex can only follow an operator, opener, keyword boundary,
+ * or start of input.
  */
-const codeOnly = (source: string) => {
+const codeOnly = (source: string): string => {
   let out = "";
   let i = 0;
+  let lastCode = "";
+  const remember = (ch: string) => {
+    if (!/\s/.test(ch)) {
+      lastCode = ch;
+    }
+  };
+  const regexCanStart = () =>
+    lastCode === "" || "([{,;=:!&|?+-*%<>~^".includes(lastCode);
+
   while (i < source.length) {
     const two = source.slice(i, i + 2);
     if (two === "//") {
@@ -57,16 +70,53 @@ const codeOnly = (source: string) => {
       continue;
     }
     const ch = source[i];
-    if (ch === '"' || ch === "'" || ch === "`") {
-      const quote = ch;
+    if (ch === '"' || ch === "'") {
       i += 1;
-      while (i < source.length && source[i] !== quote) {
+      while (i < source.length && source[i] !== ch) {
         i += source[i] === "\\" ? 2 : 1;
       }
       i += 1;
+      remember('"');
+      continue;
+    }
+    if (ch === "`") {
+      // Blank the text but recurse into ${}: interpolations are code, and a
+      // real reference inside one must not be hidden.
+      i += 1;
+      while (i < source.length && source[i] !== "`") {
+        if (source.slice(i, i + 2) === "${") {
+          let depth = 1;
+          const exprStart = i + 2;
+          i += 2;
+          while (i < source.length && depth > 0) {
+            if (source[i] === "{") depth += 1;
+            if (source[i] === "}") depth -= 1;
+            i += 1;
+          }
+          out += ` ${codeOnly(source.slice(exprStart, i - 1))} `;
+          continue;
+        }
+        i += source[i] === "\\" ? 2 : 1;
+      }
+      i += 1;
+      remember('"');
+      continue;
+    }
+    if (ch === "/" && regexCanStart()) {
+      i += 1;
+      let inClass = false;
+      while (i < source.length && (inClass || source[i] !== "/")) {
+        if (source[i] === "\\") i += 1;
+        else if (source[i] === "[") inClass = true;
+        else if (source[i] === "]") inClass = false;
+        i += 1;
+      }
+      i += 1;
+      remember('"');
       continue;
     }
     out += ch;
+    remember(ch);
     i += 1;
   }
   return out;
@@ -78,7 +128,7 @@ const codeOnly = (source: string) => {
  * Any reference counts, not just a named import: a file can reach the atom
  * through a namespace import (`import * as chart` then
  * `chart.selectedGpuIdAtom`), and member access still contains the name.
- * Comments and strings name it without consuming it — `gpuIdentity.ts`
+ * Comments and literals name it without consuming it — `gpuIdentity.ts`
  * documents the contract in prose — so they are removed first.
  */
 const consumesAtom = (source: string) => ATOM.test(codeOnly(source));
@@ -93,11 +143,31 @@ describe("codeOnly", () => {
     ).toContain("selectedGpuIdAtom");
   });
 
+  it("keeps a reference after a regex literal containing a quote", () => {
+    expect(
+      codeOnly(`const p = /["']/; use(chart.selectedGpuIdAtom);`),
+    ).toContain("selectedGpuIdAtom");
+  });
+
+  it("keeps a reference inside a template interpolation", () => {
+    // eslint-style template: the text is a literal, the ${} is code.
+    expect(codeOnly("const s = `atom: ${chart.selectedGpuIdAtom}`;")).toContain(
+      "selectedGpuIdAtom",
+    );
+  });
+
+  it("treats division as code, not as a regex opener", () => {
+    expect(codeOnly("const x = a / b; use(selectedGpuIdAtom);")).toContain(
+      "selectedGpuIdAtom",
+    );
+  });
+
   it.each([
     ["line comment", "// selectedGpuIdAtom"],
     ["block comment", "/* selectedGpuIdAtom */"],
     ["string literal", 'const s = "selectedGpuIdAtom";'],
-    ["template literal", "const s = `selectedGpuIdAtom`;"],
+    ["template literal text", "const s = `selectedGpuIdAtom`;"],
+    ["regex literal", "const p = /selectedGpuIdAtom/;"],
   ])("drops the name inside a %s", (_kind, source) => {
     expect(codeOnly(source)).not.toContain("selectedGpuIdAtom");
   });

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -30,20 +30,78 @@ const sources = import.meta.glob("/src/**/*.{ts,tsx}", {
   eager: true,
 }) as Record<string, string>;
 
-/**
- * Comments name the atom without consuming it (`gpuIdentity.ts` documents the
- * contract), so they are removed before looking for a real reference.
- */
-const stripComments = (source: string) =>
-  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+const ATOM = /\bselectedGpuIdAtom\b/;
 
 /**
- * Any reference to the identifier counts, not just a named import: a file can
- * reach the atom through a namespace import (`import * as chart` then
- * `chart.selectedGpuIdAtom`), and member access still contains the name.
+ * Blank out comments and literals so only code remains.
+ *
+ * Written as a scanner rather than a pair of regexes: stripping `//` to the
+ * end of the line silently eats a real reference that follows a URL on the
+ * same line, which turns this guard into a bypass instead of a check. The
+ * TypeScript 7 parser lives behind `unstable/` entry points, so depending on
+ * it here would trade one fragility for another.
  */
-const consumesAtom = (source: string) =>
-  /\bselectedGpuIdAtom\b/.test(stripComments(source));
+export const codeOnly = (source: string) => {
+  let out = "";
+  let i = 0;
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+    if (two === "//") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (two === "/*") {
+      i += 2;
+      while (i < source.length && source.slice(i, i + 2) !== "*/") i += 1;
+      i += 2;
+      continue;
+    }
+    const ch = source[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      i += 1;
+      while (i < source.length && source[i] !== quote) {
+        i += source[i] === "\\" ? 2 : 1;
+      }
+      i += 1;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+};
+
+/**
+ * Whether the file actually references the atom.
+ *
+ * Any reference counts, not just a named import: a file can reach the atom
+ * through a namespace import (`import * as chart` then
+ * `chart.selectedGpuIdAtom`), and member access still contains the name.
+ * Comments and strings name it without consuming it — `gpuIdentity.ts`
+ * documents the contract in prose — so they are removed first.
+ */
+const consumesAtom = (source: string) => ATOM.test(codeOnly(source));
+
+describe("codeOnly", () => {
+  // The case that motivated the scanner: a naive line-comment regex eats the
+  // rest of the line after a URL's `//`, hiding a real reference — a silent
+  // bypass, worse than a false positive.
+  it("keeps a reference that follows a URL on the same line", () => {
+    expect(
+      codeOnly('const u = "https://x/a"; use(selectedGpuIdAtom);'),
+    ).toContain("selectedGpuIdAtom");
+  });
+
+  it.each([
+    ["line comment", "// selectedGpuIdAtom"],
+    ["block comment", "/* selectedGpuIdAtom */"],
+    ["string literal", 'const s = "selectedGpuIdAtom";'],
+    ["template literal", "const s = `selectedGpuIdAtom`;"],
+  ])("drops the name inside a %s", (_kind, source) => {
+    expect(codeOnly(source)).not.toContain("selectedGpuIdAtom");
+  });
+});
 
 describe("selectedGpuIdAtom ownership", () => {
   it("is consumed only by the allowlisted resolution owners", () => {

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -30,14 +30,26 @@ const sources = import.meta.glob("/src/**/*.{ts,tsx}", {
   eager: true,
 }) as Record<string, string>;
 
-const importsAtom = (source: string) =>
-  /import[^;]*\bselectedGpuIdAtom\b[^;]*from/s.test(source);
+/**
+ * Comments name the atom without consuming it (`gpuIdentity.ts` documents the
+ * contract), so they are removed before looking for a real reference.
+ */
+const stripComments = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+/**
+ * Any reference to the identifier counts, not just a named import: a file can
+ * reach the atom through a namespace import (`import * as chart` then
+ * `chart.selectedGpuIdAtom`), and member access still contains the name.
+ */
+const consumesAtom = (source: string) =>
+  /\bselectedGpuIdAtom\b/.test(stripComments(source));
 
 describe("selectedGpuIdAtom ownership", () => {
   it("is consumed only by the allowlisted resolution owners", () => {
     const offenders = Object.entries(sources)
       .filter(([path]) => !/\.test\.tsx?$/.test(path))
-      .filter(([, source]) => importsAtom(source))
+      .filter(([, source]) => consumesAtom(source))
       .map(([path]) => path)
       .filter((path) => !ALLOWED_CONSUMERS.has(path));
 
@@ -48,8 +60,7 @@ describe("selectedGpuIdAtom ownership", () => {
     for (const path of ALLOWED_CONSUMERS) {
       const source = sources[path];
       expect(source, `${path} does not exist`).toBeDefined();
-      const touchesAtom =
-        importsAtom(source) || /export const selectedGpuIdAtom\b/.test(source);
+      const touchesAtom = consumesAtom(source);
       expect(
         touchesAtom,
         `${path} no longer defines or imports selectedGpuIdAtom; remove it from the allowlist`,

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -30,7 +30,9 @@ const sources = import.meta.glob("/src/**/*.{ts,tsx}", {
   eager: true,
 }) as Record<string, string>;
 
-const ATOM = /\bselectedGpuIdAtom\b/;
+// `$` is not a word character, so a bare \b would let the distinct
+// identifier `$selectedGpuIdAtom` count as a reference.
+const ATOM = /(?<![$\w])selectedGpuIdAtom\b/;
 
 /**
  * Blank out comments, strings, templates, and regex literals so only code
@@ -154,6 +156,13 @@ describe("codeOnly", () => {
     // Concatenated so the ${} is data here, not a lint-visible placeholder.
     const source = "const s = `atom: $" + "{chart.selectedGpuIdAtom}`;";
     expect(codeOnly(source)).toContain("selectedGpuIdAtom");
+  });
+
+  it("does not count the distinct identifier $selectedGpuIdAtom", () => {
+    expect(codeOnly("const $selectedGpuIdAtom = 1;")).toContain(
+      "$selectedGpuIdAtom",
+    );
+    expect(ATOM.test(codeOnly("const $selectedGpuIdAtom = 1;"))).toBe(false);
   });
 
   it("treats division as code, not as a regex opener", () => {

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -151,9 +151,9 @@ describe("codeOnly", () => {
 
   it("keeps a reference inside a template interpolation", () => {
     // eslint-style template: the text is a literal, the ${} is code.
-    expect(codeOnly("const s = `atom: ${chart.selectedGpuIdAtom}`;")).toContain(
-      "selectedGpuIdAtom",
-    );
+    // Concatenated so the ${} is data here, not a lint-visible placeholder.
+    const source = "const s = `atom: $" + "{chart.selectedGpuIdAtom}`;";
+    expect(codeOnly(source)).toContain("selectedGpuIdAtom");
   });
 
   it("treats division as code, not as a regex opener", () => {

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -41,7 +41,7 @@ const ATOM = /\bselectedGpuIdAtom\b/;
  * TypeScript 7 parser lives behind `unstable/` entry points, so depending on
  * it here would trade one fragility for another.
  */
-export const codeOnly = (source: string) => {
+const codeOnly = (source: string) => {
   let out = "";
   let i = 0;
   while (i < source.length) {

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * "Which GPU is effective" must be answered in exactly one place. Rounds 5-8
+ * of the PR #1944 review were one mechanism repeating: a surface re-derived
+ * the selection from `selectedGpuIdAtom` on its own and drifted from the
+ * others, labelling one adapter while rendering another's values.
+ *
+ * This test enumerates the files allowed to touch the atom. A new surface
+ * that needs the selection imports `useGpuAdapters` (or the derived atoms in
+ * `store/chart.ts`) instead of joining the atom itself. Extending the
+ * allowlist is a deliberate act reviewed with `verify-identity-contracts`.
+ */
+const ALLOWED_CONSUMERS = new Set([
+  // Defines the atom and the derived resolution every read-only surface uses.
+  "/src/features/hardware/store/chart.ts",
+  // The one resolution owner components consume.
+  "/src/features/hardware/hooks/useGpuAdapters.ts",
+  // Restores, persists, and migrates the stored intent.
+  "/src/features/hardware/hooks/useSelectedGpuPersistence.ts",
+  // Writes the auto-selection when nothing is selected yet.
+  "/src/features/hardware/hooks/useHardwareEventListener.ts",
+  // The classic card resolves through findInventoryGpu/toLiveGpuId.
+  "/src/features/hardware/dashboard/components/DashboardItems.tsx",
+]);
+
+const sources = import.meta.glob("/src/**/*.{ts,tsx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+const importsAtom = (source: string) =>
+  /import[^;]*\bselectedGpuIdAtom\b[^;]*from/s.test(source);
+
+describe("selectedGpuIdAtom ownership", () => {
+  it("is consumed only by the allowlisted resolution owners", () => {
+    const offenders = Object.entries(sources)
+      .filter(([path]) => !/\.test\.tsx?$/.test(path))
+      .filter(([, source]) => importsAtom(source))
+      .map(([path]) => path)
+      .filter((path) => !ALLOWED_CONSUMERS.has(path));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every allowlisted consumer real, so the list cannot rot", () => {
+    for (const path of ALLOWED_CONSUMERS) {
+      const source = sources[path];
+      expect(source, `${path} does not exist`).toBeDefined();
+      const touchesAtom =
+        importsAtom(source) || /export const selectedGpuIdAtom\b/.test(source);
+      expect(
+        touchesAtom,
+        `${path} no longer defines or imports selectedGpuIdAtom; remove it from the allowlist`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -1,8 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { Provider, useAtom } from "jotai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { chartConfig } from "@/features/hardware/consts/chart";
+import { asLiveGpuId } from "@/features/hardware/gpuIdentity";
 import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
 import {
   cpuTempAtom,
@@ -679,8 +679,9 @@ describe("useHardwareEventListener", () => {
       );
 
       const histories = result.current;
-      expect(histories["nvapi:0"][histories["nvapi:0"].length - 1]).toBe(50);
-      expect(histories["nvapi:1"][histories["nvapi:1"].length - 1]).toBe(80);
+      const [gpu0, gpu1] = [asLiveGpuId("nvapi:0"), asLiveGpuId("nvapi:1")];
+      expect(histories[gpu0][histories[gpu0].length - 1]).toBe(50);
+      expect(histories[gpu1][histories[gpu1].length - 1]).toBe(80);
     });
 
     it("auto-selects first GPU ID when selectedGpuIdAtom is null", () => {

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -81,8 +81,10 @@ export const useHardwareEventListener = () => {
       setGpuHistories((prev) =>
         gpus.reduce(
           (acc, gpu) => {
-            // The payload is the one place live ids enter the app, so the
-            // brand is minted here and nowhere downstream.
+            // The monitor-payload boundary: ids from the stream are branded
+            // here. The other minting sites are the restored stored intent in
+            // `useSelectedGpuPersistence` and the unresolved fallback in
+            // `toLiveGpuId`; nothing else may mint.
             const gpuId = asLiveGpuId(gpu.gpuId);
             if (gpu.gpuUsage != null) {
               acc[gpuId] = padHistory([...(acc[gpuId] ?? []), gpu.gpuUsage]);

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -1,6 +1,7 @@
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect } from "react";
 import { chartConfig } from "@/features/hardware/consts/chart";
+import { asLiveGpuId } from "@/features/hardware/gpuIdentity";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
@@ -80,11 +81,11 @@ export const useHardwareEventListener = () => {
       setGpuHistories((prev) =>
         gpus.reduce(
           (acc, gpu) => {
+            // The payload is the one place live ids enter the app, so the
+            // brand is minted here and nowhere downstream.
+            const gpuId = asLiveGpuId(gpu.gpuId);
             if (gpu.gpuUsage != null) {
-              acc[gpu.gpuId] = padHistory([
-                ...(acc[gpu.gpuId] ?? []),
-                gpu.gpuUsage,
-              ]);
+              acc[gpuId] = padHistory([...(acc[gpuId] ?? []), gpu.gpuUsage]);
             }
             return acc;
           },
@@ -101,7 +102,7 @@ export const useHardwareEventListener = () => {
                 g.gpuTemperature != null,
             )
             .map((g) => [
-              g.gpuId,
+              asLiveGpuId(g.gpuId),
               { name: g.gpuName, value: g.gpuTemperature },
             ]),
         ),
@@ -116,12 +117,16 @@ export const useHardwareEventListener = () => {
       // would jump to another GPU on a transient hiccup.
       setGpuNames((prev) => ({
         ...prev,
-        ...Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuName])),
+        ...Object.fromEntries(
+          gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuName]),
+        ),
       }));
 
       // Usage sources from all GPUs
       setGpuSources(
-        Object.fromEntries(gpus.map((gpu) => [gpu.gpuId, gpu.gpuSource])),
+        Object.fromEntries(
+          gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuSource]),
+        ),
       );
 
       // Dedicated memory from all GPUs (only update when not null)
@@ -129,7 +134,7 @@ export const useHardwareEventListener = () => {
         gpus.reduce(
           (acc, gpu) => {
             if (gpu.gpuDedicatedMemoryUsageKb != null) {
-              acc[gpu.gpuId] = gpu.gpuDedicatedMemoryUsageKb;
+              acc[asLiveGpuId(gpu.gpuId)] = gpu.gpuDedicatedMemoryUsageKb;
             }
             return acc;
           },
@@ -146,7 +151,7 @@ export const useHardwareEventListener = () => {
                 g.gpuCoolerLevel != null,
             )
             .map((g) => [
-              g.gpuId,
+              asLiveGpuId(g.gpuId),
               { name: g.gpuName, value: g.gpuCoolerLevel },
             ]),
         ),
@@ -154,7 +159,11 @@ export const useHardwareEventListener = () => {
 
       // Auto-select first GPU if none selected
       setSelectedGpuId((prev) =>
-        prev != null ? prev : gpus.length > 0 ? gpus[0].gpuId : null,
+        prev != null
+          ? prev
+          : gpus.length > 0
+            ? asLiveGpuId(gpus[0].gpuId)
+            : null,
       );
 
       setProcessorsHistory((prev) => {

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -1,7 +1,7 @@
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect } from "react";
 import { chartConfig } from "@/features/hardware/consts/chart";
-import { asLiveGpuId } from "@/features/hardware/gpuIdentity";
+import { asLiveGpuId, liveGpuRecord } from "@/features/hardware/gpuIdentity";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
@@ -97,7 +97,7 @@ export const useHardwareEventListener = () => {
 
       // Temperature from all GPUs
       setGpuTempMap(
-        Object.fromEntries(
+        liveGpuRecord(
           gpus
             .filter(
               (g): g is typeof g & { gpuTemperature: number } =>
@@ -119,14 +119,14 @@ export const useHardwareEventListener = () => {
       // would jump to another GPU on a transient hiccup.
       setGpuNames((prev) => ({
         ...prev,
-        ...Object.fromEntries(
+        ...liveGpuRecord(
           gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuName]),
         ),
       }));
 
       // Usage sources from all GPUs
       setGpuSources(
-        Object.fromEntries(
+        liveGpuRecord(
           gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuSource]),
         ),
       );
@@ -146,7 +146,7 @@ export const useHardwareEventListener = () => {
 
       // Fan speed from all GPUs
       setGpuFanSpeedMap(
-        Object.fromEntries(
+        liveGpuRecord(
           gpus
             .filter(
               (g): g is typeof g & { gpuCoolerLevel: number } =>

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { Provider, useAtom } from "jotai";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { asLiveGpuId, type LiveGpuId } from "@/features/hardware/gpuIdentity";
 import {
   gpuNamesAtom,
   selectedGpuIdAtom,
@@ -30,6 +31,10 @@ vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
 const wrapper = ({ children }: { children: ReactNode }) => (
   <Provider>{children}</Provider>
 );
+
+/** Seeds mint live ids the way the event listener does at the boundary. */
+const liveMap = (map: Record<string, string>) =>
+  map as unknown as Record<LiveGpuId, string>;
 
 const useHarness = () => {
   useSelectedGpuPersistence();
@@ -70,7 +75,7 @@ describe("useSelectedGpuPersistence", () => {
     mocks.storeValue = "nvapi:12345";
 
     const { result } = renderHook(() => useHarness(), { wrapper });
-    act(() => result.current.setSelected("pci:0:2:0"));
+    act(() => result.current.setSelected(asLiveGpuId("pci:0:2:0")));
 
     expect(mocks.setStored).toHaveBeenCalledWith("pci:0:2:0");
   });
@@ -101,10 +106,12 @@ describe("useSelectedGpuPersistence", () => {
     expect(result.current.selected).toBe("67890");
 
     act(() =>
-      result.current.setNames({
-        "nvapi:1": "NVIDIA GeForce RTX 4080",
-        "pci:0:2:0": "Intel UHD Graphics 770",
-      }),
+      result.current.setNames(
+        liveMap({
+          "nvapi:1": "NVIDIA GeForce RTX 4080",
+          "pci:0:2:0": "Intel UHD Graphics 770",
+        }),
+      ),
     );
 
     expect(result.current.selected).toBe("pci:0:2:0");
@@ -117,7 +124,9 @@ describe("useSelectedGpuPersistence", () => {
 
     const { result } = renderHook(() => useHarness(), { wrapper });
     act(() =>
-      result.current.setNames({ "nvapi:1": "NVIDIA GeForce RTX 4080" }),
+      result.current.setNames(
+        liveMap({ "nvapi:1": "NVIDIA GeForce RTX 4080" }),
+      ),
     );
 
     expect(result.current.selected).toBe("nvapi:absent");
@@ -132,7 +141,9 @@ describe("useSelectedGpuPersistence", () => {
 
     const { result } = renderHook(() => useHarness(), { wrapper });
     act(() =>
-      result.current.setNames({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+      result.current.setNames(
+        liveMap({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+      ),
     );
 
     expect(mocks.init).toHaveBeenCalled();
@@ -144,7 +155,9 @@ describe("useSelectedGpuPersistence", () => {
 
     const { result } = renderHook(() => useHarness(), { wrapper });
     act(() =>
-      result.current.setNames({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+      result.current.setNames(
+        liveMap({ "pci:0:2:0": "Intel UHD Graphics 770" }),
+      ),
     );
 
     expect(mocks.init).not.toHaveBeenCalled();

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,6 +1,6 @@
 import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useRef, useState } from "react";
-import { toLiveGpuId } from "@/features/hardware/gpuIdentity";
+import { asLiveGpuId, toLiveGpuId } from "@/features/hardware/gpuIdentity";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   gpuNamesAtom,
@@ -26,6 +26,9 @@ const STORE_KEY = "selectedGpuId";
  * disk so it applies again when the adapter comes back.
  */
 export const useSelectedGpuPersistence = () => {
+  // Stored as a plain string on disk. Minted as intent on restore: shipped
+  // versions wrote inventory ids into this key, which is exactly what the
+  // migration effect below translates once the stream names the adapter.
   const [storedId, setStoredId, isPending] = useTauriStore<string | null>(
     STORE_KEY,
     null,
@@ -45,7 +48,7 @@ export const useSelectedGpuPersistence = () => {
     if (storedId != null) {
       // Explicit intent outranks the event listener's auto-selection of the
       // first reporting adapter, whichever of the two lands first.
-      setSelectedGpuId(storedId);
+      setSelectedGpuId(asLiveGpuId(storedId));
     }
     setHydrated(true);
   }, [isPending, hydrated, storedId, setSelectedGpuId]);

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { asLiveGpuId, type LiveGpuId } from "@/features/hardware/gpuIdentity";
 import {
   cpuUsageHistoryAtom,
   gpuDedicatedMemoryKbMapAtom,
@@ -11,6 +12,12 @@ import {
   selectedGpuIdAtom,
 } from "@/features/hardware/store/chart";
 import { Performance } from "./Performance";
+
+/** Seeds mint live ids the way the event listener does at the boundary. */
+// biome-ignore format: keep the generic arrow readable
+const liveMap = <T,>(map: Record<string, T>) =>
+  map as unknown as Record<LiveGpuId, T>;
+
 import type {
   PerformanceCustomLayout,
   PerformancePanelColumns,
@@ -195,7 +202,7 @@ describe("Performance", () => {
     // The GPU atoms are rewritten on every sample. A subscription in the
     // Performance parent would rerender the whole screen once a second.
     const store = createStore();
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25] }));
 
     render(
       <Provider store={store}>
@@ -205,7 +212,7 @@ describe("Performance", () => {
 
     const before = { ...state.chartRenders, process: state.processRenders };
 
-    act(() => store.set(gpuUsageHistoriesAtom, { "gpu-1": [25, 40] }));
+    act(() => store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25, 40] })));
 
     expect(state.processRenders).toBe(before.process);
     expect(state.chartRenders.cpu).toBe(before.cpu);
@@ -267,15 +274,21 @@ describe("Performance", () => {
 
   it("shows the temperature for the GPU selected by the usage history", () => {
     const store = createStore();
-    store.set(selectedGpuIdAtom, "gpu-2");
-    store.set(gpuUsageHistoriesAtom, {
-      "gpu-1": [25],
-      "gpu-2": [50],
-    });
-    store.set(gpuTempMapAtom, {
-      "gpu-1": { name: "GPU 1", value: 45 },
-      "gpu-2": { name: "GPU 2", value: 67 },
-    });
+    store.set(selectedGpuIdAtom, asLiveGpuId("gpu-2"));
+    store.set(
+      gpuUsageHistoriesAtom,
+      liveMap({
+        "gpu-1": [25],
+        "gpu-2": [50],
+      }),
+    );
+    store.set(
+      gpuTempMapAtom,
+      liveMap({
+        "gpu-1": { name: "GPU 1", value: 45 },
+        "gpu-2": { name: "GPU 2", value: 67 },
+      }),
+    );
 
     render(
       <Provider store={store}>
@@ -307,14 +320,20 @@ describe("Performance", () => {
     const store = createStore();
     // A selection left over from an adapter that is no longer detected: it
     // appears in no live map and in no detected list, so it cannot be honored.
-    store.set(selectedGpuIdAtom, "removed-gpu");
-    store.set(gpuUsageHistoriesAtom, {
-      "gpu-1": [25],
-    });
-    store.set(gpuTempMapAtom, {
-      "gpu-1": { name: "GPU 1", value: 45 },
-      "gpu-2": { name: "GPU 2", value: 67 },
-    });
+    store.set(selectedGpuIdAtom, asLiveGpuId("removed-gpu"));
+    store.set(
+      gpuUsageHistoriesAtom,
+      liveMap({
+        "gpu-1": [25],
+      }),
+    );
+    store.set(
+      gpuTempMapAtom,
+      liveMap({
+        "gpu-1": { name: "GPU 1", value: 45 },
+        "gpu-2": { name: "GPU 2", value: 67 },
+      }),
+    );
 
     render(
       <Provider store={store}>
@@ -331,8 +350,8 @@ describe("Performance", () => {
   it("names the adapter behind the GPU readings without offering a choice there is none of", () => {
     const store = createStore();
     state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
-    store.set(gpuNamesAtom, { "gpu-1": "NVIDIA GeForce RTX 4080" });
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [42] });
+    store.set(gpuNamesAtom, liveMap({ "gpu-1": "NVIDIA GeForce RTX 4080" }));
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [42] }));
 
     render(
       <Provider store={store}>
@@ -355,9 +374,12 @@ describe("Performance", () => {
       gpuFixture("inventory-a", "NVIDIA GeForce RTX 4090"),
       gpuFixture("inventory-b", "NVIDIA GeForce RTX 4090"),
     ];
-    store.set(gpuNamesAtom, { "nvapi:1": "NVIDIA GeForce RTX 4090" });
-    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [40] });
-    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4 * 1024 * 1024 });
+    store.set(gpuNamesAtom, liveMap({ "nvapi:1": "NVIDIA GeForce RTX 4090" }));
+    store.set(gpuUsageHistoriesAtom, liveMap({ "nvapi:1": [40] }));
+    store.set(
+      gpuDedicatedMemoryKbMapAtom,
+      liveMap({ "nvapi:1": 4 * 1024 * 1024 }),
+    );
 
     render(
       <Provider store={store}>
@@ -373,9 +395,12 @@ describe("Performance", () => {
   it("keeps the VRAM total when exactly one inventory entry matches", () => {
     const store = createStore();
     state.gpus = [gpuFixture("inventory-a", "NVIDIA GeForce RTX 4090")];
-    store.set(gpuNamesAtom, { "nvapi:1": "NVIDIA GeForce RTX 4090" });
-    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [40] });
-    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4 * 1024 * 1024 });
+    store.set(gpuNamesAtom, liveMap({ "nvapi:1": "NVIDIA GeForce RTX 4090" }));
+    store.set(gpuUsageHistoriesAtom, liveMap({ "nvapi:1": [40] }));
+    store.set(
+      gpuDedicatedMemoryKbMapAtom,
+      liveMap({ "nvapi:1": 4 * 1024 * 1024 }),
+    );
 
     render(
       <Provider store={store}>
@@ -394,15 +419,21 @@ describe("Performance", () => {
       gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
-    store.set(gpuNamesAtom, {
-      "gpu-1": "NVIDIA GeForce RTX 4080",
-      "gpu-2": "Intel UHD Graphics 770",
-    });
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
-    store.set(gpuTempMapAtom, {
-      "gpu-1": { name: "GPU 1", value: 45 },
-      "gpu-2": { name: "GPU 2", value: 67 },
-    });
+    store.set(
+      gpuNamesAtom,
+      liveMap({
+        "gpu-1": "NVIDIA GeForce RTX 4080",
+        "gpu-2": "Intel UHD Graphics 770",
+      }),
+    );
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25], "gpu-2": [50] }));
+    store.set(
+      gpuTempMapAtom,
+      liveMap({
+        "gpu-1": { name: "GPU 1", value: 45 },
+        "gpu-2": { name: "GPU 2", value: 67 },
+      }),
+    );
 
     render(
       <Provider store={store}>
@@ -433,14 +464,20 @@ describe("Performance", () => {
       gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
-    store.set(selectedGpuIdAtom, "gpu-2");
+    store.set(selectedGpuIdAtom, asLiveGpuId("gpu-2"));
     // gpu-2 named itself in the stream but reported no values at all.
-    store.set(gpuNamesAtom, {
-      "gpu-1": "NVIDIA GeForce RTX 4080",
-      "gpu-2": "Intel UHD Graphics 770",
-    });
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
-    store.set(gpuTempMapAtom, { "gpu-1": { name: "GPU 1", value: 45 } });
+    store.set(
+      gpuNamesAtom,
+      liveMap({
+        "gpu-1": "NVIDIA GeForce RTX 4080",
+        "gpu-2": "Intel UHD Graphics 770",
+      }),
+    );
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25] }));
+    store.set(
+      gpuTempMapAtom,
+      liveMap({ "gpu-1": { name: "GPU 1", value: 45 } }),
+    );
 
     render(
       <Provider store={store}>
@@ -461,7 +498,7 @@ describe("Performance", () => {
   it("does not call an adapter unavailable before the first sample arrives", () => {
     const store = createStore();
     state.gpus = [gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080")];
-    store.set(gpuNamesAtom, { "gpu-1": "NVIDIA GeForce RTX 4080" });
+    store.set(gpuNamesAtom, liveMap({ "gpu-1": "NVIDIA GeForce RTX 4080" }));
 
     render(
       <Provider store={store}>
@@ -477,12 +514,15 @@ describe("Performance", () => {
   it("says why a Compact row is dashed when its adapter is silent", () => {
     const store = createStore();
     state.view = "compact";
-    store.set(selectedGpuIdAtom, "gpu-2");
-    store.set(gpuNamesAtom, {
-      "gpu-1": "NVIDIA GeForce RTX 4080",
-      "gpu-2": "Intel UHD Graphics 770",
-    });
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25] });
+    store.set(selectedGpuIdAtom, asLiveGpuId("gpu-2"));
+    store.set(
+      gpuNamesAtom,
+      liveMap({
+        "gpu-1": "NVIDIA GeForce RTX 4080",
+        "gpu-2": "Intel UHD Graphics 770",
+      }),
+    );
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25] }));
 
     render(
       <Provider store={store}>
@@ -503,12 +543,15 @@ describe("Performance", () => {
       gpuFixture("gpu-1", "NVIDIA GeForce RTX 4080"),
       gpuFixture("gpu-2", "Intel UHD Graphics 770"),
     ];
-    store.set(selectedGpuIdAtom, "gpu-2");
-    store.set(gpuNamesAtom, {
-      "gpu-1": "NVIDIA GeForce RTX 4080",
-      "gpu-2": "Intel UHD Graphics 770",
-    });
-    store.set(gpuUsageHistoriesAtom, { "gpu-1": [25], "gpu-2": [50] });
+    store.set(selectedGpuIdAtom, asLiveGpuId("gpu-2"));
+    store.set(
+      gpuNamesAtom,
+      liveMap({
+        "gpu-1": "NVIDIA GeForce RTX 4080",
+        "gpu-2": "Intel UHD Graphics 770",
+      }),
+    );
+    store.set(gpuUsageHistoriesAtom, liveMap({ "gpu-1": [25], "gpu-2": [50] }));
 
     render(
       <Provider store={store}>

--- a/src/features/hardware/performance/components/GpuAdapterSelector.tsx
+++ b/src/features/hardware/performance/components/GpuAdapterSelector.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import type { GpuAdapter } from "@/features/hardware/gpuIdentity";
+import type { GpuAdapter, LiveGpuId } from "@/features/hardware/gpuIdentity";
 import { cn } from "@/lib/utils";
 
 /**
@@ -25,8 +25,8 @@ export const GpuAdapterSelector = ({
   className,
 }: {
   adapters: GpuAdapter[];
-  selectedId: string | undefined;
-  onSelect: (gpuId: string) => void;
+  selectedId: LiveGpuId | undefined;
+  onSelect: (gpuId: LiveGpuId) => void;
   className?: string;
 }) => {
   const { t } = useTranslation();

--- a/src/features/hardware/store/chart.test.ts
+++ b/src/features/hardware/store/chart.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from "jotai";
 import { describe, expect, it } from "vitest";
+import { asLiveGpuId, type LiveGpuId } from "@/features/hardware/gpuIdentity";
 import {
   gpuDedicatedMemoryKbAtom,
   gpuDedicatedMemoryKbMapAtom,
@@ -19,19 +20,29 @@ import {
  * label one adapter and graph another.
  */
 describe("derived GPU atoms", () => {
+  /** Seeds mint live ids the way the event listener does at the boundary. */
+  const liveMap = <T>(map: Record<string, T>) =>
+    map as unknown as Record<LiveGpuId, T>;
+
   const withSelection = (selected: string) => {
     const store = createStore();
-    store.set(selectedGpuIdAtom, selected);
-    store.set(gpuNamesAtom, {
-      "nvapi:1": "GeForce RTX 4080",
-      "pci:0:2:0": "UHD Graphics 770",
-    });
-    store.set(gpuUsageHistoriesAtom, { "nvapi:1": [70] });
-    store.set(gpuUsageSourcesAtom, { "nvapi:1": "NVAPI" });
-    store.set(gpuDedicatedMemoryKbMapAtom, { "nvapi:1": 4096 });
-    store.set(gpuTempMapAtom, {
-      "pci:0:2:0": { name: "UHD Graphics 770", value: 48 },
-    });
+    store.set(selectedGpuIdAtom, asLiveGpuId(selected));
+    store.set(
+      gpuNamesAtom,
+      liveMap({
+        "nvapi:1": "GeForce RTX 4080",
+        "pci:0:2:0": "UHD Graphics 770",
+      }),
+    );
+    store.set(gpuUsageHistoriesAtom, liveMap({ "nvapi:1": [70] }));
+    store.set(gpuUsageSourcesAtom, liveMap({ "nvapi:1": "NVAPI" }));
+    store.set(gpuDedicatedMemoryKbMapAtom, liveMap({ "nvapi:1": 4096 }));
+    store.set(
+      gpuTempMapAtom,
+      liveMap({
+        "pci:0:2:0": { name: "UHD Graphics 770", value: 48 },
+      }),
+    );
     return store;
   };
 

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -1,5 +1,8 @@
 import { atom } from "jotai";
-import { getEffectiveGpuId } from "@/features/hardware/gpuIdentity";
+import {
+  getEffectiveGpuId,
+  type LiveGpuId,
+} from "@/features/hardware/gpuIdentity";
 import type {
   MotherboardFanSpeedValues,
   MotherboardTemperatureValues,
@@ -13,7 +16,7 @@ export const memoryUsageHistoryAtom = atom<(number | null)[]>([]);
 // ── Multi-GPU state ──
 
 /** Per-GPU usage histories keyed by gpuId */
-export const gpuUsageHistoriesAtom = atom<Record<string, (number | null)[]>>(
+export const gpuUsageHistoriesAtom = atom<Record<LiveGpuId, (number | null)[]>>(
   {},
 );
 
@@ -27,30 +30,30 @@ export const gpuUsageHistoriesAtom = atom<Record<string, (number | null)[]>>(
  * BDF. So a live id cannot be resolved against the inventory, and every
  * sample carries its own name for exactly that reason.
  */
-export const gpuNamesAtom = atom<Record<string, string>>({});
+export const gpuNamesAtom = atom<Record<LiveGpuId, string>>({});
 
 /** Currently selected GPU ID for dashboard/usage view */
-export const selectedGpuIdAtom = atom<string | null>(null);
+export const selectedGpuIdAtom = atom<LiveGpuId | null>(null);
 
 /** Currently selected storage device id for the Storage Health Display */
 export const selectedStorageDeviceIdAtom = atom<string | null>(null);
 
 /** Per-GPU usage source keyed by gpuId */
-export const gpuUsageSourcesAtom = atom<Record<string, string | null>>({});
+export const gpuUsageSourcesAtom = atom<Record<LiveGpuId, string | null>>({});
 
 /** Per-GPU dedicated memory (KB) keyed by gpuId */
-export const gpuDedicatedMemoryKbMapAtom = atom<Record<string, number | null>>(
-  {},
-);
+export const gpuDedicatedMemoryKbMapAtom = atom<
+  Record<LiveGpuId, number | null>
+>({});
 
 /** Per-GPU temperature keyed by gpuId */
 export const gpuTempMapAtom = atom<
-  Record<string, { name: string; value: number }>
+  Record<LiveGpuId, { name: string; value: number }>
 >({});
 
 /** Per-GPU fan speed keyed by gpuId */
 export const gpuFanSpeedMapAtom = atom<
-  Record<string, { name: string; value: number }>
+  Record<LiveGpuId, { name: string; value: number }>
 >({});
 
 export const cpuTempAtom = atom<NameValues>([]);
@@ -88,7 +91,7 @@ export const gpuFanSpeedAtom = atom<NameValues>((get) =>
  * selection that reports no usage resolves to itself, so the consumers below
  * return nothing rather than borrowing the first adapter's values.
  */
-const effectiveGpuIdAtom = atom<string | undefined>((get) =>
+const effectiveGpuIdAtom = atom<LiveGpuId | undefined>((get) =>
   getEffectiveGpuId(
     get(selectedGpuIdAtom),
     {
@@ -97,7 +100,7 @@ const effectiveGpuIdAtom = atom<string | undefined>((get) =>
       fanSpeeds: get(gpuFanSpeedMapAtom),
       dedicatedMemoryKb: get(gpuDedicatedMemoryKbMapAtom),
     },
-    Object.keys(get(gpuNamesAtom)),
+    Object.keys(get(gpuNamesAtom)) as LiveGpuId[],
   ),
 );
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,48 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 
-// TEMP DIAGNOSTIC for #1960 — remove before commit.
-// Beacons page-visibility / event-arrival / rAF activity to a local collector
-// every 5s, and closes the window after 45s to exercise the real
-// close-to-tray hide path (requires HARDVIZ_CLOSE_TO_BACKGROUND=1).
-(async () => {
-  const { listen } = await import("@tauri-apps/api/event");
-  const { getCurrentWindow } = await import("@tauri-apps/api/window");
-  if (getCurrentWindow().label !== "main") return;
-  let evCount = 0;
-  let rafCount = 0;
-  let timerCount = 0;
-  await listen("hardware-monitor-update", () => {
-    evCount++;
-  });
-  const rafTick = () => {
-    rafCount++;
-    requestAnimationFrame(rafTick);
-  };
-  requestAnimationFrame(rafTick);
-  setInterval(() => {
-    timerCount++;
-  }, 1000);
-  setInterval(() => {
-    void fetch("http://127.0.0.1:9876/beacon", {
-      method: "POST",
-      body: JSON.stringify({
-        t: new Date().toISOString().slice(11, 19),
-        vis: document.visibilityState,
-        ev: evCount,
-        raf: rafCount,
-        timer: timerCount,
-      }),
-    }).catch(() => {});
-    evCount = 0;
-    rafCount = 0;
-    timerCount = 0;
-  }, 5000);
-  setTimeout(() => {
-    void getCurrentWindow().close();
-  }, 45000);
-})();
-
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,48 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 
+// TEMP DIAGNOSTIC for #1960 — remove before commit.
+// Beacons page-visibility / event-arrival / rAF activity to a local collector
+// every 5s, and closes the window after 45s to exercise the real
+// close-to-tray hide path (requires HARDVIZ_CLOSE_TO_BACKGROUND=1).
+(async () => {
+  const { listen } = await import("@tauri-apps/api/event");
+  const { getCurrentWindow } = await import("@tauri-apps/api/window");
+  if (getCurrentWindow().label !== "main") return;
+  let evCount = 0;
+  let rafCount = 0;
+  let timerCount = 0;
+  await listen("hardware-monitor-update", () => {
+    evCount++;
+  });
+  const rafTick = () => {
+    rafCount++;
+    requestAnimationFrame(rafTick);
+  };
+  requestAnimationFrame(rafTick);
+  setInterval(() => {
+    timerCount++;
+  }, 1000);
+  setInterval(() => {
+    void fetch("http://127.0.0.1:9876/beacon", {
+      method: "POST",
+      body: JSON.stringify({
+        t: new Date().toISOString().slice(11, 19),
+        vis: document.visibilityState,
+        ev: evCount,
+        raf: rafCount,
+        timer: timerCount,
+      }),
+    }).catch(() => {});
+    evCount = 0;
+    rafCount = 0;
+    timerCount = 0;
+  }, 5000);
+  setTimeout(() => {
+    void getCurrentWindow().close();
+  }, 45000);
+})();
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Closes #1956. Third layer of the #1944 retrospective: the judgment half went into the `verify-identity-contracts` skill (#1957); this PR is the deterministic half.

## Branded `LiveGpuId` (compile time)

Live ids now carry a branded type, minted only at the two namespace boundaries — the monitor payload (`useHardwareEventListener`) and the restored stored intent (`useSelectedGpuPersistence`). Every live map, `selectedGpuIdAtom`, and the identity helpers are typed with the brand, so the compiler rejects:

- writing an inventory id into the shared selection (`setSelectedGpuId(gpu.id)` — the shipped classic-card bug),
- indexing a live map with a plain or inventory string,
- seeding a live map with unminted keys (tests mint explicitly via `asLiveGpuId`/`liveMap`).

**Deviation from the issue:** no `InventoryGpuId` brand. A plain string already fails every `LiveGpuId` position, and no inventory-keyed map exists for a second brand to protect — it would add friction without catching anything. Reasoning recorded here rather than silently dropped.

**The brand paid for itself during implementation:** it flagged that the classic card's per-GPU VRAM row indexes the live memory map with an inventory id (`gpuDedicatedMemoryKbMap[gpu.id]`), so the usage half of "used / total" could never resolve on real hardware — a shipped bug that eleven review rounds and the full test suite missed. Fixed via the `toLiveGpuId` name join.

## Fixture-realism test (deterministic)

`src/e2e/fixtures/hardware.test.ts` asserts `GPU_FIXTURES` keeps inventory and live ids distinct, unique per namespace, and non-overlapping — the way every platform does (ADR 0016). A future "simplification" re-flattening the namespaces now fails CI instead of silently re-certifying cross-namespace joins.

## Ownership test (deterministic)

`src/features/hardware/gpuIdentityOwnership.test.ts` allowlists the files that may import `selectedGpuIdAtom` (definition, resolution owner, persistence/migration, auto-selection, classic card). A new surface must consume `useGpuAdapters` or the derived atoms instead of re-deriving resolution — the mechanism behind rounds 5–8 of the #1944 review. A companion assertion flags stale allowlist entries so the list cannot rot.

Both guards were verified in the failing direction: a scratch consumer importing the atom fails the ownership test; the fixture test fails if ids are shared.

## Verification

- `tsc --noEmit`, `npm run lint:ci` clean
- 545 unit tests (78 files) and 20 e2e pass
- ADR 0016 records the compile-time enforcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU performance data matching so dedicated-memory usage is not duplicated across similarly named adapters.
  * Preserved GPU selections when restoring saved preferences, including compatibility with existing identifiers.
  * Improved consistency of live GPU monitoring data across usage, temperature, fan-speed, and selection displays.

* **Tests**
  * Added coverage validating separation and uniqueness of GPU identifiers.
  * Updated hardware and performance tests for more reliable GPU data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->