### PR TITLE
fix(core): distinguish same-model Intel GPU IDs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,7 +44,13 @@ sqlx = { version = "0.8.6", features = [
 [target.'cfg(windows)'.dependencies]
 wmi = "0.18.4"
 dxgi = "0.1.7"
-winapi = { version = "0.3", features = ["dxgi", "setupapi", "devguid"] }
+winapi = { version = "0.3", features = [
+    "dxgi",
+    "setupapi",
+    "devguid",
+    "devpkey",
+    "devpropdef",
+] }
 windows = { version = "0.62.2", features = [
     "Data_Xml_Dom",
     "Win32_Foundation",

--- a/core/src/infrastructure/providers/windows/directx.rs
+++ b/core/src/infrastructure/providers/windows/directx.rs
@@ -25,9 +25,7 @@ pub async fn get_intel_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
       .into_iter()
       .filter_map(|adapter| {
         let luid = adapter.adapter_luid?;
-        let stable_id = adapter.device_instance_id.unwrap_or_else(|| {
-          format!("pci:{}:{}:{}", adapter.bus, adapter.device, adapter.function)
-        });
+        let stable_id = adapter.device_instance_id?;
         Some((luid, stable_id))
       })
       .collect();

--- a/core/src/infrastructure/providers/windows/directx.rs
+++ b/core/src/infrastructure/providers/windows/directx.rs
@@ -3,6 +3,7 @@ use crate::{log_debug, log_error};
 
 use dxgi::Factory;
 use dxgi::adapter::AdapterDesc;
+use std::collections::HashMap;
 use tokio::task::spawn_blocking;
 
 /// Lightweight LUID info for a GPU adapter, used to match PDH counters.
@@ -10,6 +11,8 @@ pub struct GpuLuidInfo {
   pub name: String,
   pub luid_high: i32,
   pub luid_low: u32,
+  /// PnP identity, when SetupDi can associate it with this DXGI LUID.
+  pub device_instance_id: Option<String>,
 }
 
 /// Get Intel GPU LUID information for matching with PDH performance counters.
@@ -17,6 +20,17 @@ pub async fn get_intel_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
   let handle = spawn_blocking(|| {
     let factory =
       Factory::new().map_err(|e| format!("Failed to create DXGI Factory: {e:?}"))?;
+    let stable_ids: HashMap<(i32, u32), String> = crate::infrastructure::providers::windows::
+      setupdi_provider::enumerate_display_adapters()
+      .into_iter()
+      .filter_map(|adapter| {
+        let luid = adapter.adapter_luid?;
+        let stable_id = adapter.device_instance_id.unwrap_or_else(|| {
+          format!("pci:{}:{}:{}", adapter.bus, adapter.device, adapter.function)
+        });
+        Some((luid, stable_id))
+      })
+      .collect();
     let mut result = Vec::new();
 
     for adapter in factory.adapters() {
@@ -28,6 +42,7 @@ pub async fn get_intel_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
           name: gpu_name.trim_end_matches('\0').to_string(),
           luid_high: luid.HighPart,
           luid_low: luid.LowPart,
+          device_instance_id: stable_ids.get(&(luid.HighPart, luid.LowPart)).cloned(),
         });
       }
     }

--- a/core/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/core/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -171,16 +171,18 @@ unsafe fn read_adapter_luid(
   let mut property_type: DEVPROPTYPE = 0;
   let mut required_size: DWORD = 0;
   let mut value: u64 = 0;
-  let ok = SetupDiGetDevicePropertyW(
-    dev_info,
-    dev_info_data,
-    &DEVPKEY_DEVICE_ADAPTER_LUID,
-    &mut property_type,
-    &mut value as *mut u64 as *mut BYTE,
-    std::mem::size_of::<u64>() as DWORD,
-    &mut required_size,
-    0,
-  );
+  let ok = unsafe {
+    SetupDiGetDevicePropertyW(
+      dev_info,
+      dev_info_data,
+      &DEVPKEY_DEVICE_ADAPTER_LUID,
+      &mut property_type,
+      &mut value as *mut u64 as *mut BYTE,
+      std::mem::size_of::<u64>() as DWORD,
+      &mut required_size,
+      0,
+    )
+  };
   if ok == FALSE
     || property_type & DEVPROP_MASK_TYPE != DEVPROP_TYPE_UINT64
     || required_size < std::mem::size_of::<u64>() as DWORD
@@ -203,25 +205,29 @@ unsafe fn read_device_instance_id(
 
   let mut buffer = vec![0u16; 256];
   let mut required_size: DWORD = 0;
-  if SetupDiGetDeviceInstanceIdW(
-    dev_info,
-    dev_info_data,
-    buffer.as_mut_ptr(),
-    buffer.len() as DWORD,
-    &mut required_size,
-  ) == FALSE
-  {
-    if GetLastError() != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
-      return None;
-    }
-    buffer.resize(required_size as usize, 0);
-    if SetupDiGetDeviceInstanceIdW(
+  if unsafe {
+    SetupDiGetDeviceInstanceIdW(
       dev_info,
       dev_info_data,
       buffer.as_mut_ptr(),
       buffer.len() as DWORD,
       &mut required_size,
-    ) == FALSE
+    )
+  } == FALSE
+  {
+    if unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
+      return None;
+    }
+    buffer.resize(required_size as usize, 0);
+    if unsafe {
+      SetupDiGetDeviceInstanceIdW(
+        dev_info,
+        dev_info_data,
+        buffer.as_mut_ptr(),
+        buffer.len() as DWORD,
+        &mut required_size,
+      )
+    } == FALSE
     {
       return None;
     }

--- a/core/src/infrastructure/providers/windows/setupdi_provider.rs
+++ b/core/src/infrastructure/providers/windows/setupdi_provider.rs
@@ -10,6 +10,24 @@
 ///
 use crate::log_debug;
 
+use winapi::shared::devpropdef::DEVPROPKEY;
+
+winapi::DEFINE_DEVPROPKEY! {
+  DEVPKEY_DEVICE_ADAPTER_LUID,
+  0xc50a3f10,
+  0xaa5c,
+  0x4247,
+  0xb8,
+  0x30,
+  0xd6,
+  0xa6,
+  0xf8,
+  0xea,
+  0xa3,
+  0x10,
+  3
+}
+
 /// PCI Bus/Device/Function together with the Windows device description
 /// (which matches the DXGI adapter name).
 #[derive(Debug, Clone)]
@@ -18,6 +36,10 @@ pub struct DisplayAdapterBdf {
   pub bus: i32,
   pub device: i32,
   pub function: i32,
+  /// DXGI's adapter LUID, used to associate this PnP device with PDH data.
+  pub adapter_luid: Option<(i32, u32)>,
+  /// Reboot-stable identity for this installed adapter.
+  pub device_instance_id: Option<String>,
 }
 
 /// Enumerate all *present* display adapters and return their device
@@ -117,6 +139,8 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
         bus: bus as i32,
         device: device_num,
         function: function_num,
+        adapter_luid: read_adapter_luid(dev_info, &mut dev_info_data),
+        device_instance_id: read_device_instance_id(dev_info, &mut dev_info_data),
       });
     }
 
@@ -130,6 +154,84 @@ pub fn enumerate_display_adapters() -> Vec<DisplayAdapterBdf> {
 
     result
   }
+}
+
+/// Read the DXGI adapter LUID exposed by the display device properties.
+///
+/// This is the bridge between SetupDi's reboot-stable device identity and
+/// DXGI/PDH's process-lifetime adapter handle.
+unsafe fn read_adapter_luid(
+  dev_info: winapi::um::setupapi::HDEVINFO,
+  dev_info_data: &mut winapi::um::setupapi::SP_DEVINFO_DATA,
+) -> Option<(i32, u32)> {
+  use winapi::shared::devpropdef::{DEVPROP_MASK_TYPE, DEVPROP_TYPE_UINT64, DEVPROPTYPE};
+  use winapi::shared::minwindef::{BYTE, DWORD, FALSE};
+  use winapi::um::setupapi::SetupDiGetDevicePropertyW;
+
+  let mut property_type: DEVPROPTYPE = 0;
+  let mut required_size: DWORD = 0;
+  let mut value: u64 = 0;
+  let ok = SetupDiGetDevicePropertyW(
+    dev_info,
+    dev_info_data,
+    &DEVPKEY_DEVICE_ADAPTER_LUID,
+    &mut property_type,
+    &mut value as *mut u64 as *mut BYTE,
+    std::mem::size_of::<u64>() as DWORD,
+    &mut required_size,
+    0,
+  );
+  if ok == FALSE
+    || property_type & DEVPROP_MASK_TYPE != DEVPROP_TYPE_UINT64
+    || required_size < std::mem::size_of::<u64>() as DWORD
+  {
+    return None;
+  }
+
+  Some(((value >> 32) as i32, value as u32))
+}
+
+/// Read the PnP instance id used to persist an adapter across reboots.
+unsafe fn read_device_instance_id(
+  dev_info: winapi::um::setupapi::HDEVINFO,
+  dev_info_data: &mut winapi::um::setupapi::SP_DEVINFO_DATA,
+) -> Option<String> {
+  use winapi::shared::minwindef::{DWORD, FALSE};
+  use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
+  use winapi::um::errhandlingapi::GetLastError;
+  use winapi::um::setupapi::SetupDiGetDeviceInstanceIdW;
+
+  let mut buffer = vec![0u16; 256];
+  let mut required_size: DWORD = 0;
+  if SetupDiGetDeviceInstanceIdW(
+    dev_info,
+    dev_info_data,
+    buffer.as_mut_ptr(),
+    buffer.len() as DWORD,
+    &mut required_size,
+  ) == FALSE
+  {
+    if GetLastError() != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
+      return None;
+    }
+    buffer.resize(required_size as usize, 0);
+    if SetupDiGetDeviceInstanceIdW(
+      dev_info,
+      dev_info_data,
+      buffer.as_mut_ptr(),
+      buffer.len() as DWORD,
+      &mut required_size,
+    ) == FALSE
+    {
+      return None;
+    }
+  }
+
+  let length = buffer
+    .iter()
+    .position(|&value| value == 0)
+    .unwrap_or(buffer.len());
+  Some(String::from_utf16_lossy(&buffer[..length]))
 }
 
 /// Read a REG_SZ registry property from a SetupDi device, dynamically

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -364,40 +364,44 @@ impl ArchiveTracker {
       .chain(self.gpu_dedicated_memory_histories.keys())
       .collect();
 
-    let per_id = gpu_ids
+    // The archive API selects GPU data by display name. Keep one row per
+    // name and interval so distinct live ids cannot interleave into one chart
+    // when two adapters share the same name. Group the raw histories before
+    // calculating aggregates so an adapter with fewer samples does not have
+    // the same weight as an adapter with a full history.
+    let mut ids_by_name: HashMap<String, Vec<&String>> = HashMap::new();
+    for gpu_id in gpu_ids {
+      let gpu_name = self
+        .gpu_name_map
+        .get(gpu_id)
+        .cloned()
+        .unwrap_or_else(|| gpu_id.clone());
+      ids_by_name.entry(gpu_name).or_default().push(gpu_id);
+    }
+
+    ids_by_name
       .into_iter()
-      .map(|gpu_id| {
+      .map(|(gpu_name, ids)| {
         let (usage_avg, usage_max, usage_min) = StatsCalculator::compute_f32_aggregates(
-          self
-            .gpu_usage_histories
-            .get(gpu_id)
-            .map(|h| h.iter().copied())
-            .into_iter()
-            .flatten(),
+          ids
+            .iter()
+            .filter_map(|gpu_id| self.gpu_usage_histories.get(*gpu_id))
+            .flat_map(|history| history.iter().copied()),
         );
         let (temp_avg, temp_max, temp_min) = StatsCalculator::compute_i32_aggregates(
-          self
-            .gpu_temperature_histories
-            .get(gpu_id)
-            .map(|h| h.iter().copied())
-            .into_iter()
-            .flatten(),
+          ids
+            .iter()
+            .filter_map(|gpu_id| self.gpu_temperature_histories.get(*gpu_id))
+            .flat_map(|history| history.iter().copied()),
         );
         let (mem_avg_f32, mem_max, mem_min) = StatsCalculator::compute_i32_aggregates(
-          self
-            .gpu_dedicated_memory_histories
-            .get(gpu_id)
-            .map(|h| h.iter().copied())
-            .into_iter()
-            .flatten(),
+          ids
+            .iter()
+            .filter_map(|gpu_id| self.gpu_dedicated_memory_histories.get(*gpu_id))
+            .flat_map(|history| history.iter().copied()),
         );
-        let gpu_name = self
-          .gpu_name_map
-          .get(gpu_id)
-          .cloned()
-          .unwrap_or_else(|| gpu_id.clone());
         GpuData {
-          gpu_id: Some(gpu_id.clone()),
+          gpu_id: (ids.len() == 1).then(|| ids[0].clone()),
           gpu_name,
           usage_avg,
           usage_max,
@@ -410,19 +414,7 @@ impl ArchiveTracker {
           dedicated_memory_min: mem_min,
         }
       })
-      .collect::<Vec<_>>();
-
-    // The archive API selects GPU data by display name. Keep one row per
-    // name and interval so distinct live ids cannot interleave into one
-    // chart when two adapters share the same name.
-    let mut by_name = HashMap::new();
-    for gpu in per_id {
-      by_name
-        .entry(gpu.gpu_name.clone())
-        .and_modify(|existing: &mut GpuData| merge_gpu_data(existing, &gpu))
-        .or_insert(gpu);
-    }
-    by_name.into_values().collect()
+      .collect()
   }
 
   fn collect_process_stats(&self) -> Vec<ProcessStatData> {
@@ -455,73 +447,6 @@ impl ArchiveTracker {
       .collect();
 
     rank_top_processes(all_stats)
-  }
-}
-
-fn merge_gpu_data(existing: &mut GpuData, incoming: &GpuData) {
-  existing.gpu_id = None;
-  existing.usage_avg = average_optional(existing.usage_avg, incoming.usage_avg);
-  existing.usage_max = max_f32_optional(existing.usage_max, incoming.usage_max);
-  existing.usage_min = min_f32_optional(existing.usage_min, incoming.usage_min);
-  existing.temperature_avg =
-    average_optional(existing.temperature_avg, incoming.temperature_avg);
-  existing.temperature_max =
-    max_optional(existing.temperature_max, incoming.temperature_max);
-  existing.temperature_min =
-    min_optional(existing.temperature_min, incoming.temperature_min);
-  existing.dedicated_memory_avg =
-    average_i32_optional(existing.dedicated_memory_avg, incoming.dedicated_memory_avg);
-  existing.dedicated_memory_max =
-    max_optional(existing.dedicated_memory_max, incoming.dedicated_memory_max);
-  existing.dedicated_memory_min =
-    min_optional(existing.dedicated_memory_min, incoming.dedicated_memory_min);
-}
-
-fn average_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
-  match (left, right) {
-    (Some(left), Some(right)) => Some((left + right) / 2.0),
-    (Some(value), None) | (None, Some(value)) => Some(value),
-    (None, None) => None,
-  }
-}
-
-fn average_i32_optional(left: Option<i32>, right: Option<i32>) -> Option<i32> {
-  average_optional(
-    left.map(|value| value as f32),
-    right.map(|value| value as f32),
-  )
-  .map(|value| value.round() as i32)
-}
-
-fn max_f32_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
-  match (left, right) {
-    (Some(left), Some(right)) => Some(left.max(right)),
-    (Some(value), None) | (None, Some(value)) => Some(value),
-    (None, None) => None,
-  }
-}
-
-fn min_f32_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
-  match (left, right) {
-    (Some(left), Some(right)) => Some(left.min(right)),
-    (Some(value), None) | (None, Some(value)) => Some(value),
-    (None, None) => None,
-  }
-}
-
-fn max_optional<T: Ord>(left: Option<T>, right: Option<T>) -> Option<T> {
-  match (left, right) {
-    (Some(left), Some(right)) => Some(left.max(right)),
-    (Some(value), None) | (None, Some(value)) => Some(value),
-    (None, None) => None,
-  }
-}
-
-fn min_optional<T: Ord>(left: Option<T>, right: Option<T>) -> Option<T> {
-  match (left, right) {
-    (Some(left), Some(right)) => Some(left.min(right)),
-    (Some(value), None) | (None, Some(value)) => Some(value),
-    (None, None) => None,
   }
 }
 
@@ -1007,7 +932,7 @@ mod tests {
   }
 
   #[test]
-  fn collect_gpu_data_aggregates_same_name_ids_for_name_based_archive() {
+  fn collect_gpu_data_aggregates_raw_same_name_histories_for_archive() {
     let mut t = ArchiveTracker::new();
     t.ingest(MetricsSnapshot {
       cpu_usage: 0.0,
@@ -1033,6 +958,27 @@ mod tests {
           gpu_cooler_level: None,
         },
       ],
+      processes: vec![],
+      cpu_temperature: None,
+      sensor_temperatures: vec![],
+      motherboard_temperatures: vec![],
+      motherboard_fan_speeds: vec![],
+      external_component_guidance_candidates: vec![],
+    });
+
+    t.ingest(MetricsSnapshot {
+      cpu_usage: 0.0,
+      memory_usage: 0.0,
+      processors_usage: vec![0.0],
+      gpus: vec![GpuMetric {
+        gpu_id: "pdh:instance:adapter-a".into(),
+        gpu_name: "Intel UHD Graphics".into(),
+        gpu_usage: Some(20.0),
+        gpu_temperature: Some(50.0),
+        gpu_source: "PDH".into(),
+        gpu_dedicated_memory_usage_kb: Some(200.0),
+        gpu_cooler_level: None,
+      }],
       processes: vec![],
       cpu_temperature: None,
       sensor_temperatures: vec![],

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -364,7 +364,7 @@ impl ArchiveTracker {
       .chain(self.gpu_dedicated_memory_histories.keys())
       .collect();
 
-    gpu_ids
+    let per_id = gpu_ids
       .into_iter()
       .map(|gpu_id| {
         let (usage_avg, usage_max, usage_min) = StatsCalculator::compute_f32_aggregates(
@@ -410,7 +410,19 @@ impl ArchiveTracker {
           dedicated_memory_min: mem_min,
         }
       })
-      .collect()
+      .collect::<Vec<_>>();
+
+    // The archive API selects GPU data by display name. Keep one row per
+    // name and interval so distinct live ids cannot interleave into one
+    // chart when two adapters share the same name.
+    let mut by_name = HashMap::new();
+    for gpu in per_id {
+      by_name
+        .entry(gpu.gpu_name.clone())
+        .and_modify(|existing: &mut GpuData| merge_gpu_data(existing, &gpu))
+        .or_insert(gpu);
+    }
+    by_name.into_values().collect()
   }
 
   fn collect_process_stats(&self) -> Vec<ProcessStatData> {
@@ -443,6 +455,73 @@ impl ArchiveTracker {
       .collect();
 
     rank_top_processes(all_stats)
+  }
+}
+
+fn merge_gpu_data(existing: &mut GpuData, incoming: &GpuData) {
+  existing.gpu_id = None;
+  existing.usage_avg = average_optional(existing.usage_avg, incoming.usage_avg);
+  existing.usage_max = max_f32_optional(existing.usage_max, incoming.usage_max);
+  existing.usage_min = min_f32_optional(existing.usage_min, incoming.usage_min);
+  existing.temperature_avg =
+    average_optional(existing.temperature_avg, incoming.temperature_avg);
+  existing.temperature_max =
+    max_optional(existing.temperature_max, incoming.temperature_max);
+  existing.temperature_min =
+    min_optional(existing.temperature_min, incoming.temperature_min);
+  existing.dedicated_memory_avg =
+    average_i32_optional(existing.dedicated_memory_avg, incoming.dedicated_memory_avg);
+  existing.dedicated_memory_max =
+    max_optional(existing.dedicated_memory_max, incoming.dedicated_memory_max);
+  existing.dedicated_memory_min =
+    min_optional(existing.dedicated_memory_min, incoming.dedicated_memory_min);
+}
+
+fn average_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some((left + right) / 2.0),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn average_i32_optional(left: Option<i32>, right: Option<i32>) -> Option<i32> {
+  average_optional(
+    left.map(|value| value as f32),
+    right.map(|value| value as f32),
+  )
+  .map(|value| value.round() as i32)
+}
+
+fn max_f32_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.max(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn min_f32_optional(left: Option<f32>, right: Option<f32>) -> Option<f32> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn max_optional<T: Ord>(left: Option<T>, right: Option<T>) -> Option<T> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.max(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
+  }
+}
+
+fn min_optional<T: Ord>(left: Option<T>, right: Option<T>) -> Option<T> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(left.min(right)),
+    (Some(value), None) | (None, Some(value)) => Some(value),
+    (None, None) => None,
   }
 }
 
@@ -925,6 +1004,52 @@ mod tests {
     assert_eq!(gpus[0].usage_avg, Some(50.0));
     assert_eq!(gpus[0].temperature_max, Some(70));
     assert_eq!(gpus[0].dedicated_memory_min, Some(4096));
+  }
+
+  #[test]
+  fn collect_gpu_data_aggregates_same_name_ids_for_name_based_archive() {
+    let mut t = ArchiveTracker::new();
+    t.ingest(MetricsSnapshot {
+      cpu_usage: 0.0,
+      memory_usage: 0.0,
+      processors_usage: vec![0.0],
+      gpus: vec![
+        GpuMetric {
+          gpu_id: "pdh:instance:adapter-a".into(),
+          gpu_name: "Intel UHD Graphics".into(),
+          gpu_usage: Some(10.0),
+          gpu_temperature: Some(40.0),
+          gpu_source: "PDH".into(),
+          gpu_dedicated_memory_usage_kb: Some(100.0),
+          gpu_cooler_level: None,
+        },
+        GpuMetric {
+          gpu_id: "pdh:instance:adapter-b".into(),
+          gpu_name: "Intel UHD Graphics".into(),
+          gpu_usage: Some(30.0),
+          gpu_temperature: Some(60.0),
+          gpu_source: "PDH".into(),
+          gpu_dedicated_memory_usage_kb: Some(300.0),
+          gpu_cooler_level: None,
+        },
+      ],
+      processes: vec![],
+      cpu_temperature: None,
+      sensor_temperatures: vec![],
+      motherboard_temperatures: vec![],
+      motherboard_fan_speeds: vec![],
+      external_component_guidance_candidates: vec![],
+    });
+
+    let gpus = t.collect_gpu_data();
+    assert_eq!(gpus.len(), 1);
+    assert_eq!(gpus[0].gpu_id, None);
+    assert_eq!(gpus[0].gpu_name, "Intel UHD Graphics");
+    assert_eq!(gpus[0].usage_avg, Some(20.0));
+    assert_eq!(gpus[0].usage_min, Some(10.0));
+    assert_eq!(gpus[0].usage_max, Some(30.0));
+    assert_eq!(gpus[0].temperature_avg, Some(50.0));
+    assert_eq!(gpus[0].dedicated_memory_avg, Some(200));
   }
 
   #[test]

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -279,7 +279,11 @@ async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
     .map(|v| (v * 100.0).round());
 
     gpu_metrics.push(GpuSample {
-      gpu_id: pdh_gpu_id(gpu.luid_high, gpu.luid_low),
+      gpu_id: pdh_gpu_id(
+        gpu.device_instance_id.as_deref(),
+        gpu.luid_high,
+        gpu.luid_low,
+      ),
       name: gpu.name.clone(),
       usage,
       temperature: None,
@@ -294,8 +298,10 @@ async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
 ///
 /// The DXGI LUID identifies the physical adapter independently of its display
 /// name, which is not unique when Windows exposes two same-model adapters.
-fn pdh_gpu_id(luid_high: i32, luid_low: u32) -> String {
-  format!("pdh:{luid_high}:{luid_low}")
+fn pdh_gpu_id(device_instance_id: Option<&str>, luid_high: i32, luid_low: u32) -> String {
+  device_instance_id
+    .map(|id| format!("pdh:instance:{id}"))
+    .unwrap_or_else(|| format!("pdh:{luid_high}:{luid_low}"))
 }
 
 #[cfg(test)]
@@ -338,8 +344,16 @@ mod tests {
   }
 
   #[test]
-  fn pdh_gpu_id_distinguishes_same_name_adapters_by_luid() {
-    assert_eq!(pdh_gpu_id(1, 2), "pdh:1:2");
-    assert_ne!(pdh_gpu_id(1, 2), pdh_gpu_id(3, 4));
+  fn pdh_gpu_id_prefers_reboot_stable_device_identity() {
+    assert_eq!(
+      pdh_gpu_id(Some(r"PCI\VEN_8086&DEV_1234&1"), 1, 2),
+      r"pdh:instance:PCI\VEN_8086&DEV_1234&1"
+    );
+  }
+
+  #[test]
+  fn pdh_gpu_id_falls_back_to_luid_when_device_identity_is_unavailable() {
+    assert_eq!(pdh_gpu_id(None, 1, 2), "pdh:1:2");
+    assert_ne!(pdh_gpu_id(None, 1, 2), pdh_gpu_id(None, 3, 4));
   }
 }

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -279,7 +279,7 @@ async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
     .map(|v| (v * 100.0).round());
 
     gpu_metrics.push(GpuSample {
-      gpu_id: format!("pdh:{}", gpu.name),
+      gpu_id: pdh_gpu_id(gpu.luid_high, gpu.luid_low),
       name: gpu.name.clone(),
       usage,
       temperature: None,
@@ -288,6 +288,14 @@ async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
       source: "PDH".to_string(),
     });
   }
+}
+
+/// Build the live id for an Intel adapter sampled through PDH.
+///
+/// The DXGI LUID identifies the physical adapter independently of its display
+/// name, which is not unique when Windows exposes two same-model adapters.
+fn pdh_gpu_id(luid_high: i32, luid_low: u32) -> String {
+  format!("pdh:{luid_high}:{luid_low}")
 }
 
 #[cfg(test)]
@@ -327,5 +335,11 @@ mod tests {
       resolve_gpu_name_from_bdf_map(&map, "fallback", 9, 0, 0),
       "fallback"
     );
+  }
+
+  #[test]
+  fn pdh_gpu_id_distinguishes_same_name_adapters_by_luid() {
+    assert_eq!(pdh_gpu_id(1, 2), "pdh:1:2");
+    assert_ne!(pdh_gpu_id(1, 2), pdh_gpu_id(3, 4));
   }
 }

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -39,7 +39,8 @@ there is no longer anything to honor.
 
 The `getHardwareInfo` inventory and the monitor stream key their GPUs in
 different namespaces on every platform. Windows NVIDIA reports the raw NVAPI id
-as `GraphicInfo.id` but samples as `nvapi:<id>`; macOS pairs
+as `GraphicInfo.id` but samples as `nvapi:<id>`; Windows Intel PDH samples use
+the DXGI adapter LUID as `pdh:<luid_high>:<luid_low>`; macOS pairs
 `0x<registry_id>` with `iokit:<name>`; Linux pairs `card<n>` with the PCI BDF.
 The two id spaces are disjoint, so they cannot be joined, unioned, or looked up
 across. The frontend enforces this at compile time: live ids carry the branded
@@ -83,8 +84,17 @@ screen, because grouped navigation never mounts the classic card and the
 stored choice would stay inert forever. The migration fetches the inventory
 itself when an id needs translating, since a restart can land on a view
 (Monitor, Compact) that never fetches it; it waits for the first sample
-before deciding, because until then every id looks unresolved. An id that cannot address readings is
-what leaves the card's highlight and the graphs describing different adapters.
+before deciding, because until then every id looks unresolved. Legacy Intel PDH
+ids in the form `pdh:<name>` are migrated at that same app-level boundary only
+when exactly one current PDH entry has that name. If the name is ambiguous, the
+old intent is preserved and the display fallback is used rather than guessing.
+An id that cannot address readings is what leaves the card's highlight and the
+graphs describing different adapters.
+
+The Hardware Archive stores both GPU id and name, but archive queries select by
+name. Changing the live Intel id therefore separates future per-id collection
+and archive rows without requiring a historical id migration or changing name
+based archive retrieval.
 
 Where the join is ambiguous, the caller refuses rather than falls back: the
 classic card claims no adapter identity for a selection it cannot resolve,

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -40,7 +40,10 @@ there is no longer anything to honor.
 The `getHardwareInfo` inventory and the monitor stream key their GPUs in
 different namespaces on every platform. Windows NVIDIA reports the raw NVAPI id
 as `GraphicInfo.id` but samples as `nvapi:<id>`; Windows Intel PDH samples use
-the DXGI adapter LUID as `pdh:<luid_high>:<luid_low>`; macOS pairs
+the reboot-stable PnP device instance id as
+`pdh:instance:<device_instance_id>` when SetupDi can associate it with the
+DXGI adapter LUID, and fall back to `pdh:<luid_high>:<luid_low>` when it
+cannot; macOS pairs
 `0x<registry_id>` with `iokit:<name>`; Linux pairs `card<n>` with the PCI BDF.
 The two id spaces are disjoint, so they cannot be joined, unioned, or looked up
 across. The frontend enforces this at compile time: live ids carry the branded
@@ -91,10 +94,11 @@ old intent is preserved and the display fallback is used rather than guessing.
 An id that cannot address readings is what leaves the card's highlight and the
 graphs describing different adapters.
 
-The Hardware Archive stores both GPU id and name, but archive queries select by
-name. Changing the live Intel id therefore separates future per-id collection
-and archive rows without requiring a historical id migration or changing name
-based archive retrieval.
+The Hardware Archive stores both GPU id and name for distinct live identities,
+but archive queries select by name. When multiple live identities share one
+name, the archive writer aggregates them into one row per name and interval;
+this preserves the existing name-based archive API without interleaving two
+devices into one chart. No historical id migration is required.
 
 Where the join is ambiguous, the caller refuses rather than falls back: the
 classic card claims no adapter identity for a selection it cannot resolve,

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -420,4 +420,16 @@ describe("migrateLegacyPdhGpuId", () => {
       ),
     ).toBeUndefined();
   });
+
+  it("does not rewrite an already current PnP instance id", () => {
+    expect(
+      migrateLegacyPdhGpuId(
+        "pdh:instance:PCI\\VEN_8086&DEV_1234&1",
+        names([
+          "pdh:instance:PCI\\VEN_8086&DEV_1234&1",
+          "Intel(R) UHD Graphics 770",
+        ]),
+      ),
+    ).toBeUndefined();
+  });
 });

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -7,6 +7,7 @@ import {
   hasNoLiveGpuReadings,
   type LiveGpuId,
   listGpuAdapters,
+  migrateLegacyPdhGpuId,
   toLiveGpuId,
 } from "./gpuIdentity";
 
@@ -386,5 +387,37 @@ describe("toLiveGpuId", () => {
         ),
       ),
     ).toBe("a");
+  });
+});
+
+describe("migrateLegacyPdhGpuId", () => {
+  it("migrates a legacy name id when one current PDH adapter matches", () => {
+    expect(
+      migrateLegacyPdhGpuId(
+        "pdh:Intel(R) UHD Graphics 770",
+        names(["pdh:1:2", "Intel(R) UHD Graphics 770"]),
+      ),
+    ).toBe("pdh:1:2");
+  });
+
+  it("refuses to guess when same-name PDH adapters are ambiguous", () => {
+    expect(
+      migrateLegacyPdhGpuId(
+        "pdh:Intel(R) UHD Graphics 770",
+        names(
+          ["pdh:1:2", "Intel(R) UHD Graphics 770"],
+          ["pdh:3:4", "Intel(R) UHD Graphics 770"],
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not rewrite an already current LUID id", () => {
+    expect(
+      migrateLegacyPdhGpuId(
+        "pdh:1:2",
+        names(["pdh:1:2", "Intel(R) UHD Graphics 770"]),
+      ),
+    ).toBeUndefined();
   });
 });

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -275,6 +275,29 @@ export const toLiveGpuId = (
   return matches.length === 1 ? matches[0][0] : asLiveGpuId(gpu.id);
 };
 
+const CURRENT_PDH_GPU_ID = /^pdh:-?\d+:\d+$/;
+
+/**
+ * Translate the pre-LUID Intel PDH id when the current live stream can name
+ * exactly one matching PDH adapter. An old name cannot identify either
+ * adapter when two same-model devices exist, so ambiguity deliberately keeps
+ * the stored intent unresolved instead of guessing.
+ */
+export const migrateLegacyPdhGpuId = (
+  storedGpuId: string,
+  gpuNames: Record<LiveGpuId, string>,
+): LiveGpuId | undefined => {
+  if (!storedGpuId.startsWith("pdh:") || CURRENT_PDH_GPU_ID.test(storedGpuId)) {
+    return undefined;
+  }
+
+  const legacyName = storedGpuId.slice("pdh:".length);
+  const matches = liveEntries(gpuNames).filter(
+    ([id, name]) => CURRENT_PDH_GPU_ID.test(id) && name === legacyName,
+  );
+  return matches.length === 1 ? matches[0][0] : undefined;
+};
+
 /**
  * The GPU both Performance views agree on.
  *

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -275,7 +275,7 @@ export const toLiveGpuId = (
   return matches.length === 1 ? matches[0][0] : asLiveGpuId(gpu.id);
 };
 
-const CURRENT_PDH_GPU_ID = /^pdh:-?\d+:\d+$/;
+const CURRENT_PDH_GPU_ID = /^pdh:(?:instance:.+|-?\d+:\d+)$/;
 
 /**
  * Translate the pre-LUID Intel PDH id when the current live stream can name

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.test.tsx
@@ -133,6 +133,39 @@ describe("useSelectedGpuPersistence", () => {
     expect(mocks.setStored).not.toHaveBeenCalled();
   });
 
+  it("migrates a legacy Intel PDH name id when one current adapter matches", () => {
+    mocks.storeValue = "pdh:Intel(R) UHD Graphics 770";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() =>
+      result.current.setNames(
+        liveMap({ "pdh:1:2": "Intel(R) UHD Graphics 770" }),
+      ),
+    );
+
+    expect(result.current.selected).toBe("pdh:1:2");
+    expect(mocks.setStored).toHaveBeenLastCalledWith("pdh:1:2");
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+
+  it("keeps an ambiguous legacy Intel PDH intent instead of guessing", () => {
+    mocks.storeValue = "pdh:Intel(R) UHD Graphics 770";
+
+    const { result } = renderHook(() => useHarness(), { wrapper });
+    act(() =>
+      result.current.setNames(
+        liveMap({
+          "pdh:1:2": "Intel(R) UHD Graphics 770",
+          "pdh:3:4": "Intel(R) UHD Graphics 770",
+        }),
+      ),
+    );
+
+    expect(result.current.selected).toBe("pdh:Intel(R) UHD Graphics 770");
+    expect(mocks.setStored).not.toHaveBeenCalled();
+    expect(mocks.init).not.toHaveBeenCalled();
+  });
+
   it("fetches the inventory itself when a stored id cannot be resolved", () => {
     // A restart into Monitor or Compact mounts nothing that fetches the
     // inventory, and the migration cannot read what nothing has fetched.

--- a/src/features/hardware/hooks/useSelectedGpuPersistence.ts
+++ b/src/features/hardware/hooks/useSelectedGpuPersistence.ts
@@ -1,6 +1,10 @@
 import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useRef, useState } from "react";
-import { asLiveGpuId, toLiveGpuId } from "@/features/hardware/gpuIdentity";
+import {
+  asLiveGpuId,
+  migrateLegacyPdhGpuId,
+  toLiveGpuId,
+} from "@/features/hardware/gpuIdentity";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   gpuNamesAtom,
@@ -71,6 +75,16 @@ export const useSelectedGpuPersistence = () => {
     // needed.
     if (Object.keys(gpuNames).length === 0) return;
     if (gpuNames[selectedGpuId] != null) return;
+
+    const migratedPdhId = migrateLegacyPdhGpuId(selectedGpuId, gpuNames);
+    if (migratedPdhId != null) {
+      setSelectedGpuId(migratedPdhId);
+      return;
+    }
+    // A PDH id is already in the live namespace. If it is not present, the
+    // inventory cannot resolve it, so preserve the intent without an
+    // unnecessary inventory fetch.
+    if (selectedGpuId.startsWith("pdh:")) return;
 
     // A restart can land on a view that never fetches the inventory (Monitor,
     // Compact), and the migration cannot read what nothing has fetched. Only


### PR DESCRIPTION
## Summary

- Use the DXGI adapter LUID in Windows Intel PDH live GPU ids so same-model adapters remain distinct.
- Migrate legacy name-based PDH selections only when exactly one current adapter matches, preserving ambiguous user intent without guessing.
- Document the live-id and archive-query contract.

## Related Issues

Closes #1948

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Unit tests
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p hardviz-core` (243 unit tests and 2 integration tests passed)
- [x] `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- [x] `tsc --noEmit`
- [x] `biome ci`
- [x] `vitest run --coverage` (78 files, 560 tests passed)
- Windows-specific Rust compilation will be covered by CI; local macOS cross-compilation was blocked in the `ring` dependency because the available C toolchain could not provide `assert.h`.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass
- [x] Tests pass
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Intel GPU identification with reboot-stable adapter identities and reliable fallback handling.
  * Preserved existing GPU selections when a unique matching adapter is found.
  * Safely retains ambiguous selections rather than assigning them incorrectly.
  * Prevented attribution conflicts when adapters share a name.
  * Consolidated historical metrics for adapters sharing the same display name.
* **Documentation**
  * Clarified GPU identification, selection migration, and historical data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->