### PR TITLE
fix(core): emit every Linux DRM card regardless of vendor

### DIFF
--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -214,7 +214,6 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
     let bdf = infrastructure::providers::drm_sys::get_card_bdf(card_id);
     let lspci_name = bdf.as_deref().and_then(|bdf| {
       lspci_output
-        .as_deref()
         .and_then(|out| infrastructure::providers::lspci::parse_gpu_name_by_bdf(out, bdf))
     });
     let identity = resolve_card_identity(vendor, card_id, lspci_name.as_deref());

--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -200,15 +200,12 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
     .collect::<Vec<_>>();
 
   // lspci is the name source for every vendor except Intel, whose live
-  // name is fixed — an Intel-only machine still skips the fork.
+  // name is fixed — an Intel-only machine never touches the cache.
   let lspci_output = if card_vendors
     .iter()
     .any(|(_, vendor)| *vendor != GpuVendor::Intel)
   {
-    tokio::task::spawn_blocking(infrastructure::providers::lspci::get_lspci_nn_output)
-      .await
-      .ok()
-      .flatten()
+    lspci_output_cached().await
   } else {
     None
   };
@@ -262,6 +259,32 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
   }
 
   metrics
+}
+
+/// The `lspci -nn` output, fetched once and cached for the process
+/// lifetime.
+///
+/// `sample_gpus` runs at the monitor cadence, and forking `lspci` every
+/// second to re-read a static adapter name would make the monitor its own
+/// workload. Only a successful run is cached; a failure returns `None` for
+/// that tick and the next tick retries, which costs no more than the
+/// uncached behavior did. A card hot-plugged after the first success reads
+/// a stale listing and falls back to its vendor placeholder name.
+#[cfg(target_os = "linux")]
+async fn lspci_output_cached() -> Option<&'static str> {
+  static OUTPUT: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
+
+  OUTPUT
+    .get_or_try_init(|| async {
+      tokio::task::spawn_blocking(infrastructure::providers::lspci::get_lspci_nn_output)
+        .await
+        .ok()
+        .flatten()
+        .ok_or(())
+    })
+    .await
+    .ok()
+    .map(String::as_str)
 }
 
 /// How one DRM card presents itself, resolved from the vendor alone so a

--- a/core/src/platform/linux/gpu.rs
+++ b/core/src/platform/linux/gpu.rs
@@ -32,7 +32,15 @@ pub async fn get_gpu_usage() -> Result<(f32, String), PlatformError> {
   ))
 }
 
+/// Build the GPU inventory from every DRM card, whatever its vendor.
+///
+/// ADR 0016 defines the System Specifications sheet as an inventory of
+/// every detected adapter. A vendor with no Linux reading provider
+/// (NVIDIA, unrecognized vendors) still gets a named row; ending the
+/// vendor match with a wildcard `None` is how those cards used to vanish
+/// from the sheet entirely.
 pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, PlatformError> {
+  use crate::infrastructure::providers::drm_sys::GpuVendor;
   use tokio::task::JoinSet;
 
   let card_ids = infrastructure::providers::drm_sys::get_all_card_ids();
@@ -40,14 +48,14 @@ pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, Platfo
 
   for card_id in card_ids {
     join_set.spawn(async move {
-      match infrastructure::providers::drm_sys::detect_gpu_vendor(card_id) {
-        infrastructure::providers::drm_sys::GpuVendor::Amd => {
-          get_amd_graphic_info(card_id).await.ok()
+      let vendor = infrastructure::providers::drm_sys::detect_gpu_vendor(card_id);
+      match vendor {
+        GpuVendor::Amd => get_amd_graphic_info(card_id).await.ok(),
+        GpuVendor::Intel => get_intel_graphic_info(card_id).await.ok(),
+        // A named row with unsupported values, not a missing row.
+        GpuVendor::Nvidia | GpuVendor::Unknown => {
+          Some(get_generic_graphic_info(card_id, vendor))
         }
-        infrastructure::providers::drm_sys::GpuVendor::Intel => {
-          get_intel_graphic_info(card_id).await.ok()
-        }
-        _ => None,
       }
       .map(|info| (card_id, info)) // Attach card_id for sorting
     });
@@ -69,11 +77,15 @@ pub async fn get_gpu_info() -> Result<Vec<models::hardware::GraphicInfo>, Platfo
 async fn get_amd_graphic_info(
   card_id: u8,
 ) -> Result<models::hardware::GraphicInfo, PlatformError> {
-  let name = infrastructure::providers::drm_sys::get_card_bdf(card_id)
-    .and_then(|bdf| {
+  let lspci_name =
+    infrastructure::providers::drm_sys::get_card_bdf(card_id).and_then(|bdf| {
       infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
-    })
-    .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
+    });
+  let identity = resolve_card_identity(
+    infrastructure::providers::drm_sys::GpuVendor::Amd,
+    card_id,
+    lspci_name.as_deref(),
+  );
 
   let clock = infrastructure::providers::kernel::read_pm_info_sclk(card_id).unwrap_or(0);
   let memory_total =
@@ -81,8 +93,8 @@ async fn get_amd_graphic_info(
 
   Ok(models::hardware::GraphicInfo {
     id: format!("card{card_id}"),
-    name,
-    vendor_name: "AMD".into(),
+    name: identity.name,
+    vendor_name: identity.vendor_label.into(),
     clock,
     memory_size: crate::utils::formatter::format_size(memory_total, 1),
     memory_size_dedicated: crate::utils::formatter::format_size(memory_total, 1),
@@ -102,6 +114,30 @@ pub async fn get_intel_graphic_info(
     memory_size_dedicated: "N/A".into(),
     core_count: None,
   })
+}
+
+/// Inventory entry for a card no Linux reading provider covers (NVIDIA and
+/// unrecognized vendors): named through `lspci` like the AMD path, with
+/// clock and memory reported as unsupported rather than invented.
+fn get_generic_graphic_info(
+  card_id: u8,
+  vendor: infrastructure::providers::drm_sys::GpuVendor,
+) -> models::hardware::GraphicInfo {
+  let lspci_name =
+    infrastructure::providers::drm_sys::get_card_bdf(card_id).and_then(|bdf| {
+      infrastructure::providers::lspci::get_gpu_name_from_lspci_by_bdf(&bdf)
+    });
+  let identity = resolve_card_identity(vendor, card_id, lspci_name.as_deref());
+
+  models::hardware::GraphicInfo {
+    id: format!("card{card_id}"),
+    name: identity.name,
+    vendor_name: identity.vendor_label.into(),
+    clock: 0, // Not readable without a vendor provider. Set to 0 as unsupported
+    memory_size: "N/A".into(),
+    memory_size_dedicated: "N/A".into(),
+    core_count: None,
+  }
 }
 
 /// Always returns raw degrees Celsius. Presentation conversion lives at
@@ -139,8 +175,18 @@ pub async fn get_gpu_temperature()
   }
 }
 
-/// Collect GPU metrics on Linux using DRM/sysfs for AMD and DRM for Intel.
+/// Collect GPU metrics on Linux for every DRM card.
+///
+/// AMD (sysfs/hwmon) and Intel (intel_gpu_top) have reading providers;
+/// NVIDIA and unrecognized vendors have none here, so their samples carry
+/// a name and no values. They are emitted anyway because a card absent
+/// from the sample stream has no name, no readings, and no entry in the
+/// GPU switcher: it reads as nonexistent rather than unavailable. DRM
+/// detection decides presence; what a provider can read only decides
+/// which fields are filled.
 pub async fn sample_gpus() -> Vec<models::GpuSample> {
+  use crate::infrastructure::providers::drm_sys::GpuVendor;
+
   let mut metrics: Vec<models::GpuSample> = Vec::new();
   let card_ids = infrastructure::providers::drm_sys::get_all_card_ids();
   let card_vendors = card_ids
@@ -153,9 +199,11 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
     })
     .collect::<Vec<_>>();
 
+  // lspci is the name source for every vendor except Intel, whose live
+  // name is fixed — an Intel-only machine still skips the fork.
   let lspci_output = if card_vendors
     .iter()
-    .any(|(_, vendor)| *vendor == infrastructure::providers::drm_sys::GpuVendor::Amd)
+    .any(|(_, vendor)| *vendor != GpuVendor::Intel)
   {
     tokio::task::spawn_blocking(infrastructure::providers::lspci::get_lspci_nn_output)
       .await
@@ -166,15 +214,16 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
   };
 
   for (card_id, vendor) in card_vendors {
-    let (name, usage, temperature, source) = match vendor {
-      infrastructure::providers::drm_sys::GpuVendor::Amd => {
-        let name = infrastructure::providers::drm_sys::get_card_bdf(card_id)
-          .and_then(|bdf| {
-            lspci_output.as_deref().and_then(|out| {
-              infrastructure::providers::lspci::parse_gpu_name_by_bdf(out, &bdf)
-            })
-          })
-          .unwrap_or_else(|| format!("AMD GPU (card{})", card_id));
+    let bdf = infrastructure::providers::drm_sys::get_card_bdf(card_id);
+    let lspci_name = bdf.as_deref().and_then(|bdf| {
+      lspci_output
+        .as_deref()
+        .and_then(|out| infrastructure::providers::lspci::parse_gpu_name_by_bdf(out, bdf))
+    });
+    let identity = resolve_card_identity(vendor, card_id, lspci_name.as_deref());
+
+    let (usage, temperature) = match vendor {
+      GpuVendor::Amd => {
         let usage = infrastructure::providers::drm_sys::get_amd_gpu_usage(card_id as u32)
           .await
           .map(|u| (u * 100.0) as f32)
@@ -183,37 +232,165 @@ pub async fn sample_gpus() -> Vec<models::GpuSample> {
           infrastructure::providers::hwmon::read_hwmon_temperatures(card_id)
             .ok()
             .and_then(|temps| temps.first().map(|t| t.value as f32));
-        (name, usage, temperature, "DRM (AMD)".to_string())
+        (usage, temperature)
       }
-      infrastructure::providers::drm_sys::GpuVendor::Intel => {
+      GpuVendor::Intel => {
         let usage = infrastructure::providers::drm_sys::get_intel_gpu_usage()
           .await
           .map(|u| (u * 100.0) as f32)
           .ok();
-        (
-          format!("Intel GPU (card{})", card_id),
-          usage,
-          None,
-          "DRM (Intel)".to_string(),
-        )
+        (usage, None)
       }
-      _ => continue,
+      // No reading provider — the sample still names the card so the
+      // switcher can list it in its "no live readings" state.
+      GpuVendor::Nvidia | GpuVendor::Unknown => (None, None),
     };
 
-    let gpu_id = infrastructure::providers::drm_sys::get_card_bdf(card_id)
+    let gpu_id = bdf
       .map(|bdf| format!("pci:{bdf}"))
       .unwrap_or_else(|| format!("drm:card{card_id}"));
 
     metrics.push(models::GpuSample {
       gpu_id,
-      name,
+      name: identity.name,
       usage,
       temperature,
       dedicated_memory_kb: None,
       cooler_level: None,
-      source,
+      source: identity.live_source.to_string(),
     });
   }
 
   metrics
+}
+
+/// How one DRM card presents itself, resolved from the vendor alone so a
+/// card is named even when no provider can read values for it.
+#[cfg(any(target_os = "linux", test))]
+struct CardIdentity {
+  /// Display name: the `lspci` line for the card's PCI slot when
+  /// available, otherwise a vendor placeholder carrying the card index.
+  name: String,
+  /// Vendor label for the inventory (`GraphicInfo.vendor_name`).
+  vendor_label: &'static str,
+  /// `GpuSample.source` label for the live stream.
+  live_source: &'static str,
+}
+
+/// Decide how one DRM card is presented, from its vendor and the optional
+/// `lspci` line for its PCI slot.
+///
+/// The match is exhaustive on purpose: adding a `GpuVendor` variant must
+/// be a compile error here instead of a silently dropped card. Ending the
+/// vendor match with a wildcard `continue`/`None` is exactly the bug that
+/// hid NVIDIA and unknown-vendor cards from the switcher and the
+/// inventory.
+#[cfg(any(target_os = "linux", test))]
+fn resolve_card_identity(
+  vendor: infrastructure::providers::drm_sys::GpuVendor,
+  card_id: u8,
+  lspci_name: Option<&str>,
+) -> CardIdentity {
+  use crate::infrastructure::providers::drm_sys::GpuVendor;
+
+  match vendor {
+    GpuVendor::Amd => CardIdentity {
+      name: lspci_name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("AMD GPU (card{card_id})")),
+      vendor_label: "AMD",
+      live_source: "DRM (AMD)",
+    },
+    GpuVendor::Intel => CardIdentity {
+      // Intel keeps its fixed live name rather than the lspci line: the
+      // lspci prefetch is skipped on Intel-only machines, so an
+      // lspci-based name would change with which other vendors happen to
+      // be installed.
+      name: format!("Intel GPU (card{card_id})"),
+      vendor_label: "Intel",
+      live_source: "DRM (Intel)",
+    },
+    GpuVendor::Nvidia => CardIdentity {
+      name: lspci_name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("NVIDIA GPU (card{card_id})")),
+      vendor_label: "NVIDIA",
+      live_source: "DRM",
+    },
+    GpuVendor::Unknown => CardIdentity {
+      name: lspci_name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("GPU (card{card_id})")),
+      vendor_label: "Unknown",
+      live_source: "DRM",
+    },
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::infrastructure::providers::drm_sys::GpuVendor;
+
+  // ── resolve_card_identity ──
+
+  const AMD_LSPCI_LINE: &str = "06:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Navi 31 [Radeon RX 7900 XTX] [1002:744c]";
+  const NVIDIA_LSPCI_LINE: &str = "01:00.0 VGA compatible controller [0300]: NVIDIA Corporation AD107 [GeForce RTX 4060] [10de:2882]";
+
+  #[test]
+  fn amd_card_is_named_from_lspci() {
+    let identity = resolve_card_identity(GpuVendor::Amd, 0, Some(AMD_LSPCI_LINE));
+    assert_eq!(identity.name, AMD_LSPCI_LINE);
+    assert_eq!(identity.vendor_label, "AMD");
+    assert_eq!(identity.live_source, "DRM (AMD)");
+  }
+
+  #[test]
+  fn nvidia_card_is_named_from_lspci() {
+    let identity = resolve_card_identity(GpuVendor::Nvidia, 0, Some(NVIDIA_LSPCI_LINE));
+    assert_eq!(identity.name, NVIDIA_LSPCI_LINE);
+    assert_eq!(identity.vendor_label, "NVIDIA");
+    assert_eq!(identity.live_source, "DRM");
+  }
+
+  #[test]
+  fn nvidia_card_without_lspci_falls_back_to_a_placeholder_name() {
+    let identity = resolve_card_identity(GpuVendor::Nvidia, 1, None);
+    assert_eq!(identity.name, "NVIDIA GPU (card1)");
+  }
+
+  #[test]
+  fn unknown_vendor_card_without_lspci_falls_back_to_a_placeholder_name() {
+    let identity = resolve_card_identity(GpuVendor::Unknown, 2, None);
+    assert_eq!(identity.name, "GPU (card2)");
+    assert_eq!(identity.vendor_label, "Unknown");
+    assert_eq!(identity.live_source, "DRM");
+  }
+
+  #[test]
+  fn intel_card_keeps_its_fixed_live_name() {
+    let identity = resolve_card_identity(GpuVendor::Intel, 0, Some(AMD_LSPCI_LINE));
+    assert_eq!(identity.name, "Intel GPU (card0)");
+    assert_eq!(identity.live_source, "DRM (Intel)");
+  }
+
+  #[test]
+  fn every_vendor_resolves_to_an_emitted_identity() {
+    // The regression this module carried: a wildcard vendor arm dropped
+    // the card instead of emitting it. Every vendor must resolve to a
+    // named identity, with or without an lspci line.
+    for vendor in [
+      GpuVendor::Nvidia,
+      GpuVendor::Amd,
+      GpuVendor::Intel,
+      GpuVendor::Unknown,
+    ] {
+      for lspci_name in [None, Some(NVIDIA_LSPCI_LINE)] {
+        let identity = resolve_card_identity(vendor, 3, lspci_name);
+        assert!(!identity.name.is_empty(), "{vendor:?} must be named");
+        assert!(!identity.vendor_label.is_empty());
+        assert!(identity.live_source.starts_with("DRM"));
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

On Linux, both live GPU sampling and the GPU inventory silently dropped every DRM card whose vendor is not AMD or Intel: `sample_gpus` ended its vendor match with `_ => continue` and `get_gpu_info` with `_ => None`. An NVIDIA card (vendor `0x10de`, which `drm_sys::detect_gpu_vendor` already recognizes) or an unknown-vendor card therefore had no entry in the live stream — no name, no readings, no GPU switcher entry — and no row on the System Specifications sheet. The card read as nonexistent rather than unavailable.

This applies the Windows fix pattern (#1988, delivered in #1992) to Linux: detection and emission are decoupled from a provider's ability to read values.

- `sample_gpus` emits every DRM card as a `GpuSample`. NVIDIA and unknown-vendor cards are named from `lspci` by PCI BDF like the AMD path (the prefetch now runs for every non-Intel vendor), with fallbacks `NVIDIA GPU (card{n})` / `GPU (card{n})`, no values (`usage`, `temperature`, `dedicated_memory_kb`, `cooler_level` all `None`), and `source: "DRM"` — the UI already renders the "no live readings" state. Live ids stay `pci:<bdf>` with `drm:card<n>` fallback (ADR 0016).
- `get_gpu_info` includes NVIDIA and unknown-vendor cards with `vendor_name` `"NVIDIA"` / `"Unknown"`, clock `0`, and `"N/A"` memory like the Intel entry, per ADR 0016's definition of the specifications sheet as an inventory of every detected adapter.
- The per-card decision (vendor + optional lspci line → name / vendor label / live source) is extracted into the pure `resolve_card_identity` helper, gated `#[cfg(any(target_os = "linux", test))]`, with an exhaustive vendor match so adding a `GpuVendor` variant is a compile error instead of a silently dropped card. The AMD paths now share it.
- No speculative NVIDIA reading providers are added (YAGNI): presence is the claim.

## Related Issues

Fixes #1989

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A — backend-only change; the UI already renders the unavailable state for a named adapter without readings.

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- New unit tests next to `resolve_card_identity` cover: AMD named via lspci, NVIDIA named via lspci, the NVIDIA fallback name, the unknown-vendor fallback name, Intel keeping its fixed live name, and that every vendor resolves to an emitted identity (no vendor is dropped).
- `cargo fmt --all -- --check`, `cargo clippy -p hardviz-core --all-targets -- -D warnings`, `cargo test -p hardviz-core`, `cargo tauri-lint`, and `cargo tauri-test` pass on the development machine.
- No Linux hardware verification was possible: this is a logic-level fix developed on Windows, where the `target_os = "linux"` modules do not compile. Linux compilation and the new unit tests are verified by the CI ubuntu job.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux GPU inventory now includes NVIDIA and previously unsupported DRM graphics cards.
  * GPU entries provide clearer vendor, device, and source information when available.
  * Unsupported graphics cards are shown with unavailable clock and memory readings instead of being omitted.

* **Bug Fixes**
  * Improved AMD GPU naming and device identification.
  * GPU sampling now consistently reports detected cards across supported configurations.
  * Improved reliability and performance when retrieving GPU identification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->