### PR TITLE
fix: stabilize performance memory growth gate

### DIFF
--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -113,3 +113,4 @@ shared enforcement surface.
 - [Read id producers before identity UI](read-id-producers-before-identity-ui.md)
 - [Bound bot review loops](bound-bot-review-loops.md)
 - [WebView2 suspension requires hiding the controller](webview2-suspend-requires-hidden-controller.md)
+- [Stabilize performance memory baselines](stabilize-perf-memory-baselines.md)

--- a/docs/agents/lessons/stabilize-perf-memory-baselines.md
+++ b/docs/agents/lessons/stabilize-perf-memory-baselines.md
@@ -1,0 +1,42 @@
+---
+id: LRN-20260822-stabilize-perf-memory-baselines
+status: promoted
+cause_status: confirmed
+scope: perf-monitor startup stabilization and process-tree memory growth checks
+trigger: when changing perf-monitor warmup, helper discovery, sampling, or memory growth calculations
+failure_signature: the Windows performance workflow exceeded process-tree growth while average and P95 stayed within threshold, then passed on the same commit when rerun
+root_cause: a fixed warmup could end before WebView helper RSS settled, and last-minus-first growth treated delayed initialization and endpoint noise as steady-state growth
+guardrail: perf-monitor waits for a stable helper PID set and component RSS before measurement, then computes growth from endpoint-window medians
+canonical_refs: perf-monitor/src/monitor.rs, perf-monitor/src/config.rs, perf-monitor/README.md
+verification: cargo test --manifest-path perf-monitor/Cargo.toml
+evidence: GitHub Actions run 32559708158 attempts 1 and 2; perf-monitor/src/monitor.rs regression tests
+revalidate_when: the WebView process model, sampling interval, growth thresholds, or performance runner platform changes
+---
+
+# Stabilize performance memory baselines
+
+## Observation
+
+The Windows performance gate reported 386.9 MiB of process-tree growth even
+though its average and P95 remained within threshold. WebView helpers accounted
+for 360.7 MiB of that growth. A rerun of the same commit reported -8.3 MiB of
+tree growth, while the P95 differed by only 7.9 MiB.
+
+The previous gate waited a fixed 15 seconds and defined growth as the last RSS
+sample minus the first. On a slower startup, the first sample therefore
+represented a partially initialized WebView process tree rather than the
+steady-state baseline.
+
+## Confirmed cause
+
+The measurement boundary did not prove that startup had settled. Increasing
+the measurement sample count could improve average and percentile estimates,
+but it could not make a two-endpoint growth calculation robust.
+
+## Promotion
+
+The monitor now treats the configured warmup as a minimum, then requires the
+same helper PID set and stable component RSS for a rolling window before
+measurement. It fails explicitly if no stable baseline is found. Growth uses
+the medians of short endpoint windows so one allocation or reclamation sample
+cannot decide the gate. Focused unit tests own both invariants.

--- a/perf-monitor/README.md
+++ b/perf-monitor/README.md
@@ -18,8 +18,8 @@ cargo perf-test -- --binary src-tauri/target/release/hardware-visualizer.exe
 | ---------------------- | ---------------------- | ---------------------------------- |
 | `--binary <PATH>`      | _(required)_           | Path to the target binary          |
 | `--config <PATH>`      | `perf-thresholds.toml` | Path to the threshold config file  |
-| `--warmup <SECONDS>`   | From config (10)       | Warmup duration before measurement |
-| `--duration <SECONDS>` | From config (30)       | Measurement duration               |
+| `--warmup <SECONDS>`   | From config (15)       | Minimum warmup before stabilization |
+| `--duration <SECONDS>` | From config (60)       | Measurement duration               |
 | `--output <FORMAT>`    | `text`                 | Output format: `text` or `json`    |
 
 ### Examples
@@ -50,8 +50,9 @@ max_p95_memory_mb = 500.0      # 95th percentile process-tree RSS in MB, includi
 max_memory_growth_mb = 50.0    # Process-tree memory growth over measurement
 
 [timing]
-warmup_seconds = 10            # Skip initial startup spike
-measurement_seconds = 30       # Measurement window
+warmup_seconds = 15            # Minimum delay before stabilization checks
+stabilization_timeout_seconds = 45 # Maximum additional stabilization wait
+measurement_seconds = 60       # Measurement window
 sample_interval_ms = 1000      # Sampling frequency
 ```
 
@@ -84,10 +85,16 @@ Only the fields you specify are overridden; others inherit from `[thresholds]`.
 ## How It Works
 
 1. **Launch** - Spawns the target binary as a subprocess
-2. **Warmup** - Waits for the app to stabilize (skips initialization spike)
-3. **Measure** - Samples CPU and process-tree RSS at `sample_interval_ms` intervals using `sysinfo`
-4. **Terminate** - Kills the process (RAII guard ensures cleanup on errors)
-5. **Report** - Computes statistics (avg, max, P95, memory growth) and checks against thresholds
+2. **Minimum warmup** - Waits for the configured startup delay
+3. **Stabilize** - Samples once per second until the same helper PID set and stable component RSS are observed for 10 consecutive samples, or fails after `stabilization_timeout_seconds`
+4. **Measure** - Samples CPU and process-tree RSS at `sample_interval_ms` intervals using `sysinfo`
+5. **Terminate** - Kills the process (RAII guard ensures cleanup on errors)
+6. **Report** - Computes statistics (avg, max, P95, memory growth) and checks against thresholds
+
+RSS is considered stable when the median shift between the first and second
+halves of the 10-sample window is at most 5 MiB for the app, WebView, and other
+helper components. A fixed delay alone is insufficient because shared runners
+can finish WebView startup at different times.
 
 Memory samples track both the launched app process RSS and the total process-tree RSS that includes associated helper processes. Helpers are discovered by walking the `parent()` chain from the launched PID. Windows and macOS also include WebView helper processes that were created after launch and expose the target app identity in process metadata, because WebView helpers are not always reliably parented under the app PID.
 
@@ -98,7 +105,7 @@ Memory samples track both the launched app process RSS and the total process-tre
 | CPU Avg / P95    | Launched process CPU usage normalized by logical CPU count (0-100%)      |
 | App Memory Avg / P95 | Launched app process Resident Set Size (RSS) in MB                   |
 | Total Memory Avg / P95 | Total process-tree RSS in MB, including WebView                  |
-| Memory Growth    | Last RSS sample minus first sample for each memory budget                 |
+| Memory Growth    | Median of the last five RSS samples minus the median of the first five samples for each memory budget |
 | Memory Breakdown | Parent, WebView, and other helper RSS breakdown in text and JSON reports |
 
 ### Exit Code

--- a/perf-monitor/src/config.rs
+++ b/perf-monitor/src/config.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+pub const STABILITY_WINDOW_SAMPLES: usize = 10;
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
   pub thresholds: Thresholds,
@@ -30,6 +32,8 @@ pub struct Thresholds {
 #[derive(Debug, Deserialize)]
 pub struct Timing {
   pub warmup_seconds: u64,
+  #[serde(default = "default_stabilization_timeout_seconds")]
+  pub stabilization_timeout_seconds: u64,
   pub measurement_seconds: u64,
   pub sample_interval_ms: u64,
 }
@@ -61,6 +65,7 @@ impl Default for Timing {
   fn default() -> Self {
     Self {
       warmup_seconds: 15,
+      stabilization_timeout_seconds: default_stabilization_timeout_seconds(),
       measurement_seconds: 60,
       sample_interval_ms: 1000,
     }
@@ -87,6 +92,13 @@ impl Config {
       return Err(ValidationError(format!(
         "measurement_seconds ({}s) must be >= sample_interval_ms ({}ms)",
         self.timing.measurement_seconds, self.timing.sample_interval_ms
+      )));
+    }
+
+    if self.timing.stabilization_timeout_seconds < STABILITY_WINDOW_SAMPLES as u64 {
+      return Err(ValidationError(format!(
+        "stabilization_timeout_seconds ({}s) must be at least {}s",
+        self.timing.stabilization_timeout_seconds, STABILITY_WINDOW_SAMPLES
       )));
     }
 
@@ -128,6 +140,10 @@ impl Config {
   }
 }
 
+fn default_stabilization_timeout_seconds() -> u64 {
+  45
+}
+
 fn current_platform() -> &'static str {
   if cfg!(target_os = "windows") {
     "windows"
@@ -137,5 +153,24 @@ fn current_platform() -> &'static str {
     "macos"
   } else {
     "unknown"
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn timing_defaults_stabilization_timeout_for_older_configs() {
+    let timing: Timing = toml::from_str(
+      r#"
+        warmup_seconds = 15
+        measurement_seconds = 60
+        sample_interval_ms = 1000
+      "#,
+    )
+    .expect("legacy timing config should deserialize");
+
+    assert_eq!(timing.stabilization_timeout_seconds, 45);
   }
 }

--- a/perf-monitor/src/main.rs
+++ b/perf-monitor/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
   #[arg(long, default_value = "perf-thresholds.toml")]
   config: PathBuf,
 
-  /// Warmup duration in seconds (skip initial spike)
+  /// Minimum warmup duration before process-tree stabilization
   #[arg(long)]
   warmup: Option<u64>,
 

--- a/perf-monitor/src/monitor.rs
+++ b/perf-monitor/src/monitor.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Read;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -8,9 +8,11 @@ use std::time::Duration;
 
 use sysinfo::{Pid, Process, ProcessesToUpdate, System};
 
-use crate::config::Timing;
+use crate::config::{STABILITY_WINDOW_SAMPLES, Timing};
 
 const BYTES_PER_MIB: f64 = 1024.0 * 1024.0;
+const GROWTH_WINDOW_SAMPLES: usize = 5;
+const STABILITY_MAX_MEDIAN_SHIFT_MB: f64 = 5.0;
 const STDERR_BUFFER_LIMIT_BYTES: usize = 64 * 1024;
 const STDERR_READ_CHUNK_BYTES: usize = 8 * 1024;
 const WEBVIEW_PROCESS_MARKERS: &[&str] = &[
@@ -94,6 +96,14 @@ struct ProcessMemoryBreakdown {
   other_process_memory_bytes: u64,
   process_count: usize,
   webview_process_count: usize,
+}
+
+#[derive(Debug)]
+struct StabilitySample {
+  process_ids: HashSet<Pid>,
+  parent_memory_rss_mb: f64,
+  webview_memory_rss_mb: f64,
+  other_process_memory_rss_mb: f64,
 }
 
 /// RAII guard that ensures the child process is terminated on drop.
@@ -203,9 +213,14 @@ pub fn run_monitor(
   // Initial refresh to establish CPU baselines and discover helper processes.
   system.refresh_processes(ProcessesToUpdate::All, true);
 
-  eprintln!("Warming up for {} seconds...", timing.warmup_seconds);
+  eprintln!(
+    "Warming up for at least {} seconds...",
+    timing.warmup_seconds
+  );
 
-  // Warmup phase: wait for app to stabilize
+  // Keep the configured warmup as a minimum. Startup work can take longer on
+  // shared runners, so measurement starts only after both the tracked helper
+  // set and component RSS have remained stable for a rolling window.
   for _ in 0..timing.warmup_seconds {
     thread::sleep(Duration::from_secs(1));
     if guard.child.try_wait()?.is_some() {
@@ -213,6 +228,58 @@ pub fn run_monitor(
     }
     system.refresh_processes(ProcessesToUpdate::All, true);
   }
+
+  eprintln!(
+    "Waiting up to {} seconds for process memory and helpers to stabilize...",
+    timing.stabilization_timeout_seconds
+  );
+
+  let mut stability_samples = VecDeque::with_capacity(STABILITY_WINDOW_SAMPLES);
+  let mut stabilization_seconds = 0;
+  let mut stabilized = false;
+
+  for _ in 0..timing.stabilization_timeout_seconds {
+    thread::sleep(Duration::from_secs(1));
+    stabilization_seconds += 1;
+
+    if guard.child.try_wait()?.is_some() {
+      return Err(format_exit_error(&mut guard, "stabilization", binary_path));
+    }
+
+    system.refresh_processes(ProcessesToUpdate::All, true);
+
+    let Some((metrics, process_ids)) = tracker.sample_with_process_ids(&system, num_cpus)
+    else {
+      if guard.child.try_wait()?.is_some() {
+        return Err(format_exit_error(&mut guard, "stabilization", binary_path));
+      }
+      return Err("Process disappeared during stabilization".into());
+    };
+
+    if stability_samples.len() == STABILITY_WINDOW_SAMPLES {
+      stability_samples.pop_front();
+    }
+    stability_samples.push_back(StabilitySample::new(metrics, process_ids));
+
+    if process_tree_is_stable(&stability_samples) {
+      stabilized = true;
+      break;
+    }
+  }
+
+  if !stabilized {
+    return Err(format!(
+      "Process tree did not stabilize within {} seconds after the {}-second minimum warmup",
+      timing.stabilization_timeout_seconds, timing.warmup_seconds
+    )
+    .into());
+  }
+
+  let actual_warmup_seconds = timing.warmup_seconds + stabilization_seconds;
+  eprintln!(
+    "Process tree stabilized after {} seconds ({} consecutive samples).",
+    actual_warmup_seconds, STABILITY_WINDOW_SAMPLES
+  );
 
   eprintln!(
     "Measuring for {} seconds (interval: {}ms)...",
@@ -253,8 +320,59 @@ pub fn run_monitor(
   Ok(compute_result(
     samples,
     timing.measurement_seconds,
-    timing.warmup_seconds,
+    actual_warmup_seconds,
   ))
+}
+
+impl StabilitySample {
+  fn new(metrics: ProcessMetrics, process_ids: HashSet<Pid>) -> Self {
+    Self {
+      process_ids,
+      parent_memory_rss_mb: metrics.parent_memory_rss_mb,
+      webview_memory_rss_mb: metrics.webview_memory_rss_mb,
+      other_process_memory_rss_mb: metrics.other_process_memory_rss_mb,
+    }
+  }
+}
+
+fn process_tree_is_stable(samples: &VecDeque<StabilitySample>) -> bool {
+  if samples.len() < STABILITY_WINDOW_SAMPLES {
+    return false;
+  }
+
+  let Some(first) = samples.front() else {
+    return false;
+  };
+
+  if samples
+    .iter()
+    .any(|sample| sample.process_ids != first.process_ids)
+  {
+    return false;
+  }
+
+  memory_component_is_stable(samples.iter().map(|sample| sample.parent_memory_rss_mb))
+    && memory_component_is_stable(
+      samples.iter().map(|sample| sample.webview_memory_rss_mb),
+    )
+    && memory_component_is_stable(
+      samples
+        .iter()
+        .map(|sample| sample.other_process_memory_rss_mb),
+    )
+}
+
+fn memory_component_is_stable(values: impl Iterator<Item = f64>) -> bool {
+  let values = values.collect::<Vec<_>>();
+  let midpoint = values.len() / 2;
+  if midpoint == 0 {
+    return false;
+  }
+
+  let first_median = percentile_f64(&values[..midpoint], 50.0);
+  let last_median = percentile_f64(&values[midpoint..], 50.0);
+
+  (last_median - first_median).abs() <= STABILITY_MAX_MEDIAN_SHIFT_MB
 }
 
 impl ProcessTracker {
@@ -290,15 +408,36 @@ impl ProcessTracker {
   }
 
   fn sample(&self, system: &System, num_cpus: f32) -> Option<ProcessMetrics> {
-    let processes = snapshot_processes(system);
-    self.sample_from_snapshots(&processes, num_cpus)
+    self
+      .sample_with_process_ids(system, num_cpus)
+      .map(|(metrics, _)| metrics)
   }
 
+  fn sample_with_process_ids(
+    &self,
+    system: &System,
+    num_cpus: f32,
+  ) -> Option<(ProcessMetrics, HashSet<Pid>)> {
+    let processes = snapshot_processes(system);
+    self.sample_with_process_ids_from_snapshots(&processes, num_cpus)
+  }
+
+  #[cfg(test)]
   fn sample_from_snapshots(
     &self,
     processes: &HashMap<Pid, ProcessSnapshot>,
     num_cpus: f32,
   ) -> Option<ProcessMetrics> {
+    self
+      .sample_with_process_ids_from_snapshots(processes, num_cpus)
+      .map(|(metrics, _)| metrics)
+  }
+
+  fn sample_with_process_ids_from_snapshots(
+    &self,
+    processes: &HashMap<Pid, ProcessSnapshot>,
+    num_cpus: f32,
+  ) -> Option<(ProcessMetrics, HashSet<Pid>)> {
     let root_process = processes.get(&self.root_pid)?;
     let tracked_pids = self.tracked_pids_from_snapshots(processes);
     let breakdown = process_memory_breakdown(&tracked_pids, self.root_pid, processes);
@@ -306,7 +445,7 @@ impl ProcessTracker {
       + breakdown.webview_memory_bytes
       + breakdown.other_process_memory_bytes;
 
-    Some(ProcessMetrics {
+    let metrics = ProcessMetrics {
       // Keep CPU semantics scoped to the launched process; issue #1579 changes
       // the RSS accounting that feeds memory thresholds.
       cpu_usage: root_process.cpu_usage / num_cpus,
@@ -316,7 +455,9 @@ impl ProcessTracker {
       other_process_memory_rss_mb: bytes_to_mib(breakdown.other_process_memory_bytes),
       process_count: breakdown.process_count,
       webview_process_count: breakdown.webview_process_count,
-    })
+    };
+
+    Some((metrics, tracked_pids))
   }
 
   fn tracked_pids_from_snapshots(
@@ -709,8 +850,11 @@ where
   let avg_mb = values.iter().sum::<f64>() / values.len() as f64;
   let max_mb = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
   let p95_mb = percentile_f64(&values, 95.0);
-  let first_mb = values.first().copied().unwrap_or(0.0);
-  let last_mb = values.last().copied().unwrap_or(0.0);
+  // Endpoint medians preserve the start-to-end growth signal without letting
+  // one allocation or reclamation sample decide the gate.
+  let growth_window_samples = GROWTH_WINDOW_SAMPLES.min(values.len() / 2).max(1);
+  let first_mb = percentile_f64(&values[..growth_window_samples], 50.0);
+  let last_mb = percentile_f64(&values[values.len() - growth_window_samples..], 50.0);
 
   MemoryStats {
     avg_mb,
@@ -743,6 +887,7 @@ fn percentile_f64(values: &[f64], pct: f64) -> f64 {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::collections::VecDeque;
 
   #[test]
   fn percentile_f32_empty_returns_zero() {
@@ -828,6 +973,75 @@ mod tests {
     assert!((result.webview_memory.growth_mb - 45.0).abs() < 0.01);
     assert_eq!(result.max_process_count, 3);
     assert_eq!(result.max_webview_process_count, 1);
+  }
+
+  #[test]
+  fn memory_growth_uses_endpoint_window_medians() {
+    let values = [
+      900.0, 100.0, 102.0, 98.0, 101.0, 150.0, 148.0, 151.0, 149.0, 1000.0,
+    ];
+    let samples = values
+      .into_iter()
+      .map(|memory| sample(0.0, memory, memory, 0.0, 0.0))
+      .collect::<Vec<_>>();
+
+    let stats = memory_stats(&samples, |sample| sample.memory_rss_mb);
+
+    // First-window median = 101 MB, last-window median = 150 MB. The
+    // individual 900/1000 MB endpoints must not determine growth.
+    assert!((stats.growth_mb - 49.0).abs() < 0.01);
+  }
+
+  #[test]
+  fn process_tree_stability_requires_a_full_window_with_the_same_helpers() {
+    let mut samples = VecDeque::from(
+      (0..STABILITY_WINDOW_SAMPLES)
+        .map(|_| stability_sample(&[10, 11], 70.0, 400.0, 0.0))
+        .collect::<Vec<_>>(),
+    );
+    samples[STABILITY_WINDOW_SAMPLES / 2] =
+      stability_sample(&[10, 11, 12], 70.0, 400.0, 0.0);
+
+    assert!(!process_tree_is_stable(&samples));
+
+    samples.pop_front();
+    samples.push_back(stability_sample(&[10, 11], 70.0, 400.0, 0.0));
+    assert!(!process_tree_is_stable(&samples));
+
+    while samples
+      .iter()
+      .any(|sample| sample.process_ids.contains(&pid(12)))
+    {
+      samples.pop_front();
+      samples.push_back(stability_sample(&[10, 11], 70.0, 400.0, 0.0));
+    }
+
+    assert!(process_tree_is_stable(&samples));
+  }
+
+  #[test]
+  fn process_tree_stability_waits_for_rss_growth_to_settle() {
+    let mut samples = VecDeque::from(
+      (0..STABILITY_WINDOW_SAMPLES)
+        .map(|index| {
+          let webview_memory = if index < STABILITY_WINDOW_SAMPLES / 2 {
+            100.0
+          } else {
+            130.0
+          };
+          stability_sample(&[10, 11], 70.0, webview_memory, 0.0)
+        })
+        .collect::<Vec<_>>(),
+    );
+
+    assert!(!process_tree_is_stable(&samples));
+
+    for _ in 0..STABILITY_WINDOW_SAMPLES {
+      samples.pop_front();
+      samples.push_back(stability_sample(&[10, 11], 70.0, 130.0, 0.0));
+    }
+
+    assert!(process_tree_is_stable(&samples));
   }
 
   #[test]
@@ -1127,6 +1341,20 @@ mod tests {
       other_process_memory_rss_mb,
       process_count: 3,
       webview_process_count: 1,
+    }
+  }
+
+  fn stability_sample(
+    process_ids: &[u32],
+    parent_memory_rss_mb: f64,
+    webview_memory_rss_mb: f64,
+    other_process_memory_rss_mb: f64,
+  ) -> StabilitySample {
+    StabilitySample {
+      process_ids: process_ids.iter().copied().map(pid).collect(),
+      parent_memory_rss_mb,
+      webview_memory_rss_mb,
+      other_process_memory_rss_mb,
     }
   }
 }

--- a/perf-thresholds.toml
+++ b/perf-thresholds.toml
@@ -9,7 +9,10 @@ max_p95_memory_mb = 500.0
 max_memory_growth_mb = 50.0
 
 [timing]
+# Wait at least 15s, then allow up to 45s for a stable helper set and RSS
+# baseline before the measurement window starts.
 warmup_seconds = 15
+stabilization_timeout_seconds = 45
 measurement_seconds = 60
 sample_interval_ms = 1000
 


### PR DESCRIPTION
## Summary

- treat the configured warmup as a minimum and wait for a stable helper PID set and component RSS before measuring
- calculate memory growth from five-sample endpoint medians instead of individual first/last samples
- preserve older timing configs with a default stabilization timeout and document the confirmed failure mode

## Related Issues

Fixes #1974

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing
- [x] Unit tests

- `cargo test --manifest-path perf-monitor/Cargo.toml`
- `cargo clippy --manifest-path perf-monitor/Cargo.toml -- -D warnings`
- `cargo fmt --manifest-path perf-monitor/Cargo.toml -- --check`
- `npm run check:agent-guidance`
- `npm run tauri -- build --no-bundle -- --profile ci`
- Isolated Windows CI-profile run with 0s minimum warmup: stabilized after 11s; app growth 0.5 MiB, WebView growth -39.5 MiB, tree growth -39.0 MiB. The local machine still exceeded unrelated CI-calibrated app-average and tree-P95 budgets.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance monitoring now waits for process and memory usage to stabilize before measuring.
  * Added a configurable stabilization timeout, defaulting to 45 seconds.
  * Memory growth calculations now use median values from endpoint sample windows for more reliable results.
  * Updated default workflow timings: 15-second warmup and 60-second measurement window.

* **Documentation**
  * Expanded performance-monitoring guidance, configuration details, and troubleshooting lessons.
  * Documented stabilization criteria, verification steps, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->