### PR TITLE
feat(settings): select power display targets

### DIFF
--- a/src-tauri/src/_tests/commands/settings_test.rs
+++ b/src-tauri/src/_tests/commands/settings_test.rs
@@ -21,6 +21,11 @@ mod tests {
         hardware::HardwareType::Memory,
         hardware::HardwareType::Gpu,
       ],
+      power_display_targets: vec![
+        enums::hardware::PowerDisplayTarget::Cpu,
+        enums::hardware::PowerDisplayTarget::Gpu,
+        enums::hardware::PowerDisplayTarget::Package,
+      ],
       graph_size: enums::settings::GraphSize::XL,
       graph_fit_to_window: false,
       graph_margin_px: 32,

--- a/src-tauri/src/_tests/commands/settings_test.rs
+++ b/src-tauri/src/_tests/commands/settings_test.rs
@@ -70,6 +70,10 @@ mod tests {
       expected.ui_announcement_version
     );
     assert_eq!(settings.display_targets, expected.display_targets,);
+    assert_eq!(
+      settings.power_display_targets,
+      expected.power_display_targets
+    );
     assert_eq!(settings.line_graph_border, expected.line_graph_border);
     assert_eq!(settings.graph_size, expected.graph_size);
     assert_eq!(settings.graph_fit_to_window, expected.graph_fit_to_window);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -138,6 +138,7 @@ pub mod commands {
       current_ui_announcement_version:
         services::settings_service::GROUPED_NAVIGATION_ANNOUNCEMENT_VERSION,
       display_targets: settings.display_targets,
+      power_display_targets: settings.power_display_targets,
       graph_size: settings.graph_size,
       graph_fit_to_window: settings.graph_fit_to_window,
       graph_margin_px: settings.graph_margin_px,
@@ -250,6 +251,21 @@ pub mod commands {
     let mut settings = state.settings.lock().unwrap();
 
     if let Err(e) = settings.set_display_targets(new_targets) {
+      emit_error(&window)?;
+      return Err(e);
+    }
+    Ok(())
+  }
+
+  #[tauri::command]
+  #[specta::specta]
+  pub async fn set_power_display_targets(
+    window: Window,
+    state: tauri::State<'_, AppState>,
+    new_targets: Vec<enums::hardware::PowerDisplayTarget>,
+  ) -> Result<(), String> {
+    let mut settings = state.settings.lock().unwrap();
+    if let Err(e) = settings.set_power_display_targets(new_targets) {
       emit_error(&window)?;
       return Err(e);
     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -265,11 +265,24 @@ pub mod commands {
     new_targets: Vec<enums::hardware::PowerDisplayTarget>,
   ) -> Result<(), String> {
     let mut settings = state.settings.lock().unwrap();
-    if let Err(e) = settings.set_power_display_targets(new_targets) {
+    if let Err(e) =
+      settings.set_power_display_targets(normalize_power_display_targets(new_targets))
+    {
       emit_error(&window)?;
       return Err(e);
     }
     Ok(())
+  }
+
+  fn normalize_power_display_targets(
+    targets: Vec<enums::hardware::PowerDisplayTarget>,
+  ) -> Vec<enums::hardware::PowerDisplayTarget> {
+    targets.into_iter().fold(Vec::new(), |mut unique, target| {
+      if !unique.contains(&target) {
+        unique.push(target);
+      }
+      unique
+    })
   }
 
   #[tauri::command]
@@ -969,5 +982,31 @@ pub mod commands {
       .opener()
       .open_path(path_str, None::<&str>)
       .map_err(|e| format!("Failed to open LICENSE file path: {}", e))
+  }
+
+  #[cfg(test)]
+  mod tests {
+    use super::normalize_power_display_targets;
+    use crate::enums::hardware::PowerDisplayTarget;
+
+    #[test]
+    fn power_display_targets_are_deduplicated_in_first_seen_order() {
+      let targets = vec![
+        PowerDisplayTarget::Cpu,
+        PowerDisplayTarget::Gpu,
+        PowerDisplayTarget::Cpu,
+        PowerDisplayTarget::Ane,
+        PowerDisplayTarget::Gpu,
+      ];
+
+      assert_eq!(
+        normalize_power_display_targets(targets),
+        vec![
+          PowerDisplayTarget::Cpu,
+          PowerDisplayTarget::Gpu,
+          PowerDisplayTarget::Ane,
+        ]
+      );
+    }
   }
 }

--- a/src-tauri/src/enums/hardware.rs
+++ b/src-tauri/src/enums/hardware.rs
@@ -13,6 +13,15 @@ pub enum HardwareType {
   Gpu,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Type, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PowerDisplayTarget {
+  Cpu,
+  Gpu,
+  Ane,
+  Package,
+}
+
 impl<'de> Deserialize<'de> for HardwareType {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ fn build_specta_builder() -> Builder<Wry> {
       settings::commands::set_navigation_layout,
       settings::commands::acknowledge_navigation_restructure_announcement,
       settings::commands::set_display_targets,
+      settings::commands::set_power_display_targets,
       settings::commands::set_graph_size,
       settings::commands::set_graph_fit_to_window,
       settings::commands::set_graph_margin_px,

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -46,6 +46,7 @@ pub struct Settings {
   pub navigation_layout: enums::settings::NavigationLayout,
   pub ui_announcement_version: u32,
   pub display_targets: Vec<enums::hardware::HardwareType>,
+  pub power_display_targets: Vec<enums::hardware::PowerDisplayTarget>,
   pub graph_size: enums::settings::GraphSize,
   pub graph_fit_to_window: bool,
   pub graph_margin_px: u32,
@@ -99,6 +100,7 @@ pub struct ClientSettings {
   /// persisted user preference.
   pub current_ui_announcement_version: u32,
   pub display_targets: Vec<enums::hardware::HardwareType>,
+  pub power_display_targets: Vec<enums::hardware::PowerDisplayTarget>,
   pub graph_size: enums::settings::GraphSize,
   pub graph_fit_to_window: bool,
   pub graph_margin_px: u32,
@@ -143,6 +145,11 @@ impl Default for Settings {
         enums::hardware::HardwareType::Cpu,
         enums::hardware::HardwareType::Memory,
         enums::hardware::HardwareType::Gpu,
+      ],
+      power_display_targets: vec![
+        enums::hardware::PowerDisplayTarget::Cpu,
+        enums::hardware::PowerDisplayTarget::Gpu,
+        enums::hardware::PowerDisplayTarget::Package,
       ],
       graph_size: enums::settings::GraphSize::XL,
       graph_fit_to_window: false,
@@ -293,6 +300,11 @@ mod tests {
       ui_announcement_version: 1,
       current_ui_announcement_version: 1,
       display_targets: vec![enums::hardware::HardwareType::Cpu],
+      power_display_targets: vec![
+        enums::hardware::PowerDisplayTarget::Cpu,
+        enums::hardware::PowerDisplayTarget::Gpu,
+        enums::hardware::PowerDisplayTarget::Package,
+      ],
       graph_size: enums::settings::GraphSize::XL,
       graph_fit_to_window: false,
       graph_margin_px: 32,
@@ -345,6 +357,7 @@ mod tests {
     let serialized = serde_json::to_string(&settings).unwrap();
 
     assert!(serialized.contains("\"displayTargets\""));
+    assert!(serialized.contains("\"powerDisplayTargets\""));
     assert!(serialized.contains("\"graphSize\""));
     assert!(serialized.contains("\"graphFitToWindow\""));
     assert!(serialized.contains("\"graphMarginPx\""));

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -359,8 +359,26 @@ impl models::settings::Settings {
     &mut self,
     new_targets: Vec<enums::hardware::PowerDisplayTarget>,
   ) -> Result<(), String> {
-    self.power_display_targets = new_targets;
-    self.write_file()
+    self.set_power_display_targets_with_writer(new_targets, |settings| {
+      settings.write_file()
+    })
+  }
+
+  fn set_power_display_targets_with_writer<F>(
+    &mut self,
+    new_targets: Vec<enums::hardware::PowerDisplayTarget>,
+    writer: F,
+  ) -> Result<(), String>
+  where
+    F: FnOnce(&Self) -> Result<(), String>,
+  {
+    let previous_targets =
+      std::mem::replace(&mut self.power_display_targets, new_targets);
+    if let Err(error) = writer(self) {
+      self.power_display_targets = previous_targets;
+      return Err(error);
+    }
+    Ok(())
   }
 
   pub fn set_graph_size(
@@ -853,6 +871,22 @@ mod tests {
     let mut settings = models::settings::Settings::default();
     read_settings_from_str(&mut settings, r#"{"powerDisplayTargets":[]}"#).unwrap();
     assert!(settings.power_display_targets.is_empty());
+  }
+
+  #[test]
+  fn set_power_display_targets_restores_value_when_writer_fails() {
+    let mut settings = models::settings::Settings::default();
+    let previous_targets = settings.power_display_targets.clone();
+
+    let error = settings
+      .set_power_display_targets_with_writer(
+        vec![enums::hardware::PowerDisplayTarget::Ane],
+        |_| Err("write failed".to_string()),
+      )
+      .unwrap_err();
+
+    assert_eq!(error, "write failed");
+    assert_eq!(settings.power_display_targets, previous_targets);
   }
 
   #[test]

--- a/src-tauri/src/services/settings_service.rs
+++ b/src-tauri/src/services/settings_service.rs
@@ -212,6 +212,7 @@ impl models::settings::Settings {
     try_field!(navigation_layout, "navigationLayout");
     try_field!(ui_announcement_version, "uiAnnouncementVersion");
     try_field!(display_targets, "displayTargets");
+    try_field!(power_display_targets, "powerDisplayTargets");
     try_field!(graph_size, "graphSize");
     try_field!(graph_fit_to_window, "graphFitToWindow");
     try_field!(graph_margin_px, "graphMarginPx");
@@ -351,6 +352,14 @@ impl models::settings::Settings {
     new_targets: Vec<enums::hardware::HardwareType>,
   ) -> Result<(), String> {
     self.display_targets = new_targets;
+    self.write_file()
+  }
+
+  pub fn set_power_display_targets(
+    &mut self,
+    new_targets: Vec<enums::hardware::PowerDisplayTarget>,
+  ) -> Result<(), String> {
+    self.power_display_targets = new_targets;
     self.write_file()
   }
 
@@ -820,6 +829,33 @@ mod tests {
   }
 
   #[test]
+  fn invalid_power_display_targets_recover_to_defaults() {
+    let mut settings = models::settings::Settings {
+      language: "ja".to_string(),
+      ..Default::default()
+    };
+
+    read_settings_from_str(
+      &mut settings,
+      r#"{"language":"en","powerDisplayTargets":["cpu","invalid"]}"#,
+    )
+    .unwrap();
+
+    assert_eq!(settings.language, "en");
+    assert_eq!(
+      settings.power_display_targets,
+      models::settings::Settings::default().power_display_targets
+    );
+  }
+
+  #[test]
+  fn valid_empty_power_display_targets_preserve_explicit_intent() {
+    let mut settings = models::settings::Settings::default();
+    read_settings_from_str(&mut settings, r#"{"powerDisplayTargets":[]}"#).unwrap();
+    assert!(settings.power_display_targets.is_empty());
+  }
+
+  #[test]
   fn set_elevated_startup_mode_persists_when_writer_succeeds() {
     let mut settings = models::settings::Settings::default();
     let mut persisted_value = false;
@@ -884,6 +920,13 @@ mod tests {
       Some("v1:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
     );
     assert!(value.get("language").is_some());
+    assert_eq!(
+      value
+        .get("powerDisplayTargets")
+        .and_then(|targets| targets.as_array())
+        .map(Vec::len),
+      Some(3)
+    );
   }
 
   #[test]

--- a/src/e2e/fixtures/settings.ts
+++ b/src/e2e/fixtures/settings.ts
@@ -16,6 +16,7 @@ export const settingsFixture: ClientSettings_Serialize = {
   uiAnnouncementVersion: 1,
   currentUiAnnouncementVersion: 1,
   displayTargets: ["cpu", "memory", "gpu"],
+  powerDisplayTargets: ["cpu", "gpu", "package"],
   graphSize: "xl",
   graphFitToWindow: false,
   graphMarginPx: 32,

--- a/src/features/hardware/insights/Insights.tsx
+++ b/src/features/hardware/insights/Insights.tsx
@@ -21,6 +21,7 @@ import type {
   DataStats,
   GpuDataType,
 } from "@/features/hardware/types/hardwareDataType";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import type { DataArchiveHardwareType } from "@/rspc/bindings";
 import { useGpuNames } from "../hooks/useGpuNames";
@@ -171,6 +172,7 @@ const MainInsights = () => {
 
 const CoolingInsights = () => {
   const { t } = useTranslation();
+  const { settings } = useSettingsAtom();
   const [periodAvgCpuTemperature, setPeriodAvgCpuTemperature] = useTauriStore<
     (typeof archivePeriods)[number]
   >("periodAvgCpuTemperature", 60);
@@ -239,21 +241,35 @@ const CoolingInsights = () => {
       stats: "min",
       period: [periodMinCpuTemperature, setPeriodMinCpuTemperature],
     },
-    {
-      type: "packagePower",
-      stats: "avg",
-      period: [periodAvgPackagePower, setPeriodAvgPackagePower],
-    },
-    {
-      type: "packagePower",
-      stats: "max",
-      period: [periodMaxPackagePower, setPeriodMaxPackagePower],
-    },
-    {
-      type: "packagePower",
-      stats: "min",
-      period: [periodMinPackagePower, setPeriodMinPackagePower],
-    },
+    ...settings.powerDisplayTargets.flatMap((target) => {
+      const type = `${target}Power` as DataArchiveHardwareType;
+      return [
+        {
+          type,
+          stats: "avg" as const,
+          period: [periodAvgPackagePower, setPeriodAvgPackagePower] as [
+            typeof periodAvgPackagePower,
+            typeof setPeriodAvgPackagePower,
+          ],
+        },
+        {
+          type,
+          stats: "max" as const,
+          period: [periodMaxPackagePower, setPeriodMaxPackagePower] as [
+            typeof periodMaxPackagePower,
+            typeof setPeriodMaxPackagePower,
+          ],
+        },
+        {
+          type,
+          stats: "min" as const,
+          period: [periodMinPackagePower, setPeriodMinPackagePower] as [
+            typeof periodMinPackagePower,
+            typeof setPeriodMinPackagePower,
+          ],
+        },
+      ];
+    }),
   ];
 
   return (
@@ -464,11 +480,18 @@ const ChartArea = (data: {
     typeof setInterval
   > | null>(null);
   const { t } = useTranslation();
+  const powerTitles: Partial<Record<DataArchiveHardwareType, string>> = {
+    cpuPower: t("pages.performance.power.cpu"),
+    gpuPower: t("pages.performance.power.gpu"),
+    anePower: t("pages.performance.power.ane"),
+    packagePower: t("pages.performance.power.package"),
+  };
+  const powerTitle = powerTitles[type];
   const title =
     type === "cpuTemperature"
       ? `CPU ${t("shared.temperature.full")}`
-      : type === "packagePower"
-        ? `${t("pages.insights.cooling.packagePower")} (W)`
+      : powerTitle
+        ? `${powerTitle} (W)`
         : t(type === "cpu" ? "shared.cpuUsage" : "shared.memoryUsage");
 
   const handleMouseDown = (increment: number) => {

--- a/src/features/hardware/insights/components/InsightChart.tsx
+++ b/src/features/hardware/insights/components/InsightChart.tsx
@@ -34,6 +34,15 @@ export const InsightChart = ({
 
   const isTemperature = hardwareType === "cpuTemperature";
   const isPower = hardwareType.endsWith("Power");
+  const powerLabels = {
+    cpuPower: t("pages.performance.power.cpu"),
+    gpuPower: t("pages.performance.power.gpu"),
+    anePower: t("pages.performance.power.ane"),
+    packagePower: t("pages.performance.power.package"),
+  } as const;
+  const powerLabel = isPower
+    ? powerLabels[hardwareType as keyof typeof powerLabels]
+    : powerLabels.packagePower;
   const dataType: "cpu" | "memory" | "temp" | "power" = isTemperature
     ? "temp"
     : isPower
@@ -58,7 +67,7 @@ export const InsightChart = ({
       color: "254, 192, 57",
     },
     power: {
-      label: t("pages.insights.cooling.packagePower"),
+      label: powerLabel,
       color: "245, 158, 11",
     },
   } satisfies ChartConfig;
@@ -92,7 +101,7 @@ export const InsightChart = ({
           isTemperature
             ? `CPU ${t("shared.temperature.full")} (${settings.temperatureUnit === "C" ? "°C" : "°F"})`
             : isPower
-              ? `${t("pages.insights.cooling.packagePower")} (W)`
+              ? `${powerLabel} (W)`
               : `${t("shared.usage")} (%)`
         }
         range={

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -72,6 +72,7 @@ const settings = vi.hoisted(() => ({
   lineGraphMix: false,
   temperatureUnit: "C" as const,
   displayTargets: ["cpu", "memory", "gpu"],
+  powerDisplayTargets: ["cpu", "gpu", "package"],
   lineGraphColor: {
     cpu: "75, 192, 192",
     memory: "255, 99, 132",

--- a/src/features/hardware/performance/components/PowerPanel.test.tsx
+++ b/src/features/hardware/performance/components/PowerPanel.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { powerDrawAtom } from "@/features/hardware/store/chart";
 import { PowerPanel } from "./PowerPanel";
 
+let powerDisplayTargets = ["cpu", "gpu", "package"];
+
+vi.mock("@/features/settings/hooks/useSettingsAtom", () => ({
+  useSettingsAtom: () => ({ settings: { powerDisplayTargets } }),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -11,7 +17,8 @@ vi.mock("react-i18next", () => ({
 describe("PowerPanel", () => {
   afterEach(cleanup);
 
-  it("shows every component while preserving missing readings", () => {
+  it("shows only selected components while preserving missing readings", () => {
+    powerDisplayTargets = ["cpu", "ane", "package"];
     const store = createStore();
     store.set(powerDrawAtom, {
       cpuWatts: 10.1,
@@ -27,7 +34,9 @@ describe("PowerPanel", () => {
     );
 
     expect(screen.getByText("10.1 W")).toBeVisible();
-    expect(screen.getByText("2.2 W")).toBeVisible();
+    expect(screen.queryByText("2.2 W")).toBeNull();
     expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getByText("pages.performance.power.ane")).toBeVisible();
+    expect(screen.queryByText("pages.performance.power.gpu")).toBeNull();
   });
 });

--- a/src/features/hardware/performance/components/PowerPanel.tsx
+++ b/src/features/hardware/performance/components/PowerPanel.tsx
@@ -1,16 +1,24 @@
 import { useAtomValue } from "jotai";
 import { useTranslation } from "react-i18next";
 import { powerDrawAtom } from "@/features/hardware/store/chart";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
 
 export const PowerPanel = () => {
   const { t } = useTranslation();
   const power = useAtomValue(powerDrawAtom);
-  const readings = [
+  const { settings } = useSettingsAtom();
+  const allReadings: readonly [
+    "cpu" | "gpu" | "ane" | "package",
+    number | null,
+  ][] = [
     ["cpu", power.cpuWatts],
     ["gpu", power.gpuWatts],
     ["ane", power.aneWatts],
     ["package", power.packageWatts],
-  ] as const;
+  ];
+  const readings = allReadings.filter(([component]) =>
+    settings.powerDisplayTargets.includes(component),
+  );
 
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(12rem,1fr))] gap-x-8 gap-y-1 p-4 pt-2">

--- a/src/features/settings/components/graph/GraphSettings.tsx
+++ b/src/features/settings/components/graph/GraphSettings.tsx
@@ -9,6 +9,7 @@ import { GraphColorSettings } from "./GraphColorSettings";
 import { GraphSizeSlider } from "./GraphSizeSlider";
 import { GraphStyleSettings } from "./GraphStyleSettings";
 import { GraphTypeSelector } from "./GraphTypeSelector";
+import { PowerDisplayTargetSelector } from "./PowerDisplayTargetSelector";
 
 export const GraphSettings = () => {
   const { t } = useTranslation();
@@ -34,6 +35,10 @@ export const GraphSettings = () => {
                 {t("pages.settings.general.hardwareType")}
               </h4>
               <GraphTypeSelector />
+              <h4 className="font-bold text-xl">
+                {t("pages.settings.general.powerDisplayTargets")}
+              </h4>
+              <PowerDisplayTargetSelector />
             </div>
           </div>
           <div className="col-span-3">

--- a/src/features/settings/components/graph/PowerDisplayTargetSelector.tsx
+++ b/src/features/settings/components/graph/PowerDisplayTargetSelector.tsx
@@ -1,0 +1,34 @@
+import { useId } from "react";
+import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import type { PowerDisplayTarget } from "@/rspc/bindings";
+
+const targets: PowerDisplayTarget[] = ["cpu", "gpu", "ane", "package"];
+
+export const PowerDisplayTargetSelector = () => {
+  const { t } = useTranslation();
+  const { settings, togglePowerDisplayTarget } = useSettingsAtom();
+  const baseId = useId();
+
+  return (
+    <div className="py-6">
+      {targets.map((target) => {
+        const id = `${baseId}-${target}`;
+        return (
+          <div key={target} className="flex items-center space-x-2 py-3">
+            <Checkbox
+              id={id}
+              checked={settings.powerDisplayTargets.includes(target)}
+              onCheckedChange={() => togglePowerDisplayTarget(target)}
+            />
+            <Label htmlFor={id} className="text-lg">
+              {t(`pages.performance.power.${target}`)}
+            </Label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/features/settings/hooks/useSettingsAtom.test.ts
+++ b/src/features/settings/hooks/useSettingsAtom.test.ts
@@ -215,12 +215,80 @@ describe("useSettingsAtom", () => {
     await act(async () => {
       await result.current.togglePowerDisplayTarget("ane");
     });
+    expect(commands.setPowerDisplayTargets).toHaveBeenNthCalledWith(1, [
+      "cpu",
+      "gpu",
+      "package",
+      "ane",
+    ]);
     expect(result.current.settings.powerDisplayTargets).toContain("ane");
 
     await act(async () => {
       await result.current.togglePowerDisplayTarget("gpu");
     });
+    expect(commands.setPowerDisplayTargets).toHaveBeenNthCalledWith(2, [
+      "cpu",
+      "package",
+      "ane",
+    ]);
     expect(result.current.settings.powerDisplayTargets).not.toContain("gpu");
+  });
+
+  it("togglePowerDisplayTarget serializes rapid changes and persists the latest selection", async () => {
+    let resolveFirst: ((value: { data: null }) => void) | undefined;
+    let resolveSecond: ((value: { data: null }) => void) | undefined;
+    (commands.setPowerDisplayTargets as Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ data: null }>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ data: null }>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    const { result } = renderHook(() => useSettingsAtom(), {
+      wrapper: Provider,
+    });
+
+    let firstMutation: Promise<boolean> | undefined;
+    let secondMutation: Promise<boolean> | undefined;
+    act(() => {
+      firstMutation = result.current.togglePowerDisplayTarget("ane");
+      secondMutation = result.current.togglePowerDisplayTarget("gpu");
+    });
+
+    expect(commands.setPowerDisplayTargets).toHaveBeenCalledTimes(1);
+    expect(commands.setPowerDisplayTargets).toHaveBeenNthCalledWith(1, [
+      "cpu",
+      "gpu",
+      "package",
+      "ane",
+    ]);
+
+    await act(async () => {
+      resolveFirst?.({ data: null });
+      await Promise.resolve();
+    });
+    expect(commands.setPowerDisplayTargets).toHaveBeenCalledTimes(2);
+    expect(commands.setPowerDisplayTargets).toHaveBeenNthCalledWith(2, [
+      "cpu",
+      "package",
+      "ane",
+    ]);
+
+    await act(async () => {
+      resolveSecond?.({ data: null });
+      await Promise.all([firstMutation, secondMutation]);
+    });
+    expect(result.current.settings.powerDisplayTargets).toEqual([
+      "cpu",
+      "package",
+      "ane",
+    ]);
   });
 
   it("updateLineGraphColorAtom: lineGraphColor is updated on success", async () => {

--- a/src/features/settings/hooks/useSettingsAtom.test.ts
+++ b/src/features/settings/hooks/useSettingsAtom.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/rspc/bindings", () => ({
     getSettings: vi.fn(),
     setTheme: vi.fn(),
     setDisplayTargets: vi.fn(),
+    setPowerDisplayTargets: vi.fn(),
     setGraphSize: vi.fn(),
     setGraphFitToWindow: vi.fn(),
     setGraphMarginPx: vi.fn(),
@@ -75,6 +76,7 @@ describe("useSettingsAtom", () => {
       language: "ja",
       theme: "dark",
       displayTargets: ["cpu"],
+      powerDisplayTargets: ["cpu", "gpu", "package"],
       graphSize: "lg",
       graphFitToWindow: true,
       graphMarginPx: 24,
@@ -202,6 +204,23 @@ describe("useSettingsAtom", () => {
     expect(errorMock).toHaveBeenCalledWith(errorMsg);
     // On error, remains at initial state (empty array)
     expect(result.current.settings.displayTargets).toEqual([]);
+  });
+
+  it("togglePowerDisplayTarget persists opt-in and opt-out selections", async () => {
+    (commands.setPowerDisplayTargets as Mock).mockResolvedValue({ data: null });
+    const { result } = renderHook(() => useSettingsAtom(), {
+      wrapper: Provider,
+    });
+
+    await act(async () => {
+      await result.current.togglePowerDisplayTarget("ane");
+    });
+    expect(result.current.settings.powerDisplayTargets).toContain("ane");
+
+    await act(async () => {
+      await result.current.togglePowerDisplayTarget("gpu");
+    });
+    expect(result.current.settings.powerDisplayTargets).not.toContain("gpu");
   });
 
   it("updateLineGraphColorAtom: lineGraphColor is updated on success", async () => {

--- a/src/features/settings/hooks/useSettingsAtom.ts
+++ b/src/features/settings/hooks/useSettingsAtom.ts
@@ -69,6 +69,17 @@ const settingsAtom = atom<ClientSettings>({
 
 export const navigationMutationPendingAtom = atom(false);
 let navigationMutationInFlight = false;
+type PowerDisplayTargets = ClientSettings["powerDisplayTargets"];
+let desiredPowerDisplayTargets: PowerDisplayTargets | null = null;
+let persistedPowerDisplayTargets: PowerDisplayTargets | null = null;
+let powerDisplayTargetMutation: Promise<boolean> | null = null;
+
+const samePowerDisplayTargets = (
+  left: PowerDisplayTargets,
+  right: PowerDisplayTargets,
+) =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
 
 export const useSettingsAtom = () => {
   const { error } = useTauriDialog();
@@ -195,16 +206,56 @@ export const useSettingsAtom = () => {
   const togglePowerDisplayTarget = async (
     target: ClientSettings["powerDisplayTargets"][number],
   ) => {
-    const newTargets = settings.powerDisplayTargets.includes(target)
-      ? settings.powerDisplayTargets.filter((value) => value !== target)
-      : [...settings.powerDisplayTargets, target];
-    const result = await commands.setPowerDisplayTargets(newTargets);
-    if (isError(result)) {
-      error(result.error);
-      console.error(result.error);
-      return;
+    if (desiredPowerDisplayTargets === null) {
+      desiredPowerDisplayTargets = [...settings.powerDisplayTargets];
+      persistedPowerDisplayTargets = [...settings.powerDisplayTargets];
     }
-    setSettings((prev) => ({ ...prev, powerDisplayTargets: newTargets }));
+
+    desiredPowerDisplayTargets = desiredPowerDisplayTargets.includes(target)
+      ? desiredPowerDisplayTargets.filter((value) => value !== target)
+      : [...desiredPowerDisplayTargets, target];
+    setSettings((prev) => ({
+      ...prev,
+      powerDisplayTargets:
+        desiredPowerDisplayTargets ?? prev.powerDisplayTargets,
+    }));
+
+    if (powerDisplayTargetMutation === null) {
+      powerDisplayTargetMutation = (async () => {
+        while (
+          desiredPowerDisplayTargets !== null &&
+          persistedPowerDisplayTargets !== null &&
+          !samePowerDisplayTargets(
+            desiredPowerDisplayTargets,
+            persistedPowerDisplayTargets,
+          )
+        ) {
+          const nextTargets = [...desiredPowerDisplayTargets];
+          const result = await commands.setPowerDisplayTargets(nextTargets);
+          if (isError(result)) {
+            await error(result.error);
+            console.error(result.error);
+            const rollbackTargets = persistedPowerDisplayTargets;
+            setSettings((prev) => ({
+              ...prev,
+              powerDisplayTargets: rollbackTargets,
+            }));
+            desiredPowerDisplayTargets = null;
+            persistedPowerDisplayTargets = null;
+            powerDisplayTargetMutation = null;
+            return false;
+          }
+          persistedPowerDisplayTargets = nextTargets;
+        }
+
+        desiredPowerDisplayTargets = null;
+        persistedPowerDisplayTargets = null;
+        powerDisplayTargetMutation = null;
+        return true;
+      })();
+    }
+
+    return powerDisplayTargetMutation;
   };
 
   const setNavigationLayoutAtom = async (

--- a/src/features/settings/hooks/useSettingsAtom.ts
+++ b/src/features/settings/hooks/useSettingsAtom.ts
@@ -16,6 +16,7 @@ const settingsAtom = atom<ClientSettings>({
   uiAnnouncementVersion: 0,
   currentUiAnnouncementVersion: 0,
   displayTargets: [],
+  powerDisplayTargets: ["cpu", "gpu", "package"],
   graphSize: "xl",
   graphFitToWindow: false,
   graphMarginPx: 32,
@@ -90,6 +91,7 @@ export const useSettingsAtom = () => {
   } = {
     theme: commands.setTheme,
     displayTargets: commands.setDisplayTargets,
+    powerDisplayTargets: commands.setPowerDisplayTargets,
     graphSize: commands.setGraphSize,
     graphFitToWindow: commands.setGraphFitToWindow,
     graphMarginPx: commands.setGraphMarginPx,
@@ -188,6 +190,21 @@ export const useSettingsAtom = () => {
     }
 
     setSettings((prev) => ({ ...prev, displayTargets: newTargets }));
+  };
+
+  const togglePowerDisplayTarget = async (
+    target: ClientSettings["powerDisplayTargets"][number],
+  ) => {
+    const newTargets = settings.powerDisplayTargets.includes(target)
+      ? settings.powerDisplayTargets.filter((value) => value !== target)
+      : [...settings.powerDisplayTargets, target];
+    const result = await commands.setPowerDisplayTargets(newTargets);
+    if (isError(result)) {
+      error(result.error);
+      console.error(result.error);
+      return;
+    }
+    setSettings((prev) => ({ ...prev, powerDisplayTargets: newTargets }));
   };
 
   const setNavigationLayoutAtom = async (
@@ -448,6 +465,7 @@ export const useSettingsAtom = () => {
     settings,
     loadSettings,
     toggleDisplayTarget,
+    togglePowerDisplayTarget,
     updateSettingAtom,
     updateLineGraphColorAtom,
     toggleHardwareArchiveAtom,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -376,6 +376,7 @@
           "espresso": "Espresso"
         },
         "hardwareType": "Hardware Type",
+        "powerDisplayTargets": "Power Display Targets",
         "temperatureUnit": {
           "name": "Temperature Unit",
           "celsius": "Celsius (°C)",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -376,6 +376,7 @@
           "espresso": "エスプレッソ"
         },
         "hardwareType": "ハードウェア種別",
+        "powerDisplayTargets": "消費電力の表示対象",
         "temperatureUnit": {
           "name": "温度の単位",
           "celsius": "摂氏（℃）",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -366,6 +366,7 @@
           "espresso": "Эспрессо"
         },
         "hardwareType": "Тип оборудования",
+        "powerDisplayTargets": "Отображаемая мощность",
         "temperatureUnit": {
           "name": "Единица измерения температуры",
           "celsius": "Цельсий (°C)",

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -130,6 +130,7 @@ export const commands = {
 	setNavigationLayout: (newLayout: NavigationLayout) => typedError<null, string>(__TAURI_INVOKE("set_navigation_layout", { newLayout })),
 	acknowledgeNavigationRestructureAnnouncement: () => typedError<null, string>(__TAURI_INVOKE("acknowledge_navigation_restructure_announcement")),
 	setDisplayTargets: (newTargets: HardwareType[]) => typedError<null, string>(__TAURI_INVOKE("set_display_targets", { newTargets })),
+	setPowerDisplayTargets: (newTargets: PowerDisplayTarget[]) => typedError<null, string>(__TAURI_INVOKE("set_power_display_targets", { newTargets })),
 	setGraphSize: (newSize: GraphSize) => typedError<null, string>(__TAURI_INVOKE("set_graph_size", { newSize })),
 	setGraphFitToWindow: (newValue: boolean) => typedError<null, string>(__TAURI_INVOKE("set_graph_fit_to_window", { newValue })),
 	setGraphMarginPx: (newValue: number) => typedError<null, string>(__TAURI_INVOKE("set_graph_margin_px", { newValue })),
@@ -276,6 +277,7 @@ export type ClientSettings_Deserialize = {
 	 */
 	currentUiAnnouncementVersion: number,
 	displayTargets: HardwareType[],
+	powerDisplayTargets: PowerDisplayTarget[],
 	graphSize: GraphSize,
 	graphFitToWindow: boolean,
 	graphMarginPx: number,
@@ -320,6 +322,7 @@ export type ClientSettings_Serialize = {
 	 */
 	currentUiAnnouncementVersion: number,
 	displayTargets: HardwareType[],
+	powerDisplayTargets: PowerDisplayTarget[],
 	graphSize: GraphSize,
 	graphFitToWindow: boolean,
 	graphMarginPx: number,
@@ -548,6 +551,8 @@ export type PawnIoRuntimeDiagnostics = {
 	version: number | null,
 	fallbackReason: string | null,
 };
+
+export type PowerDisplayTarget = "cpu" | "gpu" | "ane" | "package";
 
 export type ProcessInfo = ProcessInfo_Serialize | ProcessInfo_Deserialize;
 


### PR DESCRIPTION
## Summary

- add a typed `powerDisplayTargets` Application Preference with CPU, GPU, and package selected by default
- preserve explicit selections across restarts and recover invalid persisted values safely without overwriting settings owned by Core
- apply the preference to both the live Performance Power panel and Cooling Insight power history, including opt-in ANE charts
- add the approved selector beside the existing display-target controls with English, Japanese, and Russian strings

## Related Issues

Closes #1979

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

The selector and ANE opt-in flow were inspected in the E2E browser at the desktop layout. The selector remains stable beside Hardware Type, and selected power charts retain the existing two-column Cooling Insight layout.

## Test Plan

- [x] Manual testing
- [x] Unit tests

- `env HOME=/private/tmp/hv1979-test-home RUSTUP_HOME=/Users/shm11c3/.rustup CARGO_HOME=/Users/shm11c3/.cargo cargo test -p hardware_visualizer --lib` (236 passed)
- `cargo clippy -p hardware_visualizer --all-targets -- -D warnings`
- `npm test -- --run --coverage.enabled=false` (604 passed)
- `npm run lint:ci`
- `npm run build`
- `cargo fmt --all -- --check`
- `git diff --check`
- rendered Settings and Cooling Insight through the E2E mock server; verified the default CPU/GPU/package selection and ANE opt-in

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings to choose which power metrics appear: CPU, GPU, ANE, and package power.
  * Performance and cooling insights now display charts for selected power metrics.
  * Added localized labels and translations for power metric selections.

* **Bug Fixes**
  * Selected metrics remain labeled and configurable even when readings are temporarily unavailable.

* **Tests**
  * Added coverage for saving, restoring, toggling, and displaying power metric preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->