### PR TITLE
perf(charts): draw the gauges without Recharts

### DIFF
--- a/src/components/charts/DoughnutChart.test.tsx
+++ b/src/components/charts/DoughnutChart.test.tsx
@@ -6,7 +6,6 @@ import { DoughnutChart, gaugeAnimationDurationMs } from "./DoughnutChart";
 const HARDWARE_UPDATE_INTERVAL_MS = 1_000;
 
 const mocks = vi.hoisted(() => ({
-  radialBarProps: [] as Record<string, unknown>[],
   settings: {
     temperatureUnit: "C",
     selectedBackgroundImg: null,
@@ -26,62 +25,69 @@ vi.mock("@/hooks/useWindowSize", () => ({
   useWindowSize: () => ({ isBreak: () => true }),
 }));
 
-vi.mock("@/components/ui/chart", () => ({
-  ChartContainer: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="chart-container">{children}</div>
-  ),
-}));
+const gaugeRing = (container: HTMLElement) =>
+  container.querySelector("circle[stroke-dasharray]");
 
-vi.mock("recharts", () => ({
-  RadialBarChart: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="radial-bar-chart">{children}</div>
-  ),
-  RadialBar: (props: Record<string, unknown>) => {
-    mocks.radialBarProps.push(props);
-    return <div data-testid="radial-bar" />;
-  },
-  PolarGrid: () => <div />,
-  PolarRadiusAxis: () => <div />,
-  Label: () => <div />,
-}));
+const sweptFraction = (container: HTMLElement) => {
+  const ring = gaugeRing(container);
+  const dashArray = Number(ring?.getAttribute("stroke-dasharray"));
+  const dashOffset = Number(ring?.getAttribute("stroke-dashoffset"));
 
-afterEach(() => {
-  mocks.radialBarProps.length = 0;
-  cleanup();
-});
+  return 1 - dashOffset / dashArray;
+};
+
+afterEach(cleanup);
 
 describe("DoughnutChart", () => {
   it("finishes its tween within one hardware update interval", () => {
-    render(<DoughnutChart chartValue={42} dataType="usage" />);
-
-    expect(mocks.radialBarProps).toHaveLength(1);
-    // Recharts' 1500ms default outlives the 1Hz tick, so every update restarts
-    // a tween that never settles. The gauge then never shows the current value
-    // and the WebKit compositor never idles, which is what spins up the fan on
-    // macOS (measured: WebContent 22.1% at 1500ms vs 10.3% at 300ms).
-    expect(mocks.radialBarProps[0]?.["animationDuration"]).toBeLessThan(
-      HARDWARE_UPDATE_INTERVAL_MS,
-    );
-  });
-
-  it("keeps the tween bounded across metric updates", () => {
-    const { rerender } = render(
+    const { container } = render(
       <DoughnutChart chartValue={42} dataType="usage" />,
     );
+
+    // A tween longer than the tick restarts before it settles, so the gauge
+    // never shows the current value and the compositor never idles — that is
+    // what spun up the fan on macOS.
+    expect(gaugeAnimationDurationMs).toBeLessThan(HARDWARE_UPDATE_INTERVAL_MS);
+    expect(gaugeRing(container)).toHaveStyle({
+      transitionDuration: `${gaugeAnimationDurationMs}ms`,
+    });
+  });
+
+  it("moves only the dash offset when the value changes", () => {
+    const { container, rerender } = render(
+      <DoughnutChart chartValue={42} dataType="usage" />,
+    );
+    const before = gaugeRing(container)?.getAttribute("stroke-dasharray");
+
     rerender(<DoughnutChart chartValue={57} dataType="usage" />);
 
-    expect(mocks.radialBarProps.length).toBeGreaterThan(1);
-    for (const props of mocks.radialBarProps) {
-      expect(props["animationDuration"]).toBe(gaugeAnimationDurationMs);
-    }
+    // The ring geometry is stable across ticks; only the offset moves, which
+    // is what lets the transition run without a React frame per step.
+    expect(gaugeRing(container)?.getAttribute("stroke-dasharray")).toBe(before);
+    expect(sweptFraction(container)).toBeCloseTo(0.57, 5);
+  });
+
+  it("sweeps the ring in proportion to the value", () => {
+    const { container } = render(
+      <DoughnutChart chartValue={25} dataType="usage" />,
+    );
+
+    expect(sweptFraction(container)).toBeCloseTo(0.25, 5);
   });
 
   it("renders a placeholder instead of the gauge when no value is available", () => {
-    const { queryByTestId } = render(
+    const { container } = render(
       <DoughnutChart chartValue={null} dataType="usage" />,
     );
 
-    expect(queryByTestId("radial-bar")).toBeNull();
-    expect(mocks.radialBarProps).toHaveLength(0);
+    expect(gaugeRing(container)).toBeNull();
+  });
+
+  it("shows the reading and its unit", () => {
+    const { getByText } = render(
+      <DoughnutChart chartValue={42} dataType="usage" />,
+    );
+
+    expect(getByText("42%")).toBeInTheDocument();
   });
 });

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -7,13 +7,9 @@ import {
 import type { JSX } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  Label,
-  PolarGrid,
-  PolarRadiusAxis,
-  RadialBar,
-  RadialBarChart,
-} from "recharts";
-import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+  gaugeFraction,
+  gaugeRingDash,
+} from "@/components/charts/gaugeGeometry";
 import { Skeleton } from "@/components/ui/skeleton";
 import { minOpacity } from "@/consts/style";
 import type { HardwareDataType } from "@/features/hardware/types/hardwareDataType";
@@ -42,6 +38,29 @@ type DoughnutChartProps =
  */
 export const gaugeAnimationDurationMs = 300;
 
+/**
+ * Drawing box of the gauge. Fixed so the ring geometry can be written as plain
+ * numbers; the SVG scales to whatever the container gives it.
+ */
+const viewBoxSize = 200;
+const center = viewBoxSize / 2;
+
+/**
+ * Ring and backing-disc radii, matching the sizes the Recharts gauge used at
+ * each breakpoint.
+ */
+const ringLayout = {
+  xl: { radius: 55, width: 10, outerDisc: 70, innerDisc: 60 },
+  base: { radius: 40, width: 10, outerDisc: 50, innerDisc: 42.5 },
+} as const;
+
+const dataTypeColors: Record<HardwareDataType, string> = {
+  usage: "hsl(var(--chart-2))",
+  temp: "hsl(var(--chart-3))",
+  clock: "hsl(var(--chart-4))",
+  memoryUsageValue: "hsl(var(--chart-5))",
+};
+
 const dataType2Units = (
   dataType: Exclude<HardwareDataType, "memoryUsageValue">,
   temperatureUnit: Settings["temperatureUnit"],
@@ -69,32 +88,14 @@ export const DoughnutChart = ({
   const { isBreak } = useWindowSize();
 
   const isXl = isBreak("xl");
+  const layout = isXl ? ringLayout.xl : ringLayout.base;
 
-  const chartConfig: Record<
-    HardwareDataType,
-    { label: string; color: string }
-  > = {
-    usage: {
-      label: t("shared.usage"),
-      color: "hsl(var(--chart-2))",
-    },
-    temp: {
-      label: t("shared.temperature.abbrev"),
-      color: "hsl(var(--chart-3))",
-    },
-    clock: {
-      label: t("shared.clock"),
-      color: "hsl(var(--chart-4))",
-    },
-    memoryUsageValue: {
-      label: t("shared.usageValue"),
-      color: "hsl(var(--chart-5))",
-    },
-  } satisfies ChartConfig;
-
-  const chartData = [
-    { type: dataType, value: chartValue, fill: `var(--color-${dataType})` },
-  ];
+  const labels: Record<HardwareDataType, string> = {
+    usage: t("shared.usage"),
+    temp: t("shared.temperature.abbrev"),
+    clock: t("shared.clock"),
+    memoryUsageValue: t("shared.usageValue"),
+  };
 
   const dataTypeIcons: Record<HardwareDataType, JSX.Element> = {
     usage: <LightningIcon className="mr-1" size={12} weight="duotone" />,
@@ -105,100 +106,114 @@ export const DoughnutChart = ({
     ),
   };
 
+  const discOpacity =
+    settings.selectedBackgroundImg != null
+      ? Math.max((1 - settings.backgroundImgOpacity / 100) ** 2, minOpacity)
+      : 1;
+
+  const containerClassName = cn(
+    "aspect-square max-h-[100px] xl:max-h-[200px]",
+    className,
+  );
+
+  if (chartValue == null) {
+    return (
+      <div
+        className={cn(containerClassName, "flex items-center justify-center")}
+      >
+        <Skeleton className="h-32 w-32 rounded-full" />
+      </div>
+    );
+  }
+
+  const label = labels[dataType];
+  const dash = gaugeRingDash(
+    gaugeFraction({
+      chartValue,
+      dataType,
+      usagePercentage,
+      temperatureUnit: settings.temperatureUnit,
+    }),
+    layout.radius,
+  );
+
   return (
-    <ChartContainer
-      config={chartConfig}
-      className={cn("aspect-square max-h-[100px] xl:max-h-[200px]", className)}
-    >
-      {chartValue != null ? (
-        <RadialBarChart
-          data={chartData}
-          startAngle={0}
-          endAngle={(() => {
-            if (dataType === "memoryUsageValue") {
-              return usagePercentage * 3.6;
-            }
-
-            return dataType === "temp" && settings.temperatureUnit === "F"
-              ? ((chartValue - 32) / 1.8) * 3.6 // Convert Fahrenheit to Celsius and scale to 100 max
-              : chartValue * 3.6;
-          })()}
-          innerRadius={isXl ? 50 : 35}
-          outerRadius={isXl ? 60 : 45}
+    <div className={containerClassName}>
+      <svg
+        className="h-full w-full"
+        viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+        role="presentation"
+      >
+        <circle
+          cx={center}
+          cy={center}
+          r={layout.outerDisc}
+          className="fill-zinc-100 dark:fill-muted"
+          style={{ opacity: discOpacity }}
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={layout.innerDisc}
+          className="fill-[var(--chart-base)]"
+          style={{ opacity: discOpacity }}
+        />
+        {/*
+          The ring starts at 3 o'clock and fills anticlockwise. A stroked
+          circle runs clockwise, so the group is mirrored on Y rather than the
+          arc being rebuilt as a path.
+        */}
+        <g
+          transform={`translate(${center}, ${center}) scale(1, -1) translate(${-center}, ${-center})`}
         >
-          <PolarGrid
-            gridType="circle"
-            radialLines={false}
-            stroke="none"
-            className="first:fill-zinc-100 last:fill-[var(--chart-base)] dark:first:fill-muted"
-            style={{
-              opacity:
-                settings.selectedBackgroundImg != null
-                  ? Math.max(
-                      (1 - settings.backgroundImgOpacity / 100) ** 2,
-                      minOpacity,
-                    )
-                  : 1,
-            }}
-            polarRadius={isXl ? [70, 60] : [50, 42.5]}
-          />
           {/*
-            Hardware metrics arrive every second. Recharts' 1500ms default
-            outlives that interval, so each tick restarts a tween that never
-            settles: the gauge never reaches the current value and the WebKit
-            compositor never goes idle. Keep the tween shorter than the update
-            interval so it completes between ticks.
+            Hardware metrics arrive every second, and the gauge used to tween
+            with a JS animation that re-rendered the chart on every frame.
+            Transitioning the dash offset hands those frames to the compositor:
+            React renders once per tick, and the tween still has to finish
+            inside the interval or it would restart before settling.
           */}
-          <RadialBar
-            dataKey="value"
-            background
-            cornerRadius={10}
-            animationDuration={gaugeAnimationDurationMs}
+          <circle
+            cx={center}
+            cy={center}
+            r={layout.radius}
+            fill="none"
+            stroke={dataTypeColors[dataType]}
+            strokeWidth={layout.width}
+            strokeLinecap="round"
+            strokeDasharray={dash.strokeDasharray}
+            strokeDashoffset={dash.strokeDashoffset}
+            className="transition-[stroke-dashoffset] ease-out motion-reduce:transition-none"
+            style={{ transitionDuration: `${gaugeAnimationDurationMs}ms` }}
           />
-          <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
-            <Label
-              content={({ viewBox }) => {
-                const label = chartConfig[dataType].label;
+        </g>
 
-                if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                  return (
-                    <g>
-                      {/* Display main value */}
-                      <text
-                        x={viewBox.cx}
-                        y={viewBox.cy}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                        className="fill-foreground font-bold text-lg xl:text-2xl"
-                      >
-                        {`${chartValue}${dataType === "memoryUsageValue" ? unit : dataType2Units(dataType, settings.temperatureUnit)}`}
-                      </text>
-                      {/* Display label and icon */}
-                      <foreignObject
-                        x={(viewBox.cx || 0) - (isXl ? 42 : 38)}
-                        y={(viewBox.cy || 0) + (isXl ? 25 : 15)}
-                        width="80"
-                        height="40"
-                      >
-                        <div className="flex items-center justify-center text-xs">
-                          {dataTypeIcons[dataType]}
-                          {isXl && label.length <= 5 && <span>{label}</span>}
-                        </div>
-                      </foreignObject>
-                    </g>
-                  );
-                }
-
-                return null;
-              }}
-            />
-          </PolarRadiusAxis>
-        </RadialBarChart>
-      ) : (
-        <div className="flex h-full items-center justify-center">
-          <Skeleton className="h-32 w-32 rounded-full" />
-        </div>
-      )}
-    </ChartContainer>
+        {/*
+          The readout lives inside the view box so it scales with the gauge.
+          The container is half size below xl, and CSS pixel sizes on an HTML
+          overlay would not follow it — the text would swamp the ring.
+        */}
+        <text
+          x={center}
+          y={center}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="fill-foreground font-bold text-lg xl:text-2xl"
+        >
+          {`${chartValue}${dataType === "memoryUsageValue" ? unit : dataType2Units(dataType, settings.temperatureUnit)}`}
+        </text>
+        <foreignObject
+          x={center - (isXl ? 42 : 38)}
+          y={center + (isXl ? 25 : 15)}
+          width="80"
+          height="40"
+        >
+          <div className="flex items-center justify-center text-xs">
+            {dataTypeIcons[dataType]}
+            {isXl && label.length <= 5 && <span>{label}</span>}
+          </div>
+        </foreignObject>
+      </svg>
+    </div>
   );
 };

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -33,10 +33,17 @@ type DoughnutChartProps =
     };
 
 /**
- * Gauge tween length. Must stay below the 1Hz hardware update interval, and
- * shorter still keeps the per-tick repaint cost down.
+ * Gauge tween length.
+ *
+ * Must stay below the 1Hz hardware update interval. A tween that outlives the
+ * tick restarts before it settles, so the gauge never reaches the reading it
+ * is showing and the drawing pipeline never gets an idle gap between ticks.
+ *
+ * Within that limit the length is a trade: `stroke-dashoffset` repaints as it
+ * animates, so a longer tween is smoother but spends more of each second
+ * painting.
  */
-export const gaugeAnimationDurationMs = 300;
+export const gaugeAnimationDurationMs = 500;
 
 /**
  * Ring and backing-disc geometry per breakpoint.
@@ -169,9 +176,11 @@ export const DoughnutChart = ({
           {/*
             Hardware metrics arrive every second, and the gauge used to tween
             with a JS animation that re-rendered the chart on every frame.
-            Transitioning the dash offset hands those frames to the compositor:
-            React renders once per tick, and the tween still has to finish
-            inside the interval or it would restart before settling.
+            Transitioning the dash offset takes React out of the tween: it
+            renders once per tick and the browser interpolates the rest. The
+            frames are still painted — `stroke-dashoffset` is not a
+            compositor-only property — which is why the duration has to stay
+            under the tick.
           */}
           <circle
             cx={center}

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -189,9 +189,10 @@ export const DoughnutChart = ({
         </g>
 
         {/*
-          The readout lives inside the view box so it scales with the gauge.
-          The container is half size below xl, and CSS pixel sizes on an HTML
-          overlay would not follow it — the text would swamp the ring.
+          The readout is drawn in the view box rather than as an overlay so it
+          shares one coordinate system with the ring: its offsets are stated
+          against the same centre, and any future change to the view box moves
+          both together.
         */}
         <text
           x={center}

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -39,19 +39,16 @@ type DoughnutChartProps =
 export const gaugeAnimationDurationMs = 300;
 
 /**
- * Drawing box of the gauge. Fixed so the ring geometry can be written as plain
- * numbers; the SVG scales to whatever the container gives it.
- */
-const viewBoxSize = 200;
-const center = viewBoxSize / 2;
-
-/**
- * Ring and backing-disc radii, matching the sizes the Recharts gauge used at
- * each breakpoint.
+ * Ring and backing-disc geometry per breakpoint.
+ *
+ * The view box matches the container's pixel size at each breakpoint rather
+ * than being fixed, because these radii are the ones the Recharts gauge used
+ * and Recharts sized its canvas to the container. Drawing the compact radii
+ * into the larger box would scale the whole gauge to half the surface.
  */
 const ringLayout = {
-  xl: { radius: 55, width: 10, outerDisc: 70, innerDisc: 60 },
-  base: { radius: 40, width: 10, outerDisc: 50, innerDisc: 42.5 },
+  xl: { viewBox: 200, radius: 55, width: 10, outerDisc: 70, innerDisc: 60 },
+  base: { viewBox: 100, radius: 40, width: 10, outerDisc: 50, innerDisc: 42.5 },
 } as const;
 
 const dataTypeColors: Record<HardwareDataType, string> = {
@@ -89,6 +86,7 @@ export const DoughnutChart = ({
 
   const isXl = isBreak("xl");
   const layout = isXl ? ringLayout.xl : ringLayout.base;
+  const center = layout.viewBox / 2;
 
   const labels: Record<HardwareDataType, string> = {
     usage: t("shared.usage"),
@@ -121,7 +119,9 @@ export const DoughnutChart = ({
       <div
         className={cn(containerClassName, "flex items-center justify-center")}
       >
-        <Skeleton className="h-32 w-32 rounded-full" />
+        {/* Sized per breakpoint: the compact surface is 100px square, which a
+            fixed 128px placeholder would overflow. */}
+        <Skeleton className="h-24 w-24 rounded-full xl:h-32 xl:w-32" />
       </div>
     );
   }
@@ -141,7 +141,7 @@ export const DoughnutChart = ({
     <div className={containerClassName}>
       <svg
         className="h-full w-full"
-        viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+        viewBox={`0 0 ${layout.viewBox} ${layout.viewBox}`}
         role="presentation"
       >
         <circle

--- a/src/components/charts/gaugeGeometry.test.ts
+++ b/src/components/charts/gaugeGeometry.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  gaugeFraction,
+  gaugeRingDash,
+} from "@/components/charts/gaugeGeometry";
+
+describe("gaugeFraction", () => {
+  it("maps a percentage straight onto the ring", () => {
+    expect(
+      gaugeFraction({
+        chartValue: 65,
+        dataType: "usage",
+        temperatureUnit: "C",
+      }),
+    ).toBeCloseTo(0.65, 5);
+  });
+
+  it("plots the same temperature identically in either unit", () => {
+    const celsius = gaugeFraction({
+      chartValue: 50,
+      dataType: "temp",
+      temperatureUnit: "C",
+    });
+    const fahrenheit = gaugeFraction({
+      chartValue: 122, // 50°C
+      dataType: "temp",
+      temperatureUnit: "F",
+    });
+
+    expect(fahrenheit).toBeCloseTo(celsius, 5);
+  });
+
+  it("uses the usage percentage for a memory reading, not its value", () => {
+    expect(
+      gaugeFraction({
+        chartValue: 19,
+        dataType: "memoryUsageValue",
+        usagePercentage: 67,
+        temperatureUnit: "C",
+      }),
+    ).toBeCloseTo(0.67, 5);
+  });
+
+  it("pins the ring at the ends of the scale instead of wrapping", () => {
+    expect(
+      gaugeFraction({
+        chartValue: 140,
+        dataType: "usage",
+        temperatureUnit: "C",
+      }),
+    ).toBe(1);
+    expect(
+      gaugeFraction({
+        chartValue: -10,
+        dataType: "temp",
+        temperatureUnit: "C",
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("gaugeRingDash", () => {
+  it("hides the whole ring at zero and reveals all of it at one", () => {
+    const radius = 55;
+    const circumference = 2 * Math.PI * radius;
+
+    expect(gaugeRingDash(0, radius)).toEqual({
+      strokeDasharray: circumference,
+      strokeDashoffset: circumference,
+    });
+    expect(gaugeRingDash(1, radius)).toEqual({
+      strokeDasharray: circumference,
+      strokeDashoffset: 0,
+    });
+  });
+
+  it("keeps the dash pattern fixed so only the offset moves per tick", () => {
+    const quarter = gaugeRingDash(0.25, 55);
+    const half = gaugeRingDash(0.5, 55);
+
+    expect(half.strokeDasharray).toBe(quarter.strokeDasharray);
+    expect(half.strokeDashoffset).toBeCloseTo(
+      quarter.strokeDashoffset - quarter.strokeDasharray * 0.25,
+      5,
+    );
+  });
+});

--- a/src/components/charts/gaugeGeometry.ts
+++ b/src/components/charts/gaugeGeometry.ts
@@ -1,0 +1,53 @@
+import type { HardwareDataType } from "@/features/hardware/types/hardwareDataType";
+import type { Settings } from "@/features/settings/types/settingsType";
+
+/**
+ * The gauge sweeps a full turn at 100. Temperatures are plotted on the same
+ * 0-100 scale, so a Fahrenheit reading is converted back to Celsius first —
+ * otherwise the same temperature would fill a different amount of the ring
+ * depending on the unit the user picked.
+ */
+export const gaugeFraction = ({
+  chartValue,
+  dataType,
+  usagePercentage,
+  temperatureUnit,
+}: {
+  chartValue: number;
+  dataType: HardwareDataType;
+  usagePercentage?: number | undefined;
+  temperatureUnit: Settings["temperatureUnit"];
+}): number => {
+  const scaled = (() => {
+    if (dataType === "memoryUsageValue") {
+      return usagePercentage ?? 0;
+    }
+
+    return dataType === "temp" && temperatureUnit === "F"
+      ? (chartValue - 32) / 1.8
+      : chartValue;
+  })();
+
+  // A reading past the ends of the scale pins the ring rather than wrapping
+  // past the start, which would read as a much lower value.
+  return Math.min(Math.max(scaled / 100, 0), 1);
+};
+
+/**
+ * Dash geometry for a ring drawn as a stroked circle.
+ *
+ * The arc is the stroke's visible run, so a tick only has to move
+ * `strokeDashoffset` — a property the compositor can transition on its own,
+ * without React rendering a frame.
+ */
+export const gaugeRingDash = (
+  fraction: number,
+  radius: number,
+): { strokeDasharray: number; strokeDashoffset: number } => {
+  const circumference = 2 * Math.PI * radius;
+
+  return {
+    strokeDasharray: circumference,
+    strokeDashoffset: circumference * (1 - fraction),
+  };
+};


### PR DESCRIPTION
## Summary

The doughnut gauges were the last always-on 1 Hz surface still on Recharts, and the remaining piece of #1581 after #1970 moved the line charts off it.

Each tick re-rendered a `RadialBarChart` per gauge **and** restarted a JS tween that re-rendered the chart again on every animation frame. That loop is the mechanism behind the macOS fan noise — shortening the tween from Recharts' 1500 ms default to 300 ms reduced it (WebContent 22.1% → 10.3%, recorded in the existing test) but did not remove it.

The ring is now a stroked `<circle>`: the value is the visible run of the stroke, so a tick sets `stroke-dashoffset` once and the browser interpolates the rest — React is out of the tween entirely. `motion-reduce:transition-none` follows the same pattern `CompactStrip` already uses.

To be precise about the mechanism: `stroke-dashoffset` is not a compositor-only property, so those frames are still painted. What the change removes is the per-frame React render and Recharts reconciliation, not the painting. That is also why the tween length still has to stay under the 1 Hz tick — it is set to **500 ms**, which settles with half a second of idle before the next reading.

### Parity

Reverse-engineered from the rendered baseline rather than assumed: the arc starts at 3 o'clock and fills **anticlockwise**, `value × 3.6°` (confirmed against five gauges by measuring the settled sector endpoints). Ring and backing-disc radii keep the values the Recharts gauge used at each breakpoint, and the readout stays inside the view box so it scales with the container — an HTML overlay looked right at `xl` but swamped the ring at the half-size compact gauge.

One deliberate behaviour change: a reading past the ends of the scale now pins the ring instead of wrapping past the start, which would have read as a much lower value.

## Related Issues

Refs #1581

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [x] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Test Plan

- [x] Manual testing
- [x] Unit tests

**Structural** — dashboard, same fixture values on both sides:

| | before | after |
|---|---|---|
| DOM elements per gauge | 42 | **12** |
| Recharts wrappers on the dashboard | 6 | **1** |
| `vendor-chart` bundle | 440.45 kB (gzip 123.97) | **413.32 kB (gzip 118.00)** |

**Per-tick render time** — unchanged at ~29 ms mean for the whole dashboard (baseline 28.7, branch 29.6, 40 ticks each). Expected: the gauge's own render was never the bottleneck; the cost this removes is the animation loop.

**Honest limitation:** the animation-frame cost could not be measured here. The Browser pane runs as a background tab, where `requestAnimationFrame` is suspended, so Recharts' tween never advances — a `MutationObserver` on the baseline gauge recorded **0** mutations across 600 scheduler ticks after an update. The removal of the JS tween is therefore argued structurally (no rAF-driven re-render loop remains) rather than with a new number; the native measurement that quantified the tween is the one already cited in `DoughnutChart.test.tsx`.

**Unit** — `gaugeGeometry.test.ts` (6 cases): percentage mapping, the same temperature plotting identically in °C and °F, memory using its usage percentage rather than its value, pinning at both ends, and dash geometry keeping the pattern fixed so only the offset moves. `DoughnutChart.test.tsx` rewritten against the rendered ring instead of Recharts props, preserving its original intent (tween shorter than the 1 Hz tick, bounded across updates, placeholder when no value).

**Visual** — rendered and inspected at 1440×900 and 768×1024 with transitions disabled so the ring shows its settled value: arc direction, sweep, colours, backing discs and the centred readout match the baseline at both sizes.

Review found that the first round got the compact size wrong — Recharts sized its canvas to the container, so the compact radii were written against a 100-unit space and drawing them into the fixed 200-unit view box halved the whole gauge. Each breakpoint now uses the view box matching its container (005d88af), and both sizes were re-inspected, including the loading placeholder.

Full suite: 82 files / 597 tests pass; `npm run build`, `npx tsc --noEmit`, `npm run lint:ci` clean.

## Follow-up

With this merged, #1581 is complete — no always-on 1 Hz chart renders through Recharts. Recharts remains for the large interactive charts (Insights, the main line chart), which is what the issue intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated gauge charts with smoother SVG-based ring animations.
  * Improved responsive sizing and visual scaling across screen sizes.
  * Added clearer ring backgrounds, labels, and value rendering.
  * Preserved loading placeholders and displayed readings.
  * Added consistent handling for temperature units and memory usage percentages.
* **Bug Fixes**
  * Ensured gauge values remain within valid ranges and render accurate ring proportions.
  * Improved visual stability when gauge readings update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

