### PR TITLE
test: assert classic GPU selector changes usage value

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -20,7 +20,9 @@ test.describe("dashboard captures", () => {
     await seedHardwareHistory(page);
 
     const gpuCard = page.getByTestId("dashboard-gpu-readings");
-    const readingsBefore = await gpuCard.innerText();
+    const usageValue = gpuCard.locator("svg").first().locator("text").first();
+    await expect(usageValue).toBeVisible();
+    const usageBefore = await usageValue.textContent();
 
     const secondaryGpuTab = page.getByRole("tab", {
       name: GPU_FIXTURES[1].name,
@@ -28,11 +30,13 @@ test.describe("dashboard captures", () => {
     await secondaryGpuTab.click();
     await expect(secondaryGpuTab).toHaveAttribute("aria-selected", "true");
 
-    // The pressed state is not the point: the card has to actually describe
-    // the other adapter. The selection is shared with Performance and is
-    // written in the live id namespace, so a card that resolved it by id
-    // alone would keep rendering the first adapter's readings here.
-    await expect.poll(async () => gpuCard.innerText()).not.toBe(readingsBefore);
+    // The pressed state is not the point: the usage gauge has to render the
+    // other adapter's value. The fixtures keep inventory and live ids in
+    // different namespaces, so an inventory id written to the shared
+    // selection would leave the live usage map on GPU #1.
+    await expect
+      .poll(async () => usageValue.textContent())
+      .not.toBe(usageBefore);
 
     await saveCapture(page, "dashboard-gpu-secondary");
   });


### PR DESCRIPTION
## Summary

- Assert that switching the classic Hardware Dashboard GPU selector changes the rendered GPU usage gauge value.
- Scope the assertion to the usage gauge so a changed temperature, card text, or tab state cannot mask a cross-namespace selection regression.
- Keep the existing namespace-split E2E fixtures as the regression setup.

## Related Issues

Fixes #1947

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

The existing dashboard capture flow remains enabled for the test.

## Test Plan

- [x] Focused Playwright test: GPU selector case passed
- [x] Dashboard Playwright spec: 3 passed
- [x] Vitest with coverage: 555 tests passed
- [x] Biome CI check
- [x] Production frontend build

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the dashboard GPU selector test to verify that the usage gauge updates when switching to another GPU.
  * Improved test reliability by checking the gauge value rather than the entire GPU card display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->