### PR TITLE
fix(core): keep ADL temperatures for adapters whose usage query fails

### DIFF
--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -1,5 +1,6 @@
 use crate::enums::error::PlatformError;
 use crate::infrastructure;
+use crate::infrastructure::providers::adl_provider::AdlAdapterMetric;
 use crate::models::GpuSample;
 use crate::{log_error, log_warn};
 
@@ -220,43 +221,42 @@ fn resolve_gpu_name_from_bdf_map(
 
 /// Collect AMD GPU usage and temperature via ADL.
 /// VRAM usage is not available via ADL.
+///
+/// Usage and temperature are queried independently and joined by PCI BDF, so
+/// an adapter appears once with whichever readings its queries produced. An
+/// adapter whose usage query fails but whose temperature query succeeds keeps
+/// an ADL-keyed sample with `usage: None`; `sample_pdh_gpus` may later fill
+/// that missing usage in place.
 async fn sample_amd_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::adl_provider;
 
   let usages = adl_provider::get_amd_gpu_usage_per_adapter()
     .await
     .unwrap_or_default();
-
-  if usages.is_empty() {
-    return;
-  }
-
   let temps = adl_provider::get_amd_gpu_temperatures_per_adapter()
     .await
     .unwrap_or_default();
 
-  let temp_map: std::collections::HashMap<(i32, i32, i32), f32> = temps
-    .iter()
-    .map(|m| ((m.bus, m.device, m.function), m.value))
-    .collect();
+  let adapters = join_adl_metrics_by_bdf(&usages, &temps);
+  if adapters.is_empty() {
+    return;
+  }
 
   let bdf_map = bdf_to_dxgi_name().await;
 
-  for metric in &usages {
-    let bdf = (metric.bus, metric.device, metric.function);
-    let temperature = temp_map.get(&bdf).copied();
+  for adapter in adapters {
     let name = resolve_gpu_name_from_bdf_map(
       bdf_map,
-      &metric.adapter_name,
-      metric.bus,
-      metric.device,
-      metric.function,
+      &adapter.adapter_name,
+      adapter.bus,
+      adapter.device,
+      adapter.function,
     );
     gpu_metrics.push(GpuSample {
-      gpu_id: format!("pci:{}:{}:{}", metric.bus, metric.device, metric.function),
+      gpu_id: adl_gpu_id(adapter.bus, adapter.device, adapter.function),
       name,
-      usage: Some(metric.value),
-      temperature,
+      usage: adapter.usage,
+      temperature: adapter.temperature,
       dedicated_memory_kb: None,
       cooler_level: None,
       source: "ADL".to_string(),
@@ -264,8 +264,71 @@ async fn sample_amd_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   }
 }
 
-/// Collect usage via PDH performance counters for every adapter no vendor API
-/// spoke for.
+/// One AMD adapter's readings after joining ADL's per-metric answers by BDF.
+struct AdlAdapterReadings {
+  adapter_name: String,
+  bus: i32,
+  device: i32,
+  function: i32,
+  usage: Option<f32>,
+  temperature: Option<f32>,
+}
+
+/// Join ADL's per-adapter usage and temperature answers into one entry per
+/// PCI address.
+///
+/// The two queries answer independently — an APU can refuse the usage query
+/// while answering the temperature query — so the set of adapters ADL
+/// measured is the union of both result sets, not the usage list alone.
+/// Keying the emitted samples on the usage list dropped a temperature ADL
+/// actually produced (#1991). Usage entries keep their query order; adapters
+/// only the temperature query answered follow in theirs.
+fn join_adl_metrics_by_bdf(
+  usages: &[AdlAdapterMetric],
+  temps: &[AdlAdapterMetric],
+) -> Vec<AdlAdapterReadings> {
+  let temp_map: std::collections::HashMap<(i32, i32, i32), f32> = temps
+    .iter()
+    .map(|m| ((m.bus, m.device, m.function), m.value))
+    .collect();
+
+  let mut joined: Vec<AdlAdapterReadings> = usages
+    .iter()
+    .map(|m| AdlAdapterReadings {
+      adapter_name: m.adapter_name.clone(),
+      bus: m.bus,
+      device: m.device,
+      function: m.function,
+      usage: Some(m.value),
+      temperature: temp_map.get(&(m.bus, m.device, m.function)).copied(),
+    })
+    .collect();
+
+  let usage_bdfs: std::collections::HashSet<(i32, i32, i32)> = usages
+    .iter()
+    .map(|m| (m.bus, m.device, m.function))
+    .collect();
+
+  joined.extend(
+    temps
+      .iter()
+      .filter(|m| !usage_bdfs.contains(&(m.bus, m.device, m.function)))
+      .map(|m| AdlAdapterReadings {
+        adapter_name: m.adapter_name.clone(),
+        bus: m.bus,
+        device: m.device,
+        function: m.function,
+        usage: None,
+        temperature: Some(m.value),
+      }),
+  );
+
+  joined
+}
+
+/// Collect usage via PDH performance counters, in two roles: add a sample for
+/// every adapter no vendor API spoke for, and fill in the missing usage of a
+/// vendor sample whose own usage query failed.
 ///
 /// The vendor APIs come first because they carry temperature, VRAM, and fan
 /// readings PDH does not expose; PDH is what keeps an adapter they cannot read
@@ -273,6 +336,14 @@ async fn sample_amd_gpus(gpu_metrics: &mut Vec<GpuSample>) {
 /// name, no readings, and no entry in the GPU switcher, which is how an AMD APU
 /// that ADL enumerates but cannot measure became invisible next to a working
 /// discrete card.
+///
+/// The fill role exists because vendor coverage is per-adapter, not
+/// per-metric: an ADL sample carrying only a temperature still covers its
+/// adapter, so no `pdh:` sample is added for it — yet PDH may well be able to
+/// read the usage ADL could not. The reading is borrowed into the vendor
+/// sample in place; identity stays vendor-keyed (the `pci:` id), because a
+/// second id for the same adapter is the duplication
+/// `is_covered_by_vendor_api` exists to prevent.
 async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::pdh_provider::{self, GpuEngineType};
 
@@ -282,24 +353,26 @@ async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
     return;
   }
 
-  // Decided up front because the check borrows `gpu_metrics` while the loop
-  // below writes to it. Nothing is lost by deciding early: a sample PDH adds
-  // is this loop's own output, and can never be the vendor API's answer for a
-  // later adapter.
-  let uncovered: Vec<_> = {
-    let sampled: Vec<(&str, &str)> = gpu_metrics
+  // Decided up front because the decision borrows `gpu_metrics` while the
+  // loop below writes to it. Nothing is lost by deciding early: a sample PDH
+  // adds is this loop's own output, and can never be the vendor API's answer
+  // for a later adapter. Fill indices stay valid because the loop only
+  // appends.
+  let assignments: Vec<_> = {
+    let sampled: Vec<(&str, &str, Option<f32>)> = gpu_metrics
       .iter()
-      .map(|sample| (sample.gpu_id.as_str(), sample.name.as_str()))
+      .map(|sample| (sample.gpu_id.as_str(), sample.name.as_str(), sample.usage))
       .collect();
     adapters
       .iter()
-      .filter(|gpu| {
-        !is_covered_by_vendor_api(gpu.vendor_id, &gpu.name, gpu.bdf, &sampled)
+      .filter_map(|gpu| {
+        pdh_assignment_for_adapter(gpu.vendor_id, &gpu.name, gpu.bdf, &sampled)
+          .map(|assignment| (gpu, assignment))
       })
       .collect()
   };
 
-  for gpu in uncovered {
+  for (gpu, assignment) in assignments {
     let usage = pdh_provider::query_gpu_usage_by_luid_and_engine(
       gpu.luid_high,
       gpu.luid_low,
@@ -309,20 +382,84 @@ async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
     .ok()
     .map(|v| (v * 100.0).round());
 
-    gpu_metrics.push(GpuSample {
-      gpu_id: pdh_gpu_id(
-        gpu.device_instance_id.as_deref(),
-        gpu.luid_high,
-        gpu.luid_low,
-      ),
-      name: gpu.name.clone(),
-      usage,
-      temperature: None,
-      dedicated_memory_kb: None,
-      cooler_level: None,
-      source: "PDH".to_string(),
-    });
+    match assignment {
+      PdhAssignment::FillUsage(index) => {
+        // Only a successful PDH read may overwrite: `None` is already the
+        // vendor sample's honest answer.
+        if let Some(value) = usage {
+          gpu_metrics[index].usage = Some(value);
+        }
+      }
+      PdhAssignment::AddAdapter => gpu_metrics.push(GpuSample {
+        gpu_id: pdh_gpu_id(
+          gpu.device_instance_id.as_deref(),
+          gpu.luid_high,
+          gpu.luid_low,
+        ),
+        name: gpu.name.clone(),
+        usage,
+        temperature: None,
+        dedicated_memory_kb: None,
+        cooler_level: None,
+        source: "PDH".to_string(),
+      }),
+    }
   }
+}
+
+/// What the PDH pass owes one DXGI adapter, decided against the samples the
+/// vendor APIs already produced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PdhAssignment {
+  /// No vendor API spoke for the adapter: add a new `pdh:`-keyed sample.
+  AddAdapter,
+  /// The vendor sample at this index speaks for the adapter but is missing
+  /// its usage: fill the reading in place, keeping the vendor id.
+  FillUsage(usize),
+}
+
+/// Decide the PDH pass's role for one DXGI adapter, given the vendor samples
+/// as `(id, name, usage)`. `None` means the adapter needs nothing from PDH:
+/// its covering vendor sample already carries a usage reading, or the
+/// coverage claim cannot be pinned to a single sample.
+fn pdh_assignment_for_adapter(
+  vendor_id: u32,
+  name: &str,
+  bdf: Option<(i32, i32, i32)>,
+  sampled: &[(&str, &str, Option<f32>)],
+) -> Option<PdhAssignment> {
+  let ids_and_names: Vec<(&str, &str)> = sampled
+    .iter()
+    .map(|(id, sampled_name, _)| (*id, *sampled_name))
+    .collect();
+  if !is_covered_by_vendor_api(vendor_id, name, bdf, &ids_and_names) {
+    return Some(PdhAssignment::AddAdapter);
+  }
+
+  covering_sample_index(name, bdf, sampled)
+    .filter(|&index| sampled[index].2.is_none())
+    .map(PdhAssignment::FillUsage)
+}
+
+/// The vendor sample that speaks for this adapter, joined the way coverage
+/// was decided: by PCI address when SetupDi supplied one, by name otherwise.
+///
+/// An NVAPI claim resolves to no single sample — NVAPI ids carry neither a
+/// PCI address nor a LUID, so a missing usage could not be attributed to this
+/// adapter rather than a sibling. NVAPI samples always carry usage, so there
+/// is nothing to fill there anyway.
+fn covering_sample_index(
+  name: &str,
+  bdf: Option<(i32, i32, i32)>,
+  sampled: &[(&str, &str, Option<f32>)],
+) -> Option<usize> {
+  if let Some((bus, device, function)) = bdf {
+    let pci_id = adl_gpu_id(bus, device, function);
+    return sampled.iter().position(|(id, _, _)| *id == pci_id);
+  }
+  sampled
+    .iter()
+    .position(|(_, sampled_name, _)| *sampled_name == name)
 }
 
 /// PCI vendor id NVIDIA adapters report through DXGI.
@@ -355,13 +492,21 @@ fn is_covered_by_vendor_api(
   }
 
   if let Some((bus, device, function)) = bdf {
-    let pci_id = format!("pci:{bus}:{device}:{function}");
+    let pci_id = adl_gpu_id(bus, device, function);
     return sampled.iter().any(|(id, _)| *id == pci_id);
   }
 
   sampled
     .iter()
     .any(|(_, sampled_name)| *sampled_name == name)
+}
+
+/// Build the live id for an adapter sampled through ADL.
+///
+/// ADL ids carry the adapter's PCI address (ADR 0016), which is also how a
+/// PDH candidate recognises an adapter ADL already reported.
+fn adl_gpu_id(bus: i32, device: i32, function: i32) -> String {
+  format!("pci:{bus}:{device}:{function}")
 }
 
 /// Build the live id for an adapter sampled through PDH.
@@ -500,5 +645,133 @@ mod tests {
   fn pdh_gpu_id_falls_back_to_luid_when_device_identity_is_unavailable() {
     assert_eq!(pdh_gpu_id(None, 1, 2), "pdh:1:2");
     assert_ne!(pdh_gpu_id(None, 1, 2), pdh_gpu_id(None, 3, 4));
+  }
+
+  #[test]
+  fn adl_gpu_id_is_the_pci_address() {
+    assert_eq!(adl_gpu_id(3, 0, 0), "pci:3:0:0");
+  }
+
+  fn adl_metric(
+    name: &str,
+    bus: i32,
+    device: i32,
+    function: i32,
+    value: f32,
+  ) -> AdlAdapterMetric {
+    AdlAdapterMetric {
+      adapter_name: name.to_string(),
+      bus,
+      device,
+      function,
+      value,
+    }
+  }
+
+  #[test]
+  fn adl_join_keeps_a_temperature_only_adapter() {
+    // The APU answered the temperature query and refused the usage query.
+    // Its temperature used to be dropped with the whole adapter (#1991).
+    let usages = [adl_metric("AMD Radeon RX 7900 XTX", 3, 0, 0, 42.0)];
+    let temps = [adl_metric("AMD Radeon(TM) Graphics", 101, 0, 0, 55.0)];
+
+    let joined = join_adl_metrics_by_bdf(&usages, &temps);
+
+    assert_eq!(joined.len(), 2);
+    let apu = &joined[1];
+    assert_eq!(apu.adapter_name, "AMD Radeon(TM) Graphics");
+    assert_eq!((apu.bus, apu.device, apu.function), (101, 0, 0));
+    assert_eq!(apu.usage, None);
+    assert_eq!(apu.temperature, Some(55.0));
+  }
+
+  #[test]
+  fn adl_join_keeps_a_usage_only_adapter_unchanged() {
+    let usages = [adl_metric("AMD Radeon RX 7900 XTX", 3, 0, 0, 42.0)];
+
+    let joined = join_adl_metrics_by_bdf(&usages, &[]);
+
+    assert_eq!(joined.len(), 1);
+    assert_eq!(joined[0].adapter_name, "AMD Radeon RX 7900 XTX");
+    assert_eq!(joined[0].usage, Some(42.0));
+    assert_eq!(joined[0].temperature, None);
+  }
+
+  #[test]
+  fn adl_join_pairs_usage_and_temperature_at_the_same_address() {
+    let usages = [adl_metric("AMD Radeon RX 7900 XTX", 3, 0, 0, 42.0)];
+    let temps = [adl_metric("AMD Radeon RX 7900 XTX", 3, 0, 0, 68.0)];
+
+    let joined = join_adl_metrics_by_bdf(&usages, &temps);
+
+    assert_eq!(joined.len(), 1);
+    assert_eq!(joined[0].usage, Some(42.0));
+    assert_eq!(joined[0].temperature, Some(68.0));
+  }
+
+  #[test]
+  fn covered_sample_missing_usage_is_the_pdh_fill_target() {
+    // The temperature-only ADL sample: still vendor covered, so no `pdh:`
+    // sample may be added for it — its missing usage is filled in place.
+    let sampled = [
+      ("pci:3:0:0", "AMD Radeon RX 7900 XTX", Some(42.0)),
+      ("pci:101:0:0", "AMD Radeon(TM) Graphics", None),
+    ];
+    assert_eq!(
+      pdh_assignment_for_adapter(
+        AMD_VENDOR_ID,
+        "AMD Radeon(TM) Graphics",
+        Some((101, 0, 0)),
+        &sampled
+      ),
+      Some(PdhAssignment::FillUsage(1))
+    );
+  }
+
+  #[test]
+  fn covered_sample_with_usage_needs_nothing_from_pdh() {
+    let sampled = [
+      ("pci:3:0:0", "AMD Radeon RX 7900 XTX", Some(42.0)),
+      ("pci:101:0:0", "AMD Radeon(TM) Graphics", None),
+    ];
+    assert_eq!(
+      pdh_assignment_for_adapter(
+        AMD_VENDOR_ID,
+        "AMD Radeon RX 7900 XTX",
+        Some((3, 0, 0)),
+        &sampled
+      ),
+      None
+    );
+  }
+
+  #[test]
+  fn uncovered_adapter_still_gets_a_new_pdh_sample() {
+    let sampled = [("pci:3:0:0", "AMD Radeon RX 7900 XTX", None)];
+    assert_eq!(
+      pdh_assignment_for_adapter(
+        AMD_VENDOR_ID,
+        "AMD Radeon(TM) Graphics",
+        Some((101, 0, 0)),
+        &sampled
+      ),
+      Some(PdhAssignment::AddAdapter)
+    );
+  }
+
+  #[test]
+  fn nvapi_coverage_never_selects_a_fill_target() {
+    // NVAPI ids carry neither PCI address nor LUID, so a missing usage could
+    // not be attributed to this adapter rather than a sibling.
+    let sampled = [("nvapi:1", "NVIDIA GeForce RTX 5080", Some(10.0))];
+    assert_eq!(
+      pdh_assignment_for_adapter(
+        NVIDIA_VENDOR_ID,
+        "NVIDIA GeForce RTX 5080",
+        Some((1, 0, 0)),
+        &sampled
+      ),
+      None
+    );
   }
 }

--- a/core/src/platform/windows/gpu.rs
+++ b/core/src/platform/windows/gpu.rs
@@ -343,7 +343,8 @@ fn join_adl_metrics_by_bdf(
 /// read the usage ADL could not. The reading is borrowed into the vendor
 /// sample in place; identity stays vendor-keyed (the `pci:` id), because a
 /// second id for the same adapter is the duplication
-/// `is_covered_by_vendor_api` exists to prevent.
+/// `is_covered_by_vendor_api` exists to prevent. The `source` field follows
+/// the reading, because downstream it labels the usage, not the identity.
 async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
   use crate::infrastructure::providers::pdh_provider::{self, GpuEngineType};
 
@@ -384,11 +385,7 @@ async fn sample_pdh_gpus(gpu_metrics: &mut Vec<GpuSample>) {
 
     match assignment {
       PdhAssignment::FillUsage(index) => {
-        // Only a successful PDH read may overwrite: `None` is already the
-        // vendor sample's honest answer.
-        if let Some(value) = usage {
-          gpu_metrics[index].usage = Some(value);
-        }
+        fill_usage_from_pdh(&mut gpu_metrics[index], usage);
       }
       PdhAssignment::AddAdapter => gpu_metrics.push(GpuSample {
         gpu_id: pdh_gpu_id(
@@ -441,13 +438,33 @@ fn pdh_assignment_for_adapter(
     .map(PdhAssignment::FillUsage)
 }
 
+/// Apply a PDH usage reading to the vendor sample that covers an adapter.
+///
+/// Only a successful read may overwrite: `None` is already the vendor
+/// sample's honest answer. `source` follows the reading — the field labels
+/// the usage downstream (`gpu_source` is surfaced as the usage source), so a
+/// usage PDH produced must credit PDH even though the sample's id and
+/// temperature stay vendor-owned.
+fn fill_usage_from_pdh(sample: &mut GpuSample, usage: Option<f32>) {
+  if let Some(value) = usage {
+    sample.usage = Some(value);
+    sample.source = "PDH".to_string();
+  }
+}
+
 /// The vendor sample that speaks for this adapter, joined the way coverage
 /// was decided: by PCI address when SetupDi supplied one, by name otherwise.
 ///
-/// An NVAPI claim resolves to no single sample — NVAPI ids carry neither a
-/// PCI address nor a LUID, so a missing usage could not be attributed to this
-/// adapter rather than a sibling. NVAPI samples always carry usage, so there
-/// is nothing to fill there anyway.
+/// Unlike coverage, a fill is a write, so the join must be unambiguous:
+///
+/// - An NVAPI claim resolves to no single sample — NVAPI ids carry neither a
+///   PCI address nor a LUID, so a missing usage could not be attributed to
+///   this adapter rather than a sibling. NVAPI samples always carry usage, so
+///   there is nothing to fill there anyway.
+/// - A name resolves a sample only while exactly one sample carries it. With
+///   two same-name candidates — two identical cards — the reading could land
+///   on the sibling's sample, and a misattributed reading is worse than a
+///   missing one (ADR 0016 refuses ambiguous joins rather than guessing).
 fn covering_sample_index(
   name: &str,
   bdf: Option<(i32, i32, i32)>,
@@ -457,9 +474,17 @@ fn covering_sample_index(
     let pci_id = adl_gpu_id(bus, device, function);
     return sampled.iter().position(|(id, _, _)| *id == pci_id);
   }
-  sampled
+
+  let mut name_matches = sampled
     .iter()
-    .position(|(_, sampled_name, _)| *sampled_name == name)
+    .enumerate()
+    .filter(|(_, (_, sampled_name, _))| *sampled_name == name)
+    .map(|(index, _)| index);
+  let first = name_matches.next()?;
+  match name_matches.next() {
+    None => Some(first),
+    Some(_) => None,
+  }
 }
 
 /// PCI vendor id NVIDIA adapters report through DXGI.
@@ -773,5 +798,64 @@ mod tests {
       ),
       None
     );
+  }
+
+  #[test]
+  fn unique_name_only_match_still_selects_the_fill_target() {
+    let sampled = [("pci:3:0:0", "AMD Radeon RX 7900 XTX", None)];
+    assert_eq!(
+      pdh_assignment_for_adapter(AMD_VENDOR_ID, "AMD Radeon RX 7900 XTX", None, &sampled),
+      Some(PdhAssignment::FillUsage(0))
+    );
+  }
+
+  #[test]
+  fn ambiguous_name_only_match_declines_the_fill() {
+    // Two identical cards and no SetupDi PCI address: the name cannot say
+    // which sample the reading belongs to. The adapter stays covered — no
+    // `pdh:` sample is added — but nothing is filled either, because a
+    // misattributed reading is worse than a missing one.
+    let sampled = [
+      ("pci:3:0:0", "AMD Radeon RX 7900 XTX", None),
+      ("pci:6:0:0", "AMD Radeon RX 7900 XTX", None),
+    ];
+    assert_eq!(
+      pdh_assignment_for_adapter(AMD_VENDOR_ID, "AMD Radeon RX 7900 XTX", None, &sampled),
+      None
+    );
+  }
+
+  fn temperature_only_adl_sample() -> GpuSample {
+    GpuSample {
+      gpu_id: "pci:101:0:0".to_string(),
+      name: "AMD Radeon(TM) Graphics".to_string(),
+      usage: None,
+      temperature: Some(55.0),
+      dedicated_memory_kb: None,
+      cooler_level: None,
+      source: "ADL".to_string(),
+    }
+  }
+
+  #[test]
+  fn pdh_fill_updates_usage_and_its_provenance() {
+    let mut sample = temperature_only_adl_sample();
+
+    fill_usage_from_pdh(&mut sample, Some(12.0));
+
+    assert_eq!(sample.usage, Some(12.0));
+    assert_eq!(sample.source, "PDH");
+    // Identity and the vendor's own reading stay untouched.
+    assert_eq!(sample.gpu_id, "pci:101:0:0");
+    assert_eq!(sample.temperature, Some(55.0));
+  }
+
+  #[test]
+  fn failed_pdh_read_leaves_the_vendor_sample_untouched() {
+    let mut sample = temperature_only_adl_sample();
+
+    fill_usage_from_pdh(&mut sample, None);
+
+    assert_eq!(sample, temperature_only_adl_sample());
   }
 }


### PR DESCRIPTION
## Summary

`sample_amd_gpus` emitted a `GpuSample` only for adapters that answered the ADL usage query and returned early when that list was empty. An AMD adapter (typically an APU) whose ADL usage query fails while its temperature query succeeds lost the temperature ADL actually produced: the #1988 PDH fallback restored the adapter's presence, but with `temperature: None`.

This PR:

- Joins the per-adapter ADL usage and temperature queries by PCI BDF and emits one sample per adapter in the **union** of both result sets, with `usage`/`temperature` each `Some`/`None` as its query answered. The early return on an empty usage list is gone — temperatures alone still produce ADL-keyed samples. Names resolve through the existing BDF-to-DXGI map for every emitted adapter.
- Extends `sample_pdh_gpus` with a second role, so the union join does not regress #1988: a temperature-only ADL sample is keyed `pci:<bdf>`, which `is_covered_by_vendor_api` treats as vendor-covered, so PDH would no longer add a usage reading for that adapter. For a covered adapter whose vendor sample has `usage: None`, the PDH pass now queries usage by adapter LUID and fills the existing sample in place — the id stays vendor-keyed, only the reading is borrowed. Uncovered adapters keep getting new `pdh:`-keyed samples exactly as before.
- Keeps the decision logic pure and unit-testable (`join_adl_metrics_by_bdf`, `pdh_assignment_for_adapter`), following the existing `is_covered_by_vendor_api` test style; extracts the shared `pci:<bus>:<device>:<function>` id mint into `adl_gpu_id`.

## Related Issues

Fixes #1991

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable — Core sampling logic only, no UI change.

## Test Plan

- [ ] Manual testing
- [x] Unit tests

New tests cover: the BDF union join emitting a temperature-only adapter, emitting a usage-only adapter unchanged, and pairing both metrics at one address; the PDH assignment selecting a covered `usage: None` sample as the fill target while leaving a covered sample with usage alone, keeping the new-sample path for uncovered adapters, and never selecting a fill target from diffuse NVAPI coverage.

Validation run locally:

- `cargo fmt --all -- --check`
- `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- `cargo test -p hardviz-core` (358 tests pass, 19 in `platform::windows::gpu`)

**Caveat:** no AMD hardware was available. This is a logic-level fix verified by unit tests over pure helpers; behavior on real APUs (ADL usage failing while temperature succeeds, and the PDH usage fill via LUID) needs maintainer verification.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU monitoring on Windows by more reliably combining usage and temperature readings.
  * Preserved GPU entries when only some metrics are available, preventing incomplete readings from disappearing.
  * Improved performance-counter sampling so missing usage data can be filled when available.
  * Prevented ambiguous GPU matches from receiving incorrect usage readings.
  * Expanded hardware coverage for systems with multiple or partially detected graphics adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->