### PR TITLE
ci: treat rust-toolchain changes as Rust source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,14 @@ jobs:
               - 'src-tauri/**'
               - 'Cargo.*'
               - '.cargo/**'
+              - 'rust-toolchain*'
               - '.github/actions/**'
               - '.github/scripts/**'
             core:
               - 'core/**'
               - 'Cargo.*'
               - '.cargo/**'
+              - 'rust-toolchain*'
               - '.github/actions/**'
               - '.github/scripts/**'
             tauri:
@@ -71,6 +73,7 @@ jobs:
               - 'e2e-native/**'
               - 'Cargo.*'
               - '.cargo/**'
+              - 'rust-toolchain*'
               - '.github/actions/**'
               - '.github/scripts/**'
             frontend-deps:


### PR DESCRIPTION
## Summary

`change-detection` classifies a pull request with `dorny/paths-filter`, but none of the `backend`, `core`, or `tauri` filters listed `rust-toolchain.toml`. A toolchain-only pull request therefore reported no Rust change, and every Rust job is gated on `is-push == 'true' || <area>-changed == 'true'`, so all of them were skipped.

This is how #2003 (rust-toolchain 1.97.1 → 1.98.0) reached `develop` broken:

| | PR run | `develop` push run |
|---|---|---|
| `CI` result | success in **48s** | failure in **19m18s** |
| `lint-core` / `lint-tauri` / `test-core` / `rust-format` | **skipped** | ran, clippy failed |

The only required status check is `Merge Gate`, which is `if: always()` and accepts skipped needs by design, so the PR was mergeable and Dependabot auto-merge merged it 47 seconds after enabling. The toolchain bump was never compiled with the new toolchain before merge; the `clippy::chunks_exact_to_as_chunks` errors fixed in #2008 only appeared on the post-merge push.

Adding `rust-toolchain*` to the `backend`, `core`, and `tauri` filters makes a toolchain change run `rust-format`, `lint-core`, `test-core`, `lint-tauri`, and `test-tauri` on the pull request itself.

The glob form matches the existing house style in this file (`Cargo.*`, `package*.json`, `tsconfig*.json`) and covers both `rust-toolchain.toml` and the bare `rust-toolchain` filename Dependabot also supports.

`backend-deps` and `cargo-license-config` are intentionally left alone: a toolchain bump changes neither the dependency set nor the license surface, so `license-check-cargo` should keep skipping.

## Related Issues

<!-- No tracking Issue; this is the follow-up to the #2003 / #2008 CI escape. -->

Follow-up to #2003, related to #2008.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch) — CI-only change (`ci:` Conventional Commit, `chore/` branch per CONTRIBUTING.md)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Verified the glob resolves the way `dorny/paths-filter` (picomatch) evaluates it:

```
rust-toolchain.toml      -> true
rust-toolchain           -> true
core/rust-toolchain.toml -> false   # root-only, as intended
```

Traced the job gating to confirm coverage after the change:

- `rust-format` — `backend-changed` ✅
- `lint-core`, `test-core` — `core-changed` ✅
- `lint-tauri`, `test-tauri` — `tauri-changed` ✅
- `test-build` — `core-changed` / `tauri-changed` ✅
- `check-core-tauri-integration` — stays skipped, correct: it is the "core changed but tauri did not" case, and a toolchain bump touches both.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`) — N/A, workflow YAML only
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — N/A, workflow YAML only
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated change detection so Rust toolchain updates correctly trigger backend, core, and desktop application checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->