### PR TITLE
fix(rust): resolve clippy errors introduced by Rust 1.98.0

### DIFF
--- a/core/src/infrastructure/providers/macos/io_kit/iokit_info.rs
+++ b/core/src/infrastructure/providers/macos/io_kit/iokit_info.rs
@@ -548,7 +548,7 @@ pub fn read_gpu_dvfs_freqs_mhz() -> Option<Vec<u32>> {
     let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
 
     let mut freqs = Vec::with_capacity(len / 8);
-    for chunk in bytes.chunks_exact(8) {
+    for chunk in bytes.as_chunks::<8>().0 {
       let freq_hz = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
       freqs.push(freq_hz / 1_000_000); // Hz → MHz
     }

--- a/core/src/settings/storage_health.rs
+++ b/core/src/settings/storage_health.rs
@@ -66,7 +66,7 @@ impl StorageHealthIdentitySettings {
     }
 
     let mut key = [0u8; STORAGE_HEALTH_IDENTITY_HASH_KEY_BYTES];
-    for (index, chunk) in encoded.as_bytes().chunks_exact(2).enumerate() {
+    for (index, chunk) in encoded.as_bytes().as_chunks::<2>().0.iter().enumerate() {
       key[index] = decode_hex_pair(chunk).ok_or_else(|| {
         "Storage Health identity hash key contains invalid hex".to_string()
       })?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,5 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![macro_use]
 
 // Re-export the logging macros from `hardviz_core` so existing
 // `use crate::{log_internal, log_warn};` sites keep compiling. The macros

--- a/src-tauri/src/tray/surface/windows.rs
+++ b/src-tauri/src/tray/surface/windows.rs
@@ -902,7 +902,14 @@ mod tests {
     assert_eq!(image.width(), ICON_SIZE);
     assert_eq!(image.height(), ICON_SIZE);
     assert_eq!(image.rgba().len(), (ICON_SIZE * ICON_SIZE * 4) as usize);
-    assert!(image.rgba().chunks_exact(4).any(|pixel| pixel[3] > 0));
+    assert!(
+      image
+        .rgba()
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .any(|pixel| pixel[3] > 0)
+    );
   }
 
   #[test]
@@ -956,7 +963,9 @@ mod tests {
     assert!(
       image
         .rgba()
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .any(|pixel| pixel[0..3] == CRITICAL_COLOR.0[0..3] && pixel[3] > 0)
     );
   }
@@ -974,7 +983,9 @@ mod tests {
     assert!(
       image
         .rgba()
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .any(|pixel| pixel[0..3] == ICON_COLOR.0[0..3] && pixel[3] > 0)
     );
   }


### PR DESCRIPTION
## Summary

The `rust-toolchain` bump to 1.98.0 (#2003) broke `lint-core` and `lint-tauri` on `develop`. Two separate causes:

1. **`clippy::chunks_exact_to_as_chunks`** — a new lint in 1.98.0. Replace `chunks_exact` with `as_chunks`:
   - `core/src/settings/storage_health.rs` — `chunks_exact(2)` → `as_chunks::<2>().0.iter()`
   - `core/src/infrastructure/providers/macos/io_kit/iokit_info.rs` (macOS-only) — `chunks_exact(8)` → `as_chunks::<8>().0`
   - `src-tauri/src/tray/surface/windows.rs` (Windows-only, `#[cfg(target_os = "windows")]`, test module, 3 call sites) — same migration. This one was not caught by local `cargo clippy` on macOS because the module is platform-gated; it surfaced from the `lint-tauri (windows-latest)` CI log and is confirmed fixed by a repo-wide `grep -rn chunks_exact` returning no remaining hits.
2. **`#![macro_use]` on a crate root** — previously a deprecation warning, now a hard error under `-D unused-attributes`. The attribute was already dead in `src-tauri/src/lib.rs`: that crate defines no `macro_rules!`, and the logging macros are re-exported through `pub use hardviz_core::{...}` on the next line. Removed.

Both slipped past PR CI because `change-detection` does not treat `rust-toolchain.toml` as a Rust change, so #2003 skipped every Rust job and auto-merged. #2009 closes that gap.

## Related Issues

Follow-up to #2003. CI gap fixed separately in #2009.

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A — no user-visible change.

## Test Plan

- [x] Manual testing
- [x] Unit tests

Run locally on the pinned 1.98.0 toolchain (`rustc 1.98.0 (88d9e12ae 2026-08-18)`), macOS host target:

```
cargo clippy -p hardviz-core --all-targets -- -D warnings        # clean
cargo clippy -p hardware_visualizer --all-targets -- -D warnings # clean
cargo fmt --check                                                # clean
cargo tauri-test                                                 # 241 passed, 0 failed (workspace)
cargo test -p hardviz-core storage_health                        # 29 passed, 0 failed
grep -rn chunks_exact core/src src-tauri/src                     # no remaining hits, any platform
grep -rln macro_use core/src src-tauri/src                       # no remaining hits
```

`iokit_info.rs` (macOS-only) and `tray/surface/windows.rs` (Windows-only) are behind
`#[cfg(target_os = "...")]` and cannot be compiled from this macOS host — cross-compiling
`hardware_visualizer` for `x86_64-pc-windows-msvc` fails locally on an unrelated dependency
(`ring`'s C build needs MSVC headers not present here). Verified those two files with the
platform-independent `grep` above instead, and rely on the `lint-core` / `lint-tauri` macOS
and Windows matrix legs in CI for final confirmation. The Windows fix was in fact discovered
from a `lint-tauri (windows-latest)` failure the maintainer pasted after the first push, so
this PR already went through one real Windows-CI round-trip.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal byte and pixel data processing for clearer, more efficient fixed-size chunk handling.
  - Removed an unnecessary crate-level macro import.
- **Tests**
  - Preserved existing image-data validation behavior while modernizing test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->