### PR TITLE
feat(performance): add switchable Power Draw modes to Performance views

### DIFF
--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -111,6 +111,101 @@ test.describe("Grouped navigation destinations", () => {
     await saveCapture(page, "performance-monitor-desktop");
   });
 
+  test("switches Monitor Power Draw between current and graph modes", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+    await seedHardwareHistory(page);
+    await page.getByRole("tab", { name: "Monitor" }).click();
+
+    await expect(
+      page.getByTestId("performance-monitor-power-mode-switcher"),
+    ).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Current" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(
+      page.getByTestId("performance-monitor-power-rail"),
+    ).toContainText("Package");
+    await saveCapture(page, "performance-monitor-power-current");
+
+    await page.getByRole("tab", { name: "Graph" }).click();
+    await expect(
+      page.getByTestId("performance-monitor-power-graph"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("performance-monitor-power-rail"),
+    ).toHaveCount(0);
+    await saveCapture(page, "performance-monitor-power-graph");
+
+    await page.setViewportSize({ width: 520, height: 800 });
+    await expect(
+      page.getByTestId("performance-monitor-power-mode-switcher"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("performance-monitor-power-graph"),
+    ).toBeVisible();
+    const assertNoMonitorOverflow = async () => {
+      const overflow = await page.evaluate(() => {
+        const screen = document.querySelector<HTMLElement>(
+          '[data-testid="performance-screen"]',
+        );
+        return {
+          documentScrollWidth: document.documentElement.scrollWidth,
+          documentClientWidth: document.documentElement.clientWidth,
+          documentScrollHeight: document.documentElement.scrollHeight,
+          documentClientHeight: document.documentElement.clientHeight,
+          screenScrollWidth: screen?.scrollWidth ?? 0,
+          screenClientWidth: screen?.clientWidth ?? 0,
+          screenScrollHeight: screen?.scrollHeight ?? 0,
+          screenClientHeight: screen?.clientHeight ?? 0,
+        };
+      });
+      expect(overflow.documentScrollWidth).toBeLessThanOrEqual(
+        overflow.documentClientWidth,
+      );
+      expect(overflow.documentScrollHeight).toBeLessThanOrEqual(
+        overflow.documentClientHeight,
+      );
+      expect(overflow.screenScrollWidth).toBeLessThanOrEqual(
+        overflow.screenClientWidth,
+      );
+      expect(overflow.screenScrollHeight).toBeLessThanOrEqual(
+        overflow.screenClientHeight,
+      );
+    };
+
+    await assertNoMonitorOverflow();
+    await saveCapture(page, "performance-monitor-power-graph-compact-window");
+
+    await page.getByRole("tab", { name: "Current" }).click();
+    await expect(
+      page.getByTestId("performance-monitor-power-rail"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("performance-monitor-power-graph"),
+    ).toHaveCount(0);
+    await assertNoMonitorOverflow();
+    await saveCapture(page, "performance-monitor-power-current-compact-window");
+
+    await page.getByRole("tab", { name: "Graph" }).click();
+
+    await navigateTo(page, "settings");
+    await navigateTo(page, "performance");
+    await expect(page.getByRole("tab", { name: "Monitor" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(page.getByRole("tab", { name: "Graph" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(
+      page.getByTestId("performance-monitor-power-graph"),
+    ).toBeVisible();
+  });
+
   test("attributes the GPU readings to a named adapter the user can change", async ({
     page,
   }) => {

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -111,15 +111,36 @@ test.describe("Grouped navigation destinations", () => {
     await saveCapture(page, "performance-monitor-desktop");
   });
 
-  test("switches Monitor Power Draw between current and graph modes", async ({
+  test("shares Power Draw modes between the Panels power panel and Monitor", async ({
     page,
   }) => {
     await gotoApp(page);
     await seedHardwareHistory(page);
+
+    const powerPanel = page.getByTestId("performance-panel-power");
+    await expect(powerPanel).toBeVisible();
+    await expect(
+      powerPanel.getByTestId("performance-power-mode-switcher"),
+    ).toBeVisible();
+    await expect(
+      powerPanel.getByRole("tab", { name: "Current" }),
+    ).toHaveAttribute("data-state", "active");
+    await powerPanel.getByRole("tab", { name: "Graph" }).click();
+    await expect(
+      powerPanel.getByTestId("performance-power-graph"),
+    ).toBeVisible();
+    await saveCapture(page, "performance-panels-power-graph");
+
     await page.getByRole("tab", { name: "Monitor" }).click();
+    await expect(page.getByRole("tab", { name: "Graph" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    await expect(page.getByTestId("performance-power-graph")).toBeVisible();
+    await page.getByRole("tab", { name: "Current" }).click();
 
     await expect(
-      page.getByTestId("performance-monitor-power-mode-switcher"),
+      page.getByTestId("performance-power-mode-switcher"),
     ).toBeVisible();
     await expect(page.getByRole("tab", { name: "Current" })).toHaveAttribute(
       "data-state",
@@ -131,9 +152,7 @@ test.describe("Grouped navigation destinations", () => {
     await saveCapture(page, "performance-monitor-power-current");
 
     await page.getByRole("tab", { name: "Graph" }).click();
-    await expect(
-      page.getByTestId("performance-monitor-power-graph"),
-    ).toBeVisible();
+    await expect(page.getByTestId("performance-power-graph")).toBeVisible();
     await expect(
       page.getByTestId("performance-monitor-power-rail"),
     ).toHaveCount(0);
@@ -141,11 +160,9 @@ test.describe("Grouped navigation destinations", () => {
 
     await page.setViewportSize({ width: 520, height: 800 });
     await expect(
-      page.getByTestId("performance-monitor-power-mode-switcher"),
+      page.getByTestId("performance-power-mode-switcher"),
     ).toBeVisible();
-    await expect(
-      page.getByTestId("performance-monitor-power-graph"),
-    ).toBeVisible();
+    await expect(page.getByTestId("performance-power-graph")).toBeVisible();
     const assertNoMonitorOverflow = async () => {
       const overflow = await page.evaluate(() => {
         const screen = document.querySelector<HTMLElement>(
@@ -183,9 +200,7 @@ test.describe("Grouped navigation destinations", () => {
     await expect(
       page.getByTestId("performance-monitor-power-rail"),
     ).toBeVisible();
-    await expect(
-      page.getByTestId("performance-monitor-power-graph"),
-    ).toHaveCount(0);
+    await expect(page.getByTestId("performance-power-graph")).toHaveCount(0);
     await assertNoMonitorOverflow();
     await saveCapture(page, "performance-monitor-power-current-compact-window");
 
@@ -201,9 +216,25 @@ test.describe("Grouped navigation destinations", () => {
       "data-state",
       "active",
     );
+    await expect(page.getByTestId("performance-power-graph")).toBeVisible();
+  });
+
+  test("labels Usage Graph and Power Draw targets separately in Settings", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+    await navigateTo(page, "settings");
+
     await expect(
-      page.getByTestId("performance-monitor-power-graph"),
+      page.getByRole("heading", { name: "Display Targets" }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Usage Graph", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Power Draw", exact: true }),
+    ).toBeVisible();
+    await saveCapture(page, "settings-display-targets");
   });
 
   test("attributes the GPU readings to a named adapter the user can change", async ({

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { Provider, useAtom } from "jotai";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chartConfig } from "@/features/hardware/consts/chart";
 import { asLiveGpuId } from "@/features/hardware/gpuIdentity";
 import { useHardwareEventListener } from "@/features/hardware/hooks/useHardwareEventListener";
@@ -103,6 +103,10 @@ describe("useHardwareEventListener", () => {
     vi.clearAllMocks();
     capturedCallback = null;
     setDocumentHidden(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   // ── Listener registration / cleanup ──
@@ -463,6 +467,84 @@ describe("useHardwareEventListener", () => {
     expect(result.current.gpuWatts.slice(-2)).toEqual([2.2, null]);
     expect(result.current.aneWatts.slice(-2)).toEqual([null, null]);
     expect(result.current.packageWatts.slice(-2)).toEqual([null, null]);
+  });
+
+  it("inserts nullable Power Draw gaps for elapsed hidden time", () => {
+    const dateNow = vi
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(5_000);
+    const { result } = renderHook(
+      () => {
+        useHardwareEventListener();
+        const [history] = useAtom(powerDrawHistoryAtom);
+        return history;
+      },
+      { wrapper: Provider },
+    );
+
+    act(() =>
+      emit(
+        makePayload({
+          cpuPowerWatts: 10.1,
+          gpuPowerWatts: 2.2,
+          anePowerWatts: 3.3,
+          packagePowerWatts: 15.6,
+        }),
+      ),
+    );
+    setDocumentHidden(true);
+    act(() =>
+      emit(
+        makePayload({
+          cpuPowerWatts: 99.9,
+          gpuPowerWatts: 99.9,
+          anePowerWatts: 99.9,
+          packagePowerWatts: 99.9,
+        }),
+      ),
+    );
+    setDocumentHidden(false);
+    act(() =>
+      emit(
+        makePayload({
+          cpuPowerWatts: 20.2,
+          gpuPowerWatts: 4.4,
+          anePowerWatts: 6.6,
+          packagePowerWatts: 31.2,
+        }),
+      ),
+    );
+
+    expect(result.current.cpuWatts.slice(-5)).toEqual([
+      10.1,
+      null,
+      null,
+      null,
+      20.2,
+    ]);
+    expect(result.current.gpuWatts.slice(-5)).toEqual([
+      2.2,
+      null,
+      null,
+      null,
+      4.4,
+    ]);
+    expect(result.current.aneWatts.slice(-5)).toEqual([
+      3.3,
+      null,
+      null,
+      null,
+      6.6,
+    ]);
+    expect(result.current.packageWatts.slice(-5)).toEqual([
+      15.6,
+      null,
+      null,
+      null,
+      31.2,
+    ]);
+    expect(dateNow).toHaveBeenCalledTimes(2);
   });
 
   it("does not allocate Power Draw history before capability is established", () => {

--- a/src/features/hardware/hooks/useHardwareEventListener.test.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.test.ts
@@ -23,6 +23,7 @@ import {
   motherboardTempsAtom,
   powerDrawAtom,
   powerDrawAvailableAtom,
+  powerDrawHistoryAtom,
   processorsUsageHistoryAtom,
   selectedGpuIdAtom,
   sensorTempsAtom,
@@ -432,6 +433,55 @@ describe("useHardwareEventListener", () => {
       gpuWatts: null,
       aneWatts: null,
       packageWatts: null,
+    });
+  });
+
+  it("retains nullable Power Draw samples for the full short window", () => {
+    const { result } = renderHook(
+      () => {
+        useHardwareEventListener();
+        const [history] = useAtom(powerDrawHistoryAtom);
+        return history;
+      },
+      { wrapper: Provider },
+    );
+
+    act(() => {
+      emit(
+        makePayload({
+          cpuPowerWatts: 10.1,
+          gpuPowerWatts: 2.2,
+          anePowerWatts: null,
+          packagePowerWatts: null,
+        }),
+      );
+      emit(makePayload());
+    });
+
+    expect(result.current.cpuWatts).toHaveLength(chartConfig.historyLengthSec);
+    expect(result.current.cpuWatts.slice(-2)).toEqual([10.1, null]);
+    expect(result.current.gpuWatts.slice(-2)).toEqual([2.2, null]);
+    expect(result.current.aneWatts.slice(-2)).toEqual([null, null]);
+    expect(result.current.packageWatts.slice(-2)).toEqual([null, null]);
+  });
+
+  it("does not allocate Power Draw history before capability is established", () => {
+    const { result } = renderHook(
+      () => {
+        useHardwareEventListener();
+        const [history] = useAtom(powerDrawHistoryAtom);
+        return history;
+      },
+      { wrapper: Provider },
+    );
+
+    act(() => emit(makePayload()));
+
+    expect(result.current).toEqual({
+      cpuWatts: [],
+      gpuWatts: [],
+      aneWatts: [],
+      packageWatts: [],
     });
   });
 

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -34,6 +34,14 @@ const padHistory = (arr: (number | null)[]): (number | null)[] => {
   return padded.slice(-chartConfig.historyLengthSec);
 };
 
+const MONITOR_SAMPLE_INTERVAL_MS = 1000;
+
+const getMissingSampleCount = (elapsedMs: number): number =>
+  Math.min(
+    Math.max(Math.round(elapsedMs / MONITOR_SAMPLE_INTERVAL_MS) - 1, 0),
+    chartConfig.historyLengthSec - 1,
+  );
+
 // One omitted sample can be a provider hiccup. Three consecutive visible
 // samples establish that the adapter is no longer part of the live set while
 // keeping unplug/fallback feedback within a few seconds at the 1 Hz cadence.
@@ -45,6 +53,7 @@ const GPU_RETIREMENT_MISSED_SAMPLES = 3;
  */
 export const useHardwareEventListener = () => {
   const gpuMissedSamples = useRef(new Map<LiveGpuId, number>());
+  const lastVisibleUpdateAt = useRef<number | null>(null);
   const setCpuHistory = useSetAtom(cpuUsageHistoryAtom);
   const setMemoryHistory = useSetAtom(memoryUsageHistoryAtom);
   const setGpuHistories = useSetAtom(gpuUsageHistoriesAtom);
@@ -68,6 +77,21 @@ export const useHardwareEventListener = () => {
       if (document.hidden) {
         return;
       }
+
+      const updateReceivedAt = Date.now();
+      // The App stops forwarding snapshots while the main window is hidden.
+      // Keep the Power Draw graph's one-sample-per-second positions honest
+      // when delivery resumes instead of presenting pre-hide values as recent.
+      const missingSampleCount =
+        lastVisibleUpdateAt.current == null
+          ? 0
+          : getMissingSampleCount(
+              updateReceivedAt - lastVisibleUpdateAt.current,
+            );
+      lastVisibleUpdateAt.current = updateReceivedAt;
+      const missingPowerDrawSamples = Array<number | null>(
+        missingSampleCount,
+      ).fill(null);
 
       const {
         cpuUsage,
@@ -142,11 +166,24 @@ export const useHardwareEventListener = () => {
         }
 
         return {
-          cpuWatts: padHistory([...previous.cpuWatts, powerDraw.cpuWatts]),
-          gpuWatts: padHistory([...previous.gpuWatts, powerDraw.gpuWatts]),
-          aneWatts: padHistory([...previous.aneWatts, powerDraw.aneWatts]),
+          cpuWatts: padHistory([
+            ...previous.cpuWatts,
+            ...missingPowerDrawSamples,
+            powerDraw.cpuWatts,
+          ]),
+          gpuWatts: padHistory([
+            ...previous.gpuWatts,
+            ...missingPowerDrawSamples,
+            powerDraw.gpuWatts,
+          ]),
+          aneWatts: padHistory([
+            ...previous.aneWatts,
+            ...missingPowerDrawSamples,
+            powerDraw.aneWatts,
+          ]),
           packageWatts: padHistory([
             ...previous.packageWatts,
+            ...missingPowerDrawSamples,
             powerDraw.packageWatts,
           ]),
         };

--- a/src/features/hardware/hooks/useHardwareEventListener.ts
+++ b/src/features/hardware/hooks/useHardwareEventListener.ts
@@ -20,6 +20,7 @@ import {
   motherboardTempsAtom,
   powerDrawAtom,
   powerDrawAvailableAtom,
+  powerDrawHistoryAtom,
   processorsUsageHistoryAtom,
   selectedGpuIdAtom,
   sensorTempsAtom,
@@ -60,6 +61,7 @@ export const useHardwareEventListener = () => {
   const setMotherboardFanSpeeds = useSetAtom(motherboardFanSpeedsAtom);
   const setPowerDrawAvailable = useSetAtom(powerDrawAvailableAtom);
   const setPowerDraw = useSetAtom(powerDrawAtom);
+  const setPowerDrawHistory = useSetAtom(powerDrawHistoryAtom);
 
   const handleHardwareUpdate = useCallback(
     (event: { payload: HardwareMonitorUpdate }) => {
@@ -125,9 +127,30 @@ export const useHardwareEventListener = () => {
         packageWatts: packagePowerWatts,
       };
       setPowerDraw(powerDraw);
-      if (Object.values(powerDraw).some((value) => value != null)) {
+      const hasPowerReading = Object.values(powerDraw).some(
+        (value) => value != null,
+      );
+      if (hasPowerReading) {
         setPowerDrawAvailable(true);
       }
+      setPowerDrawHistory((previous) => {
+        const historyStarted = Object.values(previous).some(
+          (history) => history.length > 0,
+        );
+        if (!hasPowerReading && !historyStarted) {
+          return previous;
+        }
+
+        return {
+          cpuWatts: padHistory([...previous.cpuWatts, powerDraw.cpuWatts]),
+          gpuWatts: padHistory([...previous.gpuWatts, powerDraw.gpuWatts]),
+          aneWatts: padHistory([...previous.aneWatts, powerDraw.aneWatts]),
+          packageWatts: padHistory([
+            ...previous.packageWatts,
+            powerDraw.packageWatts,
+          ]),
+        };
+      });
 
       // Per-GPU usage histories
       setGpuHistories((prev) => {
@@ -261,6 +284,7 @@ export const useHardwareEventListener = () => {
       setMotherboardFanSpeeds,
       setPowerDrawAvailable,
       setPowerDraw,
+      setPowerDrawHistory,
     ],
   );
   useEffect(() => {

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStore, Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,8 +23,8 @@ const liveMap = <T,>(map: Record<string, T>) =>
 
 import type {
   PerformanceCustomLayout,
-  PerformanceMonitorPowerMode,
   PerformancePanelColumns,
+  PerformancePowerMode,
   PerformanceView,
 } from "./types/performanceLayout";
 
@@ -32,8 +32,8 @@ const state = vi.hoisted(() => ({
   view: "panels" as PerformanceView,
   columns: 1 as PerformancePanelColumns,
   compactExpanded: false,
-  monitorPowerMode: "current" as PerformanceMonitorPowerMode,
-  setMonitorPowerMode: vi.fn(),
+  powerMode: "current" as PerformancePowerMode,
+  setPowerMode: vi.fn(),
   customLayout: {
     order: [
       "usageGraphs",
@@ -167,8 +167,8 @@ vi.mock("./hooks/usePerformanceLayout", () => ({
     setView: vi.fn(),
     columns: state.columns,
     setColumns: vi.fn(),
-    monitorPowerMode: state.monitorPowerMode,
-    setMonitorPowerMode: state.setMonitorPowerMode,
+    powerMode: state.powerMode,
+    setPowerMode: state.setPowerMode,
     compactExpanded: state.compactExpanded,
     setCompactExpanded: vi.fn(),
     customLayout: state.customLayout,
@@ -179,7 +179,7 @@ vi.mock("./hooks/usePerformanceLayout", () => ({
 }));
 
 vi.mock("./components/PowerDrawChart", () => ({
-  PowerDrawChart: () => <div data-testid="performance-monitor-power-graph" />,
+  PowerDrawChart: () => <div data-testid="performance-power-graph" />,
 }));
 
 describe("Performance", () => {
@@ -187,8 +187,8 @@ describe("Performance", () => {
     state.view = "panels";
     state.columns = 1;
     state.compactExpanded = false;
-    state.monitorPowerMode = "current";
-    state.setMonitorPowerMode.mockClear();
+    state.powerMode = "current";
+    state.setPowerMode.mockClear();
     state.customLayout = {
       order: [
         "usageGraphs",
@@ -304,24 +304,22 @@ describe("Performance", () => {
       </Provider>,
     );
 
-    expect(
-      screen.getByTestId("performance-monitor-power-mode-switcher"),
-    ).toBeVisible();
+    expect(screen.getByTestId("performance-power-mode-switcher")).toBeVisible();
     expect(screen.getByTestId("performance-monitor-power-rail")).toBeVisible();
-    expect(screen.queryByTestId("performance-monitor-power-graph")).toBeNull();
+    expect(screen.queryByTestId("performance-power-graph")).toBeNull();
 
     await user.click(
       screen.getByRole("tab", {
-        name: "pages.performance.monitorPowerModes.graph",
+        name: "pages.performance.powerModes.graph",
       }),
     );
 
-    expect(state.setMonitorPowerMode).toHaveBeenCalledWith("graph");
+    expect(state.setPowerMode).toHaveBeenCalledWith("graph");
   });
 
   it("shows the short-window Power Draw graph in Graph mode", () => {
     state.view = "monitor";
-    state.monitorPowerMode = "graph";
+    state.powerMode = "graph";
     const store = createStore();
     store.set(powerDrawAvailableAtom, true);
 
@@ -331,9 +329,60 @@ describe("Performance", () => {
       </Provider>,
     );
 
-    expect(screen.getByTestId("performance-monitor-power-graph")).toBeVisible();
+    expect(screen.getByTestId("performance-power-graph")).toBeVisible();
     expect(screen.queryByTestId("performance-monitor-power-rail")).toBeNull();
     expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
+  });
+
+  it("shares the Power Draw mode between the Panels power panel and Monitor", async () => {
+    const user = userEvent.setup();
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+    store.set(powerDrawAtom, {
+      cpuWatts: 10.1,
+      gpuWatts: 2.2,
+      aneWatts: null,
+      packageWatts: 12.3,
+    });
+    const view = render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const powerPanel = screen.getByTestId("performance-panel-power");
+    expect(
+      within(powerPanel).getByTestId("performance-power-mode-switcher"),
+    ).toBeVisible();
+    expect(screen.getByText("10.1 W")).toBeVisible();
+
+    await user.click(
+      within(powerPanel).getByRole("tab", {
+        name: "pages.performance.powerModes.graph",
+      }),
+    );
+    expect(state.setPowerMode).toHaveBeenCalledWith("graph");
+
+    state.powerMode = "graph";
+    view.rerender(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+    expect(
+      within(screen.getByTestId("performance-panel-power")).getByTestId(
+        "performance-power-graph",
+      ),
+    ).toBeVisible();
+
+    state.view = "monitor";
+    view.rerender(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+    expect(screen.getByTestId("performance-power-graph")).toBeVisible();
+    expect(screen.getByTestId("performance-power-mode-switcher")).toBeVisible();
   });
 
   it("keeps Power Draw controls and surfaces hidden without a selected target", () => {
@@ -348,11 +397,24 @@ describe("Performance", () => {
       </Provider>,
     );
 
-    expect(
-      screen.queryByTestId("performance-monitor-power-mode-switcher"),
-    ).toBeNull();
+    expect(screen.queryByTestId("performance-power-mode-switcher")).toBeNull();
     expect(screen.queryByTestId("performance-monitor-power-rail")).toBeNull();
-    expect(screen.queryByTestId("performance-monitor-power-graph")).toBeNull();
+    expect(screen.queryByTestId("performance-power-graph")).toBeNull();
+    expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
+  });
+
+  it("keeps the Panels Power panel hidden without a selected target", () => {
+    settings.powerDisplayTargets = [];
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(screen.queryByTestId("performance-panel-power")).toBeNull();
     expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
   });
 

--- a/src/features/hardware/performance/Performance.test.tsx
+++ b/src/features/hardware/performance/Performance.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createStore, Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { asLiveGpuId, type LiveGpuId } from "@/features/hardware/gpuIdentity";
@@ -22,6 +23,7 @@ const liveMap = <T,>(map: Record<string, T>) =>
 
 import type {
   PerformanceCustomLayout,
+  PerformanceMonitorPowerMode,
   PerformancePanelColumns,
   PerformanceView,
 } from "./types/performanceLayout";
@@ -30,6 +32,8 @@ const state = vi.hoisted(() => ({
   view: "panels" as PerformanceView,
   columns: 1 as PerformancePanelColumns,
   compactExpanded: false,
+  monitorPowerMode: "current" as PerformanceMonitorPowerMode,
+  setMonitorPowerMode: vi.fn(),
   customLayout: {
     order: [
       "usageGraphs",
@@ -163,6 +167,8 @@ vi.mock("./hooks/usePerformanceLayout", () => ({
     setView: vi.fn(),
     columns: state.columns,
     setColumns: vi.fn(),
+    monitorPowerMode: state.monitorPowerMode,
+    setMonitorPowerMode: state.setMonitorPowerMode,
     compactExpanded: state.compactExpanded,
     setCompactExpanded: vi.fn(),
     customLayout: state.customLayout,
@@ -172,11 +178,17 @@ vi.mock("./hooks/usePerformanceLayout", () => ({
   }),
 }));
 
+vi.mock("./components/PowerDrawChart", () => ({
+  PowerDrawChart: () => <div data-testid="performance-monitor-power-graph" />,
+}));
+
 describe("Performance", () => {
   beforeEach(() => {
     state.view = "panels";
     state.columns = 1;
     state.compactExpanded = false;
+    state.monitorPowerMode = "current";
+    state.setMonitorPowerMode.mockClear();
     state.customLayout = {
       order: [
         "usageGraphs",
@@ -190,6 +202,7 @@ describe("Performance", () => {
     state.chartRenders = { cpu: 0, memory: 0, gpu: 0 };
     state.processRenders = 0;
     state.gpus = null;
+    settings.powerDisplayTargets = ["cpu", "gpu", "package"];
   });
 
   afterEach(cleanup);
@@ -271,6 +284,101 @@ describe("Performance", () => {
     expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
     expect(screen.queryByTestId("performance-current-values")).toBeNull();
     expect(screen.queryByTestId("live-process-table")).toBeNull();
+  });
+
+  it("shows a switchable current Power Draw rail after capability is established", async () => {
+    state.view = "monitor";
+    const user = userEvent.setup();
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+    store.set(powerDrawAtom, {
+      cpuWatts: 10.1,
+      gpuWatts: 2.2,
+      aneWatts: null,
+      packageWatts: 12.3,
+    });
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(
+      screen.getByTestId("performance-monitor-power-mode-switcher"),
+    ).toBeVisible();
+    expect(screen.getByTestId("performance-monitor-power-rail")).toBeVisible();
+    expect(screen.queryByTestId("performance-monitor-power-graph")).toBeNull();
+
+    await user.click(
+      screen.getByRole("tab", {
+        name: "pages.performance.monitorPowerModes.graph",
+      }),
+    );
+
+    expect(state.setMonitorPowerMode).toHaveBeenCalledWith("graph");
+  });
+
+  it("shows the short-window Power Draw graph in Graph mode", () => {
+    state.view = "monitor";
+    state.monitorPowerMode = "graph";
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("performance-monitor-power-graph")).toBeVisible();
+    expect(screen.queryByTestId("performance-monitor-power-rail")).toBeNull();
+    expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
+  });
+
+  it("keeps Power Draw controls and surfaces hidden without a selected target", () => {
+    state.view = "monitor";
+    settings.powerDisplayTargets = [];
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    expect(
+      screen.queryByTestId("performance-monitor-power-mode-switcher"),
+    ).toBeNull();
+    expect(screen.queryByTestId("performance-monitor-power-rail")).toBeNull();
+    expect(screen.queryByTestId("performance-monitor-power-graph")).toBeNull();
+    expect(screen.getByTestId("performance-usage-graphs")).toBeVisible();
+  });
+
+  it("keeps Usage Graphs out of the 1 Hz current Power Draw render path", () => {
+    state.view = "monitor";
+    const store = createStore();
+    store.set(powerDrawAvailableAtom, true);
+
+    render(
+      <Provider store={store}>
+        <Performance />
+      </Provider>,
+    );
+
+    const before = { ...state.chartRenders };
+
+    act(() =>
+      store.set(powerDrawAtom, {
+        cpuWatts: 10.1,
+        gpuWatts: 2.2,
+        aneWatts: null,
+        packageWatts: 12.3,
+      }),
+    );
+
+    expect(state.chartRenders).toEqual(before);
   });
 
   it("keeps hidden panels unmounted in the panels view", () => {

--- a/src/features/hardware/performance/Performance.tsx
+++ b/src/features/hardware/performance/Performance.tsx
@@ -14,11 +14,11 @@ import { cn } from "@/lib/utils";
 import { CompactStrip } from "./components/CompactStrip";
 import { InstrumentStrip } from "./components/InstrumentStrip";
 import { MonitorGpuSelector } from "./components/MonitorGpuSelector";
-import { MonitorPowerModeSwitcher } from "./components/MonitorPowerModeSwitcher";
 import { MonitorView } from "./components/MonitorView";
 import { PanelColumnsSelector } from "./components/PanelColumnsSelector";
 import { PanelGrid } from "./components/PanelGrid";
 import { PerformanceViewSwitcher } from "./components/PerformanceViewSwitcher";
+import { PowerDisplayModeSwitcher } from "./components/PowerDisplayModeSwitcher";
 import { usePerformanceLayout } from "./hooks/usePerformanceLayout";
 
 export const Performance = ({
@@ -34,8 +34,8 @@ export const Performance = ({
     setView,
     columns,
     setColumns,
-    monitorPowerMode,
-    setMonitorPowerMode,
+    powerMode,
+    setPowerMode,
     compactExpanded,
     setCompactExpanded,
     customLayout,
@@ -121,14 +121,13 @@ export const Performance = ({
             </button>
           )}
           {/* Monitor omits the Instrument Strip, so the adapter behind its GPU
-              series needs a compact selector in the toolbar. Power Draw mode
-              is kept beside it because both controls affect Monitor only. */}
+              series needs a compact selector in the toolbar. */}
           {isMonitor && (
             <>
               <MonitorGpuSelector />
-              <MonitorPowerModeSwitcher
-                mode={monitorPowerMode}
-                onModeChange={(mode) => void setMonitorPowerMode(mode)}
+              <PowerDisplayModeSwitcher
+                mode={powerMode}
+                onModeChange={(mode) => void setPowerMode(mode)}
               />
             </>
           )}
@@ -170,7 +169,7 @@ export const Performance = ({
       ) : view === "compact" ? (
         <CompactStrip />
       ) : isMonitor ? (
-        <MonitorView powerMode={monitorPowerMode} />
+        <MonitorView powerMode={powerMode} />
       ) : (
         <div className="space-y-4">
           <InstrumentStrip />
@@ -178,6 +177,8 @@ export const Performance = ({
             layout={customLayout}
             columns={columns}
             editing={editing}
+            powerMode={powerMode}
+            onPowerModeChange={(mode) => void setPowerMode(mode)}
             onPanelToggle={togglePanel}
             onPanelDragEnd={handlePanelDragEnd}
           />

--- a/src/features/hardware/performance/Performance.tsx
+++ b/src/features/hardware/performance/Performance.tsx
@@ -10,11 +10,12 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { BurnInShift } from "@/components/shared/BurnInShift";
 import { Skeleton } from "@/components/ui/skeleton";
-import { UsageGraphPanel } from "@/features/hardware/usage/Usage";
 import { cn } from "@/lib/utils";
 import { CompactStrip } from "./components/CompactStrip";
 import { InstrumentStrip } from "./components/InstrumentStrip";
 import { MonitorGpuSelector } from "./components/MonitorGpuSelector";
+import { MonitorPowerModeSwitcher } from "./components/MonitorPowerModeSwitcher";
+import { MonitorView } from "./components/MonitorView";
 import { PanelColumnsSelector } from "./components/PanelColumnsSelector";
 import { PanelGrid } from "./components/PanelGrid";
 import { PerformanceViewSwitcher } from "./components/PerformanceViewSwitcher";
@@ -33,6 +34,8 @@ export const Performance = ({
     setView,
     columns,
     setColumns,
+    monitorPowerMode,
+    setMonitorPowerMode,
     compactExpanded,
     setCompactExpanded,
     customLayout,
@@ -72,7 +75,8 @@ export const Performance = ({
   const content = (
     <main
       className={cn(
-        "mx-auto min-h-screen w-full pt-12 pr-4 pb-8",
+        "mx-auto w-full pt-12 pr-4 pb-8",
+        isMonitor ? "flex h-screen min-h-0 flex-col" : "min-h-screen",
         isFullScreen ? "pl-4" : "pl-16",
         !isMonitor && "2xl:w-3/4 2xl:px-4",
       )}
@@ -82,6 +86,7 @@ export const Performance = ({
       <header
         className={cn(
           "mb-4 flex flex-wrap items-center gap-3",
+          isMonitor && "shrink-0",
           !showTitle && "justify-end",
         )}
       >
@@ -93,7 +98,17 @@ export const Performance = ({
             </h2>
           </div>
         )}
-        <div className={cn("flex items-center gap-2", showTitle && "ml-auto")}>
+        <div
+          className={cn(
+            "flex items-center gap-2",
+            isMonitor && "min-w-0 flex-wrap",
+            isMonitor
+              ? showTitle
+                ? "ml-auto w-full sm:w-auto"
+                : "justify-end"
+              : showTitle && "ml-auto",
+          )}
+        >
           {view === "compact" && (
             <button
               type="button"
@@ -105,10 +120,18 @@ export const Performance = ({
               {t("pages.performance.expandCompact")}
             </button>
           )}
-          {/* Monitor is only the graph, so the adapter behind its GPU series
-              has nowhere else to be named: the Instrument Strip that normally
-              carries that is not mounted here. */}
-          {isMonitor && <MonitorGpuSelector />}
+          {/* Monitor omits the Instrument Strip, so the adapter behind its GPU
+              series needs a compact selector in the toolbar. Power Draw mode
+              is kept beside it because both controls affect Monitor only. */}
+          {isMonitor && (
+            <>
+              <MonitorGpuSelector />
+              <MonitorPowerModeSwitcher
+                mode={monitorPowerMode}
+                onModeChange={(mode) => void setMonitorPowerMode(mode)}
+              />
+            </>
+          )}
           {view === "panels" && (
             <PanelColumnsSelector
               columns={columns}
@@ -147,11 +170,7 @@ export const Performance = ({
       ) : view === "compact" ? (
         <CompactStrip />
       ) : isMonitor ? (
-        <UsageGraphPanel
-          fitToContainer
-          height="calc(100dvh - 8rem)"
-          testId="performance-usage-graphs"
-        />
+        <MonitorView powerMode={monitorPowerMode} />
       ) : (
         <div className="space-y-4">
           <InstrumentStrip />

--- a/src/features/hardware/performance/components/MonitorPowerModeSwitcher.tsx
+++ b/src/features/hardware/performance/components/MonitorPowerModeSwitcher.tsx
@@ -1,0 +1,58 @@
+import { ChartLineUpIcon, LightningIcon } from "@phosphor-icons/react";
+import { useAtomValue } from "jotai";
+import { useTranslation } from "react-i18next";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { powerDrawAvailableAtom } from "@/features/hardware/store/chart";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import {
+  type PerformanceMonitorPowerMode,
+  performanceMonitorPowerModes,
+} from "../types/performanceLayout";
+
+const modeIcons = {
+  current: <LightningIcon />,
+  graph: <ChartLineUpIcon />,
+} satisfies Record<PerformanceMonitorPowerMode, React.ReactNode>;
+
+export const MonitorPowerModeSwitcher = ({
+  mode,
+  onModeChange,
+}: {
+  mode: PerformanceMonitorPowerMode;
+  onModeChange: (mode: PerformanceMonitorPowerMode) => void;
+}) => {
+  const { t } = useTranslation();
+  const powerAvailable = useAtomValue(powerDrawAvailableAtom);
+  const { settings } = useSettingsAtom();
+
+  if (!powerAvailable || settings.powerDisplayTargets.length === 0) {
+    return null;
+  }
+
+  return (
+    <Tabs
+      value={mode}
+      onValueChange={(value) =>
+        onModeChange(value as PerformanceMonitorPowerMode)
+      }
+      className="min-w-0"
+    >
+      <TabsList
+        className="h-auto max-w-full justify-start overflow-x-auto"
+        aria-label={t("pages.performance.monitorPowerModeSwitcher")}
+        data-testid="performance-monitor-power-mode-switcher"
+      >
+        {performanceMonitorPowerModes.map((candidate) => (
+          <TabsTrigger
+            key={candidate}
+            value={candidate}
+            className="min-h-9 px-3"
+          >
+            {modeIcons[candidate]}
+            {t(`pages.performance.monitorPowerModes.${candidate}`)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+};

--- a/src/features/hardware/performance/components/MonitorView.tsx
+++ b/src/features/hardware/performance/components/MonitorView.tsx
@@ -3,14 +3,14 @@ import type { CSSProperties } from "react";
 import { powerDrawAvailableAtom } from "@/features/hardware/store/chart";
 import { UsageGraphPanel } from "@/features/hardware/usage/Usage";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
-import type { PerformanceMonitorPowerMode } from "../types/performanceLayout";
+import type { PerformancePowerMode } from "../types/performanceLayout";
 import { PowerDrawChart } from "./PowerDrawChart";
 import { PowerDrawRail } from "./PowerDrawRail";
 
 export const MonitorView = ({
   powerMode,
 }: {
-  powerMode: PerformanceMonitorPowerMode;
+  powerMode: PerformancePowerMode;
 }) => {
   const powerAvailable = useAtomValue(powerDrawAvailableAtom);
   const { settings } = useSettingsAtom();

--- a/src/features/hardware/performance/components/MonitorView.tsx
+++ b/src/features/hardware/performance/components/MonitorView.tsx
@@ -1,0 +1,50 @@
+import { useAtomValue } from "jotai";
+import type { CSSProperties } from "react";
+import { powerDrawAvailableAtom } from "@/features/hardware/store/chart";
+import { UsageGraphPanel } from "@/features/hardware/usage/Usage";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import type { PerformanceMonitorPowerMode } from "../types/performanceLayout";
+import { PowerDrawChart } from "./PowerDrawChart";
+import { PowerDrawRail } from "./PowerDrawRail";
+
+export const MonitorView = ({
+  powerMode,
+}: {
+  powerMode: PerformanceMonitorPowerMode;
+}) => {
+  const powerAvailable = useAtomValue(powerDrawAvailableAtom);
+  const { settings } = useSettingsAtom();
+  const showPower = powerAvailable && settings.powerDisplayTargets.length > 0;
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col gap-4"
+      style={
+        {
+          padding: `${settings.graphMarginPx}px`,
+        } satisfies CSSProperties
+      }
+      data-power-mode={powerMode}
+    >
+      {!showPower ? (
+        <UsageGraphPanel
+          fitToContainer
+          padding={0}
+          className="min-h-0 flex-1"
+          testId="performance-usage-graphs"
+        />
+      ) : (
+        <>
+          {powerMode === "current" ? <PowerDrawRail /> : null}
+          <UsageGraphPanel
+            fitToContainer
+            padding={0}
+            className="min-h-0 flex-[3]"
+            testId="performance-usage-graphs"
+          />
+          {powerMode === "graph" ? <PowerDrawChart /> : null}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/features/hardware/performance/components/PanelGrid.tsx
+++ b/src/features/hardware/performance/components/PanelGrid.tsx
@@ -35,12 +35,21 @@ import type {
   PerformanceCustomLayout,
   PerformancePanelColumns,
   PerformancePanelId,
+  PerformancePowerMode,
 } from "../types/performanceLayout";
 import { MotherboardSensorsPanel } from "./MotherboardSensorsPanel";
 import { PerCorePanel } from "./PerCorePanel";
+import { PowerDisplayModeSwitcher } from "./PowerDisplayModeSwitcher";
+import { PowerDrawChart } from "./PowerDrawChart";
 import { PowerPanel } from "./PowerPanel";
 
-const PanelBody = ({ panel }: { panel: PerformancePanelId }) => {
+const PanelBody = ({
+  panel,
+  powerMode,
+}: {
+  panel: PerformancePanelId;
+  powerMode: PerformancePowerMode;
+}) => {
   if (panel === "usageGraphs") {
     return (
       <UsageGraphPanel
@@ -60,7 +69,11 @@ const PanelBody = ({ panel }: { panel: PerformancePanelId }) => {
   }
 
   if (panel === "power") {
-    return <PowerPanel />;
+    return powerMode === "graph" ? (
+      <PowerDrawChart showHeading={false} variant="panel" />
+    ) : (
+      <PowerPanel />
+    );
   }
 
   return <MotherboardSensorsPanel />;
@@ -70,10 +83,14 @@ const SortablePanel = ({
   panel,
   editing,
   onHide,
+  powerMode,
+  onPowerModeChange,
 }: {
   panel: PerformancePanelId;
   editing: boolean;
   onHide: (panel: PerformancePanelId) => void;
+  powerMode: PerformancePowerMode;
+  onPowerModeChange: (mode: PerformancePowerMode) => void;
 }) => {
   const { t } = useTranslation();
   const { settings } = useSettingsAtom();
@@ -121,6 +138,14 @@ const SortablePanel = ({
             <h3 className="font-mono font-semibold text-[11px] text-muted-foreground uppercase tracking-[0.18em]">
               {label}
             </h3>
+            {panel === "power" && (
+              <PowerDisplayModeSwitcher
+                mode={powerMode}
+                onModeChange={onPowerModeChange}
+                compact
+                className="ml-auto"
+              />
+            )}
           </>
         )}
         {editing && (
@@ -145,7 +170,7 @@ const SortablePanel = ({
           </>
         )}
       </div>
-      <PanelBody panel={panel} />
+      <PanelBody panel={panel} powerMode={powerMode} />
     </section>
   );
 };
@@ -159,17 +184,22 @@ export const PanelGrid = ({
   layout,
   columns,
   editing,
+  powerMode,
+  onPowerModeChange,
   onPanelToggle,
   onPanelDragEnd,
 }: {
   layout: PerformanceCustomLayout;
   columns: PerformancePanelColumns;
   editing: boolean;
+  powerMode: PerformancePowerMode;
+  onPowerModeChange: (mode: PerformancePowerMode) => void;
   onPanelToggle: (panel: PerformancePanelId) => Promise<boolean>;
   onPanelDragEnd: (event: DragEndEvent) => void;
 }) => {
   const { t } = useTranslation();
   const powerAvailable = useAtomValue(powerDrawAvailableAtom);
+  const { settings } = useSettingsAtom();
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -177,7 +207,9 @@ export const PanelGrid = ({
     }),
   );
   const availablePanels = layout.order.filter(
-    (panel) => panel !== "power" || powerAvailable,
+    (panel) =>
+      panel !== "power" ||
+      (powerAvailable && settings.powerDisplayTargets.length > 0),
   );
   const hiddenPanels = availablePanels.filter(
     (panel) => !layout.visible.includes(panel),
@@ -212,6 +244,8 @@ export const PanelGrid = ({
                   key={panel}
                   panel={panel}
                   editing={editing}
+                  powerMode={powerMode}
+                  onPowerModeChange={onPowerModeChange}
                   onHide={(hidden) => void onPanelToggle(hidden)}
                 />
               ) : null,

--- a/src/features/hardware/performance/components/PowerDisplayModeSwitcher.tsx
+++ b/src/features/hardware/performance/components/PowerDisplayModeSwitcher.tsx
@@ -4,22 +4,27 @@ import { useTranslation } from "react-i18next";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { powerDrawAvailableAtom } from "@/features/hardware/store/chart";
 import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import { cn } from "@/lib/utils";
 import {
-  type PerformanceMonitorPowerMode,
-  performanceMonitorPowerModes,
+  type PerformancePowerMode,
+  performancePowerModes,
 } from "../types/performanceLayout";
 
 const modeIcons = {
   current: <LightningIcon />,
   graph: <ChartLineUpIcon />,
-} satisfies Record<PerformanceMonitorPowerMode, React.ReactNode>;
+} satisfies Record<PerformancePowerMode, React.ReactNode>;
 
-export const MonitorPowerModeSwitcher = ({
+export const PowerDisplayModeSwitcher = ({
   mode,
   onModeChange,
+  compact = false,
+  className,
 }: {
-  mode: PerformanceMonitorPowerMode;
-  onModeChange: (mode: PerformanceMonitorPowerMode) => void;
+  mode: PerformancePowerMode;
+  onModeChange: (mode: PerformancePowerMode) => void;
+  compact?: boolean;
+  className?: string;
 }) => {
   const { t } = useTranslation();
   const powerAvailable = useAtomValue(powerDrawAvailableAtom);
@@ -32,24 +37,25 @@ export const MonitorPowerModeSwitcher = ({
   return (
     <Tabs
       value={mode}
-      onValueChange={(value) =>
-        onModeChange(value as PerformanceMonitorPowerMode)
-      }
-      className="min-w-0"
+      onValueChange={(value) => onModeChange(value as PerformancePowerMode)}
+      className={cn("min-w-0", className)}
     >
       <TabsList
-        className="h-auto max-w-full justify-start overflow-x-auto"
-        aria-label={t("pages.performance.monitorPowerModeSwitcher")}
-        data-testid="performance-monitor-power-mode-switcher"
+        className={cn(
+          "h-auto max-w-full justify-start overflow-x-auto",
+          compact && "gap-0.5 p-0.5",
+        )}
+        aria-label={t("pages.performance.powerModeSwitcher")}
+        data-testid="performance-power-mode-switcher"
       >
-        {performanceMonitorPowerModes.map((candidate) => (
+        {performancePowerModes.map((candidate) => (
           <TabsTrigger
             key={candidate}
             value={candidate}
-            className="min-h-9 px-3"
+            className={cn("min-h-9 px-3", compact && "min-h-8 px-2 text-xs")}
           >
             {modeIcons[candidate]}
-            {t(`pages.performance.monitorPowerModes.${candidate}`)}
+            {t(`pages.performance.powerModes.${candidate}`)}
           </TabsTrigger>
         ))}
       </TabsList>

--- a/src/features/hardware/performance/components/PowerDrawChart.test.tsx
+++ b/src/features/hardware/performance/components/PowerDrawChart.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { powerDrawHistoryAtom } from "@/features/hardware/store/chart";
+import { PowerDrawChart } from "./PowerDrawChart";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: { seconds?: number }) =>
+      params?.seconds == null ? key : `${key} ${params.seconds}`,
+  }),
+}));
+
+vi.mock("@/features/settings/hooks/useSettingsAtom", () => ({
+  useSettingsAtom: () => ({
+    settings: {
+      powerDisplayTargets: ["cpu", "package"],
+      lineGraphColor: {
+        cpu: "75, 192, 192",
+        gpu: "255, 206, 86",
+      },
+      lineGraphShowScale: false,
+      lineGraphShowTooltip: false,
+      lineGraphType: "default",
+      lineGraphFill: true,
+    },
+  }),
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+}));
+
+vi.mock("recharts", () => ({
+  AreaChart: ({
+    children,
+    data,
+  }: {
+    children: ReactNode;
+    data: Record<string, unknown>[];
+  }) => (
+    <div data-testid="power-area-chart" data-series={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Area: ({ dataKey }: { dataKey: string }) => (
+    <span data-testid={`power-area-${dataKey}`} />
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+describe("PowerDrawChart", () => {
+  it("renders selected series while retaining null gaps in the chart data", () => {
+    const store = createStore();
+    store.set(powerDrawHistoryAtom, {
+      cpuWatts: [null, 10.1, null],
+      gpuWatts: [null, 2.2, 2.4],
+      aneWatts: [null, null, null],
+      packageWatts: [null, 12.3, null],
+    });
+
+    render(
+      <Provider store={store}>
+        <PowerDrawChart />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("power-area-cpu")).toBeVisible();
+    expect(screen.getByTestId("power-area-package")).toBeVisible();
+    expect(screen.queryByTestId("power-area-gpu")).toBeNull();
+    expect(screen.queryByTestId("power-area-ane")).toBeNull();
+
+    const data = JSON.parse(
+      screen.getByTestId("power-area-chart").getAttribute("data-series") ??
+        "[]",
+    );
+    expect(data.at(-1)).toMatchObject({ cpu: null, package: null });
+    expect(data.at(-2)).toMatchObject({ cpu: 10.1, package: 12.3 });
+  });
+});

--- a/src/features/hardware/performance/components/PowerDrawChart.test.tsx
+++ b/src/features/hardware/performance/components/PowerDrawChart.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { powerDrawHistoryAtom } from "@/features/hardware/store/chart";
 import { PowerDrawChart } from "./PowerDrawChart";
 
@@ -55,6 +55,8 @@ vi.mock("recharts", () => ({
 }));
 
 describe("PowerDrawChart", () => {
+  afterEach(cleanup);
+
   it("renders selected series while retaining null gaps in the chart data", () => {
     const store = createStore();
     store.set(powerDrawHistoryAtom, {
@@ -81,5 +83,31 @@ describe("PowerDrawChart", () => {
     );
     expect(data.at(-1)).toMatchObject({ cpu: null, package: null });
     expect(data.at(-2)).toMatchObject({ cpu: 10.1, package: 12.3 });
+  });
+
+  it("uses a full-width layout when embedded in the Power panel", () => {
+    const store = createStore();
+    store.set(powerDrawHistoryAtom, {
+      cpuWatts: [10],
+      gpuWatts: [],
+      aneWatts: [],
+      packageWatts: [12],
+    });
+
+    render(
+      <Provider store={store}>
+        <PowerDrawChart showHeading={false} variant="panel" />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId("performance-power-graph")).toHaveClass(
+      "w-full",
+      "h-56",
+    );
+    expect(screen.getByTestId("performance-power-graph")).not.toHaveClass(
+      "flex-[2]",
+    );
+    expect(screen.getByText("pages.performance.power.cpu")).toBeVisible();
+    expect(screen.getByText("10.0 W")).toBeVisible();
   });
 });

--- a/src/features/hardware/performance/components/PowerDrawChart.tsx
+++ b/src/features/hardware/performance/components/PowerDrawChart.tsx
@@ -38,7 +38,13 @@ const fixedSeriesRgb = {
   package: "245, 158, 11",
 } as const;
 
-export const PowerDrawChart = () => {
+export const PowerDrawChart = ({
+  showHeading = true,
+  variant = "monitor",
+}: {
+  showHeading?: boolean;
+  variant?: "monitor" | "panel";
+} = {}) => {
   const { t } = useTranslation();
   const history = useAtomValue(powerDrawHistoryAtom);
   const { settings } = useSettingsAtom();
@@ -88,23 +94,38 @@ export const PowerDrawChart = () => {
 
   return (
     <section
-      className="flex min-h-30 flex-[2] flex-col"
+      className={cn(
+        "flex min-h-30 flex-col",
+        variant === "monitor" ? "flex-[2]" : "h-56 w-full px-4 pb-4",
+      )}
       aria-label={t("pages.performance.panels.power")}
-      data-testid="performance-monitor-power-graph"
+      data-testid="performance-power-graph"
     >
-      <div className="mb-1 flex flex-wrap items-center gap-x-4 gap-y-1 px-1">
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <LightningIcon size={18} className="text-amber-400" />
-          <h3 className="font-mono font-semibold text-[11px] uppercase tracking-[0.18em]">
-            {t("pages.performance.panels.power")}
-          </h3>
-          <span className="text-[10px]">
-            {t("pages.performance.shortWindow", {
-              seconds: chartConfig.historyLengthSec,
-            })}
-          </span>
-        </div>
-        <div className="ml-auto flex flex-wrap justify-end gap-x-4 gap-y-1">
+      <div
+        className={cn(
+          "mb-1 flex flex-wrap items-center gap-x-4 gap-y-1",
+          showHeading && "px-1",
+        )}
+      >
+        {showHeading ? (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <LightningIcon size={18} className="text-amber-400" />
+            <h3 className="font-mono font-semibold text-[11px] uppercase tracking-[0.18em]">
+              {t("pages.performance.panels.power")}
+            </h3>
+            <span className="text-[10px]">
+              {t("pages.performance.shortWindow", {
+                seconds: chartConfig.historyLengthSec,
+              })}
+            </span>
+          </div>
+        ) : null}
+        <div
+          className={cn(
+            "flex flex-wrap gap-x-4 gap-y-1",
+            showHeading && "ml-auto justify-end",
+          )}
+        >
           {targets.map((target) => {
             const value = history[historyKey[target]].at(-1) ?? null;
             return (

--- a/src/features/hardware/performance/components/PowerDrawChart.tsx
+++ b/src/features/hardware/performance/components/PowerDrawChart.tsx
@@ -1,0 +1,200 @@
+import { LightningIcon } from "@phosphor-icons/react";
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { CurveType } from "recharts/types/shape/Curve";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { chartConfig } from "@/features/hardware/consts/chart";
+import {
+  type PowerDrawHistory,
+  powerDrawHistoryAtom,
+} from "@/features/hardware/store/chart";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import { cn } from "@/lib/utils";
+import type { LineGraphType, PowerDisplayTarget } from "@/rspc/bindings";
+
+const curveTypes = {
+  default: "monotone",
+  step: "step",
+  linear: "linear",
+  basis: "basis",
+} satisfies Record<LineGraphType, CurveType>;
+
+const historyKey = {
+  cpu: "cpuWatts",
+  gpu: "gpuWatts",
+  ane: "aneWatts",
+  package: "packageWatts",
+} as const satisfies Record<PowerDisplayTarget, keyof PowerDrawHistory>;
+
+const fixedSeriesRgb = {
+  ane: "168, 85, 247",
+  package: "245, 158, 11",
+} as const;
+
+export const PowerDrawChart = () => {
+  const { t } = useTranslation();
+  const history = useAtomValue(powerDrawHistoryAtom);
+  const { settings } = useSettingsAtom();
+  const targets = settings.powerDisplayTargets;
+  const colorRgb = useMemo(
+    () => ({
+      cpu: settings.lineGraphColor.cpu,
+      gpu: settings.lineGraphColor.gpu,
+      ...fixedSeriesRgb,
+    }),
+    [settings.lineGraphColor.cpu, settings.lineGraphColor.gpu],
+  );
+  const config = useMemo(
+    () =>
+      Object.fromEntries(
+        targets.map((target) => [
+          target,
+          {
+            label: t(`pages.performance.power.${target}`),
+            color: `rgb(${colorRgb[target]})`,
+          },
+        ]),
+      ) satisfies ChartConfig,
+    [colorRgb, t, targets],
+  );
+  const data = useMemo(
+    () =>
+      Array.from({ length: chartConfig.historyLengthSec }, (_, index) => ({
+        second: index - chartConfig.historyLengthSec + 1,
+        cpu: history.cpuWatts.at(index - chartConfig.historyLengthSec) ?? null,
+        gpu: history.gpuWatts.at(index - chartConfig.historyLengthSec) ?? null,
+        ane: history.aneWatts.at(index - chartConfig.historyLengthSec) ?? null,
+        package:
+          history.packageWatts.at(index - chartConfig.historyLengthSec) ?? null,
+      })),
+    [history],
+  );
+  const maxValue = Math.max(
+    0,
+    ...targets.flatMap((target) =>
+      history[historyKey[target]].filter(
+        (value): value is number => value != null,
+      ),
+    ),
+  );
+  const yMax = Math.max(10, Math.ceil(maxValue / 10) * 10);
+
+  return (
+    <section
+      className="flex min-h-30 flex-[2] flex-col"
+      aria-label={t("pages.performance.panels.power")}
+      data-testid="performance-monitor-power-graph"
+    >
+      <div className="mb-1 flex flex-wrap items-center gap-x-4 gap-y-1 px-1">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <LightningIcon size={18} className="text-amber-400" />
+          <h3 className="font-mono font-semibold text-[11px] uppercase tracking-[0.18em]">
+            {t("pages.performance.panels.power")}
+          </h3>
+          <span className="text-[10px]">
+            {t("pages.performance.shortWindow", {
+              seconds: chartConfig.historyLengthSec,
+            })}
+          </span>
+        </div>
+        <div className="ml-auto flex flex-wrap justify-end gap-x-4 gap-y-1">
+          {targets.map((target) => {
+            const value = history[historyKey[target]].at(-1) ?? null;
+            return (
+              <span
+                key={target}
+                className="flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground tabular-nums"
+              >
+                <i
+                  className="size-2 rounded-sm"
+                  style={{ backgroundColor: `rgb(${colorRgb[target]})` }}
+                />
+                {t(`pages.performance.power.${target}`)}
+                <strong className="text-foreground">
+                  {value != null ? `${value.toFixed(1)} W` : "—"}
+                </strong>
+              </span>
+            );
+          })}
+        </div>
+      </div>
+      <ChartContainer
+        config={config}
+        className={cn(
+          "aspect-auto min-h-0 w-full flex-1",
+          settings.lineGraphBorder &&
+            "rounded-xl border-2 border-slate-400 py-6 dark:border-zinc-600",
+        )}
+      >
+        <AreaChart
+          data={data}
+          margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+        >
+          <CartesianGrid
+            horizontal={settings.lineGraphShowScale}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="second"
+            hide={!settings.lineGraphShowScale}
+            tickFormatter={(value) =>
+              value === 0
+                ? t("pages.performance.now")
+                : t("pages.performance.secondsAgo", { seconds: -value })
+            }
+            ticks={[-chartConfig.historyLengthSec + 1, -30, 0]}
+          />
+          <YAxis
+            domain={[0, yMax]}
+            hide={!settings.lineGraphShowScale}
+            tickFormatter={(value) => `${value} W`}
+            width={48}
+          />
+          {settings.lineGraphShowTooltip && (
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  formatter={(value, name) => (
+                    <div className="flex min-w-32 items-center justify-between gap-4">
+                      <span className="text-muted-foreground">
+                        {config[name ?? ""]?.label ?? name}
+                      </span>
+                      <span className="font-medium font-mono tabular-nums">
+                        {typeof value === "number"
+                          ? `${value.toFixed(1)} W`
+                          : "—"}
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+          )}
+          {targets.map((target) => (
+            <Area
+              key={target}
+              type={curveTypes[settings.lineGraphType]}
+              dataKey={target}
+              stroke={`rgb(${colorRgb[target]})`}
+              strokeWidth={target === "package" ? 2.5 : 1.8}
+              fill={
+                settings.lineGraphFill
+                  ? `rgba(${colorRgb[target]},${target === "package" ? 0.22 : 0.08})`
+                  : "none"
+              }
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ChartContainer>
+    </section>
+  );
+};

--- a/src/features/hardware/performance/components/PowerDrawRail.test.tsx
+++ b/src/features/hardware/performance/components/PowerDrawRail.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+import { powerDrawAtom } from "@/features/hardware/store/chart";
+import { PowerDrawRail } from "./PowerDrawRail";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/features/settings/hooks/useSettingsAtom", () => ({
+  useSettingsAtom: () => ({
+    settings: { powerDisplayTargets: ["cpu", "ane", "package"] },
+  }),
+}));
+
+describe("PowerDrawRail", () => {
+  it("shows selected current readings and preserves unavailable values", () => {
+    const store = createStore();
+    store.set(powerDrawAtom, {
+      cpuWatts: 10.1,
+      gpuWatts: 2.2,
+      aneWatts: null,
+      packageWatts: 12.3,
+    });
+
+    render(
+      <Provider store={store}>
+        <PowerDrawRail />
+      </Provider>,
+    );
+
+    const rail = screen.getByTestId("performance-monitor-power-rail");
+    expect(rail).toHaveTextContent("pages.performance.power.package");
+    expect(rail).toHaveTextContent("12.3 W");
+    expect(rail).toHaveTextContent("pages.performance.power.cpu");
+    expect(rail).toHaveTextContent("10.1 W");
+    expect(rail).toHaveTextContent("pages.performance.power.ane");
+    expect(rail).toHaveTextContent("—");
+    expect(rail).not.toHaveTextContent("pages.performance.power.gpu");
+  });
+});

--- a/src/features/hardware/performance/components/PowerDrawRail.tsx
+++ b/src/features/hardware/performance/components/PowerDrawRail.tsx
@@ -1,0 +1,69 @@
+import { LightningIcon } from "@phosphor-icons/react";
+import { useAtomValue } from "jotai";
+import { useTranslation } from "react-i18next";
+import { powerDrawAtom } from "@/features/hardware/store/chart";
+import { useSettingsAtom } from "@/features/settings/hooks/useSettingsAtom";
+import { cn } from "@/lib/utils";
+import type { PowerDisplayTarget } from "@/rspc/bindings";
+
+// Keep the same canonical order as the existing PowerPanel and target
+// settings. The package total still gets an accent, but moving it ahead of
+// CPU/GPU would make the two Power Draw surfaces disagree.
+const railOrder: readonly PowerDisplayTarget[] = [
+  "cpu",
+  "gpu",
+  "ane",
+  "package",
+];
+
+const powerKey = {
+  cpu: "cpuWatts",
+  gpu: "gpuWatts",
+  ane: "aneWatts",
+  package: "packageWatts",
+} as const;
+
+export const PowerDrawRail = () => {
+  const { t } = useTranslation();
+  const power = useAtomValue(powerDrawAtom);
+  const { settings } = useSettingsAtom();
+  const targets = railOrder.filter((target) =>
+    settings.powerDisplayTargets.includes(target),
+  );
+
+  return (
+    <section
+      className="flex shrink-0 flex-wrap items-center gap-x-5 gap-y-2 rounded-xl bg-card px-4 py-2.5"
+      aria-label={t("pages.performance.panels.power")}
+      data-testid="performance-monitor-power-rail"
+    >
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <LightningIcon size={18} className="text-amber-400" />
+        <h3 className="font-mono font-semibold text-[11px] uppercase tracking-[0.18em]">
+          {t("pages.performance.panels.power")}
+        </h3>
+      </div>
+      <div className="grid min-w-0 flex-1 grid-cols-[repeat(auto-fit,minmax(6.5rem,1fr))] gap-x-5 gap-y-1">
+        {targets.map((target) => {
+          const watts = power[powerKey[target]];
+          return (
+            <div
+              key={target}
+              className={cn(
+                "flex items-baseline justify-between gap-3 border-border/60 border-l pl-3 text-sm",
+                target === "package" && "text-amber-400",
+              )}
+            >
+              <span className="text-muted-foreground text-xs">
+                {t(`pages.performance.power.${target}`)}
+              </span>
+              <strong className="font-mono font-semibold tabular-nums">
+                {watts != null ? `${watts.toFixed(1)} W` : "—"}
+              </strong>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -65,7 +65,7 @@ describe("usePerformanceLayout", () => {
       if (key === "performanceCompactExpanded") {
         return [compactExpanded, setCompactExpanded, false] as never;
       }
-      if (key === "performancePowerMode") {
+      if (key === "performanceMonitorPowerMode") {
         return [powerMode, setPowerMode, false] as never;
       }
       return [customLayout, setCustomLayout, false] as never;
@@ -207,7 +207,7 @@ describe("usePerformanceLayout", () => {
       if (key === "performancePanelColumns") {
         return [columns, setColumns, false] as never;
       }
-      if (key === "performancePowerMode") {
+      if (key === "performanceMonitorPowerMode") {
         return [powerMode, setPowerMode, false] as never;
       }
       return [null, setCompactExpanded, true] as never;

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import type {
   PerformanceCustomLayout,
+  PerformanceMonitorPowerMode,
   PerformanceView,
 } from "../types/performanceLayout";
 import { usePerformanceLayout } from "./usePerformanceLayout";
@@ -11,8 +12,10 @@ const setView = vi.fn();
 const setCustomLayout = vi.fn();
 const setColumns = vi.fn();
 const setCompactExpanded = vi.fn();
+const setMonitorPowerMode = vi.fn();
 let columns: unknown = 1;
 let compactExpanded: unknown = false;
+let monitorPowerMode: unknown = "current" satisfies PerformanceMonitorPowerMode;
 
 let view: PerformanceView = "panels";
 let customLayout: PerformanceCustomLayout = {
@@ -46,10 +49,12 @@ describe("usePerformanceLayout", () => {
     };
     columns = 1;
     compactExpanded = false;
+    monitorPowerMode = "current";
     setView.mockResolvedValue(undefined);
     setCustomLayout.mockResolvedValue(undefined);
     setColumns.mockResolvedValue(undefined);
     setCompactExpanded.mockResolvedValue(undefined);
+    setMonitorPowerMode.mockResolvedValue(undefined);
     vi.mocked(useTauriStore).mockImplementation((key) => {
       if (key === "performanceLayoutPreset") {
         return [view, setView, false] as never;
@@ -59,6 +64,9 @@ describe("usePerformanceLayout", () => {
       }
       if (key === "performanceCompactExpanded") {
         return [compactExpanded, setCompactExpanded, false] as never;
+      }
+      if (key === "performanceMonitorPowerMode") {
+        return [monitorPowerMode, setMonitorPowerMode, false] as never;
       }
       return [customLayout, setCustomLayout, false] as never;
     });
@@ -74,6 +82,18 @@ describe("usePerformanceLayout", () => {
     await act(async () => result.current.setView("monitor"));
 
     expect(setView).toHaveBeenCalledWith("monitor");
+  });
+
+  it("persists the Monitor Power Draw mode and repairs unknown values", async () => {
+    monitorPowerMode = "overlay";
+    const { result } = renderHook(() => usePerformanceLayout());
+
+    expect(result.current.monitorPowerMode).toBe("current");
+    expect(setMonitorPowerMode).toHaveBeenCalledWith("current");
+
+    await act(async () => result.current.setMonitorPowerMode("graph"));
+
+    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
   });
 
   it("persists the panel column count and repairs unusable values", async () => {
@@ -114,6 +134,9 @@ describe("usePerformanceLayout", () => {
       }
       if (key === "performancePanelColumns") {
         return [columns, setColumns, false] as never;
+      }
+      if (key === "performanceMonitorPowerMode") {
+        return [monitorPowerMode, setMonitorPowerMode, false] as never;
       }
       return [null, setCompactExpanded, true] as never;
     });

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -98,6 +98,24 @@ describe("usePerformanceLayout", () => {
     expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
   });
 
+  it("reports a rejected Monitor Power Draw mode repair", async () => {
+    const persistenceError = new Error("store unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    monitorPowerMode = "overlay";
+    setMonitorPowerMode.mockRejectedValueOnce(persistenceError);
+
+    renderHook(() => usePerformanceLayout());
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to persist Performance Monitor Power Draw mode:",
+        persistenceError,
+      ),
+    );
+  });
+
   it("keeps the latest Monitor Power Draw mode after delayed writes", async () => {
     let resolveGraphWrite: (() => void) | undefined;
     setMonitorPowerMode

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -116,6 +116,22 @@ describe("usePerformanceLayout", () => {
     );
   });
 
+  it("reports a rejected user-selected Monitor Power Draw mode", async () => {
+    const persistenceError = new Error("store unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    setMonitorPowerMode.mockRejectedValueOnce(persistenceError);
+    const { result } = renderHook(() => usePerformanceLayout());
+
+    await act(async () => result.current.setMonitorPowerMode("graph"));
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to persist Performance Monitor Power Draw mode:",
+      persistenceError,
+    );
+  });
+
   it("keeps the latest Monitor Power Draw mode after delayed writes", async () => {
     let resolveGraphWrite: (() => void) | undefined;
     setMonitorPowerMode

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import type {
   PerformanceCustomLayout,
-  PerformanceMonitorPowerMode,
+  PerformancePowerMode,
   PerformanceView,
 } from "../types/performanceLayout";
 import { usePerformanceLayout } from "./usePerformanceLayout";
@@ -12,10 +12,10 @@ const setView = vi.fn();
 const setCustomLayout = vi.fn();
 const setColumns = vi.fn();
 const setCompactExpanded = vi.fn();
-const setMonitorPowerMode = vi.fn();
+const setPowerMode = vi.fn();
 let columns: unknown = 1;
 let compactExpanded: unknown = false;
-let monitorPowerMode: unknown = "current" satisfies PerformanceMonitorPowerMode;
+let powerMode: unknown = "current" satisfies PerformancePowerMode;
 
 let view: PerformanceView = "panels";
 let customLayout: PerformanceCustomLayout = {
@@ -49,12 +49,12 @@ describe("usePerformanceLayout", () => {
     };
     columns = 1;
     compactExpanded = false;
-    monitorPowerMode = "current";
+    powerMode = "current";
     setView.mockResolvedValue(undefined);
     setCustomLayout.mockResolvedValue(undefined);
     setColumns.mockResolvedValue(undefined);
     setCompactExpanded.mockResolvedValue(undefined);
-    setMonitorPowerMode.mockResolvedValue(undefined);
+    setPowerMode.mockResolvedValue(undefined);
     vi.mocked(useTauriStore).mockImplementation((key) => {
       if (key === "performanceLayoutPreset") {
         return [view, setView, false] as never;
@@ -65,8 +65,8 @@ describe("usePerformanceLayout", () => {
       if (key === "performanceCompactExpanded") {
         return [compactExpanded, setCompactExpanded, false] as never;
       }
-      if (key === "performanceMonitorPowerMode") {
-        return [monitorPowerMode, setMonitorPowerMode, false] as never;
+      if (key === "performancePowerMode") {
+        return [powerMode, setPowerMode, false] as never;
       }
       return [customLayout, setCustomLayout, false] as never;
     });
@@ -84,80 +84,78 @@ describe("usePerformanceLayout", () => {
     expect(setView).toHaveBeenCalledWith("monitor");
   });
 
-  it("persists the Monitor Power Draw mode and repairs unknown values", async () => {
-    monitorPowerMode = "overlay";
+  it("persists the shared Power Draw mode and repairs unknown values", async () => {
+    powerMode = "overlay";
     const { result } = renderHook(() => usePerformanceLayout());
 
-    expect(result.current.monitorPowerMode).toBe("current");
-    await waitFor(() =>
-      expect(setMonitorPowerMode).toHaveBeenCalledWith("current"),
-    );
+    expect(result.current.powerMode).toBe("current");
+    await waitFor(() => expect(setPowerMode).toHaveBeenCalledWith("current"));
 
-    await act(async () => result.current.setMonitorPowerMode("graph"));
+    await act(async () => result.current.setPowerMode("graph"));
 
-    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
+    expect(setPowerMode).toHaveBeenLastCalledWith("graph");
   });
 
-  it("reports a rejected Monitor Power Draw mode repair", async () => {
+  it("reports a rejected shared Power Draw mode repair", async () => {
     const persistenceError = new Error("store unavailable");
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    monitorPowerMode = "overlay";
-    setMonitorPowerMode.mockRejectedValueOnce(persistenceError);
+    powerMode = "overlay";
+    setPowerMode.mockRejectedValueOnce(persistenceError);
 
     renderHook(() => usePerformanceLayout());
 
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith(
-        "Failed to persist Performance Monitor Power Draw mode:",
+        "Failed to persist Performance Power Draw mode:",
         persistenceError,
       ),
     );
   });
 
-  it("reports a rejected user-selected Monitor Power Draw mode", async () => {
+  it("reports a rejected user-selected shared Power Draw mode", async () => {
     const persistenceError = new Error("store unavailable");
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    setMonitorPowerMode.mockRejectedValueOnce(persistenceError);
+    setPowerMode.mockRejectedValueOnce(persistenceError);
     const { result } = renderHook(() => usePerformanceLayout());
 
-    await act(async () => result.current.setMonitorPowerMode("graph"));
+    await act(async () => result.current.setPowerMode("graph"));
 
     expect(consoleError).toHaveBeenCalledWith(
-      "Failed to persist Performance Monitor Power Draw mode:",
+      "Failed to persist Performance Power Draw mode:",
       persistenceError,
     );
   });
 
-  it("keeps the latest Monitor Power Draw mode after delayed writes", async () => {
+  it("keeps the latest shared Power Draw mode after delayed writes", async () => {
     let resolveGraphWrite: (() => void) | undefined;
-    setMonitorPowerMode
+    setPowerMode
       .mockImplementationOnce(
-        (nextMode: PerformanceMonitorPowerMode) =>
+        (nextMode: PerformancePowerMode) =>
           new Promise<void>((resolve) => {
             resolveGraphWrite = () => {
-              monitorPowerMode = nextMode;
+              powerMode = nextMode;
               resolve();
             };
           }),
       )
-      .mockImplementationOnce(async (nextMode: PerformanceMonitorPowerMode) => {
-        monitorPowerMode = nextMode;
+      .mockImplementationOnce(async (nextMode: PerformancePowerMode) => {
+        powerMode = nextMode;
       });
     const { result, rerender } = renderHook(() => usePerformanceLayout());
 
     let graphWrite: Promise<void> | undefined;
     let currentWrite: Promise<void> | undefined;
     act(() => {
-      graphWrite = result.current.setMonitorPowerMode("graph");
-      currentWrite = result.current.setMonitorPowerMode("current");
+      graphWrite = result.current.setPowerMode("graph");
+      currentWrite = result.current.setPowerMode("current");
     });
 
-    await waitFor(() => expect(setMonitorPowerMode).toHaveBeenCalledOnce());
-    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
+    await waitFor(() => expect(setPowerMode).toHaveBeenCalledOnce());
+    expect(setPowerMode).toHaveBeenLastCalledWith("graph");
 
     await act(async () => {
       resolveGraphWrite?.();
@@ -165,9 +163,9 @@ describe("usePerformanceLayout", () => {
     });
     rerender();
 
-    expect(setMonitorPowerMode).toHaveBeenCalledTimes(2);
-    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("current");
-    expect(result.current.monitorPowerMode).toBe("current");
+    expect(setPowerMode).toHaveBeenCalledTimes(2);
+    expect(setPowerMode).toHaveBeenLastCalledWith("current");
+    expect(result.current.powerMode).toBe("current");
   });
 
   it("persists the panel column count and repairs unusable values", async () => {
@@ -209,8 +207,8 @@ describe("usePerformanceLayout", () => {
       if (key === "performancePanelColumns") {
         return [columns, setColumns, false] as never;
       }
-      if (key === "performanceMonitorPowerMode") {
-        return [monitorPowerMode, setMonitorPowerMode, false] as never;
+      if (key === "performancePowerMode") {
+        return [powerMode, setPowerMode, false] as never;
       }
       return [null, setCompactExpanded, true] as never;
     });

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.test.ts
@@ -89,11 +89,51 @@ describe("usePerformanceLayout", () => {
     const { result } = renderHook(() => usePerformanceLayout());
 
     expect(result.current.monitorPowerMode).toBe("current");
-    expect(setMonitorPowerMode).toHaveBeenCalledWith("current");
+    await waitFor(() =>
+      expect(setMonitorPowerMode).toHaveBeenCalledWith("current"),
+    );
 
     await act(async () => result.current.setMonitorPowerMode("graph"));
 
     expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
+  });
+
+  it("keeps the latest Monitor Power Draw mode after delayed writes", async () => {
+    let resolveGraphWrite: (() => void) | undefined;
+    setMonitorPowerMode
+      .mockImplementationOnce(
+        (nextMode: PerformanceMonitorPowerMode) =>
+          new Promise<void>((resolve) => {
+            resolveGraphWrite = () => {
+              monitorPowerMode = nextMode;
+              resolve();
+            };
+          }),
+      )
+      .mockImplementationOnce(async (nextMode: PerformanceMonitorPowerMode) => {
+        monitorPowerMode = nextMode;
+      });
+    const { result, rerender } = renderHook(() => usePerformanceLayout());
+
+    let graphWrite: Promise<void> | undefined;
+    let currentWrite: Promise<void> | undefined;
+    act(() => {
+      graphWrite = result.current.setMonitorPowerMode("graph");
+      currentWrite = result.current.setMonitorPowerMode("current");
+    });
+
+    await waitFor(() => expect(setMonitorPowerMode).toHaveBeenCalledOnce());
+    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("graph");
+
+    await act(async () => {
+      resolveGraphWrite?.();
+      await Promise.all([graphWrite, currentWrite]);
+    });
+    rerender();
+
+    expect(setMonitorPowerMode).toHaveBeenCalledTimes(2);
+    expect(setMonitorPowerMode).toHaveBeenLastCalledWith("current");
+    expect(result.current.monitorPowerMode).toBe("current");
   });
 
   it("persists the panel column count and repairs unusable values", async () => {

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -49,7 +49,9 @@ export const usePerformanceLayout = () => {
     useTauriStore<boolean>("performanceCompactExpanded", false);
   const [storedPowerMode, setStoredPowerMode, isPowerModePending] =
     useTauriStore<unknown>(
-      "performancePowerMode",
+      // The persisted key predates sharing this mode with Panels. Keep it so
+      // existing Monitor selections continue to apply to both views.
+      "performanceMonitorPowerMode",
       DEFAULT_PERFORMANCE_POWER_MODE,
     );
 

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -126,7 +126,7 @@ export const usePerformanceLayout = () => {
         () => undefined,
         () => undefined,
       );
-      return mutation;
+      return mutation.catch(reportMonitorPowerModePersistenceError);
     },
     [setStoredMonitorPowerMode],
   );
@@ -161,9 +161,7 @@ export const usePerformanceLayout = () => {
     }
     // Persist the normalized fallback too, so an obsolete value cannot keep
     // being re-read as unknown on every launch.
-    void setMonitorPowerMode(monitorPowerMode).catch(
-      reportMonitorPowerModePersistenceError,
-    );
+    void setMonitorPowerMode(monitorPowerMode);
   }, [
     isPowerModePending,
     monitorPowerMode,

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -22,6 +22,13 @@ const reportCustomLayoutPersistenceError = (error: unknown) => {
   console.error("Failed to persist custom Performance layout:", error);
 };
 
+const reportMonitorPowerModePersistenceError = (error: unknown) => {
+  console.error(
+    "Failed to persist Performance Monitor Power Draw mode:",
+    error,
+  );
+};
+
 export const usePerformanceLayout = () => {
   // The store key predates the preset-to-view consolidation; legacy preset
   // values keep resolving through normalizePerformanceView.
@@ -154,7 +161,9 @@ export const usePerformanceLayout = () => {
     }
     // Persist the normalized fallback too, so an obsolete value cannot keep
     // being re-read as unknown on every launch.
-    void setMonitorPowerMode(monitorPowerMode);
+    void setMonitorPowerMode(monitorPowerMode).catch(
+      reportMonitorPowerModePersistenceError,
+    );
   }, [
     isPowerModePending,
     monitorPowerMode,

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -4,11 +4,14 @@ import { useCallback, useEffect, useRef } from "react";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import {
   DEFAULT_PERFORMANCE_CUSTOM_LAYOUT,
+  DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
   DEFAULT_PERFORMANCE_PANEL_COLUMNS,
   DEFAULT_PERFORMANCE_VIEW,
   normalizePerformanceCustomLayout,
+  normalizePerformanceMonitorPowerMode,
   normalizePerformancePanelColumns,
   normalizePerformanceView,
+  type PerformanceMonitorPowerMode,
   type PerformancePanelColumns,
   type PerformancePanelId,
   type PerformanceView,
@@ -40,10 +43,21 @@ export const usePerformanceLayout = () => {
   // only the strip without being re-armed on every launch.
   const [storedCompactExpanded, setStoredCompactExpanded, isExpandedPending] =
     useTauriStore<boolean>("performanceCompactExpanded", false);
+  const [
+    storedMonitorPowerMode,
+    setStoredMonitorPowerMode,
+    isPowerModePending,
+  ] = useTauriStore<unknown>(
+    "performanceMonitorPowerMode",
+    DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
+  );
 
   const view = normalizePerformanceView(storedView);
   const columns = normalizePerformancePanelColumns(storedColumns);
   const customLayout = normalizePerformanceCustomLayout(storedCustomLayout);
+  const monitorPowerMode = normalizePerformanceMonitorPowerMode(
+    storedMonitorPowerMode,
+  );
   const latestCustomLayoutRef = useRef(customLayout);
   const customLayoutMutationQueueRef = useRef(Promise.resolve());
   const pendingCustomLayoutMutationCountRef = useRef(0);
@@ -119,10 +133,27 @@ export const usePerformanceLayout = () => {
     storedCustomLayout,
   ]);
 
+  useEffect(() => {
+    if (isPowerModePending || storedMonitorPowerMode === monitorPowerMode) {
+      return;
+    }
+    // Persist the normalized fallback too, so an obsolete value cannot keep
+    // being re-read as unknown on every launch.
+    void setStoredMonitorPowerMode(monitorPowerMode);
+  }, [
+    isPowerModePending,
+    monitorPowerMode,
+    setStoredMonitorPowerMode,
+    storedMonitorPowerMode,
+  ]);
+
   const setView = (nextView: PerformanceView) => setStoredView(nextView);
 
   const setColumns = (nextColumns: PerformancePanelColumns) =>
     setStoredColumns(nextColumns);
+
+  const setMonitorPowerMode = (nextMode: PerformanceMonitorPowerMode) =>
+    setStoredMonitorPowerMode(nextMode);
 
   const togglePanel = (panel: PerformancePanelId) =>
     enqueueCustomLayoutMutation((currentLayout) => {
@@ -167,6 +198,8 @@ export const usePerformanceLayout = () => {
     setView,
     columns,
     setColumns,
+    monitorPowerMode,
+    setMonitorPowerMode,
     compactExpanded: storedCompactExpanded === true,
     // Stable across renders (useTauriStore memoizes it), so effects can key
     // off it without resubscribing every render.
@@ -178,6 +211,7 @@ export const usePerformanceLayout = () => {
       isViewPending ||
       isCustomLayoutPending ||
       isColumnsPending ||
-      isExpandedPending,
+      isExpandedPending ||
+      isPowerModePending,
   };
 };

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -61,6 +61,7 @@ export const usePerformanceLayout = () => {
   const latestCustomLayoutRef = useRef(customLayout);
   const customLayoutMutationQueueRef = useRef(Promise.resolve());
   const pendingCustomLayoutMutationCountRef = useRef(0);
+  const monitorPowerModeMutationQueueRef = useRef(Promise.resolve());
 
   useEffect(() => {
     if (pendingCustomLayoutMutationCountRef.current === 0) {
@@ -109,6 +110,20 @@ export const usePerformanceLayout = () => {
     [setStoredCustomLayout],
   );
 
+  const setMonitorPowerMode = useCallback(
+    (nextMode: PerformanceMonitorPowerMode) => {
+      const mutation = monitorPowerModeMutationQueueRef.current.then(() =>
+        setStoredMonitorPowerMode(nextMode),
+      );
+      monitorPowerModeMutationQueueRef.current = mutation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return mutation;
+    },
+    [setStoredMonitorPowerMode],
+  );
+
   useEffect(() => {
     if (isViewPending || storedView === view) {
       return;
@@ -139,11 +154,11 @@ export const usePerformanceLayout = () => {
     }
     // Persist the normalized fallback too, so an obsolete value cannot keep
     // being re-read as unknown on every launch.
-    void setStoredMonitorPowerMode(monitorPowerMode);
+    void setMonitorPowerMode(monitorPowerMode);
   }, [
     isPowerModePending,
     monitorPowerMode,
-    setStoredMonitorPowerMode,
+    setMonitorPowerMode,
     storedMonitorPowerMode,
   ]);
 
@@ -151,9 +166,6 @@ export const usePerformanceLayout = () => {
 
   const setColumns = (nextColumns: PerformancePanelColumns) =>
     setStoredColumns(nextColumns);
-
-  const setMonitorPowerMode = (nextMode: PerformanceMonitorPowerMode) =>
-    setStoredMonitorPowerMode(nextMode);
 
   const togglePanel = (panel: PerformancePanelId) =>
     enqueueCustomLayoutMutation((currentLayout) => {

--- a/src/features/hardware/performance/hooks/usePerformanceLayout.ts
+++ b/src/features/hardware/performance/hooks/usePerformanceLayout.ts
@@ -4,16 +4,16 @@ import { useCallback, useEffect, useRef } from "react";
 import { useTauriStore } from "@/hooks/useTauriStore";
 import {
   DEFAULT_PERFORMANCE_CUSTOM_LAYOUT,
-  DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
   DEFAULT_PERFORMANCE_PANEL_COLUMNS,
+  DEFAULT_PERFORMANCE_POWER_MODE,
   DEFAULT_PERFORMANCE_VIEW,
   normalizePerformanceCustomLayout,
-  normalizePerformanceMonitorPowerMode,
   normalizePerformancePanelColumns,
+  normalizePerformancePowerMode,
   normalizePerformanceView,
-  type PerformanceMonitorPowerMode,
   type PerformancePanelColumns,
   type PerformancePanelId,
+  type PerformancePowerMode,
   type PerformanceView,
   performanceCustomLayoutsEqual,
 } from "../types/performanceLayout";
@@ -22,11 +22,8 @@ const reportCustomLayoutPersistenceError = (error: unknown) => {
   console.error("Failed to persist custom Performance layout:", error);
 };
 
-const reportMonitorPowerModePersistenceError = (error: unknown) => {
-  console.error(
-    "Failed to persist Performance Monitor Power Draw mode:",
-    error,
-  );
+const reportPowerModePersistenceError = (error: unknown) => {
+  console.error("Failed to persist Performance Power Draw mode:", error);
 };
 
 export const usePerformanceLayout = () => {
@@ -50,25 +47,20 @@ export const usePerformanceLayout = () => {
   // only the strip without being re-armed on every launch.
   const [storedCompactExpanded, setStoredCompactExpanded, isExpandedPending] =
     useTauriStore<boolean>("performanceCompactExpanded", false);
-  const [
-    storedMonitorPowerMode,
-    setStoredMonitorPowerMode,
-    isPowerModePending,
-  ] = useTauriStore<unknown>(
-    "performanceMonitorPowerMode",
-    DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
-  );
+  const [storedPowerMode, setStoredPowerMode, isPowerModePending] =
+    useTauriStore<unknown>(
+      "performancePowerMode",
+      DEFAULT_PERFORMANCE_POWER_MODE,
+    );
 
   const view = normalizePerformanceView(storedView);
   const columns = normalizePerformancePanelColumns(storedColumns);
   const customLayout = normalizePerformanceCustomLayout(storedCustomLayout);
-  const monitorPowerMode = normalizePerformanceMonitorPowerMode(
-    storedMonitorPowerMode,
-  );
+  const powerMode = normalizePerformancePowerMode(storedPowerMode);
   const latestCustomLayoutRef = useRef(customLayout);
   const customLayoutMutationQueueRef = useRef(Promise.resolve());
   const pendingCustomLayoutMutationCountRef = useRef(0);
-  const monitorPowerModeMutationQueueRef = useRef(Promise.resolve());
+  const powerModeMutationQueueRef = useRef(Promise.resolve());
 
   useEffect(() => {
     if (pendingCustomLayoutMutationCountRef.current === 0) {
@@ -117,18 +109,18 @@ export const usePerformanceLayout = () => {
     [setStoredCustomLayout],
   );
 
-  const setMonitorPowerMode = useCallback(
-    (nextMode: PerformanceMonitorPowerMode) => {
-      const mutation = monitorPowerModeMutationQueueRef.current.then(() =>
-        setStoredMonitorPowerMode(nextMode),
+  const setPowerMode = useCallback(
+    (nextMode: PerformancePowerMode) => {
+      const mutation = powerModeMutationQueueRef.current.then(() =>
+        setStoredPowerMode(nextMode),
       );
-      monitorPowerModeMutationQueueRef.current = mutation.then(
+      powerModeMutationQueueRef.current = mutation.then(
         () => undefined,
         () => undefined,
       );
-      return mutation.catch(reportMonitorPowerModePersistenceError);
+      return mutation.catch(reportPowerModePersistenceError);
     },
-    [setStoredMonitorPowerMode],
+    [setStoredPowerMode],
   );
 
   useEffect(() => {
@@ -156,18 +148,13 @@ export const usePerformanceLayout = () => {
   ]);
 
   useEffect(() => {
-    if (isPowerModePending || storedMonitorPowerMode === monitorPowerMode) {
+    if (isPowerModePending || storedPowerMode === powerMode) {
       return;
     }
     // Persist the normalized fallback too, so an obsolete value cannot keep
     // being re-read as unknown on every launch.
-    void setMonitorPowerMode(monitorPowerMode);
-  }, [
-    isPowerModePending,
-    monitorPowerMode,
-    setMonitorPowerMode,
-    storedMonitorPowerMode,
-  ]);
+    void setPowerMode(powerMode);
+  }, [isPowerModePending, powerMode, setPowerMode, storedPowerMode]);
 
   const setView = (nextView: PerformanceView) => setStoredView(nextView);
 
@@ -217,8 +204,8 @@ export const usePerformanceLayout = () => {
     setView,
     columns,
     setColumns,
-    monitorPowerMode,
-    setMonitorPowerMode,
+    powerMode,
+    setPowerMode,
     compactExpanded: storedCompactExpanded === true,
     // Stable across renders (useTauriStore memoizes it), so effects can key
     // off it without resubscribing every render.

--- a/src/features/hardware/performance/types/performanceLayout.test.ts
+++ b/src/features/hardware/performance/types/performanceLayout.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_PERFORMANCE_CUSTOM_LAYOUT,
+  DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
   DEFAULT_PERFORMANCE_VIEW,
   normalizePerformanceCustomLayout,
+  normalizePerformanceMonitorPowerMode,
   normalizePerformanceView,
   performanceCustomLayoutsEqual,
 } from "./performanceLayout";
@@ -20,6 +22,19 @@ describe("performance view normalization", () => {
   it("keeps Compact and Monitor selections", () => {
     expect(normalizePerformanceView("compact")).toBe("compact");
     expect(normalizePerformanceView("monitor")).toBe("monitor");
+  });
+});
+
+describe("Performance Monitor Power Draw mode normalization", () => {
+  it("keeps supported modes", () => {
+    expect(normalizePerformanceMonitorPowerMode("current")).toBe("current");
+    expect(normalizePerformanceMonitorPowerMode("graph")).toBe("graph");
+  });
+
+  it("falls back to Current for an unknown mode", () => {
+    expect(normalizePerformanceMonitorPowerMode("overlay")).toBe(
+      DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
+    );
   });
 });
 

--- a/src/features/hardware/performance/types/performanceLayout.test.ts
+++ b/src/features/hardware/performance/types/performanceLayout.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_PERFORMANCE_CUSTOM_LAYOUT,
-  DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
+  DEFAULT_PERFORMANCE_POWER_MODE,
   DEFAULT_PERFORMANCE_VIEW,
   normalizePerformanceCustomLayout,
-  normalizePerformanceMonitorPowerMode,
+  normalizePerformancePowerMode,
   normalizePerformanceView,
   performanceCustomLayoutsEqual,
 } from "./performanceLayout";
@@ -25,15 +25,15 @@ describe("performance view normalization", () => {
   });
 });
 
-describe("Performance Monitor Power Draw mode normalization", () => {
+describe("Performance Power Draw mode normalization", () => {
   it("keeps supported modes", () => {
-    expect(normalizePerformanceMonitorPowerMode("current")).toBe("current");
-    expect(normalizePerformanceMonitorPowerMode("graph")).toBe("graph");
+    expect(normalizePerformancePowerMode("current")).toBe("current");
+    expect(normalizePerformancePowerMode("graph")).toBe("graph");
   });
 
   it("falls back to Current for an unknown mode", () => {
-    expect(normalizePerformanceMonitorPowerMode("overlay")).toBe(
-      DEFAULT_PERFORMANCE_MONITOR_POWER_MODE,
+    expect(normalizePerformancePowerMode("overlay")).toBe(
+      DEFAULT_PERFORMANCE_POWER_MODE,
     );
   });
 });

--- a/src/features/hardware/performance/types/performanceLayout.ts
+++ b/src/features/hardware/performance/types/performanceLayout.ts
@@ -2,20 +2,18 @@ export const performanceViews = ["panels", "compact", "monitor"] as const;
 
 export type PerformanceView = (typeof performanceViews)[number];
 
-export const performanceMonitorPowerModes = ["current", "graph"] as const;
+export const performancePowerModes = ["current", "graph"] as const;
 
-export type PerformanceMonitorPowerMode =
-  (typeof performanceMonitorPowerModes)[number];
+export type PerformancePowerMode = (typeof performancePowerModes)[number];
 
-export const DEFAULT_PERFORMANCE_MONITOR_POWER_MODE: PerformanceMonitorPowerMode =
-  "current";
+export const DEFAULT_PERFORMANCE_POWER_MODE: PerformancePowerMode = "current";
 
-export const normalizePerformanceMonitorPowerMode = (
+export const normalizePerformancePowerMode = (
   value: unknown,
-): PerformanceMonitorPowerMode =>
-  performanceMonitorPowerModes.includes(value as PerformanceMonitorPowerMode)
-    ? (value as PerformanceMonitorPowerMode)
-    : DEFAULT_PERFORMANCE_MONITOR_POWER_MODE;
+): PerformancePowerMode =>
+  performancePowerModes.includes(value as PerformancePowerMode)
+    ? (value as PerformancePowerMode)
+    : DEFAULT_PERFORMANCE_POWER_MODE;
 
 export const performancePanelIds = [
   "usageGraphs",

--- a/src/features/hardware/performance/types/performanceLayout.ts
+++ b/src/features/hardware/performance/types/performanceLayout.ts
@@ -2,6 +2,21 @@ export const performanceViews = ["panels", "compact", "monitor"] as const;
 
 export type PerformanceView = (typeof performanceViews)[number];
 
+export const performanceMonitorPowerModes = ["current", "graph"] as const;
+
+export type PerformanceMonitorPowerMode =
+  (typeof performanceMonitorPowerModes)[number];
+
+export const DEFAULT_PERFORMANCE_MONITOR_POWER_MODE: PerformanceMonitorPowerMode =
+  "current";
+
+export const normalizePerformanceMonitorPowerMode = (
+  value: unknown,
+): PerformanceMonitorPowerMode =>
+  performanceMonitorPowerModes.includes(value as PerformanceMonitorPowerMode)
+    ? (value as PerformanceMonitorPowerMode)
+    : DEFAULT_PERFORMANCE_MONITOR_POWER_MODE;
+
 export const performancePanelIds = [
   "usageGraphs",
   "processTable",

--- a/src/features/hardware/store/chart.ts
+++ b/src/features/hardware/store/chart.ts
@@ -75,11 +75,22 @@ export type PowerDraw = {
   packageWatts: number | null;
 };
 
+export type PowerDrawHistory = {
+  [K in keyof PowerDraw]: (number | null)[];
+};
+
 export const powerDrawAtom = atom<PowerDraw>({
   cpuWatts: null,
   gpuWatts: null,
   aneWatts: null,
   packageWatts: null,
+});
+
+export const powerDrawHistoryAtom = atom<PowerDrawHistory>({
+  cpuWatts: [],
+  gpuWatts: [],
+  aneWatts: [],
+  packageWatts: [],
 });
 
 /** Whether this runtime has produced at least one power reading. */

--- a/src/features/settings/components/graph/GraphSettings.tsx
+++ b/src/features/settings/components/graph/GraphSettings.tsx
@@ -32,13 +32,22 @@ export const GraphSettings = () => {
             <GraphColorSettings />
             <div className="py-6">
               <h4 className="font-bold text-xl">
-                {t("pages.settings.general.hardwareType")}
+                {t("pages.settings.general.displayTargets")}
               </h4>
-              <GraphTypeSelector />
-              <h4 className="font-bold text-xl">
-                {t("pages.settings.general.powerDisplayTargets")}
-              </h4>
-              <PowerDisplayTargetSelector />
+              <div className="divide-y divide-border/60">
+                <section className="pb-4">
+                  <h5 className="font-semibold text-muted-foreground text-sm">
+                    {t("pages.settings.general.usageGraphDisplayTargets")}
+                  </h5>
+                  <GraphTypeSelector />
+                </section>
+                <section className="pt-4">
+                  <h5 className="font-semibold text-muted-foreground text-sm">
+                    {t("pages.settings.general.powerDisplayTargets")}
+                  </h5>
+                  <PowerDisplayTargetSelector />
+                </section>
+              </div>
             </div>
           </div>
           <div className="col-span-3">

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -290,8 +290,8 @@
       "hidePanel": "Hide {{panel}}",
       "reorderPanel": "Reorder {{panel}}",
       "currentValues": "Current values",
-      "monitorPowerModeSwitcher": "Power draw display",
-      "monitorPowerModes": {
+      "powerModeSwitcher": "Power draw display",
+      "powerModes": {
         "current": "Current",
         "graph": "Graph"
       },
@@ -383,8 +383,9 @@
           "cappuccino": "Cappuccino",
           "espresso": "Espresso"
         },
-        "hardwareType": "Hardware Type",
-        "powerDisplayTargets": "Power Display Targets",
+        "displayTargets": "Display Targets",
+        "usageGraphDisplayTargets": "Usage Graph",
+        "powerDisplayTargets": "Power Draw",
         "temperatureUnit": {
           "name": "Temperature Unit",
           "celsius": "Celsius (°C)",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -290,6 +290,14 @@
       "hidePanel": "Hide {{panel}}",
       "reorderPanel": "Reorder {{panel}}",
       "currentValues": "Current values",
+      "monitorPowerModeSwitcher": "Power draw display",
+      "monitorPowerModes": {
+        "current": "Current",
+        "graph": "Graph"
+      },
+      "shortWindow": "Last {{seconds}} seconds",
+      "now": "Now",
+      "secondsAgo": "{{seconds}}s ago",
       "perCoreUnavailable": "Per-core usage is not available on this system.",
       "motherboardSensorsUnavailable": "No motherboard sensors detected on this system.",
       "power": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -290,6 +290,14 @@
       "hidePanel": "{{panel}}を非表示",
       "reorderPanel": "{{panel}}を並べ替え",
       "currentValues": "現在値",
+      "monitorPowerModeSwitcher": "消費電力の表示",
+      "monitorPowerModes": {
+        "current": "現在値",
+        "graph": "グラフ"
+      },
+      "shortWindow": "過去{{seconds}}秒",
+      "now": "現在",
+      "secondsAgo": "{{seconds}}秒前",
       "perCoreUnavailable": "このシステムではコア別使用率を利用できません。",
       "motherboardSensorsUnavailable": "このシステムではマザーボードセンサーを検出できません。",
       "power": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -290,8 +290,8 @@
       "hidePanel": "{{panel}}を非表示",
       "reorderPanel": "{{panel}}を並べ替え",
       "currentValues": "現在値",
-      "monitorPowerModeSwitcher": "消費電力の表示",
-      "monitorPowerModes": {
+      "powerModeSwitcher": "消費電力の表示",
+      "powerModes": {
         "current": "現在値",
         "graph": "グラフ"
       },
@@ -383,8 +383,9 @@
           "cappuccino": "カプチーノ",
           "espresso": "エスプレッソ"
         },
-        "hardwareType": "ハードウェア種別",
-        "powerDisplayTargets": "消費電力の表示対象",
+        "displayTargets": "表示対象",
+        "usageGraphDisplayTargets": "使用率グラフ",
+        "powerDisplayTargets": "消費電力",
         "temperatureUnit": {
           "name": "温度の単位",
           "celsius": "摂氏（℃）",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -280,8 +280,8 @@
       "hidePanel": "Скрыть {{panel}}",
       "reorderPanel": "Изменить порядок: {{panel}}",
       "currentValues": "Текущие значения",
-      "monitorPowerModeSwitcher": "Отображение мощности",
-      "monitorPowerModes": {
+      "powerModeSwitcher": "Отображение мощности",
+      "powerModes": {
         "current": "Текущее",
         "graph": "График"
       },
@@ -373,8 +373,9 @@
           "cappuccino": "Капучино",
           "espresso": "Эспрессо"
         },
-        "hardwareType": "Тип оборудования",
-        "powerDisplayTargets": "Отображаемая мощность",
+        "displayTargets": "Цели отображения",
+        "usageGraphDisplayTargets": "График использования",
+        "powerDisplayTargets": "Мощность",
         "temperatureUnit": {
           "name": "Единица измерения температуры",
           "celsius": "Цельсий (°C)",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -280,6 +280,14 @@
       "hidePanel": "Скрыть {{panel}}",
       "reorderPanel": "Изменить порядок: {{panel}}",
       "currentValues": "Текущие значения",
+      "monitorPowerModeSwitcher": "Отображение мощности",
+      "monitorPowerModes": {
+        "current": "Текущее",
+        "graph": "График"
+      },
+      "shortWindow": "Последние {{seconds}} с",
+      "now": "Сейчас",
+      "secondsAgo": "{{seconds}} с назад",
       "perCoreUnavailable": "Загрузка по ядрам недоступна в этой системе.",
       "motherboardSensorsUnavailable": "Датчики материнской платы не обнаружены в этой системе.",
       "power": {


### PR DESCRIPTION
## Summary

- add capability-dependent Current and Graph Power Draw modes to both the Performance Panels and Monitor views
- share and persist the selected mode across both views while mounting only the active Current or Graph surface
- retain a nullable 60-second frontend Power Draw history so Graph is immediately populated after switching modes
- keep the Power panel readable with a compact header switch, series labels, and current readings at desktop and compact widths
- group Settings display targets once, then distinguish Usage Graph and Power Draw targets within that section

## Related Issues

Closes #2024

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Panels Current and Graph modes, Monitor Current and Graph modes, and the grouped Settings targets were captured and visually inspected through the web/mock E2E harness. Monitor was also checked at a 520x800 compact window size.

## Test Plan

- [x] Manual testing
- [x] Unit tests
- `npm test` / Vitest — 85 test files / 624 tests passed
- `npm run lint:ci`
- `npm run build`
- `npm run test:e2e -- e2e/performance.spec.ts` — 12 tests passed

The existing transient Recharts zero-size initialization warning still appears during E2E; it remains non-failing and is not introduced by this change.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable Power Draw graphs for CPU, GPU, ANE, and package readings.
  - Added shared Current/Graph display switching across Performance Panels and Monitor views, including compact layouts.
  - Power Draw display selections now persist across navigation.
  - Added clearer Settings sections for usage-graph and Power Draw display targets.
  - Power history now preserves gaps after hidden periods.

- **Bug Fixes**
  - Power displays are hidden when unavailable or no targets are configured.
  - Unavailable readings now display consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->