### PR TITLE
fix(performance): retire GPUs that stop reporting

### DIFF
--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -131,6 +131,20 @@ four. Consulting a subset turns a partially reporting adapter into a silent
 one, which is the same misattribution this decision exists to prevent, one
 level down.
 
+## Per-sample presence and adapter retirement
+
+The event listener treats the current sample as the owner of current readings.
+When a previously named adapter is omitted, its Usage Graph receives a `null`
+gap and its temperature, fan-speed, and dedicated-memory readings are cleared.
+One omission does not prove removal: the name stays in the live adapter list
+through a grace period so a provider hiccup does not make the selector flap.
+
+Three consecutive visible samples without the adapter establish retirement for
+the current live session. The listener then removes its name and live maps, so
+the effective adapter falls back to one that is currently detected. The stored
+selection is not deleted: it remains explicit user intent and applies again if
+the same live id returns.
+
 ## Not measured yet is not unavailable
 
 "This adapter is not reporting live readings" may only be stated once some
@@ -198,6 +212,8 @@ selection; it follows the choice made in Panels.
   validating it against the inventory, which it could never match. A selection
   made for an adapter that is absent at the next launch is kept on disk rather
   than overwritten, so it applies again when the adapter returns.
+- A skipped GPU sample renders a gap instead of freezing the previous reading,
+  and a continuously absent adapter leaves the selector after the grace period.
 
 ### Negative
 
@@ -210,12 +226,10 @@ selection; it follows the choice made in Panels.
 - A GPU that the inventory lists but the monitor stream never reports does not
   appear on Performance at all. It is still on the System Specifications sheet,
   but Performance cannot name a device it has no reading from.
-- The unavailable state only covers an adapter that has never reported. The
-  live maps, including the name map, are append-only, so an adapter that
-  reports and then goes silent keeps its last value on screen and stays in the
-  selector for the rest of the session. Distinguishing a stale reading from a
-  current one, and an unplugged adapter from a skipped sample, needs per-sample
-  presence tracking in the event listener, which this decision does not add.
+- A connected adapter omitted for three consecutive visible samples is treated
+  as retired until it reports again. This keeps unplug feedback prompt, but a
+  provider outage longer than the grace period can temporarily remove a still
+  connected adapter from the live selector.
 
 ### Non-goals
 

--- a/src/features/hardware/dashboard/components/DashboardItems.gpu.test.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.gpu.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { PropsWithChildren } from "react";
+import { expect, it, vi } from "vitest";
+import { asLiveGpuId, liveGpuRecord } from "@/features/hardware/gpuIdentity";
+import {
+  gpuNamesAtom,
+  gpuUsageHistoriesAtom,
+  selectedGpuIdAtom,
+} from "@/features/hardware/store/chart";
+import { GPUInfo } from "./DashboardItems";
+
+const mocks = vi.hoisted(() => ({
+  hardwareInfo: {
+    gpus: [
+      {
+        id: "inventory-a",
+        name: "GPU A",
+        vendorName: "Vendor A",
+        memorySize: "8 GB",
+        memorySizeDedicated: "8 GB",
+        coreCount: null,
+      },
+      {
+        id: "inventory-b",
+        name: "GPU B",
+        vendorName: "Vendor B",
+        memorySize: "4 GB",
+        memorySizeDedicated: "4 GB",
+        coreCount: null,
+      },
+    ],
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => "windows",
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/charts/DoughnutChart", () => ({
+  DoughnutChart: ({
+    chartValue,
+  }: {
+    chartValue: number | null | undefined;
+  }) => <div data-testid="doughnut-chart">{chartValue}</div>,
+}));
+
+vi.mock("@/components/shared/InfoTable", () => ({
+  InfoTable: () => <div data-testid="info-table" />,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: PropsWithChildren) => <>{children}</>,
+  Tooltip: ({ children }: PropsWithChildren) => <>{children}</>,
+  TooltipTrigger: ({ children }: PropsWithChildren) => <>{children}</>,
+  TooltipContent: ({ children }: PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("@/features/hardware/hooks/useHardwareInfoAtom", () => ({
+  useHardwareInfoAtom: () => ({
+    hardwareInfo: mocks.hardwareInfo,
+  }),
+}));
+
+vi.mock("@/hooks/useTauriStore", () => ({
+  useTauriStore: () => [false],
+}));
+
+vi.mock("@/hooks/useWindowSize", () => ({
+  useWindowSize: () => ({
+    isBreak: () => true,
+  }),
+}));
+
+it("shows the effective live fallback while preserving a retired selection", () => {
+  const store = createStore();
+  store.set(selectedGpuIdAtom, asLiveGpuId("nvapi:0"));
+  store.set(gpuNamesAtom, liveGpuRecord([[asLiveGpuId("nvapi:1"), "GPU B"]]));
+  store.set(
+    gpuUsageHistoriesAtom,
+    liveGpuRecord([[asLiveGpuId("nvapi:1"), [70]]]),
+  );
+
+  render(
+    <Provider store={store}>
+      <GPUInfo />
+    </Provider>,
+  );
+
+  expect(screen.getByRole("tab", { name: "GPU A" })).toHaveAttribute(
+    "aria-selected",
+    "false",
+  );
+  expect(screen.getByRole("tab", { name: "GPU B" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  expect(store.get(selectedGpuIdAtom)).toBe("nvapi:0");
+});

--- a/src/features/hardware/dashboard/components/DashboardItems.tsx
+++ b/src/features/hardware/dashboard/components/DashboardItems.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/tooltip";
 import { minOpacity } from "@/consts/style";
 import { findInventoryGpu, toLiveGpuId } from "@/features/hardware/gpuIdentity";
+import { useGpuAdapters } from "@/features/hardware/hooks/useGpuAdapters";
 import { useHardwareInfoAtom } from "@/features/hardware/hooks/useHardwareInfoAtom";
 import {
   cpuTempAtom,
@@ -39,7 +40,6 @@ import {
   motherboardFanSpeedsAtom,
   motherboardTempsAtom,
   processorsUsageHistoryAtom,
-  selectedGpuIdAtom,
   selectedStorageDeviceIdAtom,
   sensorTempsAtom,
 } from "@/features/hardware/store/chart";
@@ -140,7 +140,7 @@ export const GPUInfo = () => {
   const [graphicUsageHistory] = useAtom(graphicUsageHistoryAtom);
   const [gpuTemp] = useAtom(gpuTempAtom);
   const [gpuUsageSource] = useAtom(gpuUsageSourceAtom);
-  const [selectedGpuId, setSelectedGpuId] = useAtom(selectedGpuIdAtom);
+  const { effectiveGpuId, selectedGpuId, selectGpu } = useGpuAdapters();
   const { hardwareInfo } = useHardwareInfoAtom();
   const { isBreak } = useWindowSize();
   const [showGpuUsageSource] = useTauriStore("showGpuUsageSource", false);
@@ -149,18 +149,19 @@ export const GPUInfo = () => {
   const os = useMemo(() => platform(), []);
 
   const gpus = hardwareInfo.gpus ?? [];
-  // The shared selection is written in the live namespace by the Performance
-  // selector and by the event listener's auto-selection, so resolving it by
-  // id alone would silently land on the first inventory entry and pair its
-  // name and badge with another adapter's readings.
-  // With nothing selected yet, the first entry is the honest default. With a
-  // selection that cannot be resolved — two identically named cards, so the
-  // only available join is ambiguous — the card claims no identity at all
-  // rather than labelling one adapter's readings with another's name.
+  // The live resolver owns fallback after a selected adapter is retired. The
+  // stored selection remains untouched, while this surface follows the same
+  // effective adapter as the readings it renders.
+  //
+  // Before the first live sample, an inventory id restored from an older
+  // version can still resolve directly. Ambiguous name joins continue to
+  // refuse identity rather than labelling one adapter with another's values.
   const targetGpu =
-    selectedGpuId == null
-      ? (gpus[0] ?? null)
-      : (findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? null);
+    effectiveGpuId != null
+      ? (findInventoryGpu(gpus, gpuNames, effectiveGpuId) ?? null)
+      : selectedGpuId != null
+        ? (findInventoryGpu(gpus, gpuNames, selectedGpuId) ?? null)
+        : (gpus[0] ?? null);
   const hasMultipleGpus = gpus.length > 1;
 
   const getTargetInfo = (data: NameValues) => {
@@ -197,9 +198,7 @@ export const GPUInfo = () => {
                       role="tab"
                       aria-selected={isSelected}
                       aria-label={gpu.name}
-                      onClick={() =>
-                        setSelectedGpuId(toLiveGpuId(gpu, gpuNames))
-                      }
+                      onClick={() => selectGpu(toLiveGpuId(gpu, gpuNames))}
                       className={cn(
                         "min-w-7 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
                         isSelected

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -217,6 +217,21 @@ describe("getEffectiveGpuId", () => {
     ).toBe("gpu-1");
   });
 
+  it("skips a gapped adapter when falling back to a current reading", () => {
+    expect(
+      getEffectiveGpuId(
+        id("removed"),
+        live({
+          usageHistories: {
+            "gpu-1": [40, null],
+            "gpu-2": [70],
+          },
+        }),
+        [id("gpu-1"), id("gpu-2")],
+      ),
+    ).toBe("gpu-2");
+  });
+
   it("falls back through every map, so a fan-only adapter is still reachable", () => {
     expect(
       getEffectiveGpuId(

--- a/src/features/hardware/gpuIdentity.test.ts
+++ b/src/features/hardware/gpuIdentity.test.ts
@@ -245,6 +245,15 @@ describe("hasNoLiveGpuReadings", () => {
     ).toBe(true);
   });
 
+  it("does not treat an older usage value as a current reading after a gap", () => {
+    expect(
+      hasNoLiveGpuReadings(
+        id("gpu-2"),
+        live({ usageHistories: { "gpu-1": [20], "gpu-2": [40, null] } }),
+      ),
+    ).toBe(true);
+  });
+
   it("counts a temperature-only adapter as reporting", () => {
     expect(
       hasNoLiveGpuReadings(

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -354,5 +354,11 @@ export const hasNoLiveGpuReadings = (
   const sampled =
     detectedGpuIds.length > 0 || maps.some((map) => liveKeys(map).length > 0);
 
-  return sampled && !maps.some((map) => Object.hasOwn(map, gpuId));
+  const hasCurrentReading =
+    live.usageHistories[gpuId]?.at(-1) != null ||
+    live.temperatures[gpuId] != null ||
+    live.fanSpeeds[gpuId] != null ||
+    live.dedicatedMemoryKb[gpuId] != null;
+
+  return sampled && !hasCurrentReading;
 };

--- a/src/features/hardware/gpuIdentity.ts
+++ b/src/features/hardware/gpuIdentity.ts
@@ -80,6 +80,12 @@ const liveMapsInOrder = (live: GpuLiveMaps) => [
   live.dedicatedMemoryKb,
 ];
 
+const hasCurrentGpuReading = (gpuId: LiveGpuId, live: GpuLiveMaps) =>
+  live.usageHistories[gpuId]?.at(-1) != null ||
+  live.temperatures[gpuId] != null ||
+  live.fanSpeeds[gpuId] != null ||
+  live.dedicatedMemoryKb[gpuId] != null;
+
 /**
  * Vendor words that every adapter of a given brand repeats, so they carry no
  * information in a control that exists to tell two adapters apart. Anything
@@ -320,9 +326,10 @@ export const getEffectiveGpuId = (
   }
 
   for (const map of liveMapsInOrder(live)) {
-    const [first] = liveKeys(map);
-    if (first != null) {
-      return first;
+    for (const gpuId of liveKeys(map)) {
+      if (hasCurrentGpuReading(gpuId, live)) {
+        return gpuId;
+      }
     }
   }
   return undefined;
@@ -354,11 +361,5 @@ export const hasNoLiveGpuReadings = (
   const sampled =
     detectedGpuIds.length > 0 || maps.some((map) => liveKeys(map).length > 0);
 
-  const hasCurrentReading =
-    live.usageHistories[gpuId]?.at(-1) != null ||
-    live.temperatures[gpuId] != null ||
-    live.fanSpeeds[gpuId] != null ||
-    live.dedicatedMemoryKb[gpuId] != null;
-
-  return sampled && !hasCurrentReading;
+  return sampled && !hasCurrentGpuReading(gpuId, live);
 };

--- a/src/features/hardware/gpuIdentityOwnership.test.ts
+++ b/src/features/hardware/gpuIdentityOwnership.test.ts
@@ -20,8 +20,6 @@ const ALLOWED_CONSUMERS = new Set([
   "/src/features/hardware/hooks/useSelectedGpuPersistence.ts",
   // Writes the auto-selection when nothing is selected yet.
   "/src/features/hardware/hooks/useHardwareEventListener.ts",
-  // The classic card resolves through findInventoryGpu/toLiveGpuId.
-  "/src/features/hardware/dashboard/components/DashboardItems.tsx",
 ]);
 
 const sources = import.meta.glob("/src/**/*.{ts,tsx}", {

--- a/src/features/hardware/hooks/useGpuAdapters.ts
+++ b/src/features/hardware/hooks/useGpuAdapters.ts
@@ -59,6 +59,7 @@ export const useGpuAdapters = () => {
   return {
     live,
     adapters,
+    selectedGpuId,
     effectiveGpuId,
     effectiveAdapter: adapters.find((adapter) => adapter.id === effectiveGpuId),
     hasNoReadings: hasNoLiveGpuReadings(effectiveGpuId, live, detectedGpuIds),

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -964,6 +964,120 @@ describe("useHardwareEventListener", () => {
       });
     });
 
+    it("marks one omitted sample as unavailable without retiring the adapter", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [histories] = useAtom(gpuUsageHistoriesAtom);
+          const [names] = useAtom(gpuNamesAtom);
+          const [temperatures] = useAtom(gpuTempMapAtom);
+          const [fanSpeeds] = useAtom(gpuFanSpeedMapAtom);
+          const [memory] = useAtom(gpuDedicatedMemoryKbMapAtom);
+          return { histories, names, temperatures, fanSpeeds, memory };
+        },
+        { wrapper: Provider },
+      );
+
+      act(() => {
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({
+                gpuId: "nvapi:0",
+                gpuName: "GPU A",
+                gpuUsage: 40,
+                gpuTemperature: 60,
+                gpuCoolerLevel: 50,
+                gpuDedicatedMemoryUsageKb: 2048,
+              }),
+              makeGpu({ gpuId: "nvapi:1", gpuName: "GPU B" }),
+            ],
+          }),
+        );
+        emit(
+          makePayload({
+            gpus: [makeGpu({ gpuId: "nvapi:1", gpuName: "GPU B" })],
+          }),
+        );
+      });
+
+      expect(result.current.names[asLiveGpuId("nvapi:0")]).toBe("GPU A");
+      expect(
+        result.current.histories[asLiveGpuId("nvapi:0")].at(-1),
+      ).toBeNull();
+      expect(result.current.temperatures).not.toHaveProperty("nvapi:0");
+      expect(result.current.fanSpeeds).not.toHaveProperty("nvapi:0");
+      expect(result.current.memory).not.toHaveProperty("nvapi:0");
+    });
+
+    it("retires an adapter after three omitted samples and falls back without deleting intent", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [histories] = useAtom(gpuUsageHistoriesAtom);
+          const [names] = useAtom(gpuNamesAtom);
+          const [selectedGpuId] = useAtom(selectedGpuIdAtom);
+          const [effectiveHistory] = useAtom(graphicUsageHistoryAtom);
+          return { histories, names, selectedGpuId, effectiveHistory };
+        },
+        { wrapper: Provider },
+      );
+
+      act(() => {
+        emit(
+          makePayload({
+            gpus: [
+              makeGpu({ gpuId: "nvapi:0", gpuName: "GPU A", gpuUsage: 40 }),
+              makeGpu({ gpuId: "nvapi:1", gpuName: "GPU B", gpuUsage: 70 }),
+            ],
+          }),
+        );
+        for (let missed = 0; missed < 3; missed += 1) {
+          emit(
+            makePayload({
+              gpus: [
+                makeGpu({
+                  gpuId: "nvapi:1",
+                  gpuName: "GPU B",
+                  gpuUsage: 70 + missed,
+                }),
+              ],
+            }),
+          );
+        }
+      });
+
+      expect(result.current.names).not.toHaveProperty("nvapi:0");
+      expect(result.current.histories).not.toHaveProperty("nvapi:0");
+      expect(result.current.selectedGpuId).toBe("nvapi:0");
+      expect(result.current.effectiveHistory.at(-1)).toBe(72);
+    });
+
+    it("resets the retirement grace period when an adapter reports again", () => {
+      const { result } = renderHook(
+        () => {
+          useHardwareEventListener();
+          const [names] = useAtom(gpuNamesAtom);
+          return names;
+        },
+        { wrapper: Provider },
+      );
+
+      const gpuA = makeGpu({ gpuId: "nvapi:0", gpuName: "GPU A" });
+      const gpuB = makeGpu({ gpuId: "nvapi:1", gpuName: "GPU B" });
+
+      act(() => {
+        emit(makePayload({ gpus: [gpuA, gpuB] }));
+        emit(makePayload({ gpus: [gpuB] }));
+        emit(makePayload({ gpus: [gpuB] }));
+        emit(makePayload({ gpus: [gpuA, gpuB] }));
+        emit(makePayload({ gpus: [gpuB] }));
+        emit(makePayload({ gpus: [gpuB] }));
+      });
+
+      expect(result.current[asLiveGpuId("nvapi:0")]).toBe("GPU A");
+    });
+
     it("tracks usage sources for all GPUs", () => {
       const { result } = renderHook(
         () => {

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -1,7 +1,11 @@
 import { useSetAtom } from "jotai";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { chartConfig } from "@/features/hardware/consts/chart";
-import { asLiveGpuId, liveGpuRecord } from "@/features/hardware/gpuIdentity";
+import {
+  asLiveGpuId,
+  type LiveGpuId,
+  liveGpuRecord,
+} from "@/features/hardware/gpuIdentity";
 import {
   cpuTempAtom,
   cpuUsageHistoryAtom,
@@ -27,11 +31,17 @@ const padHistory = (arr: (number | null)[]): (number | null)[] => {
   return padded.slice(-chartConfig.historyLengthSec);
 };
 
+// One omitted sample can be a provider hiccup. Three consecutive visible
+// samples establish that the adapter is no longer part of the live set while
+// keeping unplug/fallback feedback within a few seconds at the 1 Hz cadence.
+const GPU_RETIREMENT_MISSED_SAMPLES = 3;
+
 /**
  * Listen for hardware monitor update events pushed from the backend.
  * Replaces the 4x useUsageUpdater polling hooks with a single event listener.
  */
 export const useHardwareEventListener = () => {
+  const gpuMissedSamples = useRef(new Map<LiveGpuId, number>());
   const setCpuHistory = useSetAtom(cpuUsageHistoryAtom);
   const setMemoryHistory = useSetAtom(memoryUsageHistoryAtom);
   const setGpuHistories = useSetAtom(gpuUsageHistoriesAtom);
@@ -64,6 +74,30 @@ export const useHardwareEventListener = () => {
         motherboardFanSpeeds,
       } = event.payload;
 
+      const currentGpuIds = gpus.map((gpu) => asLiveGpuId(gpu.gpuId));
+      const currentGpuIdSet = new Set(currentGpuIds);
+      const retiredGpuIds = new Set<LiveGpuId>();
+
+      for (const gpuId of currentGpuIds) {
+        gpuMissedSamples.current.set(gpuId, 0);
+      }
+      for (const [gpuId, missedSamples] of gpuMissedSamples.current) {
+        if (currentGpuIdSet.has(gpuId)) {
+          continue;
+        }
+
+        const nextMissedSamples = missedSamples + 1;
+        if (nextMissedSamples >= GPU_RETIREMENT_MISSED_SAMPLES) {
+          retiredGpuIds.add(gpuId);
+          gpuMissedSamples.current.delete(gpuId);
+        } else {
+          gpuMissedSamples.current.set(gpuId, nextMissedSamples);
+        }
+      }
+      const absentGpuIds = [...gpuMissedSamples.current.keys()].filter(
+        (gpuId) => !currentGpuIdSet.has(gpuId),
+      );
+
       setCpuHistory((prev) => padHistory([...prev, cpuUsage]));
       setMemoryHistory((prev) => padHistory([...prev, memoryUsage]));
 
@@ -78,22 +112,32 @@ export const useHardwareEventListener = () => {
       setMotherboardFanSpeeds(motherboardFanSpeeds);
 
       // Per-GPU usage histories
-      setGpuHistories((prev) =>
-        gpus.reduce(
-          (acc, gpu) => {
-            // The monitor-payload boundary: ids from the stream are branded
-            // here. The other minting sites are the restored stored intent in
-            // `useSelectedGpuPersistence` and the unresolved fallback in
-            // `toLiveGpuId`; nothing else may mint.
-            const gpuId = asLiveGpuId(gpu.gpuId);
-            if (gpu.gpuUsage != null) {
-              acc[gpuId] = padHistory([...(acc[gpuId] ?? []), gpu.gpuUsage]);
-            }
-            return acc;
-          },
-          { ...prev },
-        ),
-      );
+      setGpuHistories((prev) => {
+        const next = { ...prev };
+
+        for (const gpuId of retiredGpuIds) {
+          delete next[gpuId];
+        }
+        for (const gpuId of absentGpuIds) {
+          const history = next[gpuId];
+          if (history != null) {
+            next[gpuId] = padHistory([...history, null]);
+          }
+        }
+        for (const gpu of gpus) {
+          // The monitor-payload boundary: ids from the stream are branded
+          // here. The other minting sites are the restored stored intent in
+          // `useSelectedGpuPersistence` and the unresolved fallback in
+          // `toLiveGpuId`; nothing else may mint.
+          const gpuId = asLiveGpuId(gpu.gpuId);
+          const history = next[gpuId];
+          if (gpu.gpuUsage != null || history != null) {
+            next[gpuId] = padHistory([...(history ?? []), gpu.gpuUsage]);
+          }
+        }
+
+        return next;
+      });
 
       // Temperature from all GPUs
       setGpuTempMap(
@@ -117,12 +161,18 @@ export const useHardwareEventListener = () => {
       // provider that drops one adapter from a single sample must not erase
       // the only record that the adapter exists, or the Performance selector
       // would jump to another GPU on a transient hiccup.
-      setGpuNames((prev) => ({
-        ...prev,
-        ...liveGpuRecord(
-          gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuName]),
-        ),
-      }));
+      setGpuNames((prev) => {
+        const next = {
+          ...prev,
+          ...liveGpuRecord(
+            gpus.map((gpu) => [asLiveGpuId(gpu.gpuId), gpu.gpuName]),
+          ),
+        };
+        for (const gpuId of retiredGpuIds) {
+          delete next[gpuId];
+        }
+        return next;
+      });
 
       // Usage sources from all GPUs
       setGpuSources(
@@ -131,16 +181,19 @@ export const useHardwareEventListener = () => {
         ),
       );
 
-      // Dedicated memory from all GPUs (only update when not null)
-      setGpuMemoryMap((prev) =>
-        gpus.reduce(
-          (acc, gpu) => {
-            if (gpu.gpuDedicatedMemoryUsageKb != null) {
-              acc[asLiveGpuId(gpu.gpuId)] = gpu.gpuDedicatedMemoryUsageKb;
-            }
-            return acc;
-          },
-          { ...prev },
+      // Dedicated memory is a per-sample reading. Replacing the map clears a
+      // value when the adapter or the metric is absent instead of freezing it.
+      setGpuMemoryMap(
+        liveGpuRecord(
+          gpus
+            .filter(
+              (g): g is typeof g & { gpuDedicatedMemoryUsageKb: number } =>
+                g.gpuDedicatedMemoryUsageKb != null,
+            )
+            .map((gpu) => [
+              asLiveGpuId(gpu.gpuId),
+              gpu.gpuDedicatedMemoryUsageKb,
+            ]),
         ),
       );
 


### PR DESCRIPTION
## Summary

- append a `null` Usage Graph gap and clear current GPU metrics when an adapter is omitted from a sample
- keep the adapter selectable through a three-sample grace period, then retire it from live maps so the UI falls back
- preserve the stored selected GPU id so the explicit choice applies again if the adapter reconnects
- update ADR 0016 to record the per-sample presence and retirement policy

## Related Issues

Closes #1945

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable. This changes live data state transitions without changing layout or styling.

## Test Plan

- [ ] Manual testing
- [x] Unit tests
- [x] `npm test` (79 files, 571 tests)
- [x] `npm run lint:ci`
- [x] `npm run build`
- [x] `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GPU performance data now accurately reflects missing readings instead of displaying stale values.
  * Temporary GPU data gaps are shown clearly, while adapters that return within the grace period become available again.
  * GPUs missing from several consecutive updates are removed from active monitoring, with selections preserved for possible restoration.
  * Dedicated-memory, temperature, fan-speed, and usage data now clear correctly when unavailable.
  * The dashboard automatically falls back to an available GPU when the selected adapter is no longer active.
* **Documentation**
  * Updated performance-screen behavior documentation to describe GPU gaps, restoration, and retirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->