### PR TITLE
perf(frontend): stop dashboard polling while the window is hidden

### DIFF
--- a/src/components/shared/ExternalComponentGuidanceDialog.tsx
+++ b/src/components/shared/ExternalComponentGuidanceDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useTauriDialog } from "@/hooks/useTauriDialog";
 import { openURL } from "@/lib/openUrl";
+import { startVisiblePolling } from "@/lib/visiblePolling";
 import type { ExternalComponentGuidanceCandidate } from "@/rspc/bindings";
 import { commands } from "@/rspc/bindings";
 import { isError } from "@/types/result";
@@ -86,12 +87,13 @@ export const ExternalComponentGuidanceDialog = ({
       }
     };
 
-    void loadCandidates();
-    const intervalId = window.setInterval(loadCandidates, 60_000);
+    const stopPolling = startVisiblePolling(() => {
+      void loadCandidates();
+    }, 60_000);
 
     return () => {
       isCancelled = true;
-      window.clearInterval(intervalId);
+      stopPolling();
     };
   }, [settingsLoaded, view]);
 

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -53,6 +53,7 @@ import { useTauriStore } from "@/hooks/useTauriStore";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { formatBytes } from "@/lib/formatter";
 import { cn } from "@/lib/utils";
+import { startVisiblePolling } from "@/lib/visiblePolling";
 import type {
   LiveStorageHealth,
   StorageHealthRecord,
@@ -542,12 +543,11 @@ export const StorageDataInfo = () => {
       setStorageHealthRecords(result.data);
     };
 
-    loadStorageHealthDevices();
-    const intervalId = window.setInterval(loadStorageHealthDevices, 60_000);
+    const stopPolling = startVisiblePolling(loadStorageHealthDevices, 60_000);
 
     return () => {
       isMounted = false;
-      window.clearInterval(intervalId);
+      stopPolling();
     };
   }, [storageHealthEnabled, error, t]);
 
@@ -580,12 +580,11 @@ export const StorageDataInfo = () => {
       setLiveStorageHealth(result.data);
     };
 
-    loadLiveStorageHealth();
-    const intervalId = window.setInterval(loadLiveStorageHealth, 10_000);
+    const stopPolling = startVisiblePolling(loadLiveStorageHealth, 10_000);
 
     return () => {
       isMounted = false;
-      window.clearInterval(intervalId);
+      stopPolling();
     };
   }, [storageHealthEnabled, error, t]);
 

--- a/src/lib/visiblePolling.test.ts
+++ b/src/lib/visiblePolling.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startVisiblePolling } from "@/lib/visiblePolling";
+
+const setDocumentHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+};
+
+const goHidden = () => {
+  setDocumentHidden(true);
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+const goVisible = () => {
+  setDocumentHidden(false);
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+describe("startVisiblePolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setDocumentHidden(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setDocumentHidden(false);
+  });
+
+  it("polls immediately and on the interval while visible", () => {
+    const poll = vi.fn();
+
+    const stop = startVisiblePolling(poll, 10_000);
+
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(20_000);
+    expect(poll).toHaveBeenCalledTimes(3);
+
+    stop();
+  });
+
+  it("stops polling while the document is hidden", () => {
+    const poll = vi.fn();
+
+    const stop = startVisiblePolling(poll, 10_000);
+    poll.mockClear();
+
+    goHidden();
+    vi.advanceTimersByTime(60_000);
+
+    expect(poll).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("refreshes immediately and resumes when the document becomes visible", () => {
+    const poll = vi.fn();
+
+    const stop = startVisiblePolling(poll, 10_000);
+    goHidden();
+    poll.mockClear();
+
+    goVisible();
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    expect(poll).toHaveBeenCalledTimes(2);
+
+    stop();
+  });
+
+  it("does not poll when it starts while already hidden", () => {
+    const poll = vi.fn();
+    setDocumentHidden(true);
+
+    const stop = startVisiblePolling(poll, 10_000);
+
+    expect(poll).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(60_000);
+    expect(poll).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("keeps a single interval when repeated visibility events arrive", () => {
+    const poll = vi.fn();
+
+    const stop = startVisiblePolling(poll, 10_000);
+    poll.mockClear();
+
+    goVisible();
+    goVisible();
+    poll.mockClear();
+
+    vi.advanceTimersByTime(10_000);
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it("stops polling and detaches its listener after stop", () => {
+    const poll = vi.fn();
+
+    const stop = startVisiblePolling(poll, 10_000);
+    stop();
+    poll.mockClear();
+
+    vi.advanceTimersByTime(60_000);
+    goHidden();
+    goVisible();
+    vi.advanceTimersByTime(60_000);
+
+    expect(poll).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/visiblePolling.ts
+++ b/src/lib/visiblePolling.ts
@@ -1,0 +1,58 @@
+/**
+ * Run `poll` while the document is visible and stop while it is hidden.
+ *
+ * `poll` also runs immediately whenever polling starts, so a surface that
+ * becomes visible again shows fresh data instead of the value it was hidden
+ * with.
+ *
+ * The interval is cleared rather than left to the platform: a window hidden to
+ * the tray keeps its WebView resident, and WebKit throttles hidden-page timers
+ * only down to a ~1s floor, which does not slow an interval that is already
+ * longer than that.
+ *
+ * Callers keep owning cancellation of their own in-flight requests.
+ */
+export const startVisiblePolling = (
+  poll: () => void,
+  intervalMs: number,
+): (() => void) => {
+  let intervalId: number | undefined;
+
+  const stopInterval = () => {
+    if (intervalId === undefined) {
+      return;
+    }
+
+    window.clearInterval(intervalId);
+    intervalId = undefined;
+  };
+
+  const startInterval = () => {
+    if (intervalId !== undefined) {
+      return;
+    }
+
+    poll();
+    intervalId = window.setInterval(poll, intervalMs);
+  };
+
+  const handleVisibilityChange = () => {
+    if (document.hidden) {
+      stopInterval();
+      return;
+    }
+
+    startInterval();
+  };
+
+  if (!document.hidden) {
+    startInterval();
+  }
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    stopInterval();
+  };
+};


### PR DESCRIPTION
## Summary

Three `setInterval` timers kept running while the main window was hidden to the tray:

- `StorageDataInfo` — live storage health every **10s**, latest records every **60s**
- `ExternalComponentGuidanceDialog` — guidance candidates every **60s**

A hidden window keeps its WebView resident, so each tick still drove IPC, a `setState`, and table layout/paint for a surface nobody was looking at. WebKit throttles hidden-page timers only down to a ~1s floor, so intervals this long were not slowed at all — the interval has to be cleared.

This routes the three timers through a small `startVisiblePolling` helper that applies the visibility gating `ProcessPollingCoordinator` (`useProcessInfo`) and `useHardwareEventListener` already use: poll while visible, clear the interval while hidden, and refresh immediately on resume so a returning surface does not show the value it was hidden with.

### Why this shape

The same contract was needed at three call sites, so the scheduling lives in one tested helper instead of three copies of the visibility wiring. Each caller keeps owning cancellation of its own in-flight request (`isMounted` / `isCancelled`), so this change does not touch their existing staleness handling.

## Related Issues

Refs #1960

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Test Plan

- [x] Manual testing
- [x] Unit tests

**Unit** — `src/lib/visiblePolling.test.ts` (6 cases): immediate + interval polling while visible, no polling while hidden, immediate refresh and resume on becoming visible, no polling when started already hidden, no duplicate interval on repeated visibility events, and full teardown after stop.

**Frontend integration (mocked Tauri, real component tree)** — same `System Specifications` view, counting `invoke` calls with the document genuinely hidden for 27s:

| | before | after |
|---|---|---|
| mount while hidden | 2 × each storage command | **0** |
| hidden 27s | `get_live_storage_health` × 4 | **0** |
| on becoming visible | — | 1 × each (immediate refresh) |

**Native (macOS, M4, `tauri dev`, window hidden)** — WebContent CPU dropped from 1.5–3.7% (measured on installed v1.9.2 while hidden) to a flat **0.0%**; WebKit.GPU 0.0%. The remaining ~1.3–2.1% on the main process is Core sampling, which continues by design.

Investigation evidence, including the `sample` call stacks that attributed the burn to these timers (`DOMTimer` → JS → `RenderTable` layout/paint), is in #1960.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint:ci`, `npx tsc --noEmit`)
- [x] Tests pass (`npm test` — 77 files, 547 tests)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background updates now pause when the page is hidden and resume automatically when it becomes visible.
  * Storage health information refreshes at appropriate intervals while the dashboard is open.
* **Bug Fixes**
  * Reduced unnecessary background activity when the page is not visible.
* **Tests**
  * Added coverage for polling, visibility changes, duplicate events, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->