### PR TITLE
perf: suspend hidden Windows webviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,9 +1916,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "webview2-com",
  "winapi",
  "window-vibrancy",
  "windows 0.62.2",
+ "windows-core 0.61.2",
  "wmi",
 ]
 

--- a/docs/adr/0017-suspend-hidden-windows-webviews.md
+++ b/docs/adr/0017-suspend-hidden-windows-webviews.md
@@ -50,8 +50,9 @@ window lifecycle.
 
 ## Consequences
 
-- The measured Windows tray-resident process tree stays intact while its stable
-  Private Working Set falls by 78.9% in the tested environment.
+- The final production validation kept the Windows tray-resident process tree
+  intact while its stable Private Working Set fell from 173.7 MiB to 31.9 MiB
+  (81.6%) in the tested environment.
 - Hidden WebView scripts, timers, and animations stop without stopping Core
   collection, the native tray, Hardware Archive, or other background behavior.
 - Showing either window now has a platform lifecycle transition before WebView

--- a/docs/adr/0017-suspend-hidden-windows-webviews.md
+++ b/docs/adr/0017-suspend-hidden-windows-webviews.md
@@ -1,0 +1,64 @@
+# Suspend Hidden Windows WebViews
+
+Status: accepted
+
+Close to Tray keeps HardwareVisualizer's monitoring and tray behavior running
+after the main window is hidden. On Windows, that also kept both the main
+WebView and the pre-created Tray Widget flyout resident. A real-hardware
+experiment for [#1962](https://github.com/shm11C3/HardwareVisualizer/issues/1962)
+measured the hidden process tree at 173.7 MiB Private Working Set and 602.9 MiB
+total Working Set after the initial transition settled.
+
+WebView2 offers two best-effort memory controls for an inactive WebView. A low
+memory-usage target reduced the measured tree Private Working Set to 64.6 MiB,
+but it allows scripts and timers to keep running. Suspending both WebViews
+reduced it to 36.6 MiB and pauses their script timers and animations. Microsoft
+documents these controls as alternatives, so they are not combined.
+
+## Decision
+
+On Windows, the App lifecycle suspends the main WebView when Close to Tray hides
+it and suspends the pre-created Tray Widget flyout whenever that window hides.
+It resumes each WebView before the containing window is shown again.
+
+The lifecycle must set the WebView2 controller's `IsVisible` property to
+`false` before `TrySuspend`. Hiding the containing Tauri window did not update
+that controller property in the tested runtime, and WebView2 rejected the
+suspend request with `ERROR_INVALID_STATE` until the controller was hidden
+explicitly. Restore reverses that controller state before showing the native
+window. Suspension remains best-effort: a failure is logged but must not change
+the user's Close to Tray choice or stop Core and tray background work.
+
+App-to-WebView updates are not emitted to the hidden flyout because such API
+calls can resume a suspended WebView implicitly. The App retains the latest
+Tray Widget frame and emits it after resume when the flyout is opened.
+
+This is an App-owned Windows lifecycle policy. It does not add a Core state,
+user setting, or frontend responsibility. Other platforms keep their current
+window lifecycle.
+
+## Alternatives
+
+- **Keep hiding only.** Rejected because it preserves the measured WebView
+  memory cost and lets missed frontend visibility gates run hidden work.
+- **Use the low memory-usage target.** Rejected because it reclaimed less
+  memory in the gate experiment and deliberately leaves scripts running.
+- **Destroy and recreate both WebViews.** Deferred because suspension already
+  meets the issue's under-200-MiB target without state restoration, ready
+  handshakes, or reopen-latency risk. This preserves the hide-over-destroy
+  trade-off chosen in #1408.
+
+## Consequences
+
+- The measured Windows tray-resident process tree stays intact while its stable
+  Private Working Set falls by 78.9% in the tested environment.
+- Hidden WebView scripts, timers, and animations stop without stopping Core
+  collection, the native tray, Hardware Archive, or other background behavior.
+- Showing either window now has a platform lifecycle transition before WebView
+  interaction and must preserve acceptable reopen latency.
+- The App directly depends on the WebView2 COM interface version used by wry;
+  that compatibility must be revalidated when either dependency changes.
+- WebView2 suspension is best-effort and runtime-dependent, so native Windows
+  logs and real-window restore checks remain the evidence for this boundary.
+- Destroy/recreate and a macOS equivalent remain out of scope unless future
+  measurements show that suspension no longer meets the product target.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ ADR status describes decision maturity, not release status.
 - [0014 Performance Views and the Specification Sheet](0014-performance-views-and-specification-sheet.md)
 - [0015 Performance and System Specifications as Sidebar Destinations](0015-performance-and-system-specifications-destinations.md)
 - [0016 GPU Attribution on the Performance Screen](0016-gpu-attribution-on-the-performance-screen.md)
+- [0017 Suspend Hidden Windows WebViews](0017-suspend-hidden-windows-webviews.md)

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -112,3 +112,4 @@ shared enforcement surface.
 - [Keep shared system refresh ownership explicit](keep-shared-system-refresh-ownership-explicit.md)
 - [Read id producers before identity UI](read-id-producers-before-identity-ui.md)
 - [Bound bot review loops](bound-bot-review-loops.md)
+- [WebView2 suspension requires hiding the controller](webview2-suspend-requires-hidden-controller.md)

--- a/docs/agents/lessons/webview2-suspend-requires-hidden-controller.md
+++ b/docs/agents/lessons/webview2-suspend-requires-hidden-controller.md
@@ -1,0 +1,48 @@
+---
+id: LRN-20260822-webview2-suspend-requires-hidden-controller
+status: promoted
+cause_status: confirmed
+scope: Windows Tauri WebView2 hide, suspend, and resume lifecycle
+trigger: when implementing or changing WebView2 suspension for a Tauri window
+failure_signature: TrySuspend fails with HRESULT 0x8007139F after the native Tauri window is hidden
+root_cause: hiding the native Tauri window does not make the embedded WebView2 controller invisible, but TrySuspend requires the controller IsVisible property to be false
+guardrail: the owning Windows WebView lifecycle explicitly hides the controller before TrySuspend and restores it before Resume and native show
+canonical_refs: docs/adr/0017-suspend-hidden-windows-webviews.md, src-tauri/src/webview_memory.rs, src-tauri/src/lib.rs
+verification: the experiment failed before SetIsVisible(false); the corrected production path logged one suspension per flyout hide transition, held the stable tree Private Working Set at 31.9 MiB, restored the main window in 190 ms, and restored the flyout in 28 ms on real Windows hardware
+evidence: "issue #1962; src-tauri/src/webview_memory.rs; Microsoft CoreWebView2.TrySuspendAsync documentation"
+revalidate_when: Tauri or wry changes WebView2 controller visibility behavior, the WebView2 suspend API contract changes, or the Windows window lifecycle is redesigned
+---
+
+# WebView2 suspension requires hiding the controller
+
+## Observation
+
+Calling Tauri's native window `hide` operation was not sufficient preparation
+for WebView2 suspension. `TrySuspend` failed with `ERROR_INVALID_STATE` even
+though the containing Tauri window was no longer visible.
+
+## Confirmed cause
+
+WebView2 requires its controller's `IsVisible` property to be `false` when
+`TrySuspend` is called. The Tauri native-window hide path did not change that
+embedded controller property in the tested lifecycle.
+
+The experiment began suspending successfully only after it explicitly called
+`ICoreWebView2Controller::SetIsVisible(false)` before `TrySuspend`. On restore,
+controller visibility must be restored before the WebView is shown so a failed
+versioned-interface cast cannot leave a visible native window with a hidden
+WebView controller.
+
+An explicit flyout hide also emits `Focused(false)`. A focus-loss handler that
+unconditionally hides and suspends therefore attempts the same transition a
+second time. The focus-loss path must first verify that the flyout is still
+visible so each hide transition has exactly one suspension owner.
+
+## Promotion
+
+ADR 0017 owns the suspend-over-destroy decision. The Windows WebView lifecycle
+preserves the required visibility ordering next to the COM calls because a
+mocked unit test would not prove the Tauri/WebView2 integration behavior.
+Revalidate on real Windows hardware instead of assuming the behavior if Tauri
+or wry begins synchronizing native-window visibility with the WebView2
+controller.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,6 +81,10 @@ required-features = ["bindings-export"]
 [target.'cfg(windows)'.dependencies]
 wmi = "0.18.4"
 dxgi = "0.1.7"
+webview2-com = "0.38.2"
+# Keep this aligned with webview2-com; its COM interfaces implement this
+# windows-core version's Interface trait, not the newer version used elsewhere.
+windows-core = "0.61"
 winapi = { version = "0.3", features = ["dxgi", "setupapi", "devguid"] }
 windows = { version = "0.62.2", features = [
     "Data_Xml_Dom",

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -54,6 +54,7 @@ src-tauri/src/
 ├── app/                  ← App lifecycle helpers
 │   └── startup.rs          DB preflight error dialog + reset-and-restart flow
 ├── lifecycle.rs          ← close-to-tray, second instance, and run-event policy
+├── webview_memory.rs     ← Windows hidden-WebView suspend and resume lifecycle
 ├── workers/              ← WorkersState — holds Core controller / adapter handles
 ├── tray/                 ← tray widget windows, surface helpers, and UI policy
 ├── infrastructure/       ← App-only DB code

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -64,6 +64,13 @@ pub async fn mark_close_to_tray_listener_ready(
   crate::lifecycle::mark_close_to_tray_listener_ready(app_handle).await
 }
 
+/// Hide the main window through the App-owned close-to-tray lifecycle.
+#[tauri::command]
+#[specta::specta]
+pub fn hide_main_window_to_tray(app_handle: tauri::AppHandle) -> Result<(), String> {
+  crate::lifecycle::hide_main_window_to_tray(&app_handle)
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod models;
 mod services;
 mod tray;
 mod utils;
+mod webview_memory;
 mod workers;
 
 #[cfg(test)]
@@ -421,10 +422,17 @@ pub fn run() {
         match ev {
           tauri::WindowEvent::CloseRequested { api, .. } => {
             api.prevent_close();
-            let _ = win.hide();
+            if win.hide().is_ok() {
+              webview_memory::suspend_for_window(win);
+            }
           }
-          tauri::WindowEvent::Focused(false) => {
-            let _ = win.hide();
+          // An explicit flyout hide also emits Focused(false). Only the
+          // focus-loss path for a still-visible flyout owns another hide and
+          // suspend transition.
+          tauri::WindowEvent::Focused(false)
+            if win.is_visible().unwrap_or(false) && win.hide().is_ok() =>
+          {
+            webview_memory::suspend_for_window(win);
           }
           _ => {}
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,7 @@ fn build_specta_builder() -> Builder<Wry> {
       system::quit_app,
       system::is_close_to_tray_available,
       system::mark_close_to_tray_listener_ready,
+      system::hide_main_window_to_tray,
     ])
 }
 

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -125,16 +125,20 @@ pub fn restore_main_window(app: &AppHandle) {
 
   crate::webview_memory::resume(&window);
 
-  // Best-effort: each call may legitimately fail (window already
-  // visible, already in the foreground, OS denying focus) without
-  // affecting the others. Logging keeps the trail without aborting.
+  // Showing the native window is the ownership handoff that makes a resumed
+  // WebView useful. Restore the suspended state if that handoff fails.
   if let Err(e) = window.show() {
     log_warn!(
       &format!("failed to show main window: {e}"),
       "lifecycle::restore_main_window",
       None::<&str>
     );
+    crate::webview_memory::suspend(&window);
+    return;
   }
+
+  // Unminimize and focus are best-effort: each may legitimately fail when the
+  // window is already in the requested state or the OS denies focus.
   if let Err(e) = window.unminimize() {
     log_warn!(
       &format!("failed to unminimize main window: {e}"),
@@ -148,6 +152,16 @@ pub fn restore_main_window(app: &AppHandle) {
       "lifecycle::restore_main_window",
       None::<&str>
     );
+  }
+
+  if matches!(window.is_visible(), Ok(false)) {
+    log_warn!(
+      "main window remained hidden after restore",
+      "lifecycle::restore_main_window",
+      None::<&str>
+    );
+    crate::webview_memory::suspend(&window);
+    return;
   }
 
   emit_latest_window_snapshot(app);
@@ -258,6 +272,17 @@ pub fn is_close_to_tray_available(app: &AppHandle) -> bool {
     .try_state::<CloseToTrayRuntimeState>()
     .map(|state| state.is_available())
     .unwrap_or(true)
+}
+
+/// Hide the main window and suspend its WebView for tray-resident operation.
+pub fn hide_main_window_to_tray(app: &AppHandle) -> Result<(), String> {
+  let window = app
+    .get_webview_window("main")
+    .ok_or_else(|| "main window not found while hiding to tray".to_string())?;
+
+  window.hide().map_err(|e| e.to_string())?;
+  crate::webview_memory::suspend(&window);
+  Ok(())
 }
 
 fn hide_window_on_close(window: &Window) -> Result<(), tauri::Error> {

--- a/src-tauri/src/lifecycle.rs
+++ b/src-tauri/src/lifecycle.rs
@@ -123,6 +123,8 @@ pub fn restore_main_window(app: &AppHandle) {
     return;
   };
 
+  crate::webview_memory::resume(&window);
+
   // Best-effort: each call may legitimately fail (window already
   // visible, already in the foreground, OS denying focus) without
   // affecting the others. Logging keeps the trail without aborting.
@@ -259,7 +261,9 @@ pub fn is_close_to_tray_available(app: &AppHandle) -> bool {
 }
 
 fn hide_window_on_close(window: &Window) -> Result<(), tauri::Error> {
-  window.hide()
+  window.hide()?;
+  crate::webview_memory::suspend_for_window(window);
+  Ok(())
 }
 
 struct CloseToTraySettings {

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -1,6 +1,7 @@
 use std::{
   collections::{HashMap, VecDeque},
   sync::{Arc, Mutex},
+  time::Instant,
 };
 
 use serde::Serialize;
@@ -12,9 +13,9 @@ use tauri::{
   tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
 };
 
-use crate::log_warn;
 use crate::tray::TRAY_WIDGET_FLYOUT_LABEL;
 use crate::tray::widget::{MetricState, TrayFrame, TrayFrameItem, TrayMetric};
+use crate::{log_debug, log_warn};
 
 use super::TraySurface;
 
@@ -49,7 +50,8 @@ struct WindowsTrayState {
 impl WindowsTraySurface {
   pub fn new(app: &tauri::App) -> tauri::Result<Self> {
     let app_handle = app.handle().clone();
-    ensure_flyout_window(&app_handle)?;
+    let flyout = ensure_flyout_window(&app_handle)?;
+    crate::webview_memory::suspend(&flyout);
     register_flyout_event_handlers(&app_handle);
 
     let open_item = MenuItem::with_id(app, MENU_OPEN_ID, "Open", true, None::<&str>)?;
@@ -199,6 +201,7 @@ fn toggle_flyout_window(
   click_position: PhysicalPosition<f64>,
   tray_rect: Rect,
 ) {
+  let restore_started_at = Instant::now();
   let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) else {
     log_warn!(
       "Windows tray flyout window was not available",
@@ -209,13 +212,7 @@ fn toggle_flyout_window(
   };
 
   if window.is_visible().unwrap_or(false) {
-    if let Err(e) = window.hide() {
-      log_warn!(
-        &format!("failed to hide Windows tray flyout: {e}"),
-        "tray::surface::windows::toggle_flyout_window",
-        None::<&str>
-      );
-    }
+    hide_flyout_window(app_handle);
     return;
   }
 
@@ -251,17 +248,23 @@ fn toggle_flyout_window(
     );
   }
 
+  crate::webview_memory::resume(&window);
+
   if let Some(frame) = state.latest_frame.lock().unwrap().clone() {
     emit_flyout_frame_to_window(&window, &frame);
   }
 
-  if let Err(e) = window.show() {
-    log_warn!(
-      &format!("failed to show Windows tray flyout: {e}"),
-      "tray::surface::windows::toggle_flyout_window",
-      None::<&str>
-    );
-  }
+  let show_succeeded = match window.show() {
+    Ok(()) => true,
+    Err(e) => {
+      log_warn!(
+        &format!("failed to show Windows tray flyout: {e}"),
+        "tray::surface::windows::toggle_flyout_window",
+        None::<&str>
+      );
+      false
+    }
+  };
 
   if let Err(e) = window.set_focus() {
     log_warn!(
@@ -270,17 +273,29 @@ fn toggle_flyout_window(
       None::<&str>
     );
   }
+
+  if show_succeeded {
+    log_debug!(
+      &format!(
+        "Windows tray flyout restored in {} ms",
+        restore_started_at.elapsed().as_millis()
+      ),
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+  }
 }
 
 fn hide_flyout_window(app_handle: &AppHandle) {
-  if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL)
-    && let Err(e) = window.hide()
-  {
-    log_warn!(
-      &format!("failed to hide Windows tray flyout: {e}"),
-      "tray::surface::windows::hide_flyout_window",
-      None::<&str>
-    );
+  if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) {
+    match window.hide() {
+      Ok(()) => crate::webview_memory::suspend(&window),
+      Err(e) => log_warn!(
+        &format!("failed to hide Windows tray flyout: {e}"),
+        "tray::surface::windows::hide_flyout_window",
+        None::<&str>
+      ),
+    }
   }
 }
 
@@ -347,8 +362,17 @@ fn clamp_to_bounds(value: f64, size: f64, min: f64, max: f64) -> f64 {
 
 fn emit_flyout_frame(app_handle: &AppHandle, frame: &WindowsFlyoutFrame) {
   if let Some(window) = app_handle.get_webview_window(TRAY_WIDGET_FLYOUT_LABEL) {
+    // WebView2 APIs can resume a suspended WebView implicitly. The latest
+    // frame is retained in WindowsTrayState and emitted when the flyout opens.
+    if !should_emit_flyout_frame(window.is_visible().unwrap_or(false)) {
+      return;
+    }
     emit_flyout_frame_to_window(&window, frame);
   }
+}
+
+fn should_emit_flyout_frame(is_visible: bool) -> bool {
+  is_visible
 }
 
 fn emit_flyout_frame_to_window(window: &WebviewWindow, frame: &WindowsFlyoutFrame) {
@@ -846,6 +870,12 @@ fn rounded_rect_signed_distance(px: f32, py: f32, rect: RectF, radius: f32) -> f
 mod tests {
   use super::*;
   use crate::tray::widget::TrayMetricIcon;
+
+  #[test]
+  fn hidden_flyout_does_not_receive_frames() {
+    assert!(!should_emit_flyout_frame(false));
+    assert!(should_emit_flyout_frame(true));
+  }
 
   fn item(metric: TrayMetric, value: &str, state: MetricState) -> TrayFrameItem {
     TrayFrameItem {

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -254,17 +254,15 @@ fn toggle_flyout_window(
     emit_flyout_frame_to_window(&window, &frame);
   }
 
-  let show_succeeded = match window.show() {
-    Ok(()) => true,
-    Err(e) => {
-      log_warn!(
-        &format!("failed to show Windows tray flyout: {e}"),
-        "tray::surface::windows::toggle_flyout_window",
-        None::<&str>
-      );
-      false
-    }
-  };
+  if let Err(e) = window.show() {
+    log_warn!(
+      &format!("failed to show Windows tray flyout: {e}"),
+      "tray::surface::windows::toggle_flyout_window",
+      None::<&str>
+    );
+    crate::webview_memory::suspend(&window);
+    return;
+  }
 
   if let Err(e) = window.set_focus() {
     log_warn!(
@@ -274,16 +272,14 @@ fn toggle_flyout_window(
     );
   }
 
-  if show_succeeded {
-    log_debug!(
-      &format!(
-        "Windows tray flyout restored in {} ms",
-        restore_started_at.elapsed().as_millis()
-      ),
-      "tray::surface::windows::toggle_flyout_window",
-      None::<&str>
-    );
-  }
+  log_debug!(
+    &format!(
+      "Windows tray flyout restored in {} ms",
+      restore_started_at.elapsed().as_millis()
+    ),
+    "tray::surface::windows::toggle_flyout_window",
+    None::<&str>
+  );
 }
 
 fn hide_flyout_window(app_handle: &AppHandle) {

--- a/src-tauri/src/webview_memory.rs
+++ b/src-tauri/src/webview_memory.rs
@@ -1,0 +1,94 @@
+//! Windows WebView2 suspension for hidden App-owned windows.
+
+use tauri::{Manager, WebviewWindow, Window};
+
+use crate::{log_debug, log_warn};
+
+pub fn suspend_for_window(window: &Window) {
+  let label = window.label().to_string();
+  if let Some(webview) = window.app_handle().get_webview_window(&label) {
+    suspend(&webview);
+  }
+}
+
+pub fn suspend(window: &WebviewWindow) {
+  set_suspended(window, true);
+}
+
+pub fn resume(window: &WebviewWindow) {
+  set_suspended(window, false);
+}
+
+#[cfg(target_os = "windows")]
+fn set_suspended(window: &WebviewWindow, suspended: bool) {
+  use webview2_com::{
+    Microsoft::Web::WebView2::Win32::ICoreWebView2_3, TrySuspendCompletedHandler,
+  };
+  use windows_core::Interface;
+
+  let label = window.label().to_string();
+  let operation_label = label.clone();
+  let dispatch_result = window.with_webview(move |webview| {
+    let callback_label = operation_label.clone();
+    let operation: windows_core::Result<()> = (|| unsafe {
+      let controller = webview.controller();
+      let core_webview = controller.CoreWebView2()?;
+      match suspended {
+        false => {
+          // Restore controller visibility before the versioned cast so an
+          // unsupported Resume interface cannot leave a shown window blank.
+          controller.SetIsVisible(true)?;
+          core_webview.cast::<ICoreWebView2_3>()?.Resume()
+        }
+        true => {
+          // Hiding the native Tauri window does not change the WebView2
+          // controller's visibility. TrySuspend requires this explicit step.
+          controller.SetIsVisible(false)?;
+          let handler =
+            TrySuspendCompletedHandler::create(Box::new(move |result, success| {
+              match result {
+                Ok(()) if success => log_debug!(
+                  &format!("WebView2 suspended {callback_label}"),
+                  "webview_memory::set_suspended",
+                  None::<&str>
+                ),
+                Ok(()) => log_warn!(
+                  &format!("WebView2 declined suspension for {callback_label}"),
+                  "webview_memory::set_suspended",
+                  None::<&str>
+                ),
+                Err(error) => log_warn!(
+                  &format!(
+                    "WebView2 suspend callback failed for {callback_label}: {error}"
+                  ),
+                  "webview_memory::set_suspended",
+                  None::<&str>
+                ),
+              }
+              Ok(())
+            }));
+          core_webview.cast::<ICoreWebView2_3>()?.TrySuspend(&handler)
+        }
+      }
+    })();
+
+    if let Err(error) = operation {
+      log_warn!(
+        &format!("failed to change WebView2 suspension for {operation_label}: {error}"),
+        "webview_memory::set_suspended",
+        None::<&str>
+      );
+    }
+  });
+
+  if let Err(error) = dispatch_result {
+    log_warn!(
+      &format!("failed to access WebView2 for {label}: {error}"),
+      "webview_memory::set_suspended",
+      None::<&str>
+    );
+  }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn set_suspended(_window: &WebviewWindow, _suspended: bool) {}

--- a/src-tauri/src/webview_memory.rs
+++ b/src-tauri/src/webview_memory.rs
@@ -2,6 +2,7 @@
 
 use tauri::{Manager, WebviewWindow, Window};
 
+#[cfg(target_os = "windows")]
 use crate::{log_debug, log_warn};
 
 pub fn suspend_for_window(window: &Window) {

--- a/src/components/shared/CloseToTrayFirstRunDialog.test.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.test.tsx
@@ -7,7 +7,7 @@ import { CloseToTrayFirstRunDialog } from "./CloseToTrayFirstRunDialog";
 
 const mocks = vi.hoisted(() => ({
   error: vi.fn(),
-  hide: vi.fn(),
+  hideMainWindowToTray: vi.fn(),
   isCloseToTrayAvailable: vi.fn(),
   listen: vi.fn(),
   markCloseToTrayListenerReady: vi.fn(),
@@ -22,12 +22,6 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mocks.listen,
 }));
 
-vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({
-    hide: mocks.hide,
-  }),
-}));
-
 vi.mock("@/hooks/useTauriDialog", () => ({
   useTauriDialog: () => ({
     error: mocks.error,
@@ -36,6 +30,7 @@ vi.mock("@/hooks/useTauriDialog", () => ({
 
 vi.mock("@/rspc/bindings", () => ({
   commands: {
+    hideMainWindowToTray: mocks.hideMainWindowToTray,
     isCloseToTrayAvailable: mocks.isCloseToTrayAvailable,
     markCloseToTrayListenerReady: mocks.markCloseToTrayListenerReady,
     quitApp: mocks.quitApp,
@@ -69,6 +64,10 @@ describe("CloseToTrayFirstRunDialog", () => {
       status: "ok",
       data: true,
     });
+    mocks.hideMainWindowToTray.mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
     mocks.setCloseToTrayPreference.mockResolvedValue({
       status: "ok",
       data: null,
@@ -101,7 +100,7 @@ describe("CloseToTrayFirstRunDialog", () => {
       visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
-    expect(mocks.hide).not.toHaveBeenCalled();
+    expect(mocks.hideMainWindowToTray).not.toHaveBeenCalled();
     expect(mocks.quitApp).not.toHaveBeenCalled();
   });
 
@@ -176,8 +175,31 @@ describe("CloseToTrayFirstRunDialog", () => {
       visibleMetrics: ["cpu", "gpu", "gpu-temp"],
       updateIntervalSecs: 1,
     });
-    expect(mocks.hide).toHaveBeenCalled();
+    expect(mocks.hideMainWindowToTray).toHaveBeenCalledTimes(1);
     expect(mocks.quitApp).not.toHaveBeenCalled();
+  });
+
+  it("reports an error when the App-owned hide transition fails", async () => {
+    const user = userEvent.setup();
+    mocks.hideMainWindowToTray.mockResolvedValue({
+      status: "error",
+      error: "hide failed",
+    });
+
+    renderDialog(<CloseToTrayFirstRunDialog closeToTrayChoiceMade />);
+
+    await waitFor(() => expect(mocks.closeHandler).toBeDefined());
+    act(() => {
+      mocks.closeHandler?.();
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Continue in background" }),
+    );
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      "Failed to keep the app running in the background.",
+    );
   });
 
   it("does not show a second error dialog when rejecting tray mode fails", async () => {

--- a/src/components/shared/CloseToTrayFirstRunDialog.tsx
+++ b/src/components/shared/CloseToTrayFirstRunDialog.tsx
@@ -1,5 +1,4 @@
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -129,7 +128,11 @@ export const CloseToTrayFirstRunDialog = ({
       }
 
       if (promptReason === "close") {
-        await getCurrentWindow().hide();
+        const hidden = await commands.hideMainWindowToTray();
+
+        if (isError(hidden)) {
+          throw new Error(hidden.error);
+        }
       }
 
       setPromptReason(null);

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -218,6 +218,8 @@ export const commands = {
 	isCloseToTrayAvailable: () => typedError<boolean, string>(__TAURI_INVOKE("is_close_to_tray_available")),
 	// Mark the frontend close-to-tray dialog listener as ready.
 	markCloseToTrayListenerReady: () => typedError<null, string>(__TAURI_INVOKE("mark_close_to_tray_listener_ready")),
+	// Hide the main window through the App-owned close-to-tray lifecycle.
+	hideMainWindowToTray: () => typedError<null, string>(__TAURI_INVOKE("hide_main_window_to_tray")),
 };
 
 /** Events */


### PR DESCRIPTION
## Summary

- suspend the hidden Windows main WebView and pre-created Tray Widget flyout while preserving Core collection and native tray behavior
- resume each WebView before showing it and retain only the latest frame while the flyout is hidden
- record the suspend-over-destroy decision in ADR 0017 and preserve the WebView2 controller-visibility invariant as a maintainer lesson

Real-hardware validation reduced the stable hidden process-tree Private Working Set from 173.7 MiB to 31.9 MiB. The main window restored in 190 ms and the Tray Widget flyout restored in 28 ms.

## Related Issues

Closes #1962

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

No visual behavior changes. The existing compact flyout was inspected on physical Windows hardware with live CPU usage, GPU usage, and GPU temperature values.

## Test Plan

- [x] Manual testing
- [x] Unit tests

- `cargo tauri-fmt`
- `cargo tauri-lint`
- `npm run check:agent-guidance`
- `cargo tauri-test` (Core: 319 passed; the App settings tests exposed their existing shared-file collision in the current user profile)
- isolated `APPDATA` + `cargo test -p hardware_visualizer --lib -- --test-threads=1` (234 passed)
- physical Windows hide/restore validation for memory, rendered flyout metrics, restore latency, and one suspension per hide transition

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reduced memory usage for hidden Windows app windows and tray flyouts by suspending their web content.
  * Web content resumes automatically before windows and flyouts are displayed.
  * Hidden flyout updates are deferred and applied when the flyout reopens.
  * Added a reliable close-to-tray flow with clear error handling.
  * Added logging for suspension, restoration, and related failures.

* **Bug Fixes**
  * Prevented duplicate suspension during focus-loss and flyout-hiding transitions.

* **Documentation**
  * Added guidance and architectural records documenting Windows WebView lifecycle behavior and compatibility considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->