### PR TITLE
feat(core): cooling daily rollup with a Cooling Insight retention contract

### DIFF
--- a/core/src/infrastructure/database/archive_queries.rs
+++ b/core/src/infrastructure/database/archive_queries.rs
@@ -390,7 +390,13 @@ fn format_datetime(datetime: &DateTime<Utc>) -> String {
   datetime.to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
-fn sqlite_epoch_milliseconds() -> &'static str {
+/// SQL fragment converting the `timestamp` TEXT column to epoch
+/// milliseconds. `pub(crate)` so other Core query modules (e.g.
+/// `cooling_daily_summary`) can filter/compare against `DATA_ARCHIVE`
+/// timestamps without duplicating this conversion or relying on raw TEXT
+/// comparison, which only sorts correctly when every writer produces the
+/// exact same string shape.
+pub(crate) fn sqlite_epoch_milliseconds() -> &'static str {
   "(CAST(strftime('%s', timestamp) AS INTEGER) * 1000 + \
    CAST(substr(strftime('%f', timestamp), 4, 3) AS INTEGER))"
 }

--- a/core/src/infrastructure/database/cooling_daily_summary.rs
+++ b/core/src/infrastructure/database/cooling_daily_summary.rs
@@ -1,0 +1,529 @@
+//! `cooling_daily_summary` reads and writes.
+//!
+//! Mirrors the `_from_pool` split used by `archive_queries`: the public
+//! `async fn`s resolve Core's process-wide pool via [`db::get_pool`], and
+//! delegate to a `_from_pool` variant that takes an explicit `SqlitePool`
+//! so tests can exercise the query logic against an in-memory database
+//! without touching the process-wide `db::init` `OnceLock`.
+
+use super::archive_queries::sqlite_epoch_milliseconds;
+use super::db;
+use crate::persistence::cooling_rollup::{
+  ArchiveMinuteSample, BandSummary, DailyCoolingSummary,
+};
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::SqlitePool;
+
+pub async fn select_archive_minutes_for_range(
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+) -> Result<Vec<ArchiveMinuteSample>, sqlx::Error> {
+  let pool = db::get_pool().await?;
+  select_archive_minutes_for_range_from_pool(&pool, start, end).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, sqlx::FromRow)]
+struct ArchiveMinuteRow {
+  cpu_avg: Option<f64>,
+  cpu_temperature_avg: Option<f64>,
+  cpu_temperature_max: Option<f64>,
+  cpu_temperature_min: Option<f64>,
+}
+
+impl From<ArchiveMinuteRow> for ArchiveMinuteSample {
+  fn from(row: ArchiveMinuteRow) -> Self {
+    Self {
+      cpu_usage_avg: row.cpu_avg.map(|v| v as f32),
+      cpu_temperature_avg: row.cpu_temperature_avg.map(|v| v as f32),
+      cpu_temperature_max: row.cpu_temperature_max.map(|v| v as f32),
+      cpu_temperature_min: row.cpu_temperature_min.map(|v| v as f32),
+    }
+  }
+}
+
+async fn select_archive_minutes_for_range_from_pool(
+  pool: &SqlitePool,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+) -> Result<Vec<ArchiveMinuteSample>, sqlx::Error> {
+  // Compare via epoch milliseconds computed from `timestamp` in SQL,
+  // rather than a raw TEXT comparison: `DATA_ARCHIVE.timestamp` is
+  // written through sqlx's native `DateTime<Utc>` encoding (a `+00:00`
+  // offset suffix, no fractional part when it is exactly zero), which is
+  // not guaranteed to sort correctly against a differently-shaped bind
+  // string at exact-second boundaries. `strftime` accepts every ISO 8601
+  // shape chrono can produce, so this is robust regardless of writer.
+  let epoch_ms = sqlite_epoch_milliseconds();
+  let sql = format!(
+    "SELECT
+       CAST(cpu_avg AS REAL) AS cpu_avg,
+       CAST(cpu_temperature_avg AS REAL) AS cpu_temperature_avg,
+       CAST(cpu_temperature_max AS REAL) AS cpu_temperature_max,
+       CAST(cpu_temperature_min AS REAL) AS cpu_temperature_min
+     FROM DATA_ARCHIVE
+     WHERE {epoch_ms} >= $1 AND {epoch_ms} < $2
+     ORDER BY timestamp ASC"
+  );
+  let rows = sqlx::query_as::<_, ArchiveMinuteRow>(&sql)
+    .bind(start.timestamp_millis())
+    .bind(end.timestamp_millis())
+    .fetch_all(pool)
+    .await?;
+
+  Ok(rows.into_iter().map(ArchiveMinuteSample::from).collect())
+}
+
+pub async fn max_summarized_date() -> Result<Option<NaiveDate>, sqlx::Error> {
+  let pool = db::get_pool().await?;
+  max_summarized_date_from_pool(&pool).await
+}
+
+async fn max_summarized_date_from_pool(
+  pool: &SqlitePool,
+) -> Result<Option<NaiveDate>, sqlx::Error> {
+  sqlx::query_scalar::<_, Option<NaiveDate>>(
+    "SELECT MAX(date) FROM cooling_daily_summary",
+  )
+  .fetch_one(pool)
+  .await
+}
+
+pub async fn earliest_archived_timestamp() -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+  let pool = db::get_pool().await?;
+  earliest_archived_timestamp_from_pool(&pool).await
+}
+
+async fn earliest_archived_timestamp_from_pool(
+  pool: &SqlitePool,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+  // Decoded through sqlx's own chrono codec (not a manual string parse)
+  // so this round-trips correctly regardless of the exact TEXT shape
+  // `hardware_archive::insert`'s native `DateTime<Utc>` bind produced.
+  sqlx::query_scalar::<_, Option<DateTime<Utc>>>(
+    "SELECT MIN(timestamp) FROM DATA_ARCHIVE",
+  )
+  .fetch_one(pool)
+  .await
+}
+
+pub async fn upsert(summary: &DailyCoolingSummary) -> Result<(), sqlx::Error> {
+  let pool = db::get_pool().await?;
+  upsert_from_pool(&pool, summary).await
+}
+
+async fn upsert_from_pool(
+  pool: &SqlitePool,
+  summary: &DailyCoolingSummary,
+) -> Result<(), sqlx::Error> {
+  fn minutes(band: &BandSummary) -> i64 {
+    band.sample_minutes as i64
+  }
+
+  sqlx::query(
+    r#"
+    INSERT INTO cooling_daily_summary (
+      date,
+      idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+      low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+      mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+      high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+      coverage_minutes
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+    ON CONFLICT(date) DO UPDATE SET
+      idle_cpu_temperature_avg = excluded.idle_cpu_temperature_avg,
+      idle_cpu_temperature_max = excluded.idle_cpu_temperature_max,
+      idle_cpu_temperature_min = excluded.idle_cpu_temperature_min,
+      idle_sample_minutes = excluded.idle_sample_minutes,
+      low_cpu_temperature_avg = excluded.low_cpu_temperature_avg,
+      low_cpu_temperature_max = excluded.low_cpu_temperature_max,
+      low_cpu_temperature_min = excluded.low_cpu_temperature_min,
+      low_sample_minutes = excluded.low_sample_minutes,
+      mid_cpu_temperature_avg = excluded.mid_cpu_temperature_avg,
+      mid_cpu_temperature_max = excluded.mid_cpu_temperature_max,
+      mid_cpu_temperature_min = excluded.mid_cpu_temperature_min,
+      mid_sample_minutes = excluded.mid_sample_minutes,
+      high_cpu_temperature_avg = excluded.high_cpu_temperature_avg,
+      high_cpu_temperature_max = excluded.high_cpu_temperature_max,
+      high_cpu_temperature_min = excluded.high_cpu_temperature_min,
+      high_sample_minutes = excluded.high_sample_minutes,
+      coverage_minutes = excluded.coverage_minutes
+    "#,
+  )
+  .bind(summary.date.format("%Y-%m-%d").to_string())
+  .bind(summary.idle.avg)
+  .bind(summary.idle.max)
+  .bind(summary.idle.min)
+  .bind(minutes(&summary.idle))
+  .bind(summary.low.avg)
+  .bind(summary.low.max)
+  .bind(summary.low.min)
+  .bind(minutes(&summary.low))
+  .bind(summary.mid.avg)
+  .bind(summary.mid.max)
+  .bind(summary.mid.min)
+  .bind(minutes(&summary.mid))
+  .bind(summary.high.avg)
+  .bind(summary.high.max)
+  .bind(summary.high.min)
+  .bind(minutes(&summary.high))
+  .bind(summary.coverage_minutes as i64)
+  .execute(pool)
+  .await?;
+
+  Ok(())
+}
+
+pub async fn delete_old_data(retention_days: u32) -> Result<(), sqlx::Error> {
+  let pool = db::get_pool().await?;
+  delete_old_data_from_pool(&pool, retention_days).await
+}
+
+async fn delete_old_data_from_pool(
+  pool: &SqlitePool,
+  retention_days: u32,
+) -> Result<(), sqlx::Error> {
+  // Same cutoff style as `storage_health::delete_old_data`: a local-date
+  // TEXT comparison, since `date` is stored as "%Y-%m-%d" and compares
+  // lexicographically the same as chronologically.
+  let cutoff = (chrono::Local::now().date_naive()
+    - chrono::Duration::days(retention_days as i64))
+  .format("%Y-%m-%d")
+  .to_string();
+
+  sqlx::query("DELETE FROM cooling_daily_summary WHERE date < $1")
+    .bind(cutoff)
+    .execute(pool)
+    .await?;
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use sqlx::Row;
+
+  async fn setup_data_archive(pool: &SqlitePool) {
+    sqlx::query(
+      "CREATE TABLE DATA_ARCHIVE (
+        id INTEGER PRIMARY KEY,
+        cpu_avg REAL,
+        cpu_temperature_avg REAL,
+        cpu_temperature_max REAL,
+        cpu_temperature_min REAL,
+        timestamp DATETIME
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  async fn setup_cooling_daily_summary(pool: &SqlitePool) {
+    sqlx::query(
+      "CREATE TABLE cooling_daily_summary (
+        date TEXT PRIMARY KEY,
+        idle_cpu_temperature_avg REAL,
+        idle_cpu_temperature_max REAL,
+        idle_cpu_temperature_min REAL,
+        idle_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        low_cpu_temperature_avg REAL,
+        low_cpu_temperature_max REAL,
+        low_cpu_temperature_min REAL,
+        low_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        mid_cpu_temperature_avg REAL,
+        mid_cpu_temperature_max REAL,
+        mid_cpu_temperature_min REAL,
+        mid_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        high_cpu_temperature_avg REAL,
+        high_cpu_temperature_max REAL,
+        high_cpu_temperature_min REAL,
+        high_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        coverage_minutes INTEGER NOT NULL
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  async fn insert_archive_row(
+    pool: &SqlitePool,
+    cpu_avg: Option<f64>,
+    cpu_temperature_avg: Option<f64>,
+    timestamp: DateTime<Utc>,
+  ) {
+    // Bind the native `DateTime<Utc>` type (not a manually formatted
+    // string) so this matches exactly how the real archive writer
+    // (`hardware_archive::insert`) writes the column - the range query
+    // under test must be able to compare against sqlx's own encoding,
+    // not just a hand-formatted literal.
+    sqlx::query(
+      "INSERT INTO DATA_ARCHIVE (cpu_avg, cpu_temperature_avg, cpu_temperature_max, cpu_temperature_min, timestamp)
+       VALUES ($1, $2, $2, $2, $3)",
+    )
+    .bind(cpu_avg)
+    .bind(cpu_temperature_avg)
+    .bind(timestamp)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  fn utc(input: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(input)
+      .unwrap()
+      .with_timezone(&Utc)
+  }
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  #[tokio::test]
+  async fn select_archive_minutes_only_returns_rows_within_the_half_open_range() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_data_archive(&pool).await;
+    insert_archive_row(
+      &pool,
+      Some(5.0),
+      Some(40.0),
+      utc("2026-08-14T23:59:59.000Z"),
+    )
+    .await;
+    insert_archive_row(
+      &pool,
+      Some(6.0),
+      Some(41.0),
+      utc("2026-08-15T00:00:00.000Z"),
+    )
+    .await;
+    insert_archive_row(
+      &pool,
+      Some(7.0),
+      Some(42.0),
+      utc("2026-08-15T23:59:59.999Z"),
+    )
+    .await;
+    insert_archive_row(
+      &pool,
+      Some(8.0),
+      Some(43.0),
+      utc("2026-08-16T00:00:00.000Z"),
+    )
+    .await;
+
+    let rows = select_archive_minutes_for_range_from_pool(
+      &pool,
+      &utc("2026-08-15T00:00:00.000Z"),
+      &utc("2026-08-16T00:00:00.000Z"),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].cpu_usage_avg, Some(6.0));
+    assert_eq!(rows[1].cpu_usage_avg, Some(7.0));
+  }
+
+  #[tokio::test]
+  async fn select_archive_minutes_preserves_null_temperature_and_usage() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_data_archive(&pool).await;
+    insert_archive_row(&pool, None, None, utc("2026-08-15T12:00:00.000Z")).await;
+
+    let rows = select_archive_minutes_for_range_from_pool(
+      &pool,
+      &utc("2026-08-15T00:00:00.000Z"),
+      &utc("2026-08-16T00:00:00.000Z"),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].cpu_usage_avg, None);
+    assert_eq!(rows[0].cpu_temperature_avg, None);
+  }
+
+  #[tokio::test]
+  async fn max_summarized_date_is_none_for_an_empty_table() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+
+    assert_eq!(max_summarized_date_from_pool(&pool).await.unwrap(), None);
+  }
+
+  #[tokio::test]
+  async fn max_summarized_date_returns_the_latest_row() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+    for d in ["2026-08-10", "2026-08-20", "2026-08-15"] {
+      sqlx::query(
+        "INSERT INTO cooling_daily_summary (date, coverage_minutes) VALUES ($1, 0)",
+      )
+      .bind(d)
+      .execute(&pool)
+      .await
+      .unwrap();
+    }
+
+    assert_eq!(
+      max_summarized_date_from_pool(&pool).await.unwrap(),
+      Some(date(2026, 8, 20))
+    );
+  }
+
+  #[tokio::test]
+  async fn earliest_archived_timestamp_is_none_for_an_empty_archive() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_data_archive(&pool).await;
+
+    assert_eq!(
+      earliest_archived_timestamp_from_pool(&pool).await.unwrap(),
+      None
+    );
+  }
+
+  #[tokio::test]
+  async fn earliest_archived_timestamp_returns_the_oldest_row() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_data_archive(&pool).await;
+    insert_archive_row(&pool, Some(1.0), Some(1.0), utc("2026-08-15T00:00:00.000Z"))
+      .await;
+    insert_archive_row(&pool, Some(1.0), Some(1.0), utc("2026-08-01T00:00:00.000Z"))
+      .await;
+    insert_archive_row(&pool, Some(1.0), Some(1.0), utc("2026-08-10T00:00:00.000Z"))
+      .await;
+
+    assert_eq!(
+      earliest_archived_timestamp_from_pool(&pool).await.unwrap(),
+      Some(utc("2026-08-01T00:00:00.000Z"))
+    );
+  }
+
+  fn full_band(value: f32, minutes: u32) -> BandSummary {
+    BandSummary {
+      avg: Some(value),
+      max: Some(value + 1.0),
+      min: Some(value - 1.0),
+      sample_minutes: minutes,
+    }
+  }
+
+  fn empty_band() -> BandSummary {
+    BandSummary {
+      avg: None,
+      max: None,
+      min: None,
+      sample_minutes: 0,
+    }
+  }
+
+  #[tokio::test]
+  async fn upsert_writes_all_four_bands_and_coverage() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+
+    let summary = DailyCoolingSummary {
+      date: date(2026, 8, 15),
+      coverage_minutes: 1000,
+      idle: full_band(30.0, 600),
+      low: full_band(40.0, 300),
+      mid: empty_band(),
+      high: full_band(70.0, 100),
+    };
+    upsert_from_pool(&pool, &summary).await.unwrap();
+
+    let row = sqlx::query(
+      "SELECT idle_cpu_temperature_avg, idle_sample_minutes, mid_cpu_temperature_avg, mid_sample_minutes, coverage_minutes
+       FROM cooling_daily_summary WHERE date = $1",
+    )
+    .bind("2026-08-15")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(row.get::<f64, _>("idle_cpu_temperature_avg"), 30.0);
+    assert_eq!(row.get::<i64, _>("idle_sample_minutes"), 600);
+    assert_eq!(row.get::<Option<f64>, _>("mid_cpu_temperature_avg"), None);
+    assert_eq!(row.get::<i64, _>("mid_sample_minutes"), 0);
+    assert_eq!(row.get::<i64, _>("coverage_minutes"), 1000);
+  }
+
+  #[tokio::test]
+  async fn upsert_is_idempotent_for_the_same_date() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+
+    let mut summary = DailyCoolingSummary {
+      date: date(2026, 8, 15),
+      coverage_minutes: 500,
+      idle: full_band(30.0, 500),
+      low: empty_band(),
+      mid: empty_band(),
+      high: empty_band(),
+    };
+    upsert_from_pool(&pool, &summary).await.unwrap();
+
+    summary.coverage_minutes = 1440;
+    summary.idle.sample_minutes = 1440;
+    upsert_from_pool(&pool, &summary).await.unwrap();
+
+    let count: (i64,) =
+      sqlx::query_as("SELECT COUNT(1) FROM cooling_daily_summary WHERE date = $1")
+        .bind("2026-08-15")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let coverage: (i64,) = sqlx::query_as(
+      "SELECT coverage_minutes FROM cooling_daily_summary WHERE date = $1",
+    )
+    .bind("2026-08-15")
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+      count.0, 1,
+      "re-running a rollup for the same day must not duplicate the row"
+    );
+    assert_eq!(coverage.0, 1440);
+  }
+
+  #[tokio::test]
+  async fn delete_old_data_removes_rows_strictly_before_the_cutoff() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+    let today = chrono::Local::now().date_naive();
+    let cutoff_date = today - chrono::Duration::days(400);
+    let just_inside = cutoff_date.format("%Y-%m-%d").to_string();
+    let just_outside = (cutoff_date - chrono::Duration::days(1))
+      .format("%Y-%m-%d")
+      .to_string();
+
+    for d in [&just_inside, &just_outside] {
+      sqlx::query(
+        "INSERT INTO cooling_daily_summary (date, coverage_minutes) VALUES ($1, 0)",
+      )
+      .bind(d)
+      .execute(&pool)
+      .await
+      .unwrap();
+    }
+
+    delete_old_data_from_pool(&pool, 400).await.unwrap();
+
+    let remaining: Vec<String> =
+      sqlx::query_scalar("SELECT date FROM cooling_daily_summary")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(
+      remaining,
+      vec![just_inside],
+      "the row exactly at the retention boundary must survive; only the older row is deleted"
+    );
+  }
+}

--- a/core/src/infrastructure/database/mod.rs
+++ b/core/src/infrastructure/database/mod.rs
@@ -8,6 +8,7 @@
 //! read / write that Core executes goes through this module.
 
 pub mod archive_queries;
+pub mod cooling_daily_summary;
 pub mod db;
 pub mod gpu_archive;
 pub mod hardware_archive;

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -146,6 +146,14 @@ impl ArchiveController {
 /// enabled - that matches the pre-Phase-4 behavior of the previous
 /// `batch_delete_old_data` wrapper. The cleanup trigger is still
 /// "next process boot", not a recurring schedule.
+///
+/// Also runs the cooling daily rollup's own retention cleanup at this
+/// same `scheduled_data_deletion`-gated startup site. It intentionally
+/// does **not** use `retention_days` (that is `hardwareArchive.retentionDays`,
+/// user-configurable and defaulting to 30 days): the whole point of the
+/// daily rollup is to outlive the one-minute archive rows it is derived
+/// from, so it keeps its own fixed, independent retention window - see
+/// `crate::persistence::cooling_rollup::COOLING_DAILY_SUMMARY_RETENTION_DAYS`.
 pub async fn cleanup_old_data(retention_days: u32) {
   use crate::infrastructure::database;
   use crate::log_error;
@@ -173,6 +181,8 @@ pub async fn cleanup_old_data(retention_days: u32) {
       Some(e.to_string())
     );
   }
+
+  crate::persistence::cooling_rollup::cleanup_old_data().await;
 }
 
 // ── Internal: per-snapshot accumulator ────────────────────────────────

--- a/core/src/persistence/cooling_rollup.rs
+++ b/core/src/persistence/cooling_rollup.rs
@@ -18,7 +18,7 @@
 use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
 
 use tokio::runtime::Handle;
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval};
 
@@ -84,6 +84,9 @@ pub struct ArchiveMinuteSample {
 /// CPU temperature summary for one [`CpuLoadBand`] on one local day.
 /// `sample_minutes == 0` implies `avg`/`max`/`min` are all `None`: a band
 /// with no contributing minute is absent, never zero.
+/// `sample_minutes` counts contributing archived rows; a shutdown-flush
+/// partial-window row counts as one minute (see
+/// [`DailyCoolingSummary::coverage_minutes`]).
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct BandSummary {
   pub avg: Option<f32>,
@@ -92,15 +95,24 @@ pub struct BandSummary {
   pub sample_minutes: u32,
 }
 
+/// Minutes in a local calendar day; the cap for [`DailyCoolingSummary::coverage_minutes`].
+const MINUTES_PER_DAY: u32 = 24 * 60;
+
 /// One `cooling_daily_summary` row: the derived cooling profile for a
 /// single completed local day.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DailyCoolingSummary {
   pub date: NaiveDate,
-  /// Count of archived one-minute rows found for this local day,
-  /// regardless of whether they carried a usable CPU usage or
-  /// temperature reading. Represents how much of the day was actually
-  /// recorded (the app running), distinct from `sample_minutes` per band.
+  /// Count of archived rows found for this local day, regardless of
+  /// whether they carried a usable CPU usage or temperature reading.
+  /// Represents how much of the day was actually recorded (the app
+  /// running), distinct from `sample_minutes` per band.
+  ///
+  /// Approximation: an archived row is normally a one-minute window,
+  /// but `ArchiveController` also flushes a final partial window on
+  /// shutdown, so repeated short launches can produce more rows than
+  /// elapsed minutes. The count is capped at [`MINUTES_PER_DAY`] so a
+  /// day never reports more than a full day of coverage.
   pub coverage_minutes: u32,
   pub idle: BandSummary,
   pub low: BandSummary,
@@ -156,7 +168,7 @@ pub fn summarize_day(
 
   Some(DailyCoolingSummary {
     date,
-    coverage_minutes: minutes.len() as u32,
+    coverage_minutes: (minutes.len() as u32).min(MINUTES_PER_DAY),
     idle: idle.finish(),
     low: low.finish(),
     mid: mid.finish(),
@@ -311,11 +323,22 @@ impl CoolingRollupController {
   /// rollup, or since the earliest archived day on a first run), then
   /// checks once per [`COOLING_ROLLUP_CHECK_INTERVAL_SECONDS`] whether
   /// the local day has advanced far enough to catch up again.
-  pub fn setup(runtime: Handle) -> Self {
+  ///
+  /// Also returns a receiver that resolves once that first catch-up
+  /// pass has finished (or the worker died), so callers can order work
+  /// that deletes archive rows — the `scheduledDataDeletion` retention
+  /// cleanup — after the backfill has read the rows it needs. Rows
+  /// older than the archive Retention Period can still be present at
+  /// startup (cleanup was disabled, or the app was simply not running
+  /// past the cutoff), and racing the cleanup would silently lose those
+  /// days from the rollup forever.
+  pub fn setup(runtime: Handle) -> (Self, oneshot::Receiver<()>) {
     let (stop_tx, mut stop_rx) = watch::channel(false);
+    let (first_catch_up_tx, first_catch_up_rx) = oneshot::channel();
 
     let handle = runtime.spawn(async move {
       run_catch_up().await;
+      let _ = first_catch_up_tx.send(());
       let mut last_checked_date = Some(chrono::Local::now().date_naive());
 
       let mut ticker = interval(tokio::time::Duration::from_secs(
@@ -348,7 +371,7 @@ impl CoolingRollupController {
       }
     });
 
-    Self { handle, stop_tx }
+    (Self { handle, stop_tx }, first_catch_up_rx)
   }
 
   pub async fn terminate(self) {
@@ -585,6 +608,17 @@ mod tests {
 
     assert_eq!(summary.coverage_minutes, 500);
     assert_eq!(summary.idle.sample_minutes, 500);
+  }
+
+  #[test]
+  fn summarize_day_caps_coverage_at_a_full_day() {
+    // Shutdown flushes can archive a partial window as an extra row, so
+    // a day can hold more rows than minutes; coverage must not exceed a
+    // full day.
+    let minutes: Vec<_> = (0..1445).map(|_| full_sample(2.0, 35.0)).collect();
+    let summary = summarize_day(date(2026, 8, 20), &minutes).unwrap();
+
+    assert_eq!(summary.coverage_minutes, 1440);
   }
 
   // ── days_to_roll_up ──

--- a/core/src/persistence/cooling_rollup.rs
+++ b/core/src/persistence/cooling_rollup.rs
@@ -58,8 +58,6 @@ pub enum CpuLoadBand {
 }
 
 impl CpuLoadBand {
-  pub const ALL: [Self; 4] = [Self::Idle, Self::Low, Self::Mid, Self::High];
-
   pub fn classify(cpu_usage_percent: f32) -> Self {
     if cpu_usage_percent < 10.0 {
       Self::Idle

--- a/core/src/persistence/cooling_rollup.rs
+++ b/core/src/persistence/cooling_rollup.rs
@@ -324,21 +324,23 @@ impl CoolingRollupController {
   /// checks once per [`COOLING_ROLLUP_CHECK_INTERVAL_SECONDS`] whether
   /// the local day has advanced far enough to catch up again.
   ///
-  /// Also returns a receiver that resolves once that first catch-up
-  /// pass has finished (or the worker died), so callers can order work
-  /// that deletes archive rows — the `scheduledDataDeletion` retention
-  /// cleanup — after the backfill has read the rows it needs. Rows
-  /// older than the archive Retention Period can still be present at
-  /// startup (cleanup was disabled, or the app was simply not running
-  /// past the cutoff), and racing the cleanup would silently lose those
-  /// days from the rollup forever.
-  pub fn setup(runtime: Handle) -> (Self, oneshot::Receiver<()>) {
+  /// Also returns a receiver that resolves with the *outcome* of that
+  /// first catch-up pass, so callers can gate work that deletes archive
+  /// rows — the `scheduledDataDeletion` retention cleanup — on the
+  /// backfill having actually read the rows it needs. Rows older than
+  /// the archive Retention Period can still be present at startup
+  /// (cleanup was disabled, or the app was simply not running past the
+  /// cutoff); racing the cleanup, or running it after a failed pass,
+  /// would silently lose those days from the rollup forever. `false`
+  /// (or a closed channel, meaning the worker died) tells the caller to
+  /// skip this boot's cleanup and let the next boot retry both.
+  pub fn setup(runtime: Handle) -> (Self, oneshot::Receiver<bool>) {
     let (stop_tx, mut stop_rx) = watch::channel(false);
     let (first_catch_up_tx, first_catch_up_rx) = oneshot::channel();
 
     let handle = runtime.spawn(async move {
-      run_catch_up().await;
-      let _ = first_catch_up_tx.send(());
+      let first_pass_succeeded = run_catch_up().await;
+      let _ = first_catch_up_tx.send(first_pass_succeeded);
       let mut last_checked_date = Some(chrono::Local::now().date_naive());
 
       let mut ticker = interval(tokio::time::Duration::from_secs(
@@ -363,7 +365,7 @@ impl CoolingRollupController {
           _ = ticker.tick() => {
             let today = chrono::Local::now().date_naive();
             if last_checked_date != Some(today) {
-              run_catch_up().await;
+              let _ = run_catch_up().await;
               last_checked_date = Some(today);
             }
           }
@@ -380,13 +382,18 @@ impl CoolingRollupController {
   }
 }
 
-async fn run_catch_up() {
-  if let Err(e) = catch_up_cooling_rollup().await {
-    log_error!(
-      "Failed to catch up cooling daily rollup",
-      "persistence::cooling_rollup::run_catch_up",
-      Some(e.to_string())
-    );
+/// Run one catch-up pass; `true` when every pending day was rolled up.
+async fn run_catch_up() -> bool {
+  match catch_up_cooling_rollup().await {
+    Ok(()) => true,
+    Err(e) => {
+      log_error!(
+        "Failed to catch up cooling daily rollup",
+        "persistence::cooling_rollup::run_catch_up",
+        Some(e.to_string())
+      );
+      false
+    }
   }
 }
 

--- a/core/src/persistence/cooling_rollup.rs
+++ b/core/src/persistence/cooling_rollup.rs
@@ -1,0 +1,688 @@
+//! Cooling daily rollup worker.
+//!
+//! Derives a long-lived per-local-day cooling summary from the one-minute
+//! Hardware Archive rows (`DATA_ARCHIVE`) so Cooling Insight can show
+//! 90-day and 1-year trends without loading a year of per-minute rows and
+//! without extending the Hardware Archive Retention Period (see
+//! `crate::persistence::archive`). The rollup keeps its own retention
+//! contract ([`COOLING_DAILY_SUMMARY_RETENTION_DAYS`]), independent of
+//! `hardwareArchive.retentionDays`.
+//!
+//! Each one-minute archive row is classified into a [`CpuLoadBand`] by its
+//! average CPU usage for that minute, then folded into that band's
+//! same-day temperature statistics. A minute with no CPU usage reading or
+//! no CPU temperature reading contributes nothing; a day with zero
+//! archived minutes stays absent from the table entirely rather than
+//! becoming a zeroed-out row (see `summarize_day`).
+
+use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+
+use tokio::runtime::Handle;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::{MissedTickBehavior, interval};
+
+use crate::{log_error, log_info};
+
+/// Retention for `cooling_daily_summary` rows. Deliberately independent of
+/// `hardwareArchive.retentionDays` (default 30 days): the whole point of
+/// the daily rollup is to outlive the one-minute archive rows it is
+/// derived from, so Cooling Insight can show 90-day and 1-year trends.
+/// ~400 days covers slightly more than a year of daily rows.
+pub const COOLING_DAILY_SUMMARY_RETENTION_DAYS: u32 = 400;
+
+/// How often the worker checks whether the local calendar day has
+/// advanced. The rollup only ever acts on completed days (yesterday and
+/// earlier), so sub-minute precision is unnecessary; hourly is frequent
+/// enough that a newly completed day is caught up well within the same
+/// day, while staying cheap (the check is a single date-string compare
+/// unless the day actually changed).
+pub const COOLING_ROLLUP_CHECK_INTERVAL_SECONDS: u64 = 60 * 60;
+
+/// CPU-load bands used to bucket each archived one-minute row before
+/// computing per-band cooling temperature summaries. Boundaries are
+/// `[low, high)` in percent, except [`CpuLoadBand::Idle`] and
+/// [`CpuLoadBand::High`], which are open-ended on the low/high end
+/// respectively so no reported usage value (including a >100% or
+/// negative measurement artifact) is ever left unclassified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CpuLoadBand {
+  /// `< 10%`
+  Idle,
+  /// `10% ..< 30%`
+  Low,
+  /// `30% ..< 60%`
+  Mid,
+  /// `>= 60%`
+  High,
+}
+
+impl CpuLoadBand {
+  pub const ALL: [Self; 4] = [Self::Idle, Self::Low, Self::Mid, Self::High];
+
+  pub fn classify(cpu_usage_percent: f32) -> Self {
+    if cpu_usage_percent < 10.0 {
+      Self::Idle
+    } else if cpu_usage_percent < 30.0 {
+      Self::Low
+    } else if cpu_usage_percent < 60.0 {
+      Self::Mid
+    } else {
+      Self::High
+    }
+  }
+}
+
+/// One archived one-minute row's fields relevant to the cooling rollup.
+/// `None` means the minute has no reading for that field, not zero.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct ArchiveMinuteSample {
+  pub cpu_usage_avg: Option<f32>,
+  pub cpu_temperature_avg: Option<f32>,
+  pub cpu_temperature_max: Option<f32>,
+  pub cpu_temperature_min: Option<f32>,
+}
+
+/// CPU temperature summary for one [`CpuLoadBand`] on one local day.
+/// `sample_minutes == 0` implies `avg`/`max`/`min` are all `None`: a band
+/// with no contributing minute is absent, never zero.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct BandSummary {
+  pub avg: Option<f32>,
+  pub max: Option<f32>,
+  pub min: Option<f32>,
+  pub sample_minutes: u32,
+}
+
+/// One `cooling_daily_summary` row: the derived cooling profile for a
+/// single completed local day.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DailyCoolingSummary {
+  pub date: NaiveDate,
+  /// Count of archived one-minute rows found for this local day,
+  /// regardless of whether they carried a usable CPU usage or
+  /// temperature reading. Represents how much of the day was actually
+  /// recorded (the app running), distinct from `sample_minutes` per band.
+  pub coverage_minutes: u32,
+  pub idle: BandSummary,
+  pub low: BandSummary,
+  pub mid: BandSummary,
+  pub high: BandSummary,
+}
+
+/// Fold one local day's archived one-minute rows into a
+/// [`DailyCoolingSummary`]. Returns `None` when `minutes` is empty: a day
+/// with zero archived rows stays absent rather than becoming a zeroed row.
+pub fn summarize_day(
+  date: NaiveDate,
+  minutes: &[ArchiveMinuteSample],
+) -> Option<DailyCoolingSummary> {
+  if minutes.is_empty() {
+    return None;
+  }
+
+  let mut idle = BandAccumulator::default();
+  let mut low = BandAccumulator::default();
+  let mut mid = BandAccumulator::default();
+  let mut high = BandAccumulator::default();
+
+  for minute in minutes {
+    // A minute without a CPU usage reading cannot be classified into any
+    // band; a minute without a temperature reading has nothing to
+    // contribute even once classified. Either way it contributes nothing
+    // - but it was still archived, so it still counts toward
+    // `coverage_minutes` below.
+    let (
+      Some(cpu_usage_avg),
+      Some(temperature_avg),
+      Some(temperature_max),
+      Some(temperature_min),
+    ) = (
+      minute.cpu_usage_avg,
+      minute.cpu_temperature_avg,
+      minute.cpu_temperature_max,
+      minute.cpu_temperature_min,
+    )
+    else {
+      continue;
+    };
+
+    let band = match CpuLoadBand::classify(cpu_usage_avg) {
+      CpuLoadBand::Idle => &mut idle,
+      CpuLoadBand::Low => &mut low,
+      CpuLoadBand::Mid => &mut mid,
+      CpuLoadBand::High => &mut high,
+    };
+    band.push(temperature_avg, temperature_max, temperature_min);
+  }
+
+  Some(DailyCoolingSummary {
+    date,
+    coverage_minutes: minutes.len() as u32,
+    idle: idle.finish(),
+    low: low.finish(),
+    mid: mid.finish(),
+    high: high.finish(),
+  })
+}
+
+/// Accumulates one [`CpuLoadBand`]'s temperature readings for a single
+/// day. `avg` is the average of the per-minute averages (consistent with
+/// how `archive_queries` already aggregates `DATA_ARCHIVE` rows, since
+/// each row is itself already a one-minute average); `max`/`min` are the
+/// extremes across the per-minute extremes.
+#[derive(Default)]
+struct BandAccumulator {
+  sum: f64,
+  count: u32,
+  max: Option<f32>,
+  min: Option<f32>,
+}
+
+impl BandAccumulator {
+  fn push(&mut self, avg: f32, max: f32, min: f32) {
+    self.sum += avg as f64;
+    self.count += 1;
+    self.max = Some(self.max.map_or(max, |current| current.max(max)));
+    self.min = Some(self.min.map_or(min, |current| current.min(min)));
+  }
+
+  fn finish(self) -> BandSummary {
+    BandSummary {
+      avg: (self.count > 0).then(|| (self.sum / self.count as f64) as f32),
+      max: self.max,
+      min: self.min,
+      sample_minutes: self.count,
+    }
+  }
+}
+
+/// Determine which local days still need a rollup.
+///
+/// - `last_summarized_date`: the latest `date` already present in
+///   `cooling_daily_summary` (`MAX(date)`), or `None` if the table is
+///   empty (no rollup has ever run).
+/// - `earliest_archived_local_date`: the local calendar day of the
+///   oldest `DATA_ARCHIVE` row, or `None` if the archive itself is empty.
+///   Only consulted when `last_summarized_date` is `None`, so the very
+///   first catch-up backfills every already-archived day instead of
+///   silently skipping straight to yesterday.
+/// - `yesterday`: the most recent local day that has fully completed.
+///   The rollup never summarizes the current (incomplete) day.
+///
+/// Returns an ordered, inclusive day range with no gaps; empty when there
+/// is nothing archived yet or the rollup is already caught up through
+/// yesterday.
+pub fn days_to_roll_up(
+  last_summarized_date: Option<NaiveDate>,
+  earliest_archived_local_date: Option<NaiveDate>,
+  yesterday: NaiveDate,
+) -> Vec<NaiveDate> {
+  let start = match last_summarized_date {
+    Some(last) => last.succ_opt().unwrap_or(last),
+    None => match earliest_archived_local_date {
+      Some(earliest) => earliest,
+      // Nothing has ever been archived: there is nothing to catch up.
+      None => return Vec::new(),
+    },
+  };
+
+  let mut days = Vec::new();
+  let mut day = start;
+  while day <= yesterday {
+    days.push(day);
+    match day.succ_opt() {
+      Some(next) => day = next,
+      // `NaiveDate` upper bound reached - practically unreachable.
+      None => break,
+    }
+  }
+  days
+}
+
+/// `[start, end)` UTC instants covering local calendar day `date` in
+/// timezone `zone`. `end` is the following local midnight, so the range
+/// is a half-open interval matching the `timestamp >= start AND
+/// timestamp < end` query it is used for.
+pub(crate) fn day_utc_bounds_for_offset<Tz: TimeZone>(
+  date: NaiveDate,
+  zone: &Tz,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+  let start_naive = date.and_hms_opt(0, 0, 0).expect("midnight is always valid");
+  let end_naive = (date + Duration::days(1))
+    .and_hms_opt(0, 0, 0)
+    .expect("midnight is always valid");
+  (
+    local_naive_to_utc(start_naive, zone),
+    local_naive_to_utc(end_naive, zone),
+  )
+}
+
+/// Local calendar day of `zone` in which UTC instant `instant` falls.
+pub(crate) fn utc_to_date_for_offset<Tz: TimeZone>(
+  instant: DateTime<Utc>,
+  zone: &Tz,
+) -> NaiveDate {
+  instant.with_timezone(zone).date_naive()
+}
+
+/// Resolve a naive local wall-clock time to a UTC instant, handling the
+/// two DST edge cases `chrono` can return for `from_local_datetime`. An
+/// ambiguous result (a fall-back overlap) picks the earliest of the two,
+/// which is deterministic and good enough for a once-a-day boundary. A
+/// `None` result (a spring-forward gap, meaning the local time never
+/// occurred) falls back to treating the naive value as if it were
+/// already UTC rather than panicking a persistence worker over a
+/// vanishingly rare midnight edge case.
+fn local_naive_to_utc<Tz: TimeZone>(
+  naive: chrono::NaiveDateTime,
+  zone: &Tz,
+) -> DateTime<Utc> {
+  match zone.from_local_datetime(&naive) {
+    chrono::LocalResult::Single(dt) => dt.with_timezone(&Utc),
+    chrono::LocalResult::Ambiguous(earliest, _latest) => earliest.with_timezone(&Utc),
+    chrono::LocalResult::None => DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc),
+  }
+}
+
+/// [`day_utc_bounds_for_offset`] using the OS's configured local
+/// timezone, matching the "local date" used throughout Core (see
+/// `crate::persistence::storage_health::local_storage_health_date_string`).
+pub fn local_day_utc_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
+  day_utc_bounds_for_offset(date, &chrono::Local)
+}
+
+/// [`utc_to_date_for_offset`] using the OS's configured local timezone.
+pub fn utc_to_local_date(instant: DateTime<Utc>) -> NaiveDate {
+  utc_to_date_for_offset(instant, &chrono::Local)
+}
+
+/// Background controller for the cooling rollup worker. Unlike
+/// [`crate::persistence::archive::ArchiveController`], this worker does
+/// not subscribe to the `EventBus` — it only reads already-persisted
+/// archive rows and writes daily summaries, so it needs no live snapshot
+/// stream.
+pub struct CoolingRollupController {
+  handle: JoinHandle<()>,
+  stop_tx: watch::Sender<bool>,
+}
+
+impl CoolingRollupController {
+  /// Spawn the rollup worker on `runtime`. Runs an immediate catch-up
+  /// pass (covering every completed local day missed since the last
+  /// rollup, or since the earliest archived day on a first run), then
+  /// checks once per [`COOLING_ROLLUP_CHECK_INTERVAL_SECONDS`] whether
+  /// the local day has advanced far enough to catch up again.
+  pub fn setup(runtime: Handle) -> Self {
+    let (stop_tx, mut stop_rx) = watch::channel(false);
+
+    let handle = runtime.spawn(async move {
+      run_catch_up().await;
+      let mut last_checked_date = Some(chrono::Local::now().date_naive());
+
+      let mut ticker = interval(tokio::time::Duration::from_secs(
+        COOLING_ROLLUP_CHECK_INTERVAL_SECONDS,
+      ));
+      ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+      ticker.tick().await;
+
+      loop {
+        tokio::select! {
+          biased;
+          changed = stop_rx.changed() => {
+            if changed.is_err() || *stop_rx.borrow() {
+              log_info!(
+                "cooling rollup worker shutdown signal received",
+                "persistence::cooling_rollup",
+                None::<&str>
+              );
+              break;
+            }
+          }
+          _ = ticker.tick() => {
+            let today = chrono::Local::now().date_naive();
+            if last_checked_date != Some(today) {
+              run_catch_up().await;
+              last_checked_date = Some(today);
+            }
+          }
+        }
+      }
+    });
+
+    Self { handle, stop_tx }
+  }
+
+  pub async fn terminate(self) {
+    let _ = self.stop_tx.send(true);
+    let _ = self.handle.await;
+  }
+}
+
+async fn run_catch_up() {
+  if let Err(e) = catch_up_cooling_rollup().await {
+    log_error!(
+      "Failed to catch up cooling daily rollup",
+      "persistence::cooling_rollup::run_catch_up",
+      Some(e.to_string())
+    );
+  }
+}
+
+async fn catch_up_cooling_rollup() -> Result<(), sqlx::Error> {
+  use crate::infrastructure::database;
+
+  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+  let last_summarized_date =
+    database::cooling_daily_summary::max_summarized_date().await?;
+  let earliest_archived_local_date = match last_summarized_date {
+    Some(_) => None,
+    None => database::cooling_daily_summary::earliest_archived_timestamp()
+      .await?
+      .map(utc_to_local_date),
+  };
+
+  for date in days_to_roll_up(
+    last_summarized_date,
+    earliest_archived_local_date,
+    yesterday,
+  ) {
+    roll_up_day(date).await?;
+  }
+
+  Ok(())
+}
+
+async fn roll_up_day(date: NaiveDate) -> Result<(), sqlx::Error> {
+  use crate::infrastructure::database;
+
+  let (start, end) = local_day_utc_bounds(date);
+  let minutes =
+    database::cooling_daily_summary::select_archive_minutes_for_range(&start, &end)
+      .await?;
+
+  match summarize_day(date, &minutes) {
+    Some(summary) => database::cooling_daily_summary::upsert(&summary).await,
+    // Day without samples stays absent - never insert a zeroed row.
+    None => Ok(()),
+  }
+}
+
+/// Delete `cooling_daily_summary` rows older than
+/// [`COOLING_DAILY_SUMMARY_RETENTION_DAYS`]. Called from
+/// `crate::persistence::archive::cleanup_old_data` at the same
+/// `scheduledDataDeletion`-gated startup site as the Hardware Archive
+/// cleanup, but with its own fixed retention window rather than the
+/// user-configurable `hardwareArchive.retentionDays`.
+pub async fn cleanup_old_data() {
+  use crate::infrastructure::database;
+
+  if let Err(e) =
+    database::cooling_daily_summary::delete_old_data(COOLING_DAILY_SUMMARY_RETENTION_DAYS)
+      .await
+  {
+    log_error!(
+      "Failed to delete old cooling daily summary data",
+      "persistence::cooling_rollup::cleanup_old_data",
+      Some(e.to_string())
+    );
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── CpuLoadBand::classify ──
+
+  #[test]
+  fn classify_idle_band() {
+    assert_eq!(CpuLoadBand::classify(0.0), CpuLoadBand::Idle);
+    assert_eq!(CpuLoadBand::classify(5.0), CpuLoadBand::Idle);
+    assert_eq!(CpuLoadBand::classify(9.999), CpuLoadBand::Idle);
+  }
+
+  #[test]
+  fn classify_low_band_boundary_is_inclusive() {
+    assert_eq!(CpuLoadBand::classify(10.0), CpuLoadBand::Low);
+    assert_eq!(CpuLoadBand::classify(20.0), CpuLoadBand::Low);
+    assert_eq!(CpuLoadBand::classify(29.999), CpuLoadBand::Low);
+  }
+
+  #[test]
+  fn classify_mid_band_boundary_is_inclusive() {
+    assert_eq!(CpuLoadBand::classify(30.0), CpuLoadBand::Mid);
+    assert_eq!(CpuLoadBand::classify(45.0), CpuLoadBand::Mid);
+    assert_eq!(CpuLoadBand::classify(59.999), CpuLoadBand::Mid);
+  }
+
+  #[test]
+  fn classify_high_band_boundary_is_inclusive_and_open_ended() {
+    assert_eq!(CpuLoadBand::classify(60.0), CpuLoadBand::High);
+    assert_eq!(CpuLoadBand::classify(100.0), CpuLoadBand::High);
+    // Measurement noise above 100% must still land in a band.
+    assert_eq!(CpuLoadBand::classify(150.0), CpuLoadBand::High);
+  }
+
+  #[test]
+  fn classify_negative_usage_falls_back_to_idle() {
+    // Never expected in practice, but classify() must be total: no value
+    // should be left unclassified.
+    assert_eq!(CpuLoadBand::classify(-1.0), CpuLoadBand::Idle);
+  }
+
+  // ── summarize_day ──
+
+  fn sample(
+    cpu_usage_avg: Option<f32>,
+    temp_avg: Option<f32>,
+    temp_max: Option<f32>,
+    temp_min: Option<f32>,
+  ) -> ArchiveMinuteSample {
+    ArchiveMinuteSample {
+      cpu_usage_avg,
+      cpu_temperature_avg: temp_avg,
+      cpu_temperature_max: temp_max,
+      cpu_temperature_min: temp_min,
+    }
+  }
+
+  fn full_sample(cpu_usage_avg: f32, temp: f32) -> ArchiveMinuteSample {
+    sample(
+      Some(cpu_usage_avg),
+      Some(temp),
+      Some(temp + 1.0),
+      Some(temp - 1.0),
+    )
+  }
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  #[test]
+  fn summarize_day_returns_none_for_a_day_without_samples() {
+    assert_eq!(summarize_day(date(2026, 8, 20), &[]), None);
+  }
+
+  #[test]
+  fn summarize_day_places_single_minute_in_its_band() {
+    let summary = summarize_day(date(2026, 8, 20), &[full_sample(5.0, 40.0)]).unwrap();
+
+    assert_eq!(summary.date, date(2026, 8, 20));
+    assert_eq!(summary.coverage_minutes, 1);
+    assert_eq!(summary.idle.sample_minutes, 1);
+    assert_eq!(summary.idle.avg, Some(40.0));
+    assert_eq!(summary.idle.max, Some(41.0));
+    assert_eq!(summary.idle.min, Some(39.0));
+    // Untouched bands stay fully absent, not zero.
+    for band in [summary.low, summary.mid, summary.high] {
+      assert_eq!(band.sample_minutes, 0);
+      assert_eq!(band.avg, None);
+      assert_eq!(band.max, None);
+      assert_eq!(band.min, None);
+    }
+  }
+
+  #[test]
+  fn summarize_day_excludes_minutes_without_a_temperature_reading() {
+    let minutes = [
+      full_sample(5.0, 40.0),
+      // CPU usage was recorded (idle-band), but no temperature sensor
+      // reading that minute - this must contribute nothing.
+      sample(Some(5.0), None, None, None),
+    ];
+    let summary = summarize_day(date(2026, 8, 20), &minutes).unwrap();
+
+    // Coverage counts every archived minute regardless of temperature
+    // availability.
+    assert_eq!(summary.coverage_minutes, 2);
+    // But the band's own sample count/aggregate ignores the missing one.
+    assert_eq!(summary.idle.sample_minutes, 1);
+    assert_eq!(summary.idle.avg, Some(40.0));
+  }
+
+  #[test]
+  fn summarize_day_excludes_minutes_without_a_cpu_usage_reading() {
+    let minutes = [
+      full_sample(5.0, 40.0),
+      // No CPU usage reading at all - cannot be classified into any band.
+      sample(None, Some(99.0), Some(99.0), Some(99.0)),
+    ];
+    let summary = summarize_day(date(2026, 8, 20), &minutes).unwrap();
+
+    assert_eq!(summary.coverage_minutes, 2);
+    assert_eq!(summary.idle.sample_minutes, 1);
+    let total_sample_minutes: u32 =
+      [summary.idle, summary.low, summary.mid, summary.high]
+        .iter()
+        .map(|b| b.sample_minutes)
+        .sum();
+    assert_eq!(
+      total_sample_minutes, 1,
+      "the unclassifiable 99.0 reading must not silently land in a band"
+    );
+  }
+
+  #[test]
+  fn summarize_day_aggregates_avg_of_avgs_and_extremes_across_the_band() {
+    let minutes = [
+      full_sample(65.0, 60.0),
+      full_sample(70.0, 80.0),
+      full_sample(75.0, 70.0),
+    ];
+    let summary = summarize_day(date(2026, 8, 20), &minutes).unwrap();
+
+    assert_eq!(summary.high.sample_minutes, 3);
+    assert_eq!(summary.high.avg, Some(70.0));
+    // full_sample uses temp + 1.0 / temp - 1.0 for max/min.
+    assert_eq!(summary.high.max, Some(81.0));
+    assert_eq!(summary.high.min, Some(59.0));
+  }
+
+  #[test]
+  fn summarize_day_reports_partial_day_coverage() {
+    let minutes: Vec<_> = (0..500).map(|_| full_sample(2.0, 35.0)).collect();
+    let summary = summarize_day(date(2026, 8, 20), &minutes).unwrap();
+
+    assert_eq!(summary.coverage_minutes, 500);
+    assert_eq!(summary.idle.sample_minutes, 500);
+  }
+
+  // ── days_to_roll_up ──
+
+  #[test]
+  fn days_to_roll_up_is_empty_when_nothing_is_archived_yet() {
+    assert_eq!(days_to_roll_up(None, None, date(2026, 8, 20)), Vec::new());
+  }
+
+  #[test]
+  fn days_to_roll_up_backfills_from_earliest_archived_day_on_first_run() {
+    let days = days_to_roll_up(None, Some(date(2026, 8, 1)), date(2026, 8, 3));
+    assert_eq!(
+      days,
+      vec![date(2026, 8, 1), date(2026, 8, 2), date(2026, 8, 3)]
+    );
+  }
+
+  #[test]
+  fn days_to_roll_up_is_empty_when_already_caught_up_through_yesterday() {
+    let days = days_to_roll_up(Some(date(2026, 8, 20)), None, date(2026, 8, 20));
+    assert_eq!(days, Vec::new());
+  }
+
+  #[test]
+  fn days_to_roll_up_covers_days_missed_while_the_app_was_not_running() {
+    let days = days_to_roll_up(Some(date(2026, 8, 18)), None, date(2026, 8, 20));
+    assert_eq!(days, vec![date(2026, 8, 19), date(2026, 8, 20)]);
+  }
+
+  #[test]
+  fn days_to_roll_up_ignores_earliest_archived_once_a_rollup_exists() {
+    let days = days_to_roll_up(
+      Some(date(2026, 8, 19)),
+      Some(date(2026, 1, 1)),
+      date(2026, 8, 20),
+    );
+    assert_eq!(days, vec![date(2026, 8, 20)]);
+  }
+
+  #[test]
+  fn days_to_roll_up_is_empty_when_last_summarized_is_not_before_yesterday() {
+    let days = days_to_roll_up(Some(date(2026, 8, 25)), None, date(2026, 8, 20));
+    assert_eq!(days, Vec::new());
+  }
+
+  // ── day_utc_bounds_for_offset / utc_to_date_for_offset ──
+  //
+  // Use a fixed offset rather than `chrono::Local` so these are
+  // deterministic regardless of the machine/CI runner's configured
+  // timezone.
+
+  fn jst() -> chrono::FixedOffset {
+    chrono::FixedOffset::east_opt(9 * 3600).unwrap()
+  }
+
+  fn utc(input: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(input)
+      .unwrap()
+      .with_timezone(&Utc)
+  }
+
+  #[test]
+  fn day_bounds_for_utc_offset_match_calendar_midnight() {
+    let (start, end) = day_utc_bounds_for_offset(date(2026, 8, 15), &Utc);
+    assert_eq!(start, utc("2026-08-15T00:00:00Z"));
+    assert_eq!(end, utc("2026-08-16T00:00:00Z"));
+  }
+
+  #[test]
+  fn day_bounds_shift_by_a_positive_offset() {
+    let (start, end) = day_utc_bounds_for_offset(date(2026, 8, 15), &jst());
+    // JST local midnight is the previous UTC day at 15:00.
+    assert_eq!(start, utc("2026-08-14T15:00:00Z"));
+    assert_eq!(end, utc("2026-08-15T15:00:00Z"));
+  }
+
+  #[test]
+  fn day_bounds_shift_by_a_negative_offset() {
+    let pst = chrono::FixedOffset::west_opt(8 * 3600).unwrap();
+    let (start, end) = day_utc_bounds_for_offset(date(2026, 8, 15), &pst);
+    assert_eq!(start, utc("2026-08-15T08:00:00Z"));
+    assert_eq!(end, utc("2026-08-16T08:00:00Z"));
+  }
+
+  #[test]
+  fn utc_to_date_for_offset_maps_instant_to_local_calendar_day() {
+    assert_eq!(
+      utc_to_date_for_offset(utc("2026-08-14T15:00:00Z"), &jst()),
+      date(2026, 8, 15),
+      "exactly JST midnight must fall on the new day"
+    );
+    assert_eq!(
+      utc_to_date_for_offset(utc("2026-08-14T14:59:59Z"), &jst()),
+      date(2026, 8, 14),
+      "one second before JST midnight must stay on the previous day"
+    );
+  }
+}

--- a/core/src/persistence/mod.rs
+++ b/core/src/persistence/mod.rs
@@ -11,12 +11,14 @@
 
 pub mod archive;
 pub mod archive_data;
+pub mod cooling_rollup;
 pub mod preflight;
 pub mod storage_health;
 
 pub use archive::{
   ArchiveController, HARDWARE_ARCHIVE_INTERVAL_SECONDS, cleanup_old_data,
 };
+pub use cooling_rollup::CoolingRollupController;
 pub use storage_health::{
   ExternalComponentGuidanceSink, StorageHealthController,
   local_storage_health_date_string, refresh_storage_health_for_date,

--- a/docs/adr/0018-cooling-daily-rollup-retention.md
+++ b/docs/adr/0018-cooling-daily-rollup-retention.md
@@ -1,0 +1,9 @@
+# Cooling Daily Rollup Retention
+
+Status: accepted
+
+The cooling daily rollup (`cooling_daily_summary`) is stored and retained separately from the Hardware Archive. Hardware Archive rows summarize one-minute windows and are kept for `hardwareArchive.retentionDays` (default 30 days); the daily rollup derives one row per completed local day from those rows and keeps its own fixed retention window of about 400 days, defined as a Core constant rather than a user-configurable setting.
+
+This lets Cooling Insight show 90-day and 1-year CPU temperature trends without loading a year of per-minute archive rows and without extending how long the much larger one-minute Hardware Archive history has to be kept. It follows the same separation already established for Storage Health history (ADR 0004): a derived, long-lived summary can outlive the shorter-window raw data it is computed from.
+
+The rollup's own cleanup runs from the same `scheduledDataDeletion`-gated startup site as the Hardware Archive cleanup (`persistence::archive::cleanup_old_data`), so there is still exactly one place that decides whether startup deletion runs at all - only the retention window differs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ ADR status describes decision maturity, not release status.
 - [0015 Performance and System Specifications as Sidebar Destinations](0015-performance-and-system-specifications-destinations.md)
 - [0016 GPU Attribution on the Performance Screen](0016-gpu-attribution-on-the-performance-screen.md)
 - [0017 Suspend Hidden Windows WebViews](0017-suspend-hidden-windows-webviews.md)
+- [0018 Cooling Daily Rollup Retention](0018-cooling-daily-rollup-retention.md)

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -233,6 +233,19 @@ Hardware Archive. Dashboard display can use the latest record and recent
 changes, while future historical views can keep following long-term storage
 health even if short-window utilization archive settings are reduced.
 
+The cooling daily rollup (`core/src/persistence/cooling_rollup.rs`) derives one
+`cooling_daily_summary` row per completed local day from the one-minute
+Hardware Archive rows: CPU temperature avg/min/max per CPU-load band
+(idle/low/mid/high) plus per-band sample-minute counts and a day coverage
+count. It keeps its own fixed retention window
+(`cooling_rollup::COOLING_DAILY_SUMMARY_RETENTION_DAYS`, about 400 days),
+independent of `hardwareArchive.retentionDays`, so Cooling Insight can show
+90-day and 1-year trends without extending how long raw one-minute rows are
+kept. A day with zero archived minutes has no row at all, and a CPU-load band
+with zero contributing minutes leaves its temperature columns absent - never
+zero. Its cleanup runs from the same `scheduledDataDeletion`-gated startup
+site as the Hardware Archive cleanup (see ADR 0018).
+
 ## Settings Ownership
 
 Settings are split by consumer:

--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -122,6 +122,32 @@ pub fn get_migrations() -> Vec<SchemaMigration> {
         ALTER TABLE DATA_ARCHIVE ADD COLUMN package_power_min REAL;
       "#,
     },
+    SchemaMigration {
+      version: 11,
+      description: "create_cooling_daily_summary",
+      sql: r#"
+        CREATE TABLE cooling_daily_summary (
+          date TEXT PRIMARY KEY,
+          idle_cpu_temperature_avg REAL,
+          idle_cpu_temperature_max REAL,
+          idle_cpu_temperature_min REAL,
+          idle_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          low_cpu_temperature_avg REAL,
+          low_cpu_temperature_max REAL,
+          low_cpu_temperature_min REAL,
+          low_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          mid_cpu_temperature_avg REAL,
+          mid_cpu_temperature_max REAL,
+          mid_cpu_temperature_min REAL,
+          mid_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          high_cpu_temperature_avg REAL,
+          high_cpu_temperature_max REAL,
+          high_cpu_temperature_min REAL,
+          high_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          coverage_minutes INTEGER NOT NULL
+        );
+      "#,
+    },
   ]
 }
 
@@ -209,14 +235,44 @@ mod tests {
   }
 
   #[test]
+  fn migration_v11_creates_cooling_daily_summary_table() {
+    let migrations = get_migrations();
+    let v11 = migrations
+      .iter()
+      .find(|m| m.version == 11)
+      .expect("Version 11 up migration must exist");
+    assert!(v11.sql.contains("CREATE TABLE cooling_daily_summary"));
+    assert!(v11.sql.contains("date TEXT PRIMARY KEY"));
+    for band in ["idle", "low", "mid", "high"] {
+      assert!(
+        v11.sql
+          .contains(&format!("{band}_cpu_temperature_avg REAL"))
+      );
+      assert!(
+        v11.sql
+          .contains(&format!("{band}_cpu_temperature_max REAL"))
+      );
+      assert!(
+        v11.sql
+          .contains(&format!("{band}_cpu_temperature_min REAL"))
+      );
+      assert!(
+        v11.sql
+          .contains(&format!("{band}_sample_minutes INTEGER NOT NULL DEFAULT 0"))
+      );
+    }
+    assert!(v11.sql.contains("coverage_minutes INTEGER NOT NULL"));
+  }
+
+  #[test]
   fn max_migration_version() {
-    assert_eq!(get_max_migration_version(), 10);
+    assert_eq!(get_max_migration_version(), 11);
   }
 
   #[test]
   fn migration_count() {
     let migrations = get_migrations();
-    assert_eq!(migrations.len(), 10);
+    assert_eq!(migrations.len(), 11);
   }
 
   #[test]
@@ -320,5 +376,63 @@ mod tests {
     .execute(&pool)
     .await
     .expect("insert into storage_devices must succeed after migrations");
+  }
+
+  /// Regression guard for the cooling daily rollup (#2015): the shipped
+  /// migration set must create `cooling_daily_summary` with one row per
+  /// local day and let a full 4-band insert succeed.
+  #[tokio::test]
+  async fn shipped_migrations_create_cooling_daily_summary_table_and_allow_insert() {
+    use hardviz_core::infrastructure::database::migrate;
+    use sqlx::sqlite::SqlitePool;
+
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite:{}", file.path().to_string_lossy());
+    let pool = SqlitePool::connect(&url).await.unwrap();
+
+    migrate::run_on_pool(&pool, get_migrations())
+      .await
+      .expect("the shipped migration set must apply cleanly");
+
+    let exists: (i64,) = sqlx::query_as(
+      "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = 'cooling_daily_summary'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(exists.0, 1, "table `cooling_daily_summary` must exist after migrations");
+
+    sqlx::query(
+      "INSERT INTO cooling_daily_summary (
+         date,
+         idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+         low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+         mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+         high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+         coverage_minutes
+       ) VALUES (
+         '2026-06-21',
+         35.0, 40.0, 30.0, 600,
+         45.0, 50.0, 40.0, 300,
+         NULL, NULL, NULL, 0,
+         70.0, 80.0, 60.0, 120,
+         1020
+       )",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert into cooling_daily_summary must succeed after migrations");
+
+    // `date` is the primary key: a second row for the same local day must
+    // be rejected rather than silently duplicating the day.
+    let duplicate = sqlx::query(
+      "INSERT INTO cooling_daily_summary (date, coverage_minutes) VALUES ('2026-06-21', 1)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+      duplicate.is_err(),
+      "date must be a primary key: one row per local day"
+    );
   }
 }

--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -245,19 +245,23 @@ mod tests {
     assert!(v11.sql.contains("date TEXT PRIMARY KEY"));
     for band in ["idle", "low", "mid", "high"] {
       assert!(
-        v11.sql
+        v11
+          .sql
           .contains(&format!("{band}_cpu_temperature_avg REAL"))
       );
       assert!(
-        v11.sql
+        v11
+          .sql
           .contains(&format!("{band}_cpu_temperature_max REAL"))
       );
       assert!(
-        v11.sql
+        v11
+          .sql
           .contains(&format!("{band}_cpu_temperature_min REAL"))
       );
       assert!(
-        v11.sql
+        v11
+          .sql
           .contains(&format!("{band}_sample_minutes INTEGER NOT NULL DEFAULT 0"))
       );
     }
@@ -400,7 +404,10 @@ mod tests {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(exists.0, 1, "table `cooling_daily_summary` must exist after migrations");
+    assert_eq!(
+      exists.0, 1,
+      "table `cooling_daily_summary` must exist after migrations"
+    );
 
     sqlx::query(
       "INSERT INTO cooling_daily_summary (

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -334,6 +334,18 @@ pub fn run() {
           }
         }
 
+        // The cooling daily rollup derives its summary from whatever
+        // Hardware Archive rows already exist in the database, so it
+        // starts independently of `hardware_archive.enabled`: even when
+        // live archive collection is currently turned off, already
+        // archived days it hasn't caught up on yet still get rolled up.
+        {
+          let cooling_rollup =
+            hardviz_core::persistence::CoolingRollupController::setup(runtime_handle.clone());
+          let ws = app.state::<workers::WorkersState>();
+          ws.cooling_rollup.lock().unwrap().replace(cooling_rollup);
+        }
+
         if core_settings.storage_health.enabled {
           match core_settings.storage_health_identity.hash_key_bytes() {
             Ok(identity_hash_key) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -403,13 +403,22 @@ pub fn run() {
         // rows older than the retention cutoff can still be present at
         // startup, and the backfill must read them before they are
         // deleted or those days would be lost from the rollup forever.
-        // The receiver also resolves if the rollup worker dies, so
-        // cleanup can never be blocked indefinitely.
+        // Cleanup runs only when that pass actually succeeded — after a
+        // failed pass (or a dead worker, which closes the channel) this
+        // boot's cleanup is skipped so a transient DB error cannot let
+        // deletion outrun the rollup; the next boot retries both.
         if core_settings.hardware_archive.scheduled_data_deletion {
           let retention_days = core_settings.hardware_archive.retention_days;
           tauri::async_runtime::spawn(async move {
-            let _ = cooling_rollup_first_catch_up.await;
-            hardviz_core::persistence::cleanup_old_data(retention_days).await;
+            if cooling_rollup_first_catch_up.await == Ok(true) {
+              hardviz_core::persistence::cleanup_old_data(retention_days).await;
+            } else {
+              log_warn!(
+                "Skipping this boot's retention cleanup: the cooling rollup's first catch-up did not succeed",
+                "lib::run",
+                None::<&str>
+              );
+            }
           });
         }
       } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -339,12 +339,13 @@ pub fn run() {
         // starts independently of `hardware_archive.enabled`: even when
         // live archive collection is currently turned off, already
         // archived days it hasn't caught up on yet still get rolled up.
-        {
-          let cooling_rollup =
+        let cooling_rollup_first_catch_up = {
+          let (cooling_rollup, first_catch_up) =
             hardviz_core::persistence::CoolingRollupController::setup(runtime_handle.clone());
           let ws = app.state::<workers::WorkersState>();
           ws.cooling_rollup.lock().unwrap().replace(cooling_rollup);
-        }
+          first_catch_up
+        };
 
         if core_settings.storage_health.enabled {
           match core_settings.storage_health_identity.hash_key_bytes() {
@@ -397,10 +398,19 @@ pub fn run() {
         // The `scheduled_data_deletion` flag still means startup cleanup,
         // not a recurring background schedule.
         // See `hardviz_core::persistence::cleanup_old_data` doc comment.
+        //
+        // It waits for the cooling rollup's first catch-up pass: archive
+        // rows older than the retention cutoff can still be present at
+        // startup, and the backfill must read them before they are
+        // deleted or those days would be lost from the rollup forever.
+        // The receiver also resolves if the rollup worker dies, so
+        // cleanup can never be blocked indefinitely.
         if core_settings.hardware_archive.scheduled_data_deletion {
-          tauri::async_runtime::spawn(hardviz_core::persistence::cleanup_old_data(
-            core_settings.hardware_archive.retention_days,
-          ));
+          let retention_days = core_settings.hardware_archive.retention_days;
+          tauri::async_runtime::spawn(async move {
+            let _ = cooling_rollup_first_catch_up.await;
+            hardviz_core::persistence::cleanup_old_data(retention_days).await;
+          });
         }
       } else {
         // Database schema is incompatible — show error dialog

--- a/src-tauri/src/workers/mod.rs
+++ b/src-tauri/src/workers/mod.rs
@@ -10,6 +10,7 @@ pub struct WorkersState {
   pub monitor: Mutex<Option<hardviz_core::collector::SystemMonitorController>>,
   pub window_adapter: Mutex<Option<WindowAdapter>>,
   pub hw_archive: Mutex<Option<hardviz_core::persistence::ArchiveController>>,
+  pub cooling_rollup: Mutex<Option<hardviz_core::persistence::CoolingRollupController>>,
   pub storage_health: Mutex<Option<hardviz_core::persistence::StorageHealthController>>,
   /// On-demand Live Storage Health collector (ADR 0006). Not a worker —
   /// no background task, so `terminate_all` leaves it alone. `None` when
@@ -44,6 +45,7 @@ impl WorkersState {
     let monitor = self.monitor.lock().unwrap().take();
     let window_adapter = self.window_adapter.lock().unwrap().take();
     let hw_archive = self.hw_archive.lock().unwrap().take();
+    let cooling_rollup = self.cooling_rollup.lock().unwrap().take();
     let storage_health = self.storage_health.lock().unwrap().take();
     let tray = self.tray.lock().unwrap().take();
 
@@ -63,6 +65,10 @@ impl WorkersState {
 
     if let Some(hw_archive) = hw_archive {
       hw_archive.terminate().await;
+    }
+
+    if let Some(cooling_rollup) = cooling_rollup {
+      cooling_rollup.terminate().await;
     }
 
     if let Some(storage_health) = storage_health {


### PR DESCRIPTION
## Summary

- add a Core-owned `cooling_daily_summary` daily rollup derived from the one-minute Hardware Archive rows: per-CPU-load-band temperature summaries (idle 0–10% / low 10–30% / mid 30–60% / high 60–100%), per-band sample minutes, and per-day coverage minutes
- preserve absence honestly: a minute without a usable CPU usage or temperature reading contributes nothing, and a day with zero archived rows stays absent instead of becoming a zeroed row
- run the rollup as a Core persistence worker with startup catch-up (first run backfills from the earliest archived day; later runs continue from `MAX(date)`), checking hourly for local-day advancement
- keep a retention contract of its own (400 days, Core constant) independent of `hardwareArchive.retentionDays`, cleaned from the same `scheduledDataDeletion`-gated startup site as the Hardware Archive cleanup; recorded as ADR 0018
- compare archive timestamps via epoch milliseconds computed in SQL instead of TEXT comparison, because sqlx's native `DateTime<Utc>` binding writes a `+00:00` suffix that does not sort correctly against differently-shaped bind strings at exact-second boundaries

The rollup worker starts independently of `hardware_archive.enabled`: it only reads already-persisted rows, so already-archived days still catch up while live collection is off.

This is the first slice of the Cooling Insight foundation (#1666); the idle baseline (#2016) and the query commands (#2017) build on this table.

## Related Issues

Closes #2015
Relates to #1666

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (Core/App persistence only; no UI changes)

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- 32 new tests: band classification boundaries, NULL usage/temperature exclusion, partial-day coverage, absent days, catch-up day-range cases, upsert idempotency, half-open range boundaries, retention cutoff (day 400 kept / 401 deleted), and a migration integration test applying the shipped v11 SQL
- `cargo test -p hardviz-core --lib` → 390 passed
- `cargo tauri-test` → all targets green
- `cargo tauri-fmt -- --check` → no diff; `cargo tauri-lint` → 0 warnings

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic daily cooling summaries from archived hardware data.
  * Summaries include CPU-load bands, temperature statistics, coverage, and local-day handling.
  * Added background catch-up processing, including daylight-saving transitions.
  * Added independent retention of approximately 400 days for daily summaries.

* **Bug Fixes**
  * Improved startup coordination, cleanup safety, and worker shutdown reliability.

* **Documentation**
  * Documented summary generation, retention, and storage behavior.

* **Chores**
  * Added database storage and migration support for daily cooling summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->