### PR TITLE
ci: fail safe when a changed file matches no known CI path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       cargo-license-config-changed: ${{ steps.changes.outputs.cargo-license-config }}
       tauri-deps-changed: ${{ steps.tauri-deps.outputs.changed }}
       actions-changed: ${{ steps.changes.outputs.actions }}
+      unclassified-changed: ${{ steps.changes.outputs.unclassified }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,6 +96,29 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/scripts/**'
+            # Catch-all: true when a changed file matches none of the filters
+            # above. A file this repo has not classified yet must not let
+            # every Rust/frontend job silently skip (#2003/#2008/#2009) — so
+            # every job below also runs on `unclassified == 'true'`.
+            unclassified:
+              - '**'
+              - '!src/**'
+              - '!e2e/**'
+              - '!e2e-native/**'
+              - '!package*.json'
+              - '!vite.config.ts'
+              - '!playwright.config.ts'
+              - '!playwright.perf.config.ts'
+              - '!playwright.memory.config.ts'
+              - '!tsconfig*.json'
+              - '!core/**'
+              - '!src-tauri/**'
+              - '!Cargo.*'
+              - '!.cargo/**'
+              - '!rust-toolchain*'
+              - '!.github/actions/**'
+              - '!.github/scripts/**'
+              - '!.github/workflows/**'
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -150,7 +174,7 @@ jobs:
   #
   rust-format:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.backend-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.backend-changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -169,7 +193,7 @@ jobs:
   #
   lint-core:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.core-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.core-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -194,7 +218,7 @@ jobs:
   #
   test-core:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.core-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.core-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -221,7 +245,7 @@ jobs:
   #
   lint-tauri:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -246,7 +270,7 @@ jobs:
   #
   test-tauri:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -343,7 +367,7 @@ jobs:
   #
   check-tauri-bindings:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true' || needs.change-detection.outputs.core-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.actions-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-changed == 'true' || needs.change-detection.outputs.core-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.actions-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -375,7 +399,7 @@ jobs:
   test-build:
     needs: change-detection
     # Tauri dependency updates use the Tauri CLI build path to keep npm/Cargo version consistency checks.
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.tauri-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.tauri-deps-changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -499,7 +523,7 @@ jobs:
   #
   check-frontend:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -532,7 +556,7 @@ jobs:
   #
   test-e2e-web:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
     permissions:
       contents: write
       pull-requests: write
@@ -652,7 +676,7 @@ jobs:
   #
   test-e2e-native:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.frontend-deps-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-changed == 'true' || needs.change-detection.outputs.tauri-changed == 'true' || needs.change-detection.outputs.frontend-deps-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -693,7 +717,7 @@ jobs:
   #
   build-frontend:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -710,7 +734,7 @@ jobs:
   #
   license-check-npm:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.frontend-deps-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.frontend-deps-changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -730,7 +754,7 @@ jobs:
 
   license-check-cargo:
     needs: change-detection
-    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.cargo-license-config-changed == 'true'
+    if: needs.change-detection.outputs.is-push == 'true' || needs.change-detection.outputs.unclassified-changed == 'true' || needs.change-detection.outputs.backend-deps-changed == 'true' || needs.change-detection.outputs.cargo-license-config-changed == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       cargo-license-config-changed: ${{ steps.changes.outputs.cargo-license-config }}
       tauri-deps-changed: ${{ steps.tauri-deps.outputs.changed }}
       actions-changed: ${{ steps.changes.outputs.actions }}
-      unclassified-changed: ${{ steps.changes.outputs.unclassified }}
+      unclassified-changed: ${{ steps.unclassified.outputs.unclassified }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -96,10 +96,29 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
               - '.github/scripts/**'
-            # Catch-all: true when a changed file matches none of the filters
-            # above. A file this repo has not classified yet must not let
-            # every Rust/frontend job silently skip (#2003/#2008/#2009) — so
-            # every job below also runs on `unclassified == 'true'`.
+
+      # Catch-all: true when a changed file matches none of the filters above.
+      # A file this repo has not classified yet must not let every Rust and
+      # frontend job silently skip (#2003/#2008/#2009), so every change-gated
+      # job below also runs on `unclassified-changed == 'true'`.
+      #
+      # This needs its own paths-filter step: `predicate-quantifier` is
+      # step-scoped, and the filters above depend on the default 'some'
+      # ("matches at least one pattern"). Under 'some' the leading '**' would
+      # match every file and make this filter always true, so it uses
+      # 'some-with-excludes' ("matches a positive pattern and no negated one")
+      # to actually compute the complement.
+      #
+      # The negations below mirror the positive patterns above. Forgetting to
+      # mirror a newly added pattern is the safe direction: the file simply
+      # falls through to unclassified and over-runs CI rather than skipping it.
+      - name: Check unclassified changed files
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: unclassified
+        background: true
+        with:
+          predicate-quantifier: "some-with-excludes"
+          filters: |
             unclassified:
               - '**'
               - '!src/**'
@@ -145,7 +164,7 @@ jobs:
           node .github/scripts/check-tauri-deps-changed.ts "$base_ref"
 
       - name: Wait for changed file detection
-        wait: changes
+        wait-all: true
 
   #
   # GitHub Actions lint


### PR DESCRIPTION
## Summary

Follow-up to #2009. #2009 fixed the one known instance of the #2003/#2008 incident (`rust-toolchain.toml` was not classified as a Rust change), but the mechanism that let it slip through is still there: `merge-gate.ts` treats every required job's `skipped` result as fine, without asking whether skipping was actually justified by the diff. Any file `change-detection`'s `paths-filter` has not been taught about still silently skips every Rust/frontend job today, and `Merge Gate` still goes green.

This closes the general class of bug, not just the specific file:

- Add a catch-all `unclassified` filter — `'**'` minus every pattern already used by another named filter (the same de-duplicated glob set `frontend` ∪ `backend`/`core`/`tauri` ∪ `frontend-deps`/`backend-deps` ∪ `cargo-license-config` ∪ `actions` already cover) — as its **own** `dorny/paths-filter` step with `predicate-quantifier: 'some-with-excludes'`. It cannot share the existing step: `predicate-quantifier` is step-scoped, and the other filters depend on the default `some`.
- Expose it as `unclassified-changed` on `change-detection`.
- OR it into every change-gated job's `if:` (13 jobs: `rust-format`, `lint-core`, `test-core`, `lint-tauri`, `test-tauri`, `check-tauri-bindings`, `test-build`, `check-frontend`, `test-e2e-web`, `test-e2e-native`, `build-frontend`, `license-check-npm`, `license-check-cargo`).
- Switch the change-detection barrier from `wait: changes` to `wait-all: true` so the new background step is awaited too.

A file outside every named category now forces the full matrix to run instead of silently reporting no relevant change — including for a category nobody has invented yet.

`check-core-tauri-integration`'s inverted fast-path condition (`is-push != 'true' && core-changed == 'true' && tauri-changed != 'true' && ...`) is intentionally left alone: it is a redundant optimization for the "Core changed, Tauri did not" case, not a required safety net. `lint-core` / `lint-tauri` / `test-build` already cover an unclassified change on their own once this PR lands.

### Trade-off

A PR that touches only something outside every named filter — a new root config file, `LICENSE`, `docs/**`, `biome.jsonc`, `.gitignore` — now runs the full CI matrix instead of skipping everything, in exchange for never again being able to silently merge an uncompiled toolchain/dependency change. Given #2003 auto-merged in 48s with zero Rust jobs run and broke `develop`, erring toward "run it" over "assume it's safe to skip" for anything unrecognized seems like the right default here — flagging in case the CI-minutes cost changes that calculus.

## Related Issues

Follow-up to #2003, #2008, #2009.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch) — CI-only change (`ci:` Conventional Commit, `chore/` branch per CONTRIBUTING.md)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

Transcribed `createRuleItem()` and `Filter.isMatch()` from `src/filter.ts` at the **pinned action SHA** (`ceb8a2b`) and ran 27 representative repository paths through both quantifiers. This replaces an earlier, incorrect check that used `picomatch`'s `ignore:` option — which does not reproduce paths-filter's actual pattern semantics and is what let the `some`-quantifier bug (caught in review by CodeRabbit and Codex, fixed in 28d89b5b) through the first time:

```
=== predicate-quantifier: some (the action's default) ===
FAILED (18/27)
  rust-toolchain.toml: got true, want false
  Cargo.toml: got true, want false
  core/src/lib.rs: got true, want false
  src-tauri/src/lib.rs: got true, want false
  ...

=== predicate-quantifier: some-with-excludes (what this PR uses) ===
ALL PASS
```

Cases asserted `unclassified: false` (already covered by a named filter): `rust-toolchain.toml`, `Cargo.toml`, `Cargo.lock`, `core/src/lib.rs`, `src-tauri/src/lib.rs`, `src-tauri/deny.toml`, `.cargo/config.toml`, `.github/workflows/ci.yml`, `.github/actions/setup-rust/action.yml`, `.github/scripts/merge-gate.ts`, `src/App.tsx`, `e2e/foo.spec.ts`, `e2e-native/foo.ts`, `package.json`, `package-lock.json`, `tsconfig.json`, `vite.config.ts`, `playwright.config.ts`.

Cases asserted `unclassified: true` (genuinely outside every filter): a hypothetical `new-tool-config.yaml`, `biome.jsonc`, `LICENSE`, `README.md`, `docs/foo.md`, `.gitignore`, `AGENTS.md`, `osv-scanner.toml`, `index.html`.

Ran `actionlint` on the modified workflow and compared its findings to the same run against `develop`: identical except for one additional `unexpected key "background"` for the new step — the same known false-positive as the 9 pre-existing ones (actionlint 1.7.11 does not understand this repo's step-level `background`/`wait`/`wait-all` harness syntax, which is why `lint-actions` is disabled with `if: ${{ false }}`). No new real findings.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`) — N/A, workflow YAML only
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — N/A, workflow YAML only
- [x] No new warnings or errors
