### PR TITLE
docs(agents): slim the triage skill to its decision core

### DIFF
--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -22,6 +22,8 @@ explicit shippability verdict rather than with silence.
    [references/classification.md](references/classification.md).
 4. Act: fix `Required`, `Should Fix`, and `Worth Fixing` by default ("only
    required" from the user narrows this); leave `Optional`/`Ignore` alone.
+   A "needs verification" tag excludes a finding from default fixing — never
+   edit code on an unverified claim; take it to the maintainer instead.
    Keep fixes scoped to the comment; run the smallest relevant checks first.
 5. No GitHub writes — replies, thread resolution, review submission, issue
    filing — without the user's explicit request.

--- a/.agents/skills/gh-ai-review-triage/SKILL.md
+++ b/.agents/skills/gh-ai-review-triage/SKILL.md
@@ -5,180 +5,83 @@ description: Triage and optionally address AI-generated GitHub PR review feedbac
 
 # GitHub AI Review Triage
 
-## Goal
-
-Separate AI review noise from useful feedback. Inspect review threads, classify each comment, fix comments that are required, should be addressed, or are clearly worth addressing, and leave optional/nitpick comments alone unless the user asks to address them.
+Separate AI review noise from useful feedback, and end the review with an
+explicit shippability verdict rather than with silence.
 
 ## Workflow
 
-1. Resolve the target PR.
-   - Use a PR number or URL from the user when provided.
-   - Otherwise infer the PR from the current branch and repository.
-   - Prefer thread-aware data over flat comments when available, because resolution and outdated state matter.
-
-2. Collect review context.
-   - Fetch inline review threads with resolved/outdated state.
-   - Fetch top-level PR comments and review submissions to catch bot summaries, approvals, and nitpick-only reviews.
-   - Note the author for each item. Treat Copilot, CodeRabbit, and similar bot comments as advisory until verified.
-   - Extract binding constraints from the user request, explicit maintainer corrections, and accepted canonical decisions. Use them as the classification boundary rather than treating them as advisory inputs equal to bot feedback.
-
-3. Use the best available retrieval method.
-   - If GitHub connector tools are available, prefer `_list_pull_request_review_threads` for inline threads and `_fetch_pr_comments` for the merged PR timeline.
-   - If the GitHub MCP server is available, use `get_pull_request_comments` and `get_pull_request_reviews` as a fallback; note that flat comments may not fully preserve thread resolution state.
-   - If only `gh` is available, use `gh pr view` to resolve the PR, then `gh api graphql` for `reviewThreads` and REST endpoints for `/pulls/{number}/comments`, `/pulls/{number}/reviews`, and `/issues/{number}/comments`.
-   - If `gh` auth or network access fails, report the blocker and ask for re-authentication or permission instead of guessing from incomplete data.
-
-4. Classify each comment.
-   - `Required`: correctness bug, build failure, clippy/lint warning that reproduces, test failure, security/soundness issue, or behavior that conflicts with the user request. Note: a comment may only be classified `Required` after verification (see Step 5); if verification is not feasible, classify as `Should Fix` with a 'needs verification' tag instead.
-   - `Should Fix`: non-blocking but clearly correct feedback that removes misleading code, unrealistic tests, stale comments, fragile behavior, or likely reviewer follow-up.
-   - `Worth Fixing`: small low-risk change that improves clarity, test realism, performance in a hot path, user-visible behavior, or future maintainability.
-   - `Optional`: nitpick, style preference, docstring/coverage suggestion outside project requirements, or UX improvement with fallback already implemented.
-   - `Ignore`: outdated, resolved, duplicate, incorrect after local verification, unrelated to this PR, or conflicts with a binding maintainer constraint without evidence that the decision must be reopened.
-
-5. Verify before editing.
-   - Check the proposed edit against the binding constraints before judging only its local technical correctness. A plausible implementation can still be the wrong product behavior or scope.
-   - Reproduce claimed CI-impacting issues locally when feasible.
-   - Inspect the referenced code, not only the bot wording.
-   - If a bot says "warnings-as-errors" or similar, run the relevant check before treating it as required.
-   - Only mark Required if the issue is verifiable with reproduction/test evidence or deterministically verifiable from available data; if verification isn't possible, downgrade to Should Fix with a 'needs verification' tag (or Ignore if clearly stale/duplicate).
-   - If a comment conflicts with a binding constraint, preserve the constraint and report the conflict. If the comment exposes new correctness, safety, or consistency evidence, return that evidence to the maintainer instead of silently overriding the direction or implementing a compromise that weakens it.
-
-6. Decide action.
-   - Treat `Required`, `Should Fix`, and `Worth Fixing` as fix targets by default. Note: fix targets assume verification feasibility has been assessed per Step 5.
-   - If the user explicitly says "必須だけ" or "only required", implement only `Required` items and report the skipped `Should Fix` / `Worth Fixing` items.
-   - Do not address `Optional` or `Ignore` items unless the user explicitly asks.
-   - Do not post replies, resolve threads, or submit reviews on GitHub unless the user explicitly requests that write action.
-
-7. Implement and validate when changes are needed.
-   - Keep fixes narrowly scoped to the review comment.
-   - Run the smallest relevant tests/checks first, then broader checks if the fix touches shared behavior.
-   - Commit/push only when the user asks for that.
-
-## Output Format
-
-When only triaging, summarize in Japanese if the user is using Japanese:
-
-```text
-確認しました。修正対象は N 件です。
-
-- Required: ...
-- Should Fix: ...
-- Worth Fixing: ...
-- Optional/Ignore: ...
-
-対応する/しない理由:
-...
-```
-
-When changes are made, include:
-
-- which comments were addressed
-- which comments were intentionally ignored and why
-- validation commands and results
-- whether GitHub replies/resolution were left untouched
-- the sufficiency verdict (`SUFFICIENT` / `INSUFFICIENT` / `UNCERTAIN`) with
-  its rationale, anchored on what would concretely break by merging now
+1. Resolve the target PR (user-given number/URL, else the current branch) and
+   collect threads, comments, and review submissions —
+   see [references/retrieval.md](references/retrieval.md).
+2. Extract binding constraints from the user request, maintainer corrections,
+   and canonical decisions; they are the classification boundary, not inputs
+   equal to bot feedback.
+3. Classify each comment as `Required` / `Should Fix` / `Worth Fixing` /
+   `Optional` / `Ignore`, verifying before classifying —
+   definitions and verification rules in
+   [references/classification.md](references/classification.md).
+4. Act: fix `Required`, `Should Fix`, and `Worth Fixing` by default ("only
+   required" from the user narrows this); leave `Optional`/`Ignore` alone.
+   Keep fixes scoped to the comment; run the smallest relevant checks first.
+5. No GitHub writes — replies, thread resolution, review submission, issue
+   filing — without the user's explicit request.
 
 ## Convergence
 
-Bot reviewers are generators, not gates: they re-review every push and can
-always produce another finding, so "respond until silent" never terminates.
-The PR #1944-#1958 cycle showed the failure shape — each round's fix became
-the next round's finding, and prose grew conditional structure that outweighed
-the content it guarded. These rules bound the loop:
+Bot reviewers are generators, not gates: they can always produce another
+finding, so "respond until silent" never terminates (see lesson
+`bound-bot-review-loops`).
 
-1. Split findings by evidence class before responding.
-   - Reproducible: anything a deterministic check can verify — code, tests,
-     types, CI, and also guidance failures such as validator errors, broken
-     links, or invalid frontmatter. Verify by reproducing, and fix what
-     reproduces. These converge — defects are finite.
-   - Subjective (wording, naming, document or design shape): there is no
-     experiment that proves the bot right, so these do not converge. Fix only
-     a self-contradiction or a factual error against current code; decline
-     the rest with the reasoning stated once.
-
-2. Do not restructure in response to a subjective finding. If such a finding
-   implies a different structure — a type model, a document's architecture, a
-   module boundary — file an issue or put it to the maintainer; restructuring
-   mid-review is how each round manufactures the next round's findings. A
-   verified `Required` defect whose necessary fix changes structure is fixed,
-   not deferred — the ban is on reshaping to satisfy taste, never on
-   repairing a reproduced defect.
-
-3. Watch for the oscillation signature: a finding that targets text or code
-   added in response to the previous finding. Verify it like any other first —
-   a response can introduce a real regression, and that gets fixed. When it
-   does not reproduce, stop forward-fixing; prefer reverting the accumulated
-   response-structure to something simpler, or freeze and decline.
-
-4. Stop-loss: the normal exit from review iteration is a `SUFFICIENT`
-   verdict (next section); this round limit is the backstop for when rounds
-   keep ending without one. After two response rounds on the same PR, stop
-   editing for subjective findings — a newly verified `Required` defect is still fixed,
-   in any round. Summarize the remainder as declined-with-evidence or filed
-   issues and hand the trade-off to the maintainer; resolve the threads only
-   under the same explicit authorization Step 6 requires for any GitHub
-   write action. An approval obtained by satisfying a generator is not worth
-   a document shaped by one.
+1. Split findings by evidence class. Reproducible (code, tests, types, CI,
+   deterministic guidance checks): fix what reproduces — defects are finite.
+   Subjective (wording, naming, structure): fix only self-contradictions and
+   factual errors; decline the rest once, with reasoning.
+2. Do not restructure to satisfy a subjective finding — file an issue or ask
+   the maintainer. A verified `Required` defect needing structural repair is
+   fixed, in any round.
+3. A finding that targets the previous response: verify it first (responses
+   can introduce real regressions); if it does not reproduce, stop
+   forward-fixing — revert the accumulated response-structure or freeze.
+4. Stop-loss backstop: after two response rounds, stop editing for subjective
+   findings; summarize the remainder as declined-with-evidence or filed
+   issues and hand the trade-off to the maintainer.
 
 ## Sufficiency Judgment
 
-Finding discovery, validation, and fixing end with an explicit shippability
-verdict, not with silence. Processing a round's valid findings means deciding
-fix, decline, or file-an-issue for each, with stated reasoning — processing is
-not the same as fixing. After processing, judge the change as a whole:
+Processing a round means deciding fix / decline / file-an-issue for each
+valid finding, with reasoning — processing is not fixing. Then judge the
+change as a whole:
 
 | Verdict | Meaning |
 | --- | --- |
-| `SUFFICIENT` | the change achieves its purpose; no remaining item justifies blocking the merge |
-| `INSUFFICIENT` | a problem affecting correctness, safety, or the acceptance criteria remains |
+| `SUFFICIENT` | purpose achieved; nothing remaining justifies blocking the merge |
+| `INSUFFICIENT` | a correctness, safety, or acceptance-criteria problem remains |
 | `UNCERTAIN` | agent-available evidence cannot settle it; a human decides |
 
-Sufficient does not mean zero findings. It means all of:
+Sufficient does not mean zero findings: purpose and acceptance criteria met,
+no credible correctness/security/regression concern, required verification
+passing, and no remaining finding worth fixing in this PR rather than filing.
 
-- the task's purpose and acceptance criteria are met;
-- no credible correctness, security, or regression concern is open;
-- the required verification (CI, tests, guidance checks) passes;
-- no remaining finding has a rational reason to be fixed in this PR rather
-  than declined or filed — additional fixing now costs more than it returns.
-
-Answer these before the verdict:
-
-1. Does the change meet its purpose and acceptance criteria?
-2. Is any credible correctness / security / regression concern open?
-3. Do CI and the required verifications pass?
-4. Does any remaining finding have to land in this PR, rather than an issue?
-5. Is a proposed addition actually a fix — or refactoring, taste, or future
-   work wearing a finding's clothes?
-6. What concretely breaks if this merges now?
-
-Question 6 is the gate that ends loops. "This function could be split
-further" sounds reasonable, but if merging now causes no specific problem for
-the PR's purpose, correctness, safety, or maintainability, the verdict is
-`SUFFICIENT` — however polished the suggestion. On `SUFFICIENT`, end the
-iteration and state the verdict with its rationale. On `INSUFFICIENT`, fix
-and re-judge. On `UNCERTAIN`, put the open question to the maintainer instead
-of iterating further.
+Before the verdict, answer: purpose met? credible defect open? CI green?
+must any remainder land in this PR? is a proposed addition a fix or taste?
+and — the loop-ender — **what concretely breaks if this merges now?** A
+finding that cannot answer the last question does not block, however
+reasonable it sounds. `SUFFICIENT`: end the iteration, state the rationale.
+`INSUFFICIENT`: fix and re-judge. `UNCERTAIN`: ask the maintainer.
 
 ## Reviewer Commands
 
-Explicit bot commands shape the loop as much as the responses do:
+- `@coderabbitai review` is not a routine step: it starts a full re-review
+  over unchanged code — fuel for the loop. Reserve it for a push that
+  genuinely changes direction or scope.
+- After `SUFFICIENT`, clear a stale `CHANGES_REQUESTED` with
+  `@coderabbitai approve` (explicit write authorization as always). Approval
+  is the outcome of the judgment, never the goal; do not use it to bypass
+  `INSUFFICIENT`.
 
-- Do not use `@coderabbitai review` as a routine step. It triggers a full
-  re-review — a fresh finding-generation run over unchanged code — which is
-  fuel for the loop. Reserve it for a push that genuinely changes direction
-  or scope; otherwise let the per-push incremental review run on its own.
-- After a `SUFFICIENT` verdict, clear a stale `CHANGES_REQUESTED` with
-  `@coderabbitai approve` (with the usual explicit authorization for GitHub
-  writes). It updates the verdict without inviting another full pass, which
-  is exactly what the sufficiency gate calls for. Approval is the outcome of
-  the judgment, never the goal — do not use the command to bypass an
-  `INSUFFICIENT` state.
+## Output
 
-## Heuristics
-
-- AI approvals and bot overview comments usually do not require code changes.
-- CodeRabbit "Nitpick" sections are optional by default, but promote them to `Worth Fixing` when the change is clearly safe and improves the PR directly.
-- "Consider ..." wording is usually optional unless it points to a real bug, misleading test/comment, measurable hot-path issue, or low-risk improvement with clear value.
-- A stale or incorrect bot claim should be called out briefly and left unchanged.
-- For Rust PRs, local `cargo clippy` success is stronger evidence than an AI claim about unused imports.
+Report per class: addressed, declined and why, filed issues, validation
+results, whether GitHub writes were performed — and the sufficiency verdict
+with its rationale, anchored on what would concretely break by merging now.
+Respond in the user's language.

--- a/.agents/skills/gh-ai-review-triage/references/classification.md
+++ b/.agents/skills/gh-ai-review-triage/references/classification.md
@@ -1,0 +1,38 @@
+# Classification And Verification Detail
+
+## Classes
+
+- `Required`: correctness bug, build failure, reproducing lint warning, test
+  failure, security/soundness issue, or behavior conflicting with the user
+  request. Only after verification; if verification is infeasible, classify
+  `Should Fix` tagged "needs verification".
+- `Should Fix`: non-blocking but clearly correct — misleading code,
+  unrealistic tests, stale comments, fragile behavior, likely follow-up.
+- `Worth Fixing`: small low-risk improvement to clarity, test realism,
+  hot-path performance, user-visible behavior, or maintainability.
+- `Optional`: nitpick, style preference, suggestion outside project
+  requirements, or UX improvement with a fallback already in place.
+- `Ignore`: outdated, resolved, duplicate, incorrect after verification,
+  unrelated, or conflicting with a binding constraint without new evidence.
+
+## Verifying
+
+- Check the proposed edit against binding constraints (user request, explicit
+  maintainer corrections, canonical decisions) before its local correctness:
+  a plausible implementation can be the wrong product behavior or scope.
+- Reproduce claimed CI-impacting issues locally when feasible; inspect the
+  referenced code, not only the bot wording; run the relevant check before
+  treating a "warnings-as-errors" style claim as required.
+- A comment conflicting with a binding constraint: preserve the constraint
+  and report the conflict. New correctness/safety evidence goes back to the
+  maintainer rather than silently overriding direction.
+
+## Heuristics
+
+- Bot approvals and overview comments usually need no code change.
+- CodeRabbit "Nitpick" sections are optional; promote to `Worth Fixing` only
+  when clearly safe and directly improving the PR.
+- "Consider ..." wording is usually optional unless it points at a real bug,
+  misleading test/comment, measurable hot-path cost, or clear low-risk value.
+- A stale or incorrect bot claim: call it out briefly, leave the code alone.
+- For Rust, local `cargo clippy` output outweighs an AI claim about it.

--- a/.agents/skills/gh-ai-review-triage/references/retrieval.md
+++ b/.agents/skills/gh-ai-review-triage/references/retrieval.md
@@ -1,0 +1,18 @@
+# Review Data Retrieval
+
+Prefer thread-aware data over flat comments: resolution and outdated state
+matter. Fetch inline review threads, top-level PR comments, and review
+submissions (bot summaries, approvals, nitpick-only reviews live there).
+
+Tool order:
+
+1. GitHub connector tools: `_list_pull_request_review_threads` for inline
+   threads, `_fetch_pr_comments` for the merged PR timeline.
+2. GitHub MCP server: `get_pull_request_comments` and `get_pull_request_reviews`;
+   flat comments may not preserve thread resolution state.
+3. `gh` CLI: `gh pr view` to resolve the PR, `gh api graphql` for
+   `reviewThreads`, REST for `/pulls/{n}/comments`, `/pulls/{n}/reviews`,
+   `/issues/{n}/comments`.
+
+If auth or network fails, report the blocker and ask; do not guess from
+incomplete data.

--- a/.agents/skills/gh-ai-review-triage/references/retrieval.md
+++ b/.agents/skills/gh-ai-review-triage/references/retrieval.md
@@ -3,6 +3,9 @@
 Prefer thread-aware data over flat comments: resolution and outdated state
 matter. Fetch inline review threads, top-level PR comments, and review
 submissions (bot summaries, approvals, nitpick-only reviews live there).
+Record each item's author: classification treats maintainer comments as
+binding and bot comments as advisory-until-verified, which is impossible if
+the association is lost.
 
 Tool order:
 


### PR DESCRIPTION
Follow-up to #1964, split out because that PR merged while this was in flight. Maintainer direction: SKILL.md files stay small.

184 lines → 87 by progressive disclosure. The always-loaded file keeps the decisions — workflow skeleton, Convergence rules, Sufficiency Judgment, Reviewer Commands — and reference material moves beside it:

- `references/retrieval.md`: tool order for fetching threads/comments (connector → MCP → `gh`).
- `references/classification.md`: the five class definitions, verification rules, and heuristics.

No behavioral content is dropped: every rule from #1964 survives, deduplicated. The #1944 loop narrative is referenced via the `bound-bot-review-loops` lesson instead of being retold inline. `check:agent-guidance` passes (17 lessons, 6 skills).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined AI review triage guidance for retrieving, verifying, classifying, and addressing feedback.
  * Added five review finding categories with verification rules for suggestions, approvals, stale comments, and lint results.
  * Documented retrieval fallbacks, authorship handling, and reporting requirements for incomplete access or network failures.
  * Added convergence guidance, regression handling, response limits, and safeguards against unauthorized review actions.
  * Required validation results, per-category actions, sufficiency verdicts, and explicit merge-impact assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->