### PR TITLE
chore(build): use native-compatible Vite config paths

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -114,7 +114,7 @@ export default defineConfig(async ({ mode }) => ({
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src"),
+      "@": path.resolve(import.meta.dirname, "src"),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary

- replace `__dirname` in `vite.config.ts` with the ESM-native `import.meta.dirname`
- allow Vite to load the application config with `configLoader: native` without the migration warning
- preserve the existing `@` alias target and application behavior

## Related Issues

None. This is a small build configuration maintenance change.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] `npm exec -- vite build --configLoader native`
- [x] `npm run build`
- [x] `npm run lint:ci`
- [x] `npm test` (83 files, 606 tests)

`npm test` still reports the same native-loader migration warning for the separate `vitest.config.ts` configuration. That pre-existing file is outside this focused application Vite config change.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint:ci`)
- [x] Tests pass (`npm test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal path resolution for improved compatibility with the current build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->