### PR TITLE
refactor(core): type the platform error boundary with PlatformError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "sqlx",
  "sysinfo",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "winapi",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.52.3", features = [
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+thiserror = "2.0.18"
 tracing = "0.1.44"
 chrono = "0.4.44"
 regex = "1.12.3"

--- a/core/src/enums/error.rs
+++ b/core/src/enums/error.rs
@@ -1,17 +1,107 @@
-/// POJO mirror of the Tauri-side `BackendError` enum.
+use thiserror::Error;
+
+/// Error type for the Core platform layer (`crate::platform`).
 ///
-/// `src-tauri/src/enums/error.rs::BackendError` is the wire type derived
-/// with `specta::Type` for tauri-specta. This Core enum is the platform
-/// layer's error type; the App-side `commands::*` translate Core errors
-/// into the wire variant before returning them to the frontend.
-#[allow(dead_code)]
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum BackendError {
-  CpuInfoNotAvailable,
-  StorageInfoNotAvailable,
-  MemoryInfoNotAvailable,
-  GraphicInfoNotAvailable,
-  NetworkInfoNotAvailable,
-  NetworkUsageNotAvailable,
-  UnexpectedError,
+/// Variants preserve the DP-02 distinction between data availability and
+/// faults, mirroring [`crate::models::SensorAvailability`]:
+///
+/// - `Unsupported`: the platform or hardware path does not provide the
+///   value by design (build stub, OS-exclusive feature).
+/// - `Unavailable`: the path exists, but the current attempt could not
+///   produce a user-visible value (warm-up, every provider fallback
+///   exhausted, nothing detected).
+/// - `Fault`: a supported operation failed unexpectedly (OS API error,
+///   provider failure, task join error).
+/// - `InitializationFailed`: the OS platform implementation could not be
+///   constructed.
+///
+/// The App-side `commands::*` translate these into wire errors before
+/// returning them to the frontend; Core never depends on the wire shape.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PlatformError {
+  #[error("{reason}")]
+  Unsupported { reason: String },
+  #[error("{reason}")]
+  Unavailable { reason: String },
+  #[error("{reason}")]
+  Fault { reason: String },
+  #[error("Platform initialization failed: {reason}")]
+  InitializationFailed { reason: String },
+}
+
+impl PlatformError {
+  pub fn unsupported(reason: impl Into<String>) -> Self {
+    Self::Unsupported {
+      reason: reason.into(),
+    }
+  }
+
+  pub fn unavailable(reason: impl Into<String>) -> Self {
+    Self::Unavailable {
+      reason: reason.into(),
+    }
+  }
+
+  pub fn fault(reason: impl Into<String>) -> Self {
+    Self::Fault {
+      reason: reason.into(),
+    }
+  }
+
+  pub fn initialization_failed(reason: impl Into<String>) -> Self {
+    Self::InitializationFailed {
+      reason: reason.into(),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn display_forwards_the_reason_unchanged_for_data_errors() {
+    assert_eq!(
+      PlatformError::unsupported("not implemented for X").to_string(),
+      "not implemented for X"
+    );
+    assert_eq!(
+      PlatformError::unavailable("no sensor found").to_string(),
+      "no sensor found"
+    );
+    assert_eq!(
+      PlatformError::fault("WMI query failed").to_string(),
+      "WMI query failed"
+    );
+  }
+
+  #[test]
+  fn display_keeps_the_established_initialization_prefix() {
+    // App-side call sites format this error into user-visible strings;
+    // the prefix matches the pre-typed factory Display output.
+    assert_eq!(
+      PlatformError::initialization_failed("boom").to_string(),
+      "Platform initialization failed: boom"
+    );
+  }
+
+  #[test]
+  fn constructors_classify_into_their_variant() {
+    assert!(matches!(
+      PlatformError::unsupported("r"),
+      PlatformError::Unsupported { .. }
+    ));
+    assert!(matches!(
+      PlatformError::unavailable("r"),
+      PlatformError::Unavailable { .. }
+    ));
+    assert!(matches!(
+      PlatformError::fault("r"),
+      PlatformError::Fault { .. }
+    ));
+    assert!(matches!(
+      PlatformError::initialization_failed("r"),
+      PlatformError::InitializationFailed { .. }
+    ));
+  }
 }

--- a/core/src/platform/factory.rs
+++ b/core/src/platform/factory.rs
@@ -1,20 +1,4 @@
-/// Platform detection error
-#[derive(Debug, Clone)]
-pub enum PlatformError {
-  InitializationFailed(String),
-}
-
-impl std::fmt::Display for PlatformError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      PlatformError::InitializationFailed(reason) => {
-        write!(f, "Platform initialization failed: {reason}")
-      }
-    }
-  }
-}
-
-impl std::error::Error for PlatformError {}
+use crate::enums::error::PlatformError;
 
 /// Factory that creates Platform instances
 pub struct PlatformFactory;
@@ -30,23 +14,17 @@ impl PlatformFactory {
   -> Result<Box<dyn crate::platform::traits::Platform>, PlatformError> {
     #[cfg(target_os = "windows")]
     {
-      let platform = crate::platform::windows::WindowsPlatform::new()
-        .map_err(|e| PlatformError::InitializationFailed(e.to_string()))?;
-      Ok(Box::new(platform))
+      Ok(Box::new(crate::platform::windows::WindowsPlatform::new()?))
     }
 
     #[cfg(target_os = "linux")]
     {
-      let platform = crate::platform::linux::LinuxPlatform::new()
-        .map_err(|e| PlatformError::InitializationFailed(e.to_string()))?;
-      Ok(Box::new(platform))
+      Ok(Box::new(crate::platform::linux::LinuxPlatform::new()?))
     }
 
     #[cfg(target_os = "macos")]
     {
-      let platform = crate::platform::macos::MacOSPlatform::new()
-        .map_err(|e| PlatformError::InitializationFailed(e.to_string()))?;
-      Ok(Box::new(platform))
+      Ok(Box::new(crate::platform::macos::MacOSPlatform::new()?))
     }
   }
 }

--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -1,8 +1,11 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure;
 use crate::models;
 
-pub async fn get_gpu_usage() -> Result<(f32, String), String> {
-  let cards = infrastructure::providers::drm_sys::get_card_ids().await?;
+pub async fn get_gpu_usage() -> Result<(f32, String), PlatformError> {
+  let cards = infrastructure::providers::drm_sys::get_card_ids()
+    .await
+    .map_err(PlatformError::fault)?;
 
   for card in cards {
     // TODO Also handle Vendor ID detection in infrastructure layer
@@ -24,10 +27,12 @@ pub async fn get_gpu_usage() -> Result<(f32, String), String> {
     }
   }
 
-  Err("Failed to get GPU usage on Linux (non-NVIDIA fallback)".to_string())
+  Err(PlatformError::unavailable(
+    "Failed to get GPU usage on Linux (non-NVIDIA fallback)",
+  ))
 }
 
-pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, String> {
+pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, PlatformError> {
   use tokio::task::JoinSet;
 
   let card_ids = infrastructure::providers::drm_sys::get_all_card_ids();
@@ -63,7 +68,7 @@ pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, String
 
 async fn get_amd_graphic_info(
   card_id: u8,
-) -> Result<models::hardware::GraphicInfo, String> {
+) -> Result<models::hardware::GraphicInfo, PlatformError> {
   let name = infrastructure::providers::drm_sys::get_card_bdf(card_id)
     .and_then(|bdf| {
       infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
@@ -87,7 +92,7 @@ async fn get_amd_graphic_info(
 
 pub async fn get_intel_graphic_info(
   card_id: u8,
-) -> Result<models::hardware::GraphicInfo, String> {
+) -> Result<models::hardware::GraphicInfo, PlatformError> {
   Ok(models::hardware::GraphicInfo {
     id: format!("card{card_id}"),
     name: "Intel Integrated Graphics".into(),
@@ -101,7 +106,8 @@ pub async fn get_intel_graphic_info(
 
 /// Always returns raw degrees Celsius. Presentation conversion lives at
 /// the App-side boundary.
-pub async fn get_gpu_temperature() -> Result<Vec<models::hardware::NameValue>, String> {
+pub async fn get_gpu_temperature()
+-> Result<Vec<models::hardware::NameValue>, PlatformError> {
   let cards = infrastructure::providers::drm_sys::get_all_card_ids();
   let mut all_temps: Vec<models::hardware::NameValue> = Vec::new();
 
@@ -125,7 +131,9 @@ pub async fn get_gpu_temperature() -> Result<Vec<models::hardware::NameValue>, S
   }
 
   if all_temps.is_empty() {
-    Err("No GPU temperature sensors found on Linux".to_string())
+    Err(PlatformError::unavailable(
+      "No GPU temperature sensors found on Linux",
+    ))
   } else {
     Ok(all_temps)
   }

--- a/core/src/platform/linux/memory.rs
+++ b/core/src/platform/linux/memory.rs
@@ -1,3 +1,4 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure::providers;
 use crate::log_warn;
 use crate::models;
@@ -7,7 +8,9 @@ use crate::utils;
 use std;
 
 pub fn get_memory_info() -> std::pin::Pin<
-  Box<dyn std::future::Future<Output = Result<MemoryInfo, String>> + Send + 'static>,
+  Box<
+    dyn std::future::Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static,
+  >,
 > {
   Box::pin(async {
     if let Ok(cached) = get_memory_info_cached_detail() {
@@ -16,7 +19,7 @@ pub fn get_memory_info() -> std::pin::Pin<
 
     // fallback: Only get memory capacity
     let mem_kb = providers::procfs::get_mem_total_kb()
-      .map_err(|e| format!("Failed to read /proc/meminfo: {e}"))?;
+      .map_err(|e| PlatformError::fault(format!("Failed to read /proc/meminfo: {e}")))?;
 
     Ok(models::hardware::MemoryInfo {
       size: utils::formatter::format_size(mem_kb * 1024, 1),
@@ -31,10 +34,14 @@ pub fn get_memory_info() -> std::pin::Pin<
 }
 
 pub fn get_memory_info_detail() -> std::pin::Pin<
-  Box<dyn std::future::Future<Output = Result<MemoryInfo, String>> + Send + 'static>,
+  Box<
+    dyn std::future::Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static,
+  >,
 > {
   Box::pin(async {
-    let raw = providers::dmidecode::get_raw_dmidecode().await?;
+    let raw = providers::dmidecode::get_raw_dmidecode()
+      .await
+      .map_err(PlatformError::fault)?;
     let parsed = providers::dmidecode::parse_dmidecode_memory_info(&raw);
 
     if let Err(e) =

--- a/core/src/platform/linux/mod.rs
+++ b/core/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-use crate::enums::error::BackendError;
+use crate::enums::error::PlatformError;
 use crate::models::hardware::{
   GpuMemoryUsage, GraphicInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
@@ -17,7 +17,7 @@ pub mod network;
 pub struct LinuxPlatform;
 
 impl LinuxPlatform {
-  pub fn new() -> Result<Self, String> {
+  pub fn new() -> Result<Self, PlatformError> {
     Ok(Self)
   }
 }
@@ -27,7 +27,7 @@ impl MemoryPlatform for LinuxPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
         + Send
         + '_,
     >,
@@ -39,7 +39,7 @@ impl MemoryPlatform for LinuxPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
         + Send
         + '_,
     >,
@@ -51,8 +51,11 @@ impl MemoryPlatform for LinuxPlatform {
 impl GpuPlatform for LinuxPlatform {
   fn get_gpu_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<super::traits::GpuUsageRaw, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<
+      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
+    >,
+  > {
     Box::pin(gpu::get_gpu_usage())
   }
 
@@ -60,7 +63,7 @@ impl GpuPlatform for LinuxPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>
+      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
         + Send
         + '_,
     >,
@@ -70,14 +73,16 @@ impl GpuPlatform for LinuxPlatform {
 
   fn get_gpu_info(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
+  {
     Box::pin(gpu::get_gpu_info())
   }
 
   fn get_gpu_memory_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
+  > {
     Box::pin(async { Ok(None) })
   }
 
@@ -89,7 +94,7 @@ impl GpuPlatform for LinuxPlatform {
 }
 
 impl NetworkPlatform for LinuxPlatform {
-  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, BackendError> {
+  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, PlatformError> {
     network::get_network_info()
   }
 }
@@ -99,13 +104,15 @@ impl MotherboardPlatform for LinuxPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, PlatformError>>
         + Send
         + '_,
     >,
   > {
     Box::pin(async {
-      Err("get_motherboard_info is not implemented for LinuxPlatform".to_string())
+      Err(PlatformError::unsupported(
+        "get_motherboard_info is not implemented for LinuxPlatform",
+      ))
     })
   }
 }
@@ -131,12 +138,14 @@ impl SensorPlatform for LinuxPlatform {
 }
 
 impl ProcessElevationPlatform for LinuxPlatform {
-  fn is_process_elevated(&self) -> Result<bool, String> {
+  fn is_process_elevated(&self) -> Result<bool, PlatformError> {
     Ok(false)
   }
 
-  fn relaunch_current_process_elevated(&self) -> Result<(), String> {
-    Err("Elevated Startup Mode is only supported on Windows.".to_string())
+  fn relaunch_current_process_elevated(&self) -> Result<(), PlatformError> {
+    Err(PlatformError::unsupported(
+      "Elevated Startup Mode is only supported on Windows.",
+    ))
   }
 }
 

--- a/core/src/platform/linux/network.rs
+++ b/core/src/platform/linux/network.rs
@@ -1,6 +1,5 @@
-use crate::{enums::error::BackendError, infrastructure, models::hardware::NetworkInfo};
+use crate::{enums::error::PlatformError, infrastructure, models::hardware::NetworkInfo};
 
-pub fn get_network_info() -> Result<Vec<NetworkInfo>, BackendError> {
-  infrastructure::providers::net_sys::get_network_info()
-    .map_err(|_| BackendError::UnexpectedError)
+pub fn get_network_info() -> Result<Vec<NetworkInfo>, PlatformError> {
+  infrastructure::providers::net_sys::get_network_info().map_err(PlatformError::fault)
 }

--- a/core/src/platform/macos/gpu.rs
+++ b/core/src/platform/macos/gpu.rs
@@ -1,24 +1,27 @@
 use crate::{
+  enums::error::PlatformError,
   infrastructure::providers::macos::{gpu, gpu_info, io_kit::iokit_info},
   models,
 };
 
-pub async fn get_gpu_usage() -> Result<(f32, String), String> {
-  gpu::init_gpu_usage_sampler_thread()?;
+pub async fn get_gpu_usage() -> Result<(f32, String), PlatformError> {
+  gpu::init_gpu_usage_sampler_thread().map_err(PlatformError::fault)?;
 
   match gpu::read_gpu_usage_cached() {
     Some(v) => Ok((v * 100.0, "IOKit".to_string())),
-    None => Err("GPU usage is not ready yet".into()),
+    None => Err(PlatformError::unavailable("GPU usage is not ready yet")),
   }
 }
 
-pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, String> {
-  gpu_info::get_gpu_info().await
+pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, PlatformError> {
+  gpu_info::get_gpu_info().await.map_err(PlatformError::fault)
 }
 
 pub async fn get_gpu_memory_usage()
--> Result<Option<models::hardware::GpuMemoryUsage>, String> {
-  gpu_info::get_gpu_memory_usage().await
+-> Result<Option<models::hardware::GpuMemoryUsage>, PlatformError> {
+  gpu_info::get_gpu_memory_usage()
+    .await
+    .map_err(PlatformError::fault)
 }
 
 pub async fn sample_gpus() -> Vec<models::GpuSample> {

--- a/core/src/platform/macos/memory.rs
+++ b/core/src/platform/macos/memory.rs
@@ -1,3 +1,4 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure::providers;
 use crate::models::hardware::MemoryInfo;
 use crate::utils::formatter::format_size;
@@ -9,9 +10,10 @@ use crate::utils::formatter::format_size;
 ///   `system_profiler SPMemoryDataType -json`.
 ///
 /// `is_detailed` is set to `true` only when at least one detailed field can be extracted.
-pub fn get_memory_info() -> Result<MemoryInfo, String> {
+pub fn get_memory_info() -> Result<MemoryInfo, PlatformError> {
   // Total physical memory bytes.
-  let total_bytes = providers::sysctl::sysctl_u64("hw.memsize")?;
+  let total_bytes =
+    providers::sysctl::sysctl_u64("hw.memsize").map_err(PlatformError::fault)?;
 
   let details = providers::system_profiler_memory::get_raw_spmemory_json()
     .ok()

--- a/core/src/platform/macos/mod.rs
+++ b/core/src/platform/macos/mod.rs
@@ -1,4 +1,4 @@
-use crate::enums::error::BackendError;
+use crate::enums::error::PlatformError;
 use crate::models::hardware::{
   GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
@@ -18,7 +18,7 @@ pub mod network;
 pub struct MacOSPlatform;
 
 impl MacOSPlatform {
-  pub fn new() -> Result<Self, String> {
+  pub fn new() -> Result<Self, PlatformError> {
     Ok(Self)
   }
 }
@@ -26,20 +26,22 @@ impl MacOSPlatform {
 impl MemoryPlatform for MacOSPlatform {
   fn get_memory_info(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + '_>> {
     Box::pin(async {
       task::spawn_blocking(memory::get_memory_info)
         .await
-        .map_err(|e| format!("Failed to join memory task: {e}"))?
+        .map_err(|e| PlatformError::fault(format!("Failed to join memory task: {e}")))?
     })
   }
 
   fn get_memory_info_detail(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + '_>> {
     Box::pin(async {
       // macOS is not supported yet (build-only stub)
-      Err("get_memory_info_detail is not implemented for MacOSPlatform".to_string())
+      Err(PlatformError::unsupported(
+        "get_memory_info_detail is not implemented for MacOSPlatform",
+      ))
     })
   }
 }
@@ -47,8 +49,11 @@ impl MemoryPlatform for MacOSPlatform {
 impl GpuPlatform for MacOSPlatform {
   fn get_gpu_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<super::traits::GpuUsageRaw, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<
+      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
+    >,
+  > {
     Box::pin(async { gpu::get_gpu_usage().await })
   }
 
@@ -56,27 +61,31 @@ impl GpuPlatform for MacOSPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>
+      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
         + Send
         + '_,
     >,
   > {
     Box::pin(async {
       // macOS is not supported yet (build-only stub)
-      Err("get_gpu_temperature is not implemented for MacOSPlatform".to_string())
+      Err(PlatformError::unsupported(
+        "get_gpu_temperature is not implemented for MacOSPlatform",
+      ))
     })
   }
 
   fn get_gpu_info(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
+  {
     Box::pin(async { gpu::get_gpu_info().await })
   }
 
   fn get_gpu_memory_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
+  > {
     Box::pin(async { gpu::get_gpu_memory_usage().await })
   }
 
@@ -88,7 +97,7 @@ impl GpuPlatform for MacOSPlatform {
 }
 
 impl NetworkPlatform for MacOSPlatform {
-  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, BackendError> {
+  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, PlatformError> {
     network::get_network_info()
   }
 }
@@ -98,7 +107,7 @@ impl MotherboardPlatform for MacOSPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, PlatformError>>
         + Send
         + '_,
     >,
@@ -128,13 +137,45 @@ impl SensorPlatform for MacOSPlatform {
 }
 
 impl ProcessElevationPlatform for MacOSPlatform {
-  fn is_process_elevated(&self) -> Result<bool, String> {
+  fn is_process_elevated(&self) -> Result<bool, PlatformError> {
     Ok(false)
   }
 
-  fn relaunch_current_process_elevated(&self) -> Result<(), String> {
-    Err("Elevated Startup Mode is only supported on Windows.".to_string())
+  fn relaunch_current_process_elevated(&self) -> Result<(), PlatformError> {
+    Err(PlatformError::unsupported(
+      "Elevated Startup Mode is only supported on Windows.",
+    ))
   }
 }
 
 impl Platform for MacOSPlatform {}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn build_only_stubs_classify_as_unsupported() {
+    let platform = MacOSPlatform::new().expect("MacOSPlatform::new never fails");
+
+    assert!(matches!(
+      platform.get_memory_info_detail().await,
+      Err(PlatformError::Unsupported { .. })
+    ));
+    assert!(matches!(
+      platform.get_gpu_temperature().await,
+      Err(PlatformError::Unsupported { .. })
+    ));
+  }
+
+  #[test]
+  fn elevation_relaunch_classifies_as_unsupported() {
+    let platform = MacOSPlatform::new().expect("MacOSPlatform::new never fails");
+
+    assert!(matches!(
+      platform.relaunch_current_process_elevated(),
+      Err(PlatformError::Unsupported { .. })
+    ));
+    assert_eq!(platform.is_process_elevated(), Ok(false));
+  }
+}

--- a/core/src/platform/macos/motherboard.rs
+++ b/core/src/platform/macos/motherboard.rs
@@ -1,3 +1,4 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure::providers::macos::system_profiler_hardware::{
   self, SpHardwareDetails,
 };
@@ -23,17 +24,19 @@ const APPLE_MANUFACTURER: &str = "Apple Inc.";
 /// - `bios_version` is the system firmware (boot ROM) version.
 /// - `bios_release_date` is left empty (macOS does not expose it).
 pub fn get_motherboard_info()
--> Pin<Box<dyn Future<Output = Result<MotherboardInfo, String>> + Send>> {
+-> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send>> {
   Box::pin(async {
     tokio::task::spawn_blocking(collect_motherboard_info)
       .await
-      .map_err(|e| format!("Join error: {e}"))?
+      .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
   })
 }
 
-fn collect_motherboard_info() -> Result<MotherboardInfo, String> {
-  let raw = system_profiler_hardware::get_raw_sphardware_json()?;
-  let details = system_profiler_hardware::parse_sphardware_json(&raw)?;
+fn collect_motherboard_info() -> Result<MotherboardInfo, PlatformError> {
+  let raw =
+    system_profiler_hardware::get_raw_sphardware_json().map_err(PlatformError::fault)?;
+  let details = system_profiler_hardware::parse_sphardware_json(&raw)
+    .map_err(PlatformError::fault)?;
   Ok(map_motherboard_info(details))
 }
 

--- a/core/src/platform/macos/network.rs
+++ b/core/src/platform/macos/network.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-  enums::error::BackendError, infrastructure, models::hardware::NetworkInfo, utils::ip,
+  enums::error::PlatformError, infrastructure, models::hardware::NetworkInfo, utils::ip,
 };
 
 type GatewayV4ByIfIndex = HashMap<u32, Vec<Ipv4Addr>>;
@@ -16,12 +16,12 @@ type GatewayV6ByIfIndex = HashMap<u32, Vec<Ipv6Addr>>;
 /// - pulls raw interface facts (name, flags, MAC, IPs) from the provider
 /// - pulls default gateways (v4/v6) from PF_ROUTE via the provider
 /// - filters to active, non-loopback interfaces and formats fields for the UI
-pub fn get_network_info() -> Result<Vec<NetworkInfo>, BackendError> {
+pub fn get_network_info() -> Result<Vec<NetworkInfo>, PlatformError> {
   let raw = infrastructure::providers::net_sys::get_raw_interfaces()
-    .map_err(|_| BackendError::UnexpectedError)?;
+    .map_err(PlatformError::fault)?;
   let (gw_v4_by_index, gw_v6_by_index) =
     infrastructure::providers::net_sys::get_default_gateways_by_ifindex()
-      .map_err(|_| BackendError::UnexpectedError)?;
+      .map_err(PlatformError::fault)?;
 
   Ok(create_network_info(raw, &gw_v4_by_index, &gw_v6_by_index))
 }

--- a/core/src/platform/traits.rs
+++ b/core/src/platform/traits.rs
@@ -1,4 +1,4 @@
-use crate::enums::error::BackendError;
+use crate::enums::error::PlatformError;
 use crate::models;
 use std::future::Future;
 use std::pin::Pin;
@@ -12,14 +12,22 @@ pub trait MemoryPlatform: Send + Sync {
   fn get_memory_info(
     &self,
   ) -> Pin<
-    Box<dyn Future<Output = Result<models::hardware::MemoryInfo, String>> + Send + '_>,
+    Box<
+      dyn Future<Output = Result<models::hardware::MemoryInfo, PlatformError>>
+        + Send
+        + '_,
+    >,
   >;
 
   /// Get detailed memory information (supported platforms only)
   fn get_memory_info_detail(
     &self,
   ) -> Pin<
-    Box<dyn Future<Output = Result<models::hardware::MemoryInfo, String>> + Send + '_>,
+    Box<
+      dyn Future<Output = Result<models::hardware::MemoryInfo, PlatformError>>
+        + Send
+        + '_,
+    >,
   >;
 }
 
@@ -29,7 +37,7 @@ pub trait GpuPlatform: Send + Sync {
   /// Get GPU usage together with the data-source name
   fn get_gpu_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<GpuUsageRaw, String>> + Send + '_>>;
+  ) -> Pin<Box<dyn Future<Output = Result<GpuUsageRaw, PlatformError>> + Send + '_>>;
 
   /// Get GPU temperatures, always in raw degrees Celsius.
   ///
@@ -40,7 +48,9 @@ pub trait GpuPlatform: Send + Sync {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Vec<models::hardware::NameValue>, String>> + Send + '_,
+      dyn Future<Output = Result<Vec<models::hardware::NameValue>, PlatformError>>
+        + Send
+        + '_,
     >,
   >;
 
@@ -49,7 +59,9 @@ pub trait GpuPlatform: Send + Sync {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Vec<models::hardware::GraphicInfo>, String>> + Send + '_,
+      dyn Future<Output = Result<Vec<models::hardware::GraphicInfo>, PlatformError>>
+        + Send
+        + '_,
     >,
   >;
 
@@ -58,7 +70,7 @@ pub trait GpuPlatform: Send + Sync {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Option<models::hardware::GpuMemoryUsage>, String>>
+      dyn Future<Output = Result<Option<models::hardware::GpuMemoryUsage>, PlatformError>>
         + Send
         + '_,
     >,
@@ -76,7 +88,7 @@ pub trait NetworkPlatform: Send + Sync {
   #[allow(dead_code)]
   fn get_network_info(
     &self,
-  ) -> Result<Vec<crate::models::hardware::NetworkInfo>, BackendError>;
+  ) -> Result<Vec<crate::models::hardware::NetworkInfo>, PlatformError>;
 }
 
 /// Trait that defines platform-specific motherboard operations
@@ -86,7 +98,9 @@ pub trait MotherboardPlatform: Send + Sync {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<models::hardware::MotherboardInfo, String>> + Send + '_,
+      dyn Future<Output = Result<models::hardware::MotherboardInfo, PlatformError>>
+        + Send
+        + '_,
     >,
   >;
 }
@@ -115,10 +129,10 @@ pub trait SensorPlatform: Send + Sync {
 /// Trait that defines process elevation operations.
 pub trait ProcessElevationPlatform: Send + Sync {
   /// Returns whether the current process is running with elevated privileges.
-  fn is_process_elevated(&self) -> Result<bool, String>;
+  fn is_process_elevated(&self) -> Result<bool, PlatformError>;
 
   /// Relaunch the current executable with elevated privileges.
-  fn relaunch_current_process_elevated(&self) -> Result<(), String>;
+  fn relaunch_current_process_elevated(&self) -> Result<(), PlatformError>;
 }
 
 /// Trait that integrates all platform functionality

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -1,8 +1,9 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure;
 use crate::models::GpuSample;
 use crate::{log_error, log_warn};
 
-pub async fn get_gpu_usage() -> Result<(f32, String), String> {
+pub async fn get_gpu_usage() -> Result<(f32, String), PlatformError> {
   use infrastructure::providers::pdh_provider::GpuEngineType;
 
   // 1. NVAPI (NVIDIA)
@@ -47,16 +48,16 @@ pub async fn get_gpu_usage() -> Result<(f32, String), String> {
   .await
   {
     Ok(usage) => Ok(((usage * 100.0).round(), "PDH".to_string())),
-    Err(e) => Err(format!(
+    Err(e) => Err(PlatformError::unavailable(format!(
       "Failed to get GPU usage from NVIDIA API, AMD ADL, and PDH: {e:?}"
-    )),
+    ))),
   }
 }
 
 /// Always returns raw degrees Celsius. Presentation conversion lives at
 /// the App-side boundary.
 pub async fn get_gpu_temperature()
--> Result<Vec<crate::models::hardware::NameValue>, String> {
+-> Result<Vec<crate::models::hardware::NameValue>, PlatformError> {
   let mut all_temps: Vec<crate::models::hardware::NameValue> = Vec::new();
 
   // 1. NVAPI (NVIDIA)
@@ -84,13 +85,16 @@ pub async fn get_gpu_temperature()
   }
 
   if all_temps.is_empty() {
-    Err("Failed to get GPU temperature from any provider".to_string())
+    Err(PlatformError::unavailable(
+      "Failed to get GPU temperature from any provider",
+    ))
   } else {
     Ok(all_temps)
   }
 }
 
-pub async fn get_gpu_info() -> Result<Vec<crate::models::hardware::GraphicInfo>, String> {
+pub async fn get_gpu_info()
+-> Result<Vec<crate::models::hardware::GraphicInfo>, PlatformError> {
   let (nvidia_res, amd_res, intel_res) = tokio::join!(
     infrastructure::providers::nvapi_provider::get_nvidia_gpu_info(),
     infrastructure::providers::directx::get_amd_gpu_info(),

--- a/core/src/platform/windows/memory.rs
+++ b/core/src/platform/windows/memory.rs
@@ -1,20 +1,23 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure::providers::wmi_provider;
 use crate::models::hardware::MemoryInfo;
 use std::future::Future;
 use std::pin::Pin;
 
 pub fn get_memory_info()
--> Pin<Box<dyn Future<Output = Result<MemoryInfo, String>> + Send + 'static>> {
+-> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static>> {
   Box::pin(async {
-    // Use actual WMI implementation
-    match wmi_provider::query_memory_info().await {
-      Ok(info) => Ok(info),
-      Err(e) => Err(e),
-    }
+    wmi_provider::query_memory_info()
+      .await
+      .map_err(PlatformError::fault)
   })
 }
 
 pub fn get_memory_info_detail()
--> Pin<Box<dyn Future<Output = Result<MemoryInfo, String>> + Send + 'static>> {
-  Box::pin(async { Err("Detailed memory info is not implemented yet".to_string()) })
+-> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static>> {
+  Box::pin(async {
+    Err(PlatformError::unsupported(
+      "Detailed memory info is not implemented yet",
+    ))
+  })
 }

--- a/core/src/platform/windows/mod.rs
+++ b/core/src/platform/windows/mod.rs
@@ -1,4 +1,4 @@
-use crate::enums::error::BackendError;
+use crate::enums::error::PlatformError;
 use crate::models::hardware::{
   GpuMemoryUsage, GraphicInfo, MotherboardInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
@@ -20,7 +20,7 @@ pub mod sensors;
 pub struct WindowsPlatform;
 
 impl WindowsPlatform {
-  pub fn new() -> Result<Self, String> {
+  pub fn new() -> Result<Self, PlatformError> {
     Ok(Self)
   }
 }
@@ -30,7 +30,7 @@ impl MemoryPlatform for WindowsPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
         + Send
         + '_,
     >,
@@ -42,7 +42,7 @@ impl MemoryPlatform for WindowsPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, String>>
+      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
         + Send
         + '_,
     >,
@@ -54,8 +54,11 @@ impl MemoryPlatform for WindowsPlatform {
 impl GpuPlatform for WindowsPlatform {
   fn get_gpu_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<super::traits::GpuUsageRaw, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<
+      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
+    >,
+  > {
     Box::pin(gpu::get_gpu_usage())
   }
 
@@ -63,7 +66,7 @@ impl GpuPlatform for WindowsPlatform {
     &self,
   ) -> Pin<
     Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, String>>
+      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
         + Send
         + '_,
     >,
@@ -73,14 +76,16 @@ impl GpuPlatform for WindowsPlatform {
 
   fn get_gpu_info(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
+  {
     Box::pin(gpu::get_gpu_info())
   }
 
   fn get_gpu_memory_usage(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, String>> + Send + '_>>
-  {
+  ) -> Pin<
+    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
+  > {
     Box::pin(async { Ok(None) })
   }
 
@@ -92,7 +97,7 @@ impl GpuPlatform for WindowsPlatform {
 }
 
 impl NetworkPlatform for WindowsPlatform {
-  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, BackendError> {
+  fn get_network_info(&self) -> Result<Vec<NetworkInfo>, PlatformError> {
     network::get_network_info()
   }
 }
@@ -100,7 +105,8 @@ impl NetworkPlatform for WindowsPlatform {
 impl MotherboardPlatform for WindowsPlatform {
   fn get_motherboard_info(
     &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MotherboardInfo, String>> + Send + '_>> {
+  ) -> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send + '_>>
+  {
     motherboard::get_motherboard_info()
   }
 }
@@ -122,11 +128,11 @@ impl SensorPlatform for WindowsPlatform {
 }
 
 impl ProcessElevationPlatform for WindowsPlatform {
-  fn is_process_elevated(&self) -> Result<bool, String> {
+  fn is_process_elevated(&self) -> Result<bool, PlatformError> {
     process_elevation::is_process_elevated()
   }
 
-  fn relaunch_current_process_elevated(&self) -> Result<(), String> {
+  fn relaunch_current_process_elevated(&self) -> Result<(), PlatformError> {
     process_elevation::relaunch_current_process_elevated()
   }
 }

--- a/core/src/platform/windows/motherboard.rs
+++ b/core/src/platform/windows/motherboard.rs
@@ -1,13 +1,15 @@
+use crate::enums::error::PlatformError;
 use crate::infrastructure::providers::windows::wmi_provider;
 use crate::models::hardware::MotherboardInfo;
 use std::future::Future;
 use std::pin::Pin;
 
 pub fn get_motherboard_info()
--> Pin<Box<dyn Future<Output = Result<MotherboardInfo, String>> + Send>> {
+-> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send>> {
   Box::pin(async {
     tokio::task::spawn_blocking(wmi_provider::query_motherboard_info)
       .await
-      .map_err(|e| format!("Join error: {e}"))?
+      .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
+      .map_err(PlatformError::fault)
   })
 }

--- a/core/src/platform/windows/network.rs
+++ b/core/src/platform/windows/network.rs
@@ -1,6 +1,6 @@
-use crate::{enums::error::BackendError, infrastructure, models::hardware::NetworkInfo};
+use crate::{enums::error::PlatformError, infrastructure, models::hardware::NetworkInfo};
 
-pub fn get_network_info() -> Result<Vec<NetworkInfo>, BackendError> {
+pub fn get_network_info() -> Result<Vec<NetworkInfo>, PlatformError> {
   infrastructure::providers::wmi_provider::query_network_info()
-    .map_err(|_| BackendError::UnexpectedError)
+    .map_err(PlatformError::fault)
 }

--- a/core/src/platform/windows/process_elevation.rs
+++ b/core/src/platform/windows/process_elevation.rs
@@ -1,3 +1,4 @@
+use crate::enums::error::PlatformError;
 use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::OsStrExt;
 use windows::Win32::Foundation::CloseHandle;
@@ -7,13 +8,14 @@ use windows::Win32::UI::Shell::{
 use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 use windows::core::PCWSTR;
 
-pub fn is_process_elevated() -> Result<bool, String> {
+pub fn is_process_elevated() -> Result<bool, PlatformError> {
   Ok(unsafe { IsUserAnAdmin().as_bool() })
 }
 
-pub fn relaunch_current_process_elevated() -> Result<(), String> {
-  let exe_path = std::env::current_exe()
-    .map_err(|e| format!("Failed to obtain executable file path: {e}"))?;
+pub fn relaunch_current_process_elevated() -> Result<(), PlatformError> {
+  let exe_path = std::env::current_exe().map_err(|e| {
+    PlatformError::fault(format!("Failed to obtain executable file path: {e}"))
+  })?;
   let params = std::env::args_os()
     .skip(1)
     .map(|arg| quote_windows_arg(&arg))
@@ -34,8 +36,9 @@ pub fn relaunch_current_process_elevated() -> Result<(), String> {
     ..Default::default()
   };
 
-  unsafe { ShellExecuteExW(&mut execute_info) }
-    .map_err(|e| format!("Failed to restart as administrator: {e}"))?;
+  unsafe { ShellExecuteExW(&mut execute_info) }.map_err(|e| {
+    PlatformError::fault(format!("Failed to restart as administrator: {e}"))
+  })?;
 
   if !execute_info.hProcess.is_invalid() {
     let _ = unsafe { CloseHandle(execute_info.hProcess) };

--- a/src-tauri/src/commands/hardware.rs
+++ b/src-tauri/src/commands/hardware.rs
@@ -67,7 +67,9 @@ pub async fn get_hardware_info(
 pub async fn get_memory_info_detail() -> Result<models::hardware::MemoryInfo, String> {
   use crate::services::memory_service;
 
-  memory_service::fetch_memory_detail().await
+  memory_service::fetch_memory_detail()
+    .await
+    .map_err(|e| e.to_string())
 }
 
 ///
@@ -93,7 +95,9 @@ pub fn get_memory_usage(state: tauri::State<'_, Arc<HistoryStore>>) -> i32 {
 pub async fn get_gpu_usage() -> Result<models::hardware::GpuUsageResult, String> {
   use crate::services::gpu_service;
 
-  gpu_service::fetch_gpu_usage().await
+  gpu_service::fetch_gpu_usage()
+    .await
+    .map_err(|e| e.to_string())
 }
 
 ///
@@ -111,7 +115,9 @@ pub async fn get_gpu_temperature(
     config.temperature_unit.clone()
   };
 
-  gpu_service::fetch_gpu_temperature(temperature_unit).await
+  gpu_service::fetch_gpu_temperature(temperature_unit)
+    .await
+    .map_err(|e| e.to_string())
 }
 
 ///
@@ -127,7 +133,9 @@ pub async fn get_gpu_memory_usage()
 -> Result<Option<models::hardware::GpuMemoryUsage>, String> {
   use crate::services::gpu_service;
 
-  gpu_service::fetch_gpu_memory_usage().await
+  gpu_service::fetch_gpu_memory_usage()
+    .await
+    .map_err(|e| e.to_string())
 }
 
 ///

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -899,7 +899,7 @@ pub mod commands {
                 "{e}; additionally failed to restore setting: {save_err}"
               ));
             }
-            return Err(e);
+            return Err(e.to_string());
           }
         }
       }

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -27,7 +27,7 @@ pub async fn restart_app(app_handle: tauri::AppHandle) {
 #[tauri::command]
 #[specta::specta]
 pub fn is_process_elevated() -> Result<bool, String> {
-  crate::services::system_service::is_process_elevated()
+  crate::services::system_service::is_process_elevated().map_err(|e| e.to_string())
 }
 
 /// Stop monitoring and exit the process.

--- a/src-tauri/src/enums/error.rs
+++ b/src-tauri/src/enums/error.rs
@@ -1,7 +1,11 @@
-use hardviz_core::enums::error as core_err;
 use serde::Serialize;
 use specta::Type;
 
+/// Wire error enum exposed to the frontend through tauri-specta.
+///
+/// Core reports platform failures as
+/// `hardviz_core::enums::error::PlatformError`; the App services and
+/// commands translate them into these frontend-stable variants.
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq, Clone, Type, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,20 +18,6 @@ pub enum BackendError {
   NetworkUsageNotAvailable,
   UnexpectedError,
   // SystemError(String),
-}
-
-impl From<core_err::BackendError> for BackendError {
-  fn from(src: core_err::BackendError) -> Self {
-    match src {
-      core_err::BackendError::CpuInfoNotAvailable => Self::CpuInfoNotAvailable,
-      core_err::BackendError::StorageInfoNotAvailable => Self::StorageInfoNotAvailable,
-      core_err::BackendError::MemoryInfoNotAvailable => Self::MemoryInfoNotAvailable,
-      core_err::BackendError::GraphicInfoNotAvailable => Self::GraphicInfoNotAvailable,
-      core_err::BackendError::NetworkInfoNotAvailable => Self::NetworkInfoNotAvailable,
-      core_err::BackendError::NetworkUsageNotAvailable => Self::NetworkUsageNotAvailable,
-      core_err::BackendError::UnexpectedError => Self::UnexpectedError,
-    }
-  }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/gpu_service.rs
+++ b/src-tauri/src/services/gpu_service.rs
@@ -1,14 +1,14 @@
 use crate::enums;
 use crate::models::hardware::{GpuMemoryUsage, GpuUsageResult, NameValue};
+use hardviz_core::enums::error::PlatformError;
 use hardviz_core::platform::factory::PlatformFactory;
 
 ///
 /// Get GPU usage (%) together with the data-source name
 /// For multiple GPUs, depends on Platform implementation policy
 ///
-pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, PlatformError> {
+  let platform = PlatformFactory::create()?;
   let (usage, source) = platform.get_gpu_usage().await?;
   Ok(GpuUsageResult {
     usage: usage.round() as i32,
@@ -24,14 +24,10 @@ pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, String> {
 ///
 pub async fn fetch_gpu_temperature(
   temperature_unit: enums::settings::TemperatureUnit,
-) -> Result<Vec<NameValue>, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+) -> Result<Vec<NameValue>, PlatformError> {
+  let platform = PlatformFactory::create()?;
 
-  let core_temps = platform
-    .get_gpu_temperature()
-    .await
-    .map_err(|e| format!("Failed to get GPU temperature: {e:?}"))?;
+  let core_temps = platform.get_gpu_temperature().await?;
 
   let unit: hardviz_core::enums::settings::TemperatureUnit = temperature_unit.into();
   Ok(
@@ -67,9 +63,8 @@ pub async fn fetch_gpu_temperature(
 /// defined by that type (typically mebibytes, MiB). See
 /// [`GpuMemoryUsage`] for field-level details.
 ///
-pub async fn fetch_gpu_memory_usage() -> Result<Option<GpuMemoryUsage>, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub async fn fetch_gpu_memory_usage() -> Result<Option<GpuMemoryUsage>, PlatformError> {
+  let platform = PlatformFactory::create()?;
 
   let core_mem = platform.get_gpu_memory_usage().await?;
   Ok(core_mem.map(GpuMemoryUsage::from))

--- a/src-tauri/src/services/hardware_service.rs
+++ b/src-tauri/src/services/hardware_service.rs
@@ -49,7 +49,11 @@ pub async fn collect_hardware_info(store: &HistoryStore) -> Result<SysInfo, Stri
   let gpus = match gpus_res {
     Ok(v) => Some(v.into_iter().map(Into::into).collect()),
     Err(e) => {
-      log_error!("gpu_info_failed", "collect_hardware_info", Some(e));
+      log_error!(
+        "gpu_info_failed",
+        "collect_hardware_info",
+        Some(e.to_string())
+      );
       None
     }
   };
@@ -57,7 +61,11 @@ pub async fn collect_hardware_info(store: &HistoryStore) -> Result<SysInfo, Stri
   let memory = match memory_res {
     Ok(v) => Some(v.into()),
     Err(e) => {
-      log_error!("memory_info_failed", "collect_hardware_info", Some(e));
+      log_error!(
+        "memory_info_failed",
+        "collect_hardware_info",
+        Some(e.to_string())
+      );
       None
     }
   };
@@ -75,7 +83,11 @@ pub async fn collect_hardware_info(store: &HistoryStore) -> Result<SysInfo, Stri
   let motherboard = match motherboard_res {
     Ok(v) => Some(v),
     Err(e) => {
-      log_error!("motherboard_info_failed", "collect_hardware_info", Some(e));
+      log_error!(
+        "motherboard_info_failed",
+        "collect_hardware_info",
+        Some(e.to_string())
+      );
       None
     }
   };

--- a/src-tauri/src/services/memory_service.rs
+++ b/src-tauri/src/services/memory_service.rs
@@ -1,12 +1,12 @@
 use crate::models::hardware::MemoryInfo;
+use hardviz_core::enums::error::PlatformError;
 use hardviz_core::platform::factory::PlatformFactory;
 
 ///
 /// ## Get detailed memory information via Platform
-/// Returns `MemoryInfo` on success, error message on failure
+/// Returns `MemoryInfo` on success, a [`PlatformError`] on failure
 ///
-pub async fn fetch_memory_detail() -> Result<MemoryInfo, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub async fn fetch_memory_detail() -> Result<MemoryInfo, PlatformError> {
+  let platform = PlatformFactory::create()?;
   Ok(platform.get_memory_info_detail().await?.into())
 }

--- a/src-tauri/src/services/motherboard_service.rs
+++ b/src-tauri/src/services/motherboard_service.rs
@@ -1,12 +1,12 @@
 use crate::models::hardware::MotherboardInfo;
+use hardviz_core::enums::error::PlatformError;
 use hardviz_core::platform::factory::PlatformFactory;
 
 ///
 /// Fetch motherboard and BIOS information
 ///
-pub async fn fetch_motherboard_info() -> Result<MotherboardInfo, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub async fn fetch_motherboard_info() -> Result<MotherboardInfo, PlatformError> {
+  let platform = PlatformFactory::create()?;
 
   Ok(platform.get_motherboard_info().await?.into())
 }

--- a/src-tauri/src/services/network_service.rs
+++ b/src-tauri/src/services/network_service.rs
@@ -1,21 +1,62 @@
 use crate::enums;
 use crate::models::hardware::NetworkInfo;
+use hardviz_core::enums::error::PlatformError;
 use hardviz_core::platform::factory::PlatformFactory;
 
 ///
 /// Get network interface information.
 ///
-/// Returns `BackendError::UnexpectedError` if the Platform layer can't be
-/// instantiated. Provider-side failures are propagated through the
-/// `From<core::enums::error::BackendError>` conversion so frontend callers
-/// keep seeing the specific variants
-/// (`NetworkInfoNotAvailable` / `NetworkUsageNotAvailable`).
+/// Core reports failures as [`PlatformError`]; this service translates
+/// them into the frontend-stable wire variants.
 ///
 pub fn fetch_network_info() -> Result<Vec<NetworkInfo>, enums::error::BackendError> {
   let platform =
     PlatformFactory::create().map_err(|_| enums::error::BackendError::UnexpectedError)?;
-  let core_list = platform
-    .get_network_info()
-    .map_err(enums::error::BackendError::from)?;
+  let core_list = platform.get_network_info().map_err(wire_network_error)?;
   Ok(core_list.into_iter().map(NetworkInfo::from).collect())
+}
+
+/// Translate a Core platform error into the network wire variant.
+///
+/// Absence (unsupported/unavailable) maps to `NetworkInfoNotAvailable`;
+/// faults and initialization failures stay `UnexpectedError`, matching
+/// the pre-typed wire behavior.
+fn wire_network_error(error: PlatformError) -> enums::error::BackendError {
+  match error {
+    PlatformError::Unsupported { .. } | PlatformError::Unavailable { .. } => {
+      enums::error::BackendError::NetworkInfoNotAvailable
+    }
+    PlatformError::Fault { .. } | PlatformError::InitializationFailed { .. } => {
+      enums::error::BackendError::UnexpectedError
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn absence_maps_to_network_info_not_available() {
+    assert_eq!(
+      wire_network_error(PlatformError::unsupported("stub")),
+      enums::error::BackendError::NetworkInfoNotAvailable
+    );
+    assert_eq!(
+      wire_network_error(PlatformError::unavailable("no interface")),
+      enums::error::BackendError::NetworkInfoNotAvailable
+    );
+  }
+
+  #[test]
+  fn faults_stay_unexpected_error() {
+    assert_eq!(
+      wire_network_error(PlatformError::fault("provider failed")),
+      enums::error::BackendError::UnexpectedError
+    );
+    assert_eq!(
+      wire_network_error(PlatformError::initialization_failed("boom")),
+      enums::error::BackendError::UnexpectedError
+    );
+  }
 }

--- a/src-tauri/src/services/system_service.rs
+++ b/src-tauri/src/services/system_service.rs
@@ -1,3 +1,4 @@
+use hardviz_core::enums::error::PlatformError;
 use hardviz_core::platform::factory::PlatformFactory;
 use tauri::Manager;
 
@@ -19,7 +20,9 @@ pub async fn restart_app(app_handle: &tauri::AppHandle) {
   app_handle.exit(0);
 }
 
-pub async fn restart_app_elevated(app_handle: &tauri::AppHandle) -> Result<(), String> {
+pub async fn restart_app_elevated(
+  app_handle: &tauri::AppHandle,
+) -> Result<(), PlatformError> {
   let state = app_handle.state::<crate::workers::WorkersState>();
   state.terminate_all().await;
 
@@ -30,7 +33,7 @@ pub async fn restart_app_elevated(app_handle: &tauri::AppHandle) -> Result<(), S
 
 pub fn relaunch_for_elevated_startup_if_needed(
   app_handle: &tauri::AppHandle,
-) -> Result<bool, String> {
+) -> Result<bool, PlatformError> {
   if is_process_elevated()? {
     return Ok(false);
   }
@@ -40,14 +43,12 @@ pub fn relaunch_for_elevated_startup_if_needed(
   Ok(true)
 }
 
-pub fn is_process_elevated() -> Result<bool, String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub fn is_process_elevated() -> Result<bool, PlatformError> {
+  let platform = PlatformFactory::create()?;
   platform.is_process_elevated()
 }
 
-pub fn relaunch_current_process_elevated() -> Result<(), String> {
-  let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+pub fn relaunch_current_process_elevated() -> Result<(), PlatformError> {
+  let platform = PlatformFactory::create()?;
   platform.relaunch_current_process_elevated()
 }

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -236,6 +236,13 @@ export type ArchiveRecord = {
 	timestamp: string,
 };
 
+/**
+ *  Wire error enum exposed to the frontend through tauri-specta.
+ * 
+ *  Core reports platform failures as
+ *  `hardviz_core::enums::error::PlatformError`; the App services and
+ *  commands translate them into these frontend-stable variants.
+ */
 export type BackendError = "cpuInfoNotAvailable" | "storageInfoNotAvailable" | "memoryInfoNotAvailable" | "graphicInfoNotAvailable" | "networkInfoNotAvailable" | "networkUsageNotAvailable" | "unexpectedError";
 
 /**


### PR DESCRIPTION
## Summary

Replaces stringly-typed `Result<_, String>` across the Core platform traits, the three OS platform implementations, and the App services that consume them with a structured `hardviz_core::enums::error::PlatformError` (thiserror).

The variants preserve the DP-02 distinction that was previously only encoded in prose and per-site string conventions, mirroring `SensorAvailability`:

- `Unsupported` — the path does not provide the value by design (build stubs, OS-exclusive features)
- `Unavailable` — the path exists but the attempt produced no user-visible value (warm-up, all provider fallbacks exhausted, nothing detected)
- `Fault` — a supported operation failed unexpectedly (OS API / provider / join errors)
- `InitializationFailed` — the OS platform implementation could not be constructed (keeps the pre-existing Display prefix)

Boundary rule after this PR: **`core::platform` speaks `PlatformError`; `core::infrastructure::providers` keeps `String` (follow-up scope); App commands translate to the existing wire shapes.**

Additional cleanups that fall out of the typing:

- The dead Core `enums::error::BackendError` POJO mirror is removed. The wire `BackendError` enum in `src-tauri` is unchanged and now documents that it is the translation target.
- The network path (`windows/linux/macos network::get_network_info`) previously discarded provider error messages via `.map_err(|_| BackendError::UnexpectedError)`; it now carries them in `PlatformError::Fault`. The wire mapping (`wire_network_error`) keeps today's frontend-visible behavior: faults stay `unexpectedError`.
- `PlatformFactory` no longer needs per-call `map_err` chains; platform `new()` constructors return `PlatformError` directly.

### Compatibility

Wire contracts are unchanged: no command signature changed and the frontend `BackendError` variants are identical. The only `src/rspc/bindings.ts` diff is the generated JSDoc for the wire enum's new doc comment (regenerated via the `export_bindings` bin; no runtime type change). Frontend code does not match on backend error message text (verified by grep), so the minor message-prefix changes at two GPU command sites only affect logs.

### Context

No linked issue — this is the first slice of a Rust-refinement series agreed in a design discussion. Planned follow-ups after this merges: construct the platform once at startup and inject `Arc<dyn Platform>` (removing per-tick/per-command factory calls), and modernize the hand-rolled `Pin<Box<dyn Future>>` trait signatures. Typed `Unsupported` is the prerequisite for turning per-call "not implemented" runtime errors into a one-time startup capability probe.

## Related Issues

None (refactoring slice from a design discussion; follow-up slices will be filed separately).

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [x] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (no user-visible change).

## Test Plan

- [ ] Manual testing
- [x] Unit tests

New tests:

- `core::enums::error` — Display contract (reason forwarded unchanged; `InitializationFailed` keeps its established prefix) and constructor classification.
- `core::platform::macos` — build-only stubs (`get_memory_info_detail`, `get_gpu_temperature`) and elevation relaunch classify as `Unsupported`.
- `src-tauri services::network_service::wire_network_error` — absence maps to `networkInfoNotAvailable`, faults stay `unexpectedError` (pre-existing wire behavior).

Local verification (macOS): `cargo tauri-fmt`, `cargo tauri-lint` (clippy `-D warnings`), and `cargo tauri-test` (252 + 2 + 233 passed, 0 failed). Frontend suite not run locally because the only TypeScript diff is a generated comment.

Windows/Linux compilation relies on CI: cross-target `cargo check` from macOS fails in `ring`'s C build script (environment limitation, not a code path). The Windows/Linux edits are mechanically identical to the macOS pattern that compiles and passes tests locally.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent, categorized platform error reporting across hardware, network, memory, and process-elevation operations.
  * Improved error messages and classification for unsupported, unavailable, initialization, and fault conditions.
  * Network failures now map to clearer availability or unexpected-error states.

* **Bug Fixes**
  * Preserved underlying platform failure details instead of replacing them with generic messages.
  * Improved hardware collection error handling so other system information continues loading when one component fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
