### PR TITLE
refactor(core): resolve the platform once and modernize trait signatures

### DIFF
--- a/core/src/collector/sampling.rs
+++ b/core/src/collector/sampling.rs
@@ -13,7 +13,8 @@ use crate::models::{
   MotherboardSensorCollection, MotherboardSensorSample, PowerDraw, ProcessSample,
   SensorTemperature, TemperatureSample,
 };
-use crate::platform::factory::PlatformFactory;
+use crate::platform::factory::PlatformHandle;
+use crate::platform::traits::Platform;
 
 pub struct SystemSample {
   pub cpu_usage: f32,
@@ -22,18 +23,43 @@ pub struct SystemSample {
   pub processes: Vec<ProcessSample>,
 }
 
-pub fn sample_motherboard_sensors() -> MotherboardSensorCollection {
-  match PlatformFactory::create() {
-    Ok(platform) => platform.sample_motherboard_sensors(),
-    Err(error) => MotherboardSensorCollection::unavailable(error.to_string()),
-  }
-}
+/// Run one full sampling cycle against the platform resolved once at
+/// collector startup and compose the resulting [`MetricsSnapshot`].
+///
+/// A failed platform resolution is reported per cycle: sensor samples
+/// become unavailable with the initialization error as the reason, GPU
+/// samples stay empty, and power falls back to the default. Returns
+/// `None` only when the system sample itself is unavailable.
+pub async fn collect_snapshot(
+  store: &HistoryStore,
+  platform: &PlatformHandle,
+) -> Option<MetricsSnapshot> {
+  let system_sample = sample_system(store)?;
 
-pub fn sample_temperatures() -> TemperatureSample {
-  match PlatformFactory::create() {
-    Ok(platform) => platform.sample_temperatures(),
-    Err(error) => TemperatureSample::unavailable(error.to_string()),
-  }
+  let (gpu_samples, power_draw, temperature_sample, motherboard_collection) =
+    match platform {
+      Ok(platform) => (
+        sample_gpu(store, platform.as_ref()).await,
+        platform.sample_power_draw(),
+        platform.sample_temperatures(),
+        platform.sample_motherboard_sensors(),
+      ),
+      Err(error) => (
+        Vec::new(),
+        PowerDraw::default(),
+        TemperatureSample::unavailable(error.to_string()),
+        MotherboardSensorCollection::unavailable(error.to_string()),
+      ),
+    };
+
+  Some(build_metrics_snapshot(
+    &system_sample,
+    &gpu_samples,
+    power_draw,
+    &temperature_sample,
+    &motherboard_collection.sample,
+    &motherboard_collection.guidance_candidates,
+  ))
 }
 
 /// Run one CPU / memory / process refresh and append samples to the
@@ -112,23 +138,14 @@ fn calculate_memory_usage_percentage(used: u64, total: u64) -> f32 {
   }
 }
 
-pub async fn sample_gpu(store: &HistoryStore) -> Vec<GpuSample> {
-  let gpu_metrics = match PlatformFactory::create() {
-    Ok(platform) => platform.sample_gpus().await,
-    Err(_) => Vec::new(),
-  };
+pub async fn sample_gpu(store: &HistoryStore, platform: &dyn Platform) -> Vec<GpuSample> {
+  let gpu_metrics = platform.sample_gpus().await;
 
   if !gpu_metrics.is_empty() {
     store.update_gpu_histories(&gpu_metrics);
   }
 
   gpu_metrics
-}
-
-pub fn sample_power_draw() -> PowerDraw {
-  PlatformFactory::create()
-    .map(|platform| platform.sample_power_draw())
-    .unwrap_or_default()
 }
 
 /// Build the per-GPU metrics carried in [`MetricsSnapshot`]. Temperatures
@@ -198,7 +215,155 @@ pub fn build_metrics_snapshot(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::enums::error::PlatformError;
   use crate::models::SensorAvailability;
+  use crate::models::hardware::{
+    GpuMemoryUsage, GraphicInfo, MemoryInfo, MotherboardInfo, NameValue, NetworkInfo,
+    SuperIoChipIdDiagnostics,
+  };
+  use crate::platform::traits::{
+    GpuPlatform, GpuUsageRaw, MemoryPlatform, MotherboardPlatform, NetworkPlatform,
+    ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
+  };
+  use async_trait::async_trait;
+  use std::sync::Arc;
+
+  /// Deterministic Platform used to exercise the collector cycle without
+  /// touching OS providers — the injection seam introduced by the shared
+  /// platform handle.
+  struct FakePlatform;
+
+  #[async_trait]
+  impl MemoryPlatform for FakePlatform {
+    async fn get_memory_info(&self) -> Result<MemoryInfo, PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+
+    async fn get_memory_info_detail(&self) -> Result<MemoryInfo, PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+  }
+
+  #[async_trait]
+  impl GpuPlatform for FakePlatform {
+    async fn get_gpu_usage(&self) -> Result<GpuUsageRaw, PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+
+    async fn get_gpu_temperature(&self) -> Result<Vec<NameValue>, PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+
+    async fn get_gpu_info(&self) -> Result<Vec<GraphicInfo>, PlatformError> {
+      Ok(Vec::new())
+    }
+
+    async fn get_gpu_memory_usage(
+      &self,
+    ) -> Result<Option<GpuMemoryUsage>, PlatformError> {
+      Ok(None)
+    }
+
+    async fn sample_gpus(&self) -> Vec<GpuSample> {
+      vec![GpuSample {
+        gpu_id: "fake:0".to_string(),
+        name: "Fake GPU".to_string(),
+        usage: Some(12.4),
+        temperature: Some(55.6),
+        dedicated_memory_kb: None,
+        cooler_level: None,
+        source: "Fake".to_string(),
+      }]
+    }
+
+    fn sample_power_draw(&self) -> PowerDraw {
+      PowerDraw {
+        cpu_watts: Some(1.5),
+        gpu_watts: Some(2.5),
+        ane_watts: None,
+        package_watts: Some(4.0),
+      }
+    }
+  }
+
+  impl NetworkPlatform for FakePlatform {
+    fn get_network_info(&self) -> Result<Vec<NetworkInfo>, PlatformError> {
+      Ok(Vec::new())
+    }
+  }
+
+  #[async_trait]
+  impl MotherboardPlatform for FakePlatform {
+    async fn get_motherboard_info(&self) -> Result<MotherboardInfo, PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+  }
+
+  impl SuperIoPlatform for FakePlatform {
+    fn get_super_io_chip_id_diagnostics(&self) -> SuperIoChipIdDiagnostics {
+      SuperIoChipIdDiagnostics::unsupported_platform()
+    }
+  }
+
+  impl SensorPlatform for FakePlatform {
+    fn sample_temperatures(&self) -> TemperatureSample {
+      TemperatureSample {
+        cpu_temperature: Some(42.4),
+        ..TemperatureSample::default()
+      }
+    }
+
+    fn sample_motherboard_sensors(&self) -> MotherboardSensorCollection {
+      MotherboardSensorCollection::default()
+    }
+  }
+
+  impl ProcessElevationPlatform for FakePlatform {
+    fn is_process_elevated(&self) -> Result<bool, PlatformError> {
+      Ok(false)
+    }
+
+    fn relaunch_current_process_elevated(&self) -> Result<(), PlatformError> {
+      Err(PlatformError::unsupported("fake"))
+    }
+  }
+
+  impl Platform for FakePlatform {}
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn collect_snapshot_uses_the_injected_platform() {
+    let store = HistoryStore::new();
+    let platform: PlatformHandle = Ok(Arc::new(FakePlatform));
+
+    let snapshot = collect_snapshot(&store, &platform)
+      .await
+      .expect("system sample must be available in tests");
+
+    assert_eq!(snapshot.gpus.len(), 1);
+    assert_eq!(snapshot.gpus[0].gpu_id, "fake:0");
+    assert_eq!(snapshot.gpus[0].gpu_usage, Some(12.0));
+    assert_eq!(snapshot.gpus[0].gpu_temperature, Some(56.0));
+    assert_eq!(snapshot.cpu_temperature, Some(42.0));
+    assert_eq!(snapshot.power_draw.package_watts, Some(4.0));
+    // The fake GPU sample also landed in the history rings.
+    assert_eq!(store.gpu_history("fake:0", 60).len(), 1);
+  }
+
+  #[tokio::test(flavor = "current_thread")]
+  async fn collect_snapshot_degrades_when_the_platform_is_unavailable() {
+    let store = HistoryStore::new();
+    let platform: PlatformHandle = Err(PlatformError::initialization_failed("boom"));
+
+    let snapshot = collect_snapshot(&store, &platform)
+      .await
+      .expect("system sample must be available in tests");
+
+    assert!(snapshot.gpus.is_empty());
+    assert_eq!(snapshot.power_draw, PowerDraw::default());
+    assert_eq!(snapshot.cpu_temperature, None);
+    assert!(snapshot.sensor_temperatures.is_empty());
+    assert!(snapshot.motherboard_temperatures.is_empty());
+  }
 
   fn make_sample(
     gpu_id: &str,

--- a/core/src/collector/system_monitor.rs
+++ b/core/src/collector/system_monitor.rs
@@ -45,10 +45,11 @@ impl SystemMonitorController {
       let mut ticker = interval(Duration::from_secs(SYSTEM_INFO_INIT_INTERVAL));
       ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-      // Resolve the shared platform once for the lifetime of the loop.
-      // On failure every cycle reports unavailable sensor samples with
-      // this error as the reason.
-      let platform = PlatformFactory::shared();
+      // Resolve the shared platform once. While resolution fails, each
+      // cycle reports unavailable sensor samples with the error as the
+      // reason and the next tick retries, so a transient startup
+      // failure cannot degrade the rest of the process lifetime.
+      let mut platform = PlatformFactory::shared();
       if let Err(error) = &platform {
         log_error!(
           "platform unavailable for the collector loop",
@@ -67,6 +68,9 @@ impl SystemMonitorController {
           _ = ticker.tick() => {
             let start = std::time::Instant::now();
 
+            if platform.is_err() {
+              platform = PlatformFactory::shared();
+            }
             if let Some(snapshot) = sampling::collect_snapshot(&store, &platform).await {
               bus.publish(snapshot);
             }

--- a/core/src/collector/system_monitor.rs
+++ b/core/src/collector/system_monitor.rs
@@ -10,7 +10,8 @@ use tokio::time::{Duration, MissedTickBehavior, interval};
 
 use crate::collector::{HistoryStore, sampling};
 use crate::event_bus::EventBus;
-use crate::{log_info, log_warn};
+use crate::platform::factory::PlatformFactory;
+use crate::{log_error, log_info, log_warn};
 
 /// Cadence of the collector loop in seconds.
 const SYSTEM_INFO_INIT_INTERVAL: u64 = 1; // TODO move to a shared constants module
@@ -44,20 +45,20 @@ impl SystemMonitorController {
       let mut ticker = interval(Duration::from_secs(SYSTEM_INFO_INIT_INTERVAL));
       ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-      // Prime the snapshot once so the first emit lands without waiting a tick.
-      if let Some(system_sample) = sampling::sample_system(&store) {
-        let gpu_samples = sampling::sample_gpu(&store).await;
-        let power_draw = sampling::sample_power_draw();
-        let temperature_sample = sampling::sample_temperatures();
-        let motherboard_collection = sampling::sample_motherboard_sensors();
-        let snapshot = sampling::build_metrics_snapshot(
-          &system_sample,
-          &gpu_samples,
-          power_draw,
-          &temperature_sample,
-          &motherboard_collection.sample,
-          &motherboard_collection.guidance_candidates,
+      // Resolve the shared platform once for the lifetime of the loop.
+      // On failure every cycle reports unavailable sensor samples with
+      // this error as the reason.
+      let platform = PlatformFactory::shared();
+      if let Err(error) = &platform {
+        log_error!(
+          "platform unavailable for the collector loop",
+          "collector::system_monitor",
+          Some(error.to_string())
         );
+      }
+
+      // Prime the snapshot once so the first emit lands without waiting a tick.
+      if let Some(snapshot) = sampling::collect_snapshot(&store, &platform).await {
         bus.publish(snapshot);
       }
 
@@ -66,19 +67,7 @@ impl SystemMonitorController {
           _ = ticker.tick() => {
             let start = std::time::Instant::now();
 
-            if let Some(system_sample) = sampling::sample_system(&store) {
-              let gpu_samples = sampling::sample_gpu(&store).await;
-              let power_draw = sampling::sample_power_draw();
-              let temperature_sample = sampling::sample_temperatures();
-              let motherboard_collection = sampling::sample_motherboard_sensors();
-              let snapshot = sampling::build_metrics_snapshot(
-                &system_sample,
-                &gpu_samples,
-                power_draw,
-                &temperature_sample,
-                &motherboard_collection.sample,
-                &motherboard_collection.guidance_candidates,
-              );
+            if let Some(snapshot) = sampling::collect_snapshot(&store, &platform).await {
               bus.publish(snapshot);
             }
 

--- a/core/src/platform/factory.rs
+++ b/core/src/platform/factory.rs
@@ -1,17 +1,37 @@
-use crate::enums::error::PlatformError;
+use std::sync::{Arc, OnceLock};
 
-/// Factory that creates Platform instances
+use crate::enums::error::PlatformError;
+use crate::platform::traits::Platform;
+
+/// Outcome of resolving the shared platform once: the process-wide
+/// instance, or the initialization error that consumers report on each
+/// use (for example as per-cycle unavailable samples).
+pub type PlatformHandle = Result<Arc<dyn Platform>, PlatformError>;
+
+static SHARED: OnceLock<Arc<dyn Platform>> = OnceLock::new();
+
+/// Factory that resolves the process-wide Platform instance
 pub struct PlatformFactory;
 
 impl PlatformFactory {
-  /// Create a Platform trait object suitable for the current platform
-  pub fn create() -> Result<Box<dyn crate::platform::traits::Platform>, PlatformError> {
-    Self::create_platform()
+  /// Return the shared Platform for the current OS, constructing it on
+  /// first use.
+  ///
+  /// The instance lives for the rest of the process so platform
+  /// implementations can hold long-lived state (probed capabilities,
+  /// provider handles). A construction failure is not cached; later
+  /// calls retry.
+  pub fn shared() -> PlatformHandle {
+    if let Some(platform) = SHARED.get() {
+      return Ok(Arc::clone(platform));
+    }
+    let platform: Arc<dyn Platform> = Arc::from(Self::create_platform()?);
+    // On a construction race the first stored instance wins; platforms
+    // hold no exclusive resources at construction time.
+    Ok(Arc::clone(SHARED.get_or_init(|| platform)))
   }
 
-  /// Create a Platform trait object suitable for the current platform
-  pub fn create_platform()
-  -> Result<Box<dyn crate::platform::traits::Platform>, PlatformError> {
+  fn create_platform() -> Result<Box<dyn Platform>, PlatformError> {
     #[cfg(target_os = "windows")]
     {
       Ok(Box::new(crate::platform::windows::WindowsPlatform::new()?))
@@ -26,5 +46,18 @@ impl PlatformFactory {
     {
       Ok(Box::new(crate::platform::macos::MacOSPlatform::new()?))
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn shared_returns_the_same_instance() {
+    let first = PlatformFactory::shared().expect("platform must resolve");
+    let second = PlatformFactory::shared().expect("platform must resolve");
+
+    assert!(Arc::ptr_eq(&first, &second));
   }
 }

--- a/core/src/platform/factory.rs
+++ b/core/src/platform/factory.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::enums::error::PlatformError;
 use crate::platform::traits::Platform;
@@ -9,6 +9,11 @@ use crate::platform::traits::Platform;
 pub type PlatformHandle = Result<Arc<dyn Platform>, PlatformError>;
 
 static SHARED: OnceLock<Arc<dyn Platform>> = OnceLock::new();
+/// Serializes construction so at most one caller runs the platform
+/// constructor, even when first callers race. Platform implementations
+/// may acquire provider handles at construction time, so a discarded
+/// duplicate instance is not acceptable.
+static INIT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Factory that resolves the process-wide Platform instance
 pub struct PlatformFactory;
@@ -25,9 +30,15 @@ impl PlatformFactory {
     if let Some(platform) = SHARED.get() {
       return Ok(Arc::clone(platform));
     }
+
+    // A panicking constructor must not permanently poison resolution.
+    let _guard = INIT_LOCK
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(platform) = SHARED.get() {
+      return Ok(Arc::clone(platform));
+    }
     let platform: Arc<dyn Platform> = Arc::from(Self::create_platform()?);
-    // On a construction race the first stored instance wins; platforms
-    // hold no exclusive resources at construction time.
     Ok(Arc::clone(SHARED.get_or_init(|| platform)))
   }
 

--- a/core/src/platform/linux/memory.rs
+++ b/core/src/platform/linux/memory.rs
@@ -7,55 +7,43 @@ use crate::platform::linux;
 use crate::utils;
 use std;
 
-pub fn get_memory_info() -> std::pin::Pin<
-  Box<
-    dyn std::future::Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static,
-  >,
-> {
-  Box::pin(async {
-    if let Ok(cached) = get_memory_info_cached_detail() {
-      return Ok(cached);
-    }
+pub async fn get_memory_info() -> Result<MemoryInfo, PlatformError> {
+  if let Ok(cached) = get_memory_info_cached_detail() {
+    return Ok(cached);
+  }
 
-    // fallback: Only get memory capacity
-    let mem_kb = providers::procfs::get_mem_total_kb()
-      .map_err(|e| PlatformError::fault(format!("Failed to read /proc/meminfo: {e}")))?;
+  // fallback: Only get memory capacity
+  let mem_kb = providers::procfs::get_mem_total_kb()
+    .map_err(|e| PlatformError::fault(format!("Failed to read /proc/meminfo: {e}")))?;
 
-    Ok(models::hardware::MemoryInfo {
-      size: utils::formatter::format_size(mem_kb * 1024, 1),
-      clock: 0,
-      clock_unit: "MHz".into(),
-      memory_count: 0,
-      total_slots: 0,
-      memory_type: "Unknown".into(),
-      is_detailed: false,
-    })
+  Ok(models::hardware::MemoryInfo {
+    size: utils::formatter::format_size(mem_kb * 1024, 1),
+    clock: 0,
+    clock_unit: "MHz".into(),
+    memory_count: 0,
+    total_slots: 0,
+    memory_type: "Unknown".into(),
+    is_detailed: false,
   })
 }
 
-pub fn get_memory_info_detail() -> std::pin::Pin<
-  Box<
-    dyn std::future::Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static,
-  >,
-> {
-  Box::pin(async {
-    let raw = providers::dmidecode::get_raw_dmidecode()
-      .await
-      .map_err(PlatformError::fault)?;
-    let parsed = providers::dmidecode::parse_dmidecode_memory_info(&raw);
+pub async fn get_memory_info_detail() -> Result<MemoryInfo, PlatformError> {
+  let raw = providers::dmidecode::get_raw_dmidecode()
+    .await
+    .map_err(PlatformError::fault)?;
+  let parsed = providers::dmidecode::parse_dmidecode_memory_info(&raw);
 
-    if let Err(e) =
-      linux::cache::write_cache(&parsed, &linux::cache::get_memory_cache_path())
-    {
-      log_warn!(
-        "Failed to cache memory info",
-        "get_memory_info_detail",
-        Some(e.to_string())
-      );
-    }
+  if let Err(e) =
+    linux::cache::write_cache(&parsed, &linux::cache::get_memory_cache_path())
+  {
+    log_warn!(
+      "Failed to cache memory info",
+      "get_memory_info_detail",
+      Some(e.to_string())
+    );
+  }
 
-    Ok(parsed)
-  })
+  Ok(parsed)
 }
 
 fn get_memory_info_cached_detail() -> std::io::Result<MemoryInfo> {

--- a/core/src/platform/linux/mod.rs
+++ b/core/src/platform/linux/mod.rs
@@ -1,13 +1,12 @@
 use crate::enums::error::PlatformError;
 use crate::models::hardware::{
-  GpuMemoryUsage, GraphicInfo, NetworkInfo, SuperIoChipIdDiagnostics,
+  GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
 use crate::platform::traits::{
-  GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
+  GpuPlatform, GpuUsageRaw, MemoryPlatform, MotherboardPlatform, NetworkPlatform,
+  Platform, ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
 };
-use std::future::Future;
-use std::pin::Pin;
+use async_trait::async_trait;
 
 pub mod cache;
 pub mod gpu;
@@ -22,74 +21,39 @@ impl LinuxPlatform {
   }
 }
 
+#[async_trait]
 impl MemoryPlatform for LinuxPlatform {
-  fn get_memory_info(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    memory::get_memory_info()
+  async fn get_memory_info(&self) -> Result<MemoryInfo, PlatformError> {
+    memory::get_memory_info().await
   }
 
-  fn get_memory_info_detail(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    memory::get_memory_info_detail()
+  async fn get_memory_info_detail(&self) -> Result<MemoryInfo, PlatformError> {
+    memory::get_memory_info_detail().await
   }
 }
 
+#[async_trait]
 impl GpuPlatform for LinuxPlatform {
-  fn get_gpu_usage(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
-    >,
-  > {
-    Box::pin(gpu::get_gpu_usage())
+  async fn get_gpu_usage(&self) -> Result<GpuUsageRaw, PlatformError> {
+    gpu::get_gpu_usage().await
   }
 
-  fn get_gpu_temperature(
+  async fn get_gpu_temperature(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    Box::pin(gpu::get_gpu_temperature())
+  ) -> Result<Vec<crate::models::hardware::NameValue>, PlatformError> {
+    gpu::get_gpu_temperature().await
   }
 
-  fn get_gpu_info(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
-  {
-    Box::pin(gpu::get_gpu_info())
+  async fn get_gpu_info(&self) -> Result<Vec<GraphicInfo>, PlatformError> {
+    gpu::get_gpu_info().await
   }
 
-  fn get_gpu_memory_usage(
-    &self,
-  ) -> Pin<
-    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
-  > {
-    Box::pin(async { Ok(None) })
+  async fn get_gpu_memory_usage(&self) -> Result<Option<GpuMemoryUsage>, PlatformError> {
+    Ok(None)
   }
 
-  fn sample_gpus(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Vec<crate::models::GpuSample>> + Send + '_>> {
-    Box::pin(gpu::sample_gpus())
+  async fn sample_gpus(&self) -> Vec<crate::models::GpuSample> {
+    gpu::sample_gpus().await
   }
 }
 
@@ -99,21 +63,14 @@ impl NetworkPlatform for LinuxPlatform {
   }
 }
 
+#[async_trait]
 impl MotherboardPlatform for LinuxPlatform {
-  fn get_motherboard_info(
+  async fn get_motherboard_info(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    Box::pin(async {
-      Err(PlatformError::unsupported(
-        "get_motherboard_info is not implemented for LinuxPlatform",
-      ))
-    })
+  ) -> Result<crate::models::hardware::MotherboardInfo, PlatformError> {
+    Err(PlatformError::unsupported(
+      "get_motherboard_info is not implemented for LinuxPlatform",
+    ))
   }
 }
 

--- a/core/src/platform/macos/mod.rs
+++ b/core/src/platform/macos/mod.rs
@@ -3,11 +3,10 @@ use crate::models::hardware::{
   GpuMemoryUsage, GraphicInfo, MemoryInfo, NetworkInfo, SuperIoChipIdDiagnostics,
 };
 use crate::platform::traits::{
-  GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
+  GpuPlatform, GpuUsageRaw, MemoryPlatform, MotherboardPlatform, NetworkPlatform,
+  Platform, ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
 };
-use std::future::Future;
-use std::pin::Pin;
+use async_trait::async_trait;
 use tokio::task;
 
 mod gpu;
@@ -23,76 +22,47 @@ impl MacOSPlatform {
   }
 }
 
+#[async_trait]
 impl MemoryPlatform for MacOSPlatform {
-  fn get_memory_info(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + '_>> {
-    Box::pin(async {
-      task::spawn_blocking(memory::get_memory_info)
-        .await
-        .map_err(|e| PlatformError::fault(format!("Failed to join memory task: {e}")))?
-    })
+  async fn get_memory_info(&self) -> Result<MemoryInfo, PlatformError> {
+    task::spawn_blocking(memory::get_memory_info)
+      .await
+      .map_err(|e| PlatformError::fault(format!("Failed to join memory task: {e}")))?
   }
 
-  fn get_memory_info_detail(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + '_>> {
-    Box::pin(async {
-      // macOS is not supported yet (build-only stub)
-      Err(PlatformError::unsupported(
-        "get_memory_info_detail is not implemented for MacOSPlatform",
-      ))
-    })
+  async fn get_memory_info_detail(&self) -> Result<MemoryInfo, PlatformError> {
+    // macOS is not supported yet (build-only stub)
+    Err(PlatformError::unsupported(
+      "get_memory_info_detail is not implemented for MacOSPlatform",
+    ))
   }
 }
 
+#[async_trait]
 impl GpuPlatform for MacOSPlatform {
-  fn get_gpu_usage(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
-    >,
-  > {
-    Box::pin(async { gpu::get_gpu_usage().await })
+  async fn get_gpu_usage(&self) -> Result<GpuUsageRaw, PlatformError> {
+    gpu::get_gpu_usage().await
   }
 
-  fn get_gpu_temperature(
+  async fn get_gpu_temperature(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    Box::pin(async {
-      // macOS is not supported yet (build-only stub)
-      Err(PlatformError::unsupported(
-        "get_gpu_temperature is not implemented for MacOSPlatform",
-      ))
-    })
+  ) -> Result<Vec<crate::models::hardware::NameValue>, PlatformError> {
+    // macOS is not supported yet (build-only stub)
+    Err(PlatformError::unsupported(
+      "get_gpu_temperature is not implemented for MacOSPlatform",
+    ))
   }
 
-  fn get_gpu_info(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
-  {
-    Box::pin(async { gpu::get_gpu_info().await })
+  async fn get_gpu_info(&self) -> Result<Vec<GraphicInfo>, PlatformError> {
+    gpu::get_gpu_info().await
   }
 
-  fn get_gpu_memory_usage(
-    &self,
-  ) -> Pin<
-    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
-  > {
-    Box::pin(async { gpu::get_gpu_memory_usage().await })
+  async fn get_gpu_memory_usage(&self) -> Result<Option<GpuMemoryUsage>, PlatformError> {
+    gpu::get_gpu_memory_usage().await
   }
 
-  fn sample_gpus(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Vec<crate::models::GpuSample>> + Send + '_>> {
-    Box::pin(gpu::sample_gpus())
+  async fn sample_gpus(&self) -> Vec<crate::models::GpuSample> {
+    gpu::sample_gpus().await
   }
 
   fn sample_power_draw(&self) -> crate::models::PowerDraw {
@@ -106,17 +76,12 @@ impl NetworkPlatform for MacOSPlatform {
   }
 }
 
+#[async_trait]
 impl MotherboardPlatform for MacOSPlatform {
-  fn get_motherboard_info(
+  async fn get_motherboard_info(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MotherboardInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    motherboard::get_motherboard_info()
+  ) -> Result<crate::models::hardware::MotherboardInfo, PlatformError> {
+    motherboard::get_motherboard_info().await
   }
 }
 

--- a/core/src/platform/macos/motherboard.rs
+++ b/core/src/platform/macos/motherboard.rs
@@ -3,8 +3,6 @@ use crate::infrastructure::providers::macos::system_profiler_hardware::{
   self, SpHardwareDetails,
 };
 use crate::models::hardware::MotherboardInfo;
-use std::future::Future;
-use std::pin::Pin;
 
 /// macOS does not expose a baseboard / BIOS pair, so both the board and
 /// firmware vendor are reported as Apple.
@@ -23,13 +21,10 @@ const APPLE_MANUFACTURER: &str = "Apple Inc.";
 /// - `serial_number` is the system serial number.
 /// - `bios_version` is the system firmware (boot ROM) version.
 /// - `bios_release_date` is left empty (macOS does not expose it).
-pub fn get_motherboard_info()
--> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send>> {
-  Box::pin(async {
-    tokio::task::spawn_blocking(collect_motherboard_info)
-      .await
-      .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
-  })
+pub async fn get_motherboard_info() -> Result<MotherboardInfo, PlatformError> {
+  tokio::task::spawn_blocking(collect_motherboard_info)
+    .await
+    .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
 }
 
 fn collect_motherboard_info() -> Result<MotherboardInfo, PlatformError> {

--- a/core/src/platform/traits.rs
+++ b/core/src/platform/traits.rs
@@ -1,85 +1,49 @@
 use crate::enums::error::PlatformError;
 use crate::models;
-use std::future::Future;
-use std::pin::Pin;
+use async_trait::async_trait;
 
 /// Return type for [`GpuPlatform::get_gpu_usage`]: `(percentage, source_name)`.
 pub type GpuUsageRaw = (f32, String);
 
 /// Trait that defines platform-specific memory operations
+#[async_trait]
 pub trait MemoryPlatform: Send + Sync {
   /// Get basic memory information
-  fn get_memory_info(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  async fn get_memory_info(&self) -> Result<models::hardware::MemoryInfo, PlatformError>;
 
   /// Get detailed memory information (supported platforms only)
-  fn get_memory_info_detail(
+  async fn get_memory_info_detail(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  ) -> Result<models::hardware::MemoryInfo, PlatformError>;
 }
 
 /// Trait that defines platform-specific GPU operations
-#[allow(clippy::type_complexity)]
+#[async_trait]
 pub trait GpuPlatform: Send + Sync {
   /// Get GPU usage together with the data-source name
-  fn get_gpu_usage(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<GpuUsageRaw, PlatformError>> + Send + '_>>;
+  async fn get_gpu_usage(&self) -> Result<GpuUsageRaw, PlatformError>;
 
   /// Get GPU temperatures, always in raw degrees Celsius.
   ///
   /// Presentation conversion (Celsius/Fahrenheit) is the App's
   /// responsibility — Core never reads the user's preferred unit so the
   /// trait stays decoupled from UI preferences.
-  fn get_gpu_temperature(
+  async fn get_gpu_temperature(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Vec<models::hardware::NameValue>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  ) -> Result<Vec<models::hardware::NameValue>, PlatformError>;
 
   /// Get GPU information
-  fn get_gpu_info(
+  async fn get_gpu_info(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Vec<models::hardware::GraphicInfo>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  ) -> Result<Vec<models::hardware::GraphicInfo>, PlatformError>;
 
   /// Get realtime GPU memory usage (best-effort)
-  fn get_gpu_memory_usage(
+  async fn get_gpu_memory_usage(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Option<models::hardware::GpuMemoryUsage>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  ) -> Result<Option<models::hardware::GpuMemoryUsage>, PlatformError>;
 
   /// Collect per-GPU realtime metrics for the monitoring pipeline.
-  fn sample_gpus(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Vec<models::GpuSample>> + Send + '_>>;
+  async fn sample_gpus(&self) -> Vec<models::GpuSample>;
 
   /// Read the latest platform-wide live power sample.
   fn sample_power_draw(&self) -> models::PowerDraw {
@@ -97,17 +61,12 @@ pub trait NetworkPlatform: Send + Sync {
 }
 
 /// Trait that defines platform-specific motherboard operations
+#[async_trait]
 pub trait MotherboardPlatform: Send + Sync {
   /// Get motherboard and BIOS information
-  fn get_motherboard_info(
+  async fn get_motherboard_info(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<models::hardware::MotherboardInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  >;
+  ) -> Result<models::hardware::MotherboardInfo, PlatformError>;
 }
 
 /// Trait that defines platform-specific Super I/O chip-id diagnostics.

--- a/core/src/platform/windows/memory.rs
+++ b/core/src/platform/windows/memory.rs
@@ -1,23 +1,15 @@
 use crate::enums::error::PlatformError;
 use crate::infrastructure::providers::wmi_provider;
 use crate::models::hardware::MemoryInfo;
-use std::future::Future;
-use std::pin::Pin;
 
-pub fn get_memory_info()
--> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static>> {
-  Box::pin(async {
-    wmi_provider::query_memory_info()
-      .await
-      .map_err(PlatformError::fault)
-  })
+pub async fn get_memory_info() -> Result<MemoryInfo, PlatformError> {
+  wmi_provider::query_memory_info()
+    .await
+    .map_err(PlatformError::fault)
 }
 
-pub fn get_memory_info_detail()
--> Pin<Box<dyn Future<Output = Result<MemoryInfo, PlatformError>> + Send + 'static>> {
-  Box::pin(async {
-    Err(PlatformError::unsupported(
-      "Detailed memory info is not implemented yet",
-    ))
-  })
+pub async fn get_memory_info_detail() -> Result<MemoryInfo, PlatformError> {
+  Err(PlatformError::unsupported(
+    "Detailed memory info is not implemented yet",
+  ))
 }

--- a/core/src/platform/windows/mod.rs
+++ b/core/src/platform/windows/mod.rs
@@ -1,14 +1,13 @@
 use crate::enums::error::PlatformError;
 use crate::models::hardware::{
-  GpuMemoryUsage, GraphicInfo, MotherboardInfo, NetworkInfo, SuperIoChipIdDiagnostics,
+  GpuMemoryUsage, GraphicInfo, MemoryInfo, MotherboardInfo, NetworkInfo,
+  SuperIoChipIdDiagnostics,
 };
 use crate::platform::traits::{
-  GpuPlatform, MemoryPlatform, MotherboardPlatform, NetworkPlatform, Platform,
-  ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
+  GpuPlatform, GpuUsageRaw, MemoryPlatform, MotherboardPlatform, NetworkPlatform,
+  Platform, ProcessElevationPlatform, SensorPlatform, SuperIoPlatform,
 };
-
-use std::future::Future;
-use std::pin::Pin;
+use async_trait::async_trait;
 
 pub mod gpu;
 pub mod memory;
@@ -25,74 +24,39 @@ impl WindowsPlatform {
   }
 }
 
+#[async_trait]
 impl MemoryPlatform for WindowsPlatform {
-  fn get_memory_info(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    memory::get_memory_info()
+  async fn get_memory_info(&self) -> Result<MemoryInfo, PlatformError> {
+    memory::get_memory_info().await
   }
 
-  fn get_memory_info_detail(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<crate::models::hardware::MemoryInfo, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    memory::get_memory_info_detail()
+  async fn get_memory_info_detail(&self) -> Result<MemoryInfo, PlatformError> {
+    memory::get_memory_info_detail().await
   }
 }
 
+#[async_trait]
 impl GpuPlatform for WindowsPlatform {
-  fn get_gpu_usage(
-    &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<super::traits::GpuUsageRaw, PlatformError>> + Send + '_,
-    >,
-  > {
-    Box::pin(gpu::get_gpu_usage())
+  async fn get_gpu_usage(&self) -> Result<GpuUsageRaw, PlatformError> {
+    gpu::get_gpu_usage().await
   }
 
-  fn get_gpu_temperature(
+  async fn get_gpu_temperature(
     &self,
-  ) -> Pin<
-    Box<
-      dyn Future<Output = Result<Vec<crate::models::hardware::NameValue>, PlatformError>>
-        + Send
-        + '_,
-    >,
-  > {
-    Box::pin(gpu::get_gpu_temperature())
+  ) -> Result<Vec<crate::models::hardware::NameValue>, PlatformError> {
+    gpu::get_gpu_temperature().await
   }
 
-  fn get_gpu_info(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<Vec<GraphicInfo>, PlatformError>> + Send + '_>>
-  {
-    Box::pin(gpu::get_gpu_info())
+  async fn get_gpu_info(&self) -> Result<Vec<GraphicInfo>, PlatformError> {
+    gpu::get_gpu_info().await
   }
 
-  fn get_gpu_memory_usage(
-    &self,
-  ) -> Pin<
-    Box<dyn Future<Output = Result<Option<GpuMemoryUsage>, PlatformError>> + Send + '_>,
-  > {
-    Box::pin(async { Ok(None) })
+  async fn get_gpu_memory_usage(&self) -> Result<Option<GpuMemoryUsage>, PlatformError> {
+    Ok(None)
   }
 
-  fn sample_gpus(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Vec<crate::models::GpuSample>> + Send + '_>> {
-    Box::pin(gpu::sample_gpus())
+  async fn sample_gpus(&self) -> Vec<crate::models::GpuSample> {
+    gpu::sample_gpus().await
   }
 }
 
@@ -102,12 +66,10 @@ impl NetworkPlatform for WindowsPlatform {
   }
 }
 
+#[async_trait]
 impl MotherboardPlatform for WindowsPlatform {
-  fn get_motherboard_info(
-    &self,
-  ) -> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send + '_>>
-  {
-    motherboard::get_motherboard_info()
+  async fn get_motherboard_info(&self) -> Result<MotherboardInfo, PlatformError> {
+    motherboard::get_motherboard_info().await
   }
 }
 

--- a/core/src/platform/windows/motherboard.rs
+++ b/core/src/platform/windows/motherboard.rs
@@ -1,15 +1,10 @@
 use crate::enums::error::PlatformError;
 use crate::infrastructure::providers::windows::wmi_provider;
 use crate::models::hardware::MotherboardInfo;
-use std::future::Future;
-use std::pin::Pin;
 
-pub fn get_motherboard_info()
--> Pin<Box<dyn Future<Output = Result<MotherboardInfo, PlatformError>> + Send>> {
-  Box::pin(async {
-    tokio::task::spawn_blocking(wmi_provider::query_motherboard_info)
-      .await
-      .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
-      .map_err(PlatformError::fault)
-  })
+pub async fn get_motherboard_info() -> Result<MotherboardInfo, PlatformError> {
+  tokio::task::spawn_blocking(wmi_provider::query_motherboard_info)
+    .await
+    .map_err(|e| PlatformError::fault(format!("Join error: {e}")))?
+    .map_err(PlatformError::fault)
 }

--- a/src-tauri/src/services/gpu_service.rs
+++ b/src-tauri/src/services/gpu_service.rs
@@ -8,7 +8,7 @@ use hardviz_core::platform::factory::PlatformFactory;
 /// For multiple GPUs, depends on Platform implementation policy
 ///
 pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
   let (usage, source) = platform.get_gpu_usage().await?;
   Ok(GpuUsageResult {
     usage: usage.round() as i32,
@@ -25,7 +25,7 @@ pub async fn fetch_gpu_usage() -> Result<GpuUsageResult, PlatformError> {
 pub async fn fetch_gpu_temperature(
   temperature_unit: enums::settings::TemperatureUnit,
 ) -> Result<Vec<NameValue>, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
 
   let core_temps = platform.get_gpu_temperature().await?;
 
@@ -64,7 +64,7 @@ pub async fn fetch_gpu_temperature(
 /// [`GpuMemoryUsage`] for field-level details.
 ///
 pub async fn fetch_gpu_memory_usage() -> Result<Option<GpuMemoryUsage>, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
 
   let core_mem = platform.get_gpu_memory_usage().await?;
   Ok(core_mem.map(GpuMemoryUsage::from))

--- a/src-tauri/src/services/hardware_service.rs
+++ b/src-tauri/src/services/hardware_service.rs
@@ -36,7 +36,7 @@ pub async fn collect_hardware_info(store: &HistoryStore) -> Result<SysInfo, Stri
   };
 
   let platform =
-    PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+    PlatformFactory::shared().map_err(|e| format!("Failed to create platform: {e}"))?;
 
   // Execute GPU / Memory / Storage / Motherboard in parallel
   let (gpus_res, memory_res, storage_res, motherboard_res) = tokio::join!(
@@ -114,7 +114,7 @@ pub async fn get_super_io_chip_id_diagnostics()
 -> hardviz_core::models::hardware::SuperIoChipIdDiagnostics {
   tokio::task::spawn_blocking(|| {
     let platform =
-      PlatformFactory::create().map_err(|e| format!("Failed to create platform: {e}"))?;
+      PlatformFactory::shared().map_err(|e| format!("Failed to create platform: {e}"))?;
     Ok::<_, String>(platform.get_super_io_chip_id_diagnostics())
   })
   .await

--- a/src-tauri/src/services/memory_service.rs
+++ b/src-tauri/src/services/memory_service.rs
@@ -7,6 +7,6 @@ use hardviz_core::platform::factory::PlatformFactory;
 /// Returns `MemoryInfo` on success, a [`PlatformError`] on failure
 ///
 pub async fn fetch_memory_detail() -> Result<MemoryInfo, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
   Ok(platform.get_memory_info_detail().await?.into())
 }

--- a/src-tauri/src/services/motherboard_service.rs
+++ b/src-tauri/src/services/motherboard_service.rs
@@ -6,7 +6,7 @@ use hardviz_core::platform::factory::PlatformFactory;
 /// Fetch motherboard and BIOS information
 ///
 pub async fn fetch_motherboard_info() -> Result<MotherboardInfo, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
 
   Ok(platform.get_motherboard_info().await?.into())
 }

--- a/src-tauri/src/services/network_service.rs
+++ b/src-tauri/src/services/network_service.rs
@@ -11,7 +11,7 @@ use hardviz_core::platform::factory::PlatformFactory;
 ///
 pub fn fetch_network_info() -> Result<Vec<NetworkInfo>, enums::error::BackendError> {
   let platform =
-    PlatformFactory::create().map_err(|_| enums::error::BackendError::UnexpectedError)?;
+    PlatformFactory::shared().map_err(|_| enums::error::BackendError::UnexpectedError)?;
   let core_list = platform.get_network_info().map_err(wire_network_error)?;
   Ok(core_list.into_iter().map(NetworkInfo::from).collect())
 }

--- a/src-tauri/src/services/system_service.rs
+++ b/src-tauri/src/services/system_service.rs
@@ -44,11 +44,11 @@ pub fn relaunch_for_elevated_startup_if_needed(
 }
 
 pub fn is_process_elevated() -> Result<bool, PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
   platform.is_process_elevated()
 }
 
 pub fn relaunch_current_process_elevated() -> Result<(), PlatformError> {
-  let platform = PlatformFactory::create()?;
+  let platform = PlatformFactory::shared()?;
   platform.relaunch_current_process_elevated()
 }


### PR DESCRIPTION
## Summary

Second slice of the Rust-refinement series (follows #1985). Two coupled changes to the same boundary:

**1. Construct the platform once per process.** `PlatformFactory::create()` was called on every collector tick (4 sites in `sampling.rs`) and on every platform-touching command (9 sites across App services), and the returned ZST could not hold state. `PlatformFactory::shared()` now resolves the OS platform once behind a `OnceLock` and hands out `Arc<dyn Platform>`:

- The collector resolves the platform once at loop start and passes the handle into the new `sampling::collect_snapshot(store, &PlatformHandle)`, which also removes the previously duplicated prime/loop sampling blocks in `system_monitor.rs`.
- App services swap `create()` for `shared()`; `create()`/`create_platform()` are removed from the public API.
- A construction failure is not cached (later calls retry), and per-cycle failure behavior is preserved exactly: sensor samples report `unavailable` carrying the initialization error, GPU samples stay empty, power falls back to default. The collector now also logs the resolution failure once instead of hitting it silently every tick.

This is the structural prerequisite for platform implementations that hold state — probed capabilities, provider handles (future PawnIO work) — and it gives the collector an injection seam for tests.

**2. Modernize the trait signatures.** Every hand-rolled `Pin<Box<dyn Future<Output = …>> + Send + '_>` on `MemoryPlatform` / `GpuPlatform` / `MotherboardPlatform` (traits, three OS implementations, and their submodule functions) becomes an `#[async_trait]` `async fn`. The `async-trait` dependency was already declared in `core/Cargo.toml` but unused until now; runtime shape is unchanged (the futures were hand-boxed before, async-trait boxes them now). The `#[allow(clippy::type_complexity)]` on `GpuPlatform` is no longer needed.

The diff is net-zero lines (404+/404−): the removed signature noise pays for the new tests.

### Compatibility

No wire change: command signatures, the wire `BackendError`, and `src/rspc/bindings.ts` are untouched — verified by running the `export_bindings` bin locally and diffing (lesson from #1985). No frontend diff.

Behavioral note: the platform instance now lives for the process lifetime. Today's implementations are all zero-sized and stateless, so there is no observable difference; the change is about what the boundary *allows* next.

## Related Issues

None (refactoring slice from the design discussion behind #1985; planned as "slice 1 + 3" there).

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [x] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (no user-visible change).

## Test Plan

- [ ] Manual testing
- [x] Unit tests

New tests:

- `platform::factory` — `shared()` returns the same instance across calls (`Arc::ptr_eq`).
- `collector::sampling` — a `FakePlatform` implementing the full `Platform` trait is injected through `PlatformHandle`: `collect_snapshot` carries the fake's GPU/temperature/power values into the snapshot and the history rings; with `Err(InitializationFailed)` the snapshot degrades exactly as before (empty GPUs, default power, no temperatures). This fake is the first platform-independent test of the collector cycle.

Local verification (macOS): `cargo tauri-fmt`, `cargo tauri-lint` (clippy `-D warnings`), `cargo tauri-test` (269 + 2 + 241 passed, 0 failed), and `export_bindings` + `git diff --exit-code -- src/rspc/bindings.ts` (unchanged). Windows/Linux compilation relies on CI as in #1985 (`ring`'s C build script blocks local cross-target checks); the Windows/Linux edits follow the identical pattern as the macOS code that compiles and passes locally.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - System snapshots now continue collecting available metrics when hardware data is unavailable.
  - Platform initialization can recover automatically after temporary startup failures.

- **Bug Fixes**
  - Improved fallback handling for unavailable hardware information.
  - Reduced repeated platform initialization across hardware, memory, network, and system operations.

- **Refactor**
  - Streamlined asynchronous hardware operations across supported platforms.
  - Improved coordination when initializing shared platform services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->