### PR TITLE
perf(db): configure SQLite pool for concurrent access

### DIFF
--- a/core/src/infrastructure/database/db.rs
+++ b/core/src/infrastructure/database/db.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::time::Duration;
 
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
+use sqlx::sqlite::{
+  SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteSynchronous,
+};
 
 /// Process-wide database location. Set once at App startup via [`init`]
 /// (typically `<AppData>/<bundle-id>/hv-database.db`). Core has no way
@@ -48,7 +51,10 @@ async fn open_pool(path: &Path) -> Result<SqlitePool, sqlx::Error> {
   ensure_parent_dir(path).await?;
   let options = SqliteConnectOptions::new()
     .filename(path)
-    .create_if_missing(true);
+    .create_if_missing(true)
+    .journal_mode(SqliteJournalMode::Wal)
+    .busy_timeout(Duration::from_secs(5))
+    .synchronous(SqliteSynchronous::Normal);
   SqlitePool::connect_with(options).await
 }
 
@@ -81,6 +87,32 @@ mod tests {
     pool.close().await;
 
     assert!(db_path.exists());
+  }
+
+  #[tokio::test]
+  async fn open_pool_configures_sqlite_for_concurrent_access() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("hv-database.db");
+
+    let pool = open_pool(&db_path).await.unwrap();
+    let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+    let busy_timeout: i64 = sqlx::query_scalar("PRAGMA busy_timeout")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+    let synchronous: i64 = sqlx::query_scalar("PRAGMA synchronous")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+    pool.close().await;
+
+    assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+    assert_eq!(busy_timeout, 5_000);
+    // SQLite represents NORMAL as the integer value 1.
+    assert_eq!(synchronous, 1);
   }
 
   #[tokio::test]


### PR DESCRIPTION
## Summary

Configure the Core SQLx SQLite pool for concurrent readers and writers.

- Enable WAL journal mode.
- Set a five-second busy timeout.
- Use `synchronous=NORMAL` for the WAL-backed pool.
- Add a regression test that verifies the applied SQLite connection settings.

## Related Issues

Closes #1573

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [ ] Manual testing
- [x] Unit tests (`cargo test -p hardviz-core`)
- [x] `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved SQLite database reliability and responsiveness during concurrent operations.
  * Added safeguards to reduce temporary locking issues and improve write performance.
* **Tests**
  * Added verification that database connection settings are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->