### PR TITLE
fix(core): sample every Windows GPU adapter a vendor API cannot read

### DIFF
--- a/core/src/infrastructure/providers/windows/directx.rs
+++ b/core/src/infrastructure/providers/windows/directx.rs
@@ -1,10 +1,16 @@
 use crate::models::hardware::GraphicInfo;
 use crate::{log_debug, log_error};
 
+use super::setupdi_provider;
 use dxgi::Factory;
 use dxgi::adapter::AdapterDesc;
 use std::collections::HashMap;
 use tokio::task::spawn_blocking;
+
+/// `DXGI_ADAPTER_FLAG_SOFTWARE`: a software rasterizer such as WARP or the
+/// "Microsoft Basic Render Driver". It has no device behind it to report on,
+/// so offering it as a GPU to attribute readings to would be a fiction.
+const DXGI_ADAPTER_FLAG_SOFTWARE: u32 = 2;
 
 /// Lightweight LUID info for a GPU adapter, used to match PDH counters.
 pub struct GpuLuidInfo {
@@ -13,55 +19,67 @@ pub struct GpuLuidInfo {
   pub luid_low: u32,
   /// PnP identity, when SetupDi can associate it with this DXGI LUID.
   pub device_instance_id: Option<String>,
+  /// PCI vendor id as DXGI reports it, used to tell which vendor API — if
+  /// any — already speaks for this adapter.
+  pub vendor_id: u32,
+  /// PCI address, when SetupDi can associate it with this DXGI LUID. It is
+  /// the id ADL samples are keyed by, so it is how a PDH candidate
+  /// recognises an adapter ADL already reported.
+  pub bdf: Option<(i32, i32, i32)>,
 }
 
-/// Get Intel GPU LUID information for matching with PDH performance counters.
-pub async fn get_intel_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
+/// LUID information for every hardware GPU adapter Windows exposes.
+///
+/// Deliberately vendor-agnostic: PDH is the only usage source left for an
+/// adapter whose vendor API is missing or refuses to answer — an AMD APU
+/// whose ADL usage query fails, for one — and an adapter absent from the
+/// sample stream cannot be named, attributed, or selected at all.
+pub async fn get_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
   let handle = spawn_blocking(|| {
     let factory =
       Factory::new().map_err(|e| format!("Failed to create DXGI Factory: {e:?}"))?;
-    let stable_ids: HashMap<(i32, u32), String> = crate::infrastructure::providers::windows::
+    let pnp_by_luid: HashMap<(i32, u32), setupdi_provider::DisplayAdapterBdf> =
       setupdi_provider::enumerate_display_adapters()
-      .into_iter()
-      .filter_map(|adapter| {
-        let luid = adapter.adapter_luid?;
-        let stable_id = adapter.device_instance_id?;
-        Some((luid, stable_id))
-      })
-      .collect();
+        .into_iter()
+        .filter_map(|adapter| Some((adapter.adapter_luid?, adapter)))
+        .collect();
     let mut result = Vec::new();
 
     for adapter in factory.adapters() {
       let desc: AdapterDesc = adapter.get_desc();
-      let gpu_name = desc.description();
-      if gpu_name.contains("Intel") {
-        let luid = desc.adapter_luid();
-        result.push(GpuLuidInfo {
-          name: gpu_name.trim_end_matches('\0').to_string(),
-          luid_high: luid.HighPart,
-          luid_low: luid.LowPart,
-          device_instance_id: stable_ids.get(&(luid.HighPart, luid.LowPart)).cloned(),
-        });
+      if desc.flags() & DXGI_ADAPTER_FLAG_SOFTWARE != 0 {
+        continue;
       }
+
+      let luid = desc.adapter_luid();
+      let pnp = pnp_by_luid.get(&(luid.HighPart, luid.LowPart));
+      result.push(GpuLuidInfo {
+        name: desc.description().trim_end_matches('\0').to_string(),
+        luid_high: luid.HighPart,
+        luid_low: luid.LowPart,
+        device_instance_id: pnp.and_then(|a| a.device_instance_id.clone()),
+        vendor_id: desc.vendor_id(),
+        bdf: pnp.map(|a| (a.bus, a.device, a.function)),
+      });
     }
 
     Ok(result)
   });
 
   handle.await.map_err(|e| {
-    log_error!("join_error", "get_intel_gpu_luid_info", Some(e.to_string()));
-    "Intel GPU LUID info retrieval failed".to_string()
+    log_error!("join_error", "get_gpu_luid_info", Some(e.to_string()));
+    "GPU LUID info retrieval failed".to_string()
   })?
 }
 
-/// Get Intel GPU LUID information, cached for the process lifetime.
+/// Get GPU LUID information, cached for the process lifetime.
 /// Returns an empty slice if the initial query fails.
-pub async fn get_intel_gpu_luid_info_cached() -> &'static [GpuLuidInfo] {
+pub async fn get_gpu_luid_info_cached() -> &'static [GpuLuidInfo] {
   static INFO: tokio::sync::OnceCell<Vec<GpuLuidInfo>> =
     tokio::sync::OnceCell::const_new();
 
   INFO
-    .get_or_init(|| async { get_intel_gpu_luid_info().await.unwrap_or_default() })
+    .get_or_init(|| async { get_gpu_luid_info().await.unwrap_or_default() })
     .await
 }
 

--- a/core/src/infrastructure/providers/windows/directx.rs
+++ b/core/src/infrastructure/providers/windows/directx.rs
@@ -1,5 +1,5 @@
 use crate::models::hardware::GraphicInfo;
-use crate::{log_debug, log_error};
+use crate::{log_debug, log_error, log_warn};
 
 use super::setupdi_provider;
 use dxgi::Factory;
@@ -73,14 +73,28 @@ pub async fn get_gpu_luid_info() -> Result<Vec<GpuLuidInfo>, String> {
 }
 
 /// Get GPU LUID information, cached for the process lifetime.
-/// Returns an empty slice if the initial query fails.
+///
+/// Only a successful query is cached. A failure returns an empty slice for
+/// this call and leaves the cell uninitialized so the next sample retries:
+/// caching a transient DXGI or SetupDi failure would declare every
+/// vendor-uncovered adapter absent for the rest of the process, and absence
+/// of discovery is uncertainty, not evidence of absence.
 pub async fn get_gpu_luid_info_cached() -> &'static [GpuLuidInfo] {
   static INFO: tokio::sync::OnceCell<Vec<GpuLuidInfo>> =
     tokio::sync::OnceCell::const_new();
+  static FAILURE_LOGGED: std::sync::Once = std::sync::Once::new();
 
-  INFO
-    .get_or_init(|| async { get_gpu_luid_info().await.unwrap_or_default() })
-    .await
+  match INFO.get_or_try_init(get_gpu_luid_info).await {
+    Ok(info) => info,
+    Err(e) => {
+      // Once, not per sample: the retry runs at the monitor cadence, and a
+      // machine where discovery never succeeds would flood the log.
+      FAILURE_LOGGED.call_once(|| {
+        log_warn!("discovery_failed", "get_gpu_luid_info_cached", Some(e));
+      });
+      &[]
+    }
+  }
 }
 
 /// Get Intel GPU information

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -335,11 +335,13 @@ const NVIDIA_VENDOR_ID: u32 = 0x10DE;
 /// one physical GPU as two adapters, and the duplicated name would make the
 /// inventory join ambiguous enough to drop the VRAM total.
 ///
-/// ADL ids carry the adapter's PCI address, so an AMD adapter is matched
-/// exactly — an APU that ADL enumerates but cannot read still falls through to
-/// PDH. NVAPI ids carry neither address nor LUID, so any NVAPI sample claims
-/// every NVIDIA adapter. The reported name is the last resort, and the only
-/// join key the two sources share when SetupDi cannot supply a PCI address.
+/// ADL ids carry the adapter's PCI address, so an AMD adapter with one is
+/// decided by that comparison alone — an APU that ADL enumerates but cannot
+/// read still falls through to PDH, and a same-name sibling the vendor API did
+/// read must not claim coverage for it. NVAPI ids carry neither address nor
+/// LUID, so any NVAPI sample claims every NVIDIA adapter. The reported name is
+/// consulted only when SetupDi cannot supply a PCI address, because it is then
+/// the only join key the two sources share.
 fn is_covered_by_vendor_api(
   vendor_id: u32,
   name: &str,
@@ -354,9 +356,7 @@ fn is_covered_by_vendor_api(
 
   if let Some((bus, device, function)) = bdf {
     let pci_id = format!("pci:{bus}:{device}:{function}");
-    if sampled.iter().any(|(id, _)| *id == pci_id) {
-      return true;
-    }
+    return sampled.iter().any(|(id, _)| *id == pci_id);
   }
 
   sampled
@@ -459,6 +459,20 @@ mod tests {
       AMD_VENDOR_ID,
       "AMD Radeon(TM) Graphics",
       Some((101, 0, 0)),
+      &sampled
+    ));
+  }
+
+  #[test]
+  fn same_name_sibling_does_not_cover_an_adapter_with_a_different_pci_address() {
+    // Two identical cards; ADL read only the one on bus 3. The one on bus 6
+    // must stay uncovered, or the name match would hide it from PDH — the
+    // exact disappearance this module exists to prevent.
+    let sampled = [("pci:3:0:0", "AMD Radeon RX 7900 XTX")];
+    assert!(!is_covered_by_vendor_api(
+      AMD_VENDOR_ID,
+      "AMD Radeon RX 7900 XTX",
+      Some((6, 0, 0)),
       &sampled
     ));
   }

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -27,9 +27,11 @@ pub async fn get_gpu_usage() -> Result<(f32, String), PlatformError> {
   }
 
   // 3. Intel via PDH + DXGI LUID (cached)
-  let intel_gpus =
-    infrastructure::providers::directx::get_intel_gpu_luid_info_cached().await;
-  if let Some(gpu) = intel_gpus.first()
+  let intel_gpu = infrastructure::providers::directx::get_gpu_luid_info_cached()
+    .await
+    .iter()
+    .find(|gpu| gpu.name.contains("Intel"));
+  if let Some(gpu) = intel_gpu
     && let Ok(usage) =
       infrastructure::providers::pdh_provider::query_gpu_usage_by_luid_and_engine(
         gpu.luid_high,
@@ -157,7 +159,7 @@ pub async fn sample_gpus() -> Vec<GpuSample> {
     sample_amd_gpus(&mut gpu_metrics).await;
   }
 
-  sample_intel_gpus(&mut gpu_metrics).await;
+  sample_pdh_gpus(&mut gpu_metrics).await;
 
   gpu_metrics
 }
@@ -262,17 +264,42 @@ async fn sample_amd_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   }
 }
 
-/// Collect Intel GPU usage via PDH performance counters, filtered by LUID.
-async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
+/// Collect usage via PDH performance counters for every adapter no vendor API
+/// spoke for.
+///
+/// The vendor APIs come first because they carry temperature, VRAM, and fan
+/// readings PDH does not expose; PDH is what keeps an adapter they cannot read
+/// from disappearing entirely. An adapter absent from the sample stream has no
+/// name, no readings, and no entry in the GPU switcher, which is how an AMD APU
+/// that ADL enumerates but cannot measure became invisible next to a working
+/// discrete card.
+async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::pdh_provider::{self, GpuEngineType};
 
-  let intel_gpus =
-    crate::infrastructure::providers::directx::get_intel_gpu_luid_info_cached().await;
-  if intel_gpus.is_empty() {
+  let adapters =
+    crate::infrastructure::providers::directx::get_gpu_luid_info_cached().await;
+  if adapters.is_empty() {
     return;
   }
 
-  for gpu in intel_gpus {
+  // Decided up front because the check borrows `gpu_metrics` while the loop
+  // below writes to it. Nothing is lost by deciding early: a sample PDH adds
+  // is this loop's own output, and can never be the vendor API's answer for a
+  // later adapter.
+  let uncovered: Vec<_> = {
+    let sampled: Vec<(&str, &str)> = gpu_metrics
+      .iter()
+      .map(|sample| (sample.gpu_id.as_str(), sample.name.as_str()))
+      .collect();
+    adapters
+      .iter()
+      .filter(|gpu| {
+        !is_covered_by_vendor_api(gpu.vendor_id, &gpu.name, gpu.bdf, &sampled)
+      })
+      .collect()
+  };
+
+  for gpu in uncovered {
     let usage = pdh_provider::query_gpu_usage_by_luid_and_engine(
       gpu.luid_high,
       gpu.luid_low,
@@ -298,7 +325,46 @@ async fn sample_intel_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   }
 }
 
-/// Build the live id for an Intel adapter sampled through PDH.
+/// PCI vendor id NVIDIA adapters report through DXGI.
+const NVIDIA_VENDOR_ID: u32 = 0x10DE;
+
+/// Whether a vendor API already produced a sample for this DXGI adapter.
+///
+/// Sampling the same card twice is worse than sampling it through the weaker
+/// source: the two ids live in the same namespace, so the switcher would offer
+/// one physical GPU as two adapters, and the duplicated name would make the
+/// inventory join ambiguous enough to drop the VRAM total.
+///
+/// ADL ids carry the adapter's PCI address, so an AMD adapter is matched
+/// exactly — an APU that ADL enumerates but cannot read still falls through to
+/// PDH. NVAPI ids carry neither address nor LUID, so any NVAPI sample claims
+/// every NVIDIA adapter. The reported name is the last resort, and the only
+/// join key the two sources share when SetupDi cannot supply a PCI address.
+fn is_covered_by_vendor_api(
+  vendor_id: u32,
+  name: &str,
+  bdf: Option<(i32, i32, i32)>,
+  sampled: &[(&str, &str)],
+) -> bool {
+  if vendor_id == NVIDIA_VENDOR_ID
+    && sampled.iter().any(|(id, _)| id.starts_with("nvapi:"))
+  {
+    return true;
+  }
+
+  if let Some((bus, device, function)) = bdf {
+    let pci_id = format!("pci:{bus}:{device}:{function}");
+    if sampled.iter().any(|(id, _)| *id == pci_id) {
+      return true;
+    }
+  }
+
+  sampled
+    .iter()
+    .any(|(_, sampled_name)| *sampled_name == name)
+}
+
+/// Build the live id for an adapter sampled through PDH.
 ///
 /// The DXGI LUID identifies the physical adapter independently of its display
 /// name, which is not unique when Windows exposes two same-model adapters.
@@ -311,6 +377,8 @@ fn pdh_gpu_id(device_instance_id: Option<&str>, luid_high: i32, luid_low: u32) -
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  const AMD_VENDOR_ID: u32 = 0x1002;
 
   #[test]
   fn resolve_gpu_name_returns_dxgi_name_on_bdf_hit() {
@@ -345,6 +413,65 @@ mod tests {
       resolve_gpu_name_from_bdf_map(&map, "fallback", 9, 0, 0),
       "fallback"
     );
+  }
+
+  #[test]
+  fn nvidia_adapter_is_covered_once_nvapi_reported_anything() {
+    let sampled = [("nvapi:4294967295", "NVIDIA GeForce RTX 5080")];
+    assert!(is_covered_by_vendor_api(
+      NVIDIA_VENDOR_ID,
+      "NVIDIA GeForce RTX 5080",
+      Some((1, 0, 0)),
+      &sampled
+    ));
+  }
+
+  #[test]
+  fn nvidia_adapter_falls_through_to_pdh_when_nvapi_reported_nothing() {
+    assert!(!is_covered_by_vendor_api(
+      NVIDIA_VENDOR_ID,
+      "NVIDIA GeForce RTX 5080",
+      Some((1, 0, 0)),
+      &[]
+    ));
+  }
+
+  #[test]
+  fn amd_adapter_is_covered_by_the_adl_sample_at_its_pci_address() {
+    let sampled = [("pci:3:0:0", "AMD Radeon RX 7900 XTX")];
+    assert!(is_covered_by_vendor_api(
+      AMD_VENDOR_ID,
+      "AMD Radeon RX 7900 XTX",
+      Some((3, 0, 0)),
+      &sampled
+    ));
+  }
+
+  #[test]
+  fn amd_adapter_adl_could_not_read_still_falls_through_to_pdh() {
+    // ADL reported the discrete card only; the APU's integrated Radeon is the
+    // adapter that used to vanish from the switcher entirely.
+    let sampled = [
+      ("nvapi:1", "NVIDIA GeForce RTX 5080"),
+      ("pci:3:0:0", "AMD Radeon RX 7900 XTX"),
+    ];
+    assert!(!is_covered_by_vendor_api(
+      AMD_VENDOR_ID,
+      "AMD Radeon(TM) Graphics",
+      Some((101, 0, 0)),
+      &sampled
+    ));
+  }
+
+  #[test]
+  fn adapter_without_a_pci_address_is_covered_by_a_matching_name() {
+    let sampled = [("pci:3:0:0", "AMD Radeon RX 7900 XTX")];
+    assert!(is_covered_by_vendor_api(
+      AMD_VENDOR_ID,
+      "AMD Radeon RX 7900 XTX",
+      None,
+      &sampled
+    ));
   }
 
   #[test]

--- a/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
+++ b/docs/adr/0016-gpu-attribution-on-the-performance-screen.md
@@ -39,7 +39,9 @@ there is no longer anything to honor.
 
 The `getHardwareInfo` inventory and the monitor stream key their GPUs in
 different namespaces on every platform. Windows NVIDIA reports the raw NVAPI id
-as `GraphicInfo.id` but samples as `nvapi:<id>`; Windows Intel PDH samples use
+as `GraphicInfo.id` but samples as `nvapi:<id>`; Windows AMD ADL samples use the
+PCI address as `pci:<bus>:<device>:<function>`; Windows PDH samples — the
+fallback for every adapter no vendor API reported, not Intel alone — use
 the reboot-stable PnP device instance id as
 `pdh:instance:<device_instance_id>` when SetupDi can associate it with the
 DXGI adapter LUID, and fall back to `pdh:<luid_high>:<luid_low>` when it


### PR DESCRIPTION
## Summary

The Windows sampler only emitted GPUs that NVAPI, ADL, or Intel-filtered PDH could read, so an adapter none of them answered for — an AMD APU's integrated Radeon is the common case — never reached the live stream. The GPU switcher is built from live samples alone (ADR 0016), so that adapter could not be named, attributed, or selected.

PDH is now the vendor-agnostic fallback for every DXGI hardware adapter, with per-adapter coverage checks (`is_covered_by_vendor_api`) so a card a vendor API already reported is never sampled twice: ADL samples are matched by PCI address, any NVAPI sample claims all NVIDIA adapters, and the reported name is the last resort when SetupDi supplies no PCI address. Vendor APIs keep priority because they carry temperature, VRAM, and fan readings PDH does not expose. Software adapters (WARP / Microsoft Basic Render Driver) are excluded via `DXGI_ADAPTER_FLAG_SOFTWARE`.

The sampling gap predates v1.10.0, but v1.10.0's live-samples-only adapter list turned it into a visible regression: the adapter disappeared from the switcher entirely. The same fix is delivered to the `1.10.x` maintenance branch for v1.10.1; this PR lands it on `develop`.

No frontend changes: once a second adapter appears in the stream, `GpuAdapterSelector` renders the switcher automatically.

## Related Issues

Fixes #1988

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Before: the GPU instrument card renders the NVIDIA adapter name as static text and the AMD adapter is unreachable. After: the card's top-right corner renders the two-adapter switcher. (Verified on the reporting machine: RTX 5080 + AMD adapter.)

## Test Plan

- [x] Manual testing — verified on a Windows machine with an NVIDIA discrete GPU plus an AMD adapter ADL cannot read; the switcher now lists both and the AMD adapter shows the existing "no live readings" state
- [x] Unit tests — 5 new tests for `is_covered_by_vendor_api` (NVIDIA covered/uncovered, ADL PCI-address match, APU fall-through, name fallback)

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo fmt --all -- --check`, `cargo clippy -p hardviz-core --all-targets -- -D warnings`)
- [x] Tests pass (`cargo test -p hardviz-core`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Windows GPU detection to support all physical GPU vendors, excluding software adapters.
  * Improved GPU identification using vendor, PCI, and adapter metadata.
  * Added broader performance monitoring coverage for adapters without dedicated vendor APIs.

* **Bug Fixes**
  * Prevented same-name PCI adapters from being incorrectly treated as the same GPU.
  * Improved recovery when GPU discovery or metric retrieval fails.

* **Documentation**
  * Updated performance-screen documentation to describe vendor-neutral GPU attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->