### PR TITLE
docs(agents): bound bot review loops with convergence rules

### DIFF
--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -77,6 +77,38 @@ When changes are made, include:
 - validation commands and results
 - whether GitHub replies/resolution were left untouched
 
+## Convergence
+
+Bot reviewers are generators, not gates: they re-review every push and can
+always produce another finding, so "respond until silent" never terminates.
+The PR #1944-#1958 cycle showed the failure shape — each round's fix became
+the next round's finding, and prose grew conditional structure that outweighed
+the content it guarded. These rules bound the loop:
+
+1. Split findings by evidence class before responding.
+   - Reproducible (code, tests, types, CI): verify by reproducing, and fix
+     only what reproduces. These converge — defects are finite.
+   - Prose and design shape (docs, skills, naming, structure): there is no
+     experiment that proves the bot right, so these do not converge. Fix only
+     a self-contradiction or a factual error against current code; decline
+     the rest with the reasoning stated once.
+
+2. Never restructure in response to bot review. If a finding truly implies a
+   different structure — a type model, a document's architecture, a module
+   boundary — file an issue or put it to the maintainer. Restructuring
+   mid-review is how each round manufactures the next round's findings.
+
+3. Watch for the oscillation signature: a finding that targets text or code
+   added in response to the previous finding. When it appears, stop
+   forward-fixing; prefer reverting the accumulated response-structure to
+   something simpler, or freeze and decline.
+
+4. Stop-loss: after two response rounds on the same PR, stop editing.
+   Summarize the remaining findings as declined-with-evidence or filed
+   issues, resolve the threads, and hand the trade-off to the maintainer.
+   An approval obtained by satisfying a generator is not worth a document
+   shaped by one.
+
 ## Heuristics
 
 - AI approvals and bot overview comments usually do not require code changes.

--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -76,6 +76,8 @@ When changes are made, include:
 - which comments were intentionally ignored and why
 - validation commands and results
 - whether GitHub replies/resolution were left untouched
+- the sufficiency verdict (`SUFFICIENT` / `INSUFFICIENT` / `UNCERTAIN`) with
+  its rationale, anchored on what would concretely break by merging now
 
 ## Convergence
 
@@ -109,13 +111,54 @@ the content it guarded. These rules bound the loop:
    does not reproduce, stop forward-fixing; prefer reverting the accumulated
    response-structure to something simpler, or freeze and decline.
 
-4. Stop-loss: after two response rounds on the same PR, stop editing for
-   subjective findings — a newly verified `Required` defect is still fixed,
+4. Stop-loss: the normal exit from review iteration is a `SUFFICIENT`
+   verdict (next section); this round limit is the backstop for when rounds
+   keep ending without one. After two response rounds on the same PR, stop
+   editing for subjective findings — a newly verified `Required` defect is still fixed,
    in any round. Summarize the remainder as declined-with-evidence or filed
    issues and hand the trade-off to the maintainer; resolve the threads only
    under the same explicit authorization Step 6 requires for any GitHub
    write action. An approval obtained by satisfying a generator is not worth
    a document shaped by one.
+
+## Sufficiency Judgment
+
+Finding discovery, validation, and fixing end with an explicit shippability
+verdict, not with silence. Processing a round's valid findings means deciding
+fix, decline, or file-an-issue for each, with stated reasoning — processing is
+not the same as fixing. After processing, judge the change as a whole:
+
+| Verdict | Meaning |
+| --- | --- |
+| `SUFFICIENT` | the change achieves its purpose; no remaining item justifies blocking the merge |
+| `INSUFFICIENT` | a problem affecting correctness, safety, or the acceptance criteria remains |
+| `UNCERTAIN` | agent-available evidence cannot settle it; a human decides |
+
+Sufficient does not mean zero findings. It means all of:
+
+- the task's purpose and acceptance criteria are met;
+- no credible correctness, security, or regression concern is open;
+- the required verification (CI, tests, guidance checks) passes;
+- no remaining finding has a rational reason to be fixed in this PR rather
+  than declined or filed — additional fixing now costs more than it returns.
+
+Answer these before the verdict:
+
+1. Does the change meet its purpose and acceptance criteria?
+2. Is any credible correctness / security / regression concern open?
+3. Do CI and the required verifications pass?
+4. Does any remaining finding have to land in this PR, rather than an issue?
+5. Is a proposed addition actually a fix — or refactoring, taste, or future
+   work wearing a finding's clothes?
+6. What concretely breaks if this merges now?
+
+Question 6 is the gate that ends loops. "This function could be split
+further" sounds reasonable, but if merging now causes no specific problem for
+the PR's purpose, correctness, safety, or maintainability, the verdict is
+`SUFFICIENT` — however polished the suggestion. On `SUFFICIENT`, end the
+iteration and state the verdict with its rationale. On `INSUFFICIENT`, fix
+and re-judge. On `UNCERTAIN`, put the open question to the maintainer instead
+of iterating further.
 
 ## Heuristics
 

--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -86,28 +86,36 @@ the next round's finding, and prose grew conditional structure that outweighed
 the content it guarded. These rules bound the loop:
 
 1. Split findings by evidence class before responding.
-   - Reproducible (code, tests, types, CI): verify by reproducing, and fix
-     only what reproduces. These converge — defects are finite.
-   - Prose and design shape (docs, skills, naming, structure): there is no
+   - Reproducible: anything a deterministic check can verify — code, tests,
+     types, CI, and also guidance failures such as validator errors, broken
+     links, or invalid frontmatter. Verify by reproducing, and fix what
+     reproduces. These converge — defects are finite.
+   - Subjective (wording, naming, document or design shape): there is no
      experiment that proves the bot right, so these do not converge. Fix only
      a self-contradiction or a factual error against current code; decline
      the rest with the reasoning stated once.
 
-2. Never restructure in response to bot review. If a finding truly implies a
-   different structure — a type model, a document's architecture, a module
-   boundary — file an issue or put it to the maintainer. Restructuring
-   mid-review is how each round manufactures the next round's findings.
+2. Do not restructure in response to a subjective finding. If such a finding
+   implies a different structure — a type model, a document's architecture, a
+   module boundary — file an issue or put it to the maintainer; restructuring
+   mid-review is how each round manufactures the next round's findings. A
+   verified `Required` defect whose necessary fix changes structure is fixed,
+   not deferred — the ban is on reshaping to satisfy taste, never on
+   repairing a reproduced defect.
 
 3. Watch for the oscillation signature: a finding that targets text or code
-   added in response to the previous finding. When it appears, stop
-   forward-fixing; prefer reverting the accumulated response-structure to
-   something simpler, or freeze and decline.
+   added in response to the previous finding. Verify it like any other first —
+   a response can introduce a real regression, and that gets fixed. When it
+   does not reproduce, stop forward-fixing; prefer reverting the accumulated
+   response-structure to something simpler, or freeze and decline.
 
-4. Stop-loss: after two response rounds on the same PR, stop editing.
-   Summarize the remaining findings as declined-with-evidence or filed
-   issues, resolve the threads, and hand the trade-off to the maintainer.
-   An approval obtained by satisfying a generator is not worth a document
-   shaped by one.
+4. Stop-loss: after two response rounds on the same PR, stop editing for
+   subjective findings — a newly verified `Required` defect is still fixed,
+   in any round. Summarize the remainder as declined-with-evidence or filed
+   issues and hand the trade-off to the maintainer; resolve the threads only
+   under the same explicit authorization Step 6 requires for any GitHub
+   write action. An approval obtained by satisfying a generator is not worth
+   a document shaped by one.
 
 ## Heuristics
 

--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -160,6 +160,21 @@ iteration and state the verdict with its rationale. On `INSUFFICIENT`, fix
 and re-judge. On `UNCERTAIN`, put the open question to the maintainer instead
 of iterating further.
 
+## Reviewer Commands
+
+Explicit bot commands shape the loop as much as the responses do:
+
+- Do not use `@coderabbitai review` as a routine step. It triggers a full
+  re-review — a fresh finding-generation run over unchanged code — which is
+  fuel for the loop. Reserve it for a push that genuinely changes direction
+  or scope; otherwise let the per-push incremental review run on its own.
+- After a `SUFFICIENT` verdict, clear a stale `CHANGES_REQUESTED` with
+  `@coderabbitai approve` (with the usual explicit authorization for GitHub
+  writes). It updates the verdict without inviting another full pass, which
+  is exactly what the sufficiency gate calls for. Approval is the outcome of
+  the judgment, never the goal — do not use the command to bypass an
+  `INSUFFICIENT` state.
+
 ## Heuristics
 
 - AI approvals and bot overview comments usually do not require code changes.

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -111,3 +111,4 @@ shared enforcement surface.
 - [Deliver pull requests through review](deliver-pull-requests-through-review.md)
 - [Keep shared system refresh ownership explicit](keep-shared-system-refresh-ownership-explicit.md)
 - [Read id producers before identity UI](read-id-producers-before-identity-ui.md)
+- [Bound bot review loops](bound-bot-review-loops.md)

--- a/docs/agents/lessons/bound-bot-review-loops.md
+++ b/docs/agents/lessons/bound-bot-review-loops.md
@@ -1,0 +1,32 @@
+---
+id: LRN-20260822-bound-bot-review-loops
+status: promoted
+cause_status: confirmed
+scope: responding to AI bot review feedback on any PR
+trigger: "a bot re-review produces new findings after a response push, especially findings about text or code added in the previous response"
+failure_signature: "across PRs #1944-#1958, eleven-plus response rounds each fixed everything the bots raised; several rounds' findings targeted the previous round's fix, and skill prose accumulated conditional structure that outweighed the lesson it carried"
+root_cause: "bot reviewers are generators that always produce another finding, and fixing every finding each round - including unfalsifiable prose findings - manufactures the next round's material; the existing triage skill was also not loaded at all during the cycle"
+guardrail: .agents/skills/gh-ai-review-triage/SKILL.md
+canonical_refs: .agents/skills/gh-ai-review-triage/SKILL.md
+verification: "review responses split findings by evidence class, fix only reproduced defects and self-contradictions, never restructure mid-review, and stop editing after two response rounds"
+evidence: "PR #1944 (11 rounds), #1957 (4 restructures of one skill), #1958; the oscillation narrow-wide-narrow on verify-identity-contracts SKILL.md"
+revalidate_when: "review bots gain a converging notion of sufficiency, or the repository changes its bot-review tooling"
+---
+
+# Bound Bot Review Loops
+
+A bot reviewer re-reviews every push and can always produce another finding,
+so "respond until silent" is not a terminating strategy. Reproducible findings
+(code, tests, types, CI) converge because defects are finite — verify by
+reproducing and fix what reproduces. Prose and design-shape findings do not
+converge, because no experiment can prove the bot right; fix only
+self-contradictions and factual errors, decline the rest once, with reasoning.
+
+The loop signature is a finding that targets the previous response. When it
+appears, stop forward-fixing: revert accumulated response-structure or freeze.
+Never restructure a document, type model, or module boundary in response to
+bot review — file an issue or ask the maintainer.
+
+The [`gh-ai-review-triage`](../../../.agents/skills/gh-ai-review-triage/SKILL.md)
+skill carries the rules (Convergence section). It must actually be loaded when
+responding to bot reviews — the #1944 cycle happened with it sitting unused.

--- a/docs/agents/lessons/bound-bot-review-loops.md
+++ b/docs/agents/lessons/bound-bot-review-loops.md
@@ -8,7 +8,7 @@ failure_signature: "across PRs #1944-#1958, eleven-plus response rounds each fix
 root_cause: "bot reviewers are generators that always produce another finding, and fixing every finding each round - including unfalsifiable prose findings - manufactures the next round's material; the existing triage skill was also not loaded at all during the cycle"
 guardrail: .agents/skills/gh-ai-review-triage/SKILL.md
 canonical_refs: .agents/skills/gh-ai-review-triage/SKILL.md
-verification: "review responses split findings by evidence class, fix reproduced defects in any round, fix only self-contradictions among subjective findings, restructure only for verified defects, and stop subjective editing after two response rounds"
+verification: "review responses split findings by evidence class, process every valid finding as fix, decline, or filed issue with reasoning, and end with an explicit sufficiency verdict anchored on what concretely breaks by merging now"
 evidence: "PR #1944 (11 rounds), #1957 (4 restructures of one skill), #1958; the oscillation narrow-wide-narrow on verify-identity-contracts SKILL.md"
 revalidate_when: "review bots gain a converging notion of sufficiency, or the repository changes its bot-review tooling"
 ---
@@ -31,6 +31,14 @@ response-structure or freeze. Do not restructure a document, type model, or
 module boundary to satisfy a subjective finding — file an issue or ask the
 maintainer; a verified defect that requires structural repair is fixed.
 
+The missing piece was a positive termination condition, not only limits: the
+loop ends when the change is judged shippable, not when findings run out.
+Every valid finding is processed — fixed, declined, or filed, with reasoning —
+and then the change gets a sufficiency verdict (`SUFFICIENT` /
+`INSUFFICIENT` / `UNCERTAIN`) anchored on one question: what concretely
+breaks if this merges now? A finding that cannot answer it does not block,
+however reasonable it sounds.
+
 The [`gh-ai-review-triage`](../../../.agents/skills/gh-ai-review-triage/SKILL.md)
-skill carries the rules (Convergence section). It must actually be loaded when
+skill carries the rules (Convergence and Sufficiency Judgment sections). It must actually be loaded when
 responding to bot reviews — the #1944 cycle happened with it sitting unused.

--- a/docs/agents/lessons/bound-bot-review-loops.md
+++ b/docs/agents/lessons/bound-bot-review-loops.md
@@ -8,7 +8,7 @@ failure_signature: "across PRs #1944-#1958, eleven-plus response rounds each fix
 root_cause: "bot reviewers are generators that always produce another finding, and fixing every finding each round - including unfalsifiable prose findings - manufactures the next round's material; the existing triage skill was also not loaded at all during the cycle"
 guardrail: .agents/skills/gh-ai-review-triage/SKILL.md
 canonical_refs: .agents/skills/gh-ai-review-triage/SKILL.md
-verification: "review responses split findings by evidence class, fix only reproduced defects and self-contradictions, never restructure mid-review, and stop editing after two response rounds"
+verification: "review responses split findings by evidence class, fix reproduced defects in any round, fix only self-contradictions among subjective findings, restructure only for verified defects, and stop subjective editing after two response rounds"
 evidence: "PR #1944 (11 rounds), #1957 (4 restructures of one skill), #1958; the oscillation narrow-wide-narrow on verify-identity-contracts SKILL.md"
 revalidate_when: "review bots gain a converging notion of sufficiency, or the repository changes its bot-review tooling"
 ---
@@ -17,15 +17,19 @@ revalidate_when: "review bots gain a converging notion of sufficiency, or the re
 
 A bot reviewer re-reviews every push and can always produce another finding,
 so "respond until silent" is not a terminating strategy. Reproducible findings
-(code, tests, types, CI) converge because defects are finite — verify by
-reproducing and fix what reproduces. Prose and design-shape findings do not
-converge, because no experiment can prove the bot right; fix only
-self-contradictions and factual errors, decline the rest once, with reasoning.
+— anything a deterministic check can verify: code, tests, types, CI, guidance
+validators — converge because defects are finite; verify by reproducing and
+fix what reproduces, in any round. Subjective findings (wording, naming,
+document or design shape) do not converge, because no experiment can prove
+the bot right; fix only self-contradictions and factual errors, decline the
+rest once, with reasoning.
 
-The loop signature is a finding that targets the previous response. When it
-appears, stop forward-fixing: revert accumulated response-structure or freeze.
-Never restructure a document, type model, or module boundary in response to
-bot review — file an issue or ask the maintainer.
+The loop signature is a finding that targets the previous response. Verify it
+first — a response can introduce a real regression, which gets fixed — and
+when it does not reproduce, stop forward-fixing: revert accumulated
+response-structure or freeze. Do not restructure a document, type model, or
+module boundary to satisfy a subjective finding — file an issue or ask the
+maintainer; a verified defect that requires structural repair is fixed.
 
 The [`gh-ai-review-triage`](../../../.agents/skills/gh-ai-review-triage/SKILL.md)
 skill carries the rules (Convergence section). It must actually be loaded when


### PR DESCRIPTION
Root-cause follow-up to the #1944 → #1957/#1958 review cycle, split into its own PR per maintainer direction.

## Problem

Eleven-plus response rounds across three PRs, because every bot finding was fixed in every round. The two evidence classes behaved differently:

- **Reproducible findings** (code, types, tests, CI) converged — each was verified by reproduction, several were real shipped bugs, and the class exhausted itself.
- **Prose findings** did not converge. One skill document was restructured four times, oscillating narrow → wide → narrow, with several rounds' findings targeting text added in the previous round. The accumulated conditional structure outweighed the lesson it carried.

A second, independent root cause: the repository already had `gh-ai-review-triage` — verify before editing, leave Optional alone, call out incorrect claims and move on — and it sat unused through the whole cycle.

## Change

`gh-ai-review-triage` gains a **Convergence** section with four rules:

1. **Split findings by evidence class.** Fix reproducible findings that reproduce; for prose, fix only self-contradictions and factual errors, decline the rest once with reasoning.
2. **Never restructure in response to bot review.** A finding that implies a different structure becomes an issue or a maintainer question.
3. **The oscillation signature is a stop signal.** A finding targeting the previous response means revert-or-freeze, not forward-fix.
4. **Stop-loss at two response rounds.** Decline the remainder with evidence, resolve, and hand the trade-off to the maintainer.

Lesson `LRN-20260822-bound-bot-review-loops` records the provenance and the unused-skill failure.

`npm run check:agent-guidance` passes (16 lessons, 5 skills on this base).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AI review triage guidance with required sufficiency verdicts: sufficient, insufficient, or uncertain.
  * Added criteria for evaluating acceptance requirements, correctness and security concerns, verification status, remaining findings, and merge impact.
  * Updated review-loop guidance to prioritize evidence-based processing and stop when changes are demonstrably shippable.
  * Clarified handling of valid findings, verified regressions, subjective requests, and unresolved concerns.
  * Added new lessons to the lessons index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->