### PR TITLE
fix(core): persist the cooling baseline once established

### DIFF
--- a/core/src/infrastructure/database/cooling_baseline.rs
+++ b/core/src/infrastructure/database/cooling_baseline.rs
@@ -1,0 +1,176 @@
+//! `cooling_baseline` reads and writes: the single pinned row holding the
+//! established cooling baseline.
+//!
+//! The table exists so the baseline outlives the `cooling_daily_summary`
+//! rows it was derived from, which are cleaned up under their own
+//! retention window - see [`crate::persistence::cooling_baseline`] for
+//! why re-deriving forever would drift.
+//!
+//! Follows the `_from_pool` split used by the other query modules: the
+//! public `async fn`s resolve Core's process-wide pool via
+//! [`db::get_pool`], and delegate to a `_from_pool` variant taking an
+//! explicit `SqlitePool` so tests can exercise the query logic against an
+//! in-memory database.
+
+use super::db;
+use crate::persistence::cooling_baseline::EstablishedBaseline;
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::SqlitePool;
+
+pub async fn select_established_baseline()
+-> Result<Option<EstablishedBaseline>, sqlx::Error> {
+  let pool = db::get_pool().await?;
+  select_established_baseline_from_pool(&pool).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, sqlx::FromRow)]
+struct BaselineRow {
+  window_start_date: NaiveDate,
+  window_end_date: NaiveDate,
+  idle_temperature_avg: f64,
+  sample_minutes: i64,
+}
+
+impl From<BaselineRow> for EstablishedBaseline {
+  fn from(row: BaselineRow) -> Self {
+    Self {
+      idle_temperature_avg: row.idle_temperature_avg as f32,
+      window_start_date: row.window_start_date,
+      window_end_date: row.window_end_date,
+      // The column is written from a `u32`; clamp rather than wrap if a
+      // hand-edited database ever carries a negative count.
+      sample_minutes: row.sample_minutes.max(0) as u32,
+    }
+  }
+}
+
+pub(crate) async fn select_established_baseline_from_pool(
+  pool: &SqlitePool,
+) -> Result<Option<EstablishedBaseline>, sqlx::Error> {
+  let row = sqlx::query_as::<_, BaselineRow>(
+    "SELECT window_start_date, window_end_date, idle_temperature_avg, sample_minutes
+     FROM cooling_baseline
+     WHERE id = 1",
+  )
+  .fetch_optional(pool)
+  .await?;
+
+  Ok(row.map(EstablishedBaseline::from))
+}
+
+pub async fn insert_established_baseline(
+  baseline: &EstablishedBaseline,
+) -> Result<(), sqlx::Error> {
+  let pool = db::get_pool().await?;
+  insert_established_baseline_from_pool(&pool, baseline, Utc::now()).await
+}
+
+pub(crate) async fn insert_established_baseline_from_pool(
+  pool: &SqlitePool,
+  baseline: &EstablishedBaseline,
+  established_at: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+  // `OR IGNORE` against the fixed `id = 1` is what makes establishment
+  // write-once: a concurrent reader that derived the same establishment,
+  // or any later read, must never replace the pinned value - replacing it
+  // is exactly the drift this table exists to prevent.
+  sqlx::query(
+    "INSERT OR IGNORE INTO cooling_baseline
+       (id, window_start_date, window_end_date, idle_temperature_avg, sample_minutes, established_at)
+     VALUES (1, $1, $2, $3, $4, $5)",
+  )
+  .bind(baseline.window_start_date.format("%Y-%m-%d").to_string())
+  .bind(baseline.window_end_date.format("%Y-%m-%d").to_string())
+  .bind(baseline.idle_temperature_avg)
+  .bind(baseline.sample_minutes as i64)
+  .bind(established_at)
+  .execute(pool)
+  .await?;
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  async fn setup_cooling_baseline(pool: &SqlitePool) {
+    sqlx::query(
+      "CREATE TABLE cooling_baseline (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        window_start_date TEXT NOT NULL,
+        window_end_date TEXT NOT NULL,
+        idle_temperature_avg REAL NOT NULL,
+        sample_minutes INTEGER NOT NULL,
+        established_at TEXT NOT NULL
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  fn baseline(temperature: f32) -> EstablishedBaseline {
+    EstablishedBaseline {
+      idle_temperature_avg: temperature,
+      window_start_date: date(2026, 8, 1),
+      window_end_date: date(2026, 8, 7),
+      sample_minutes: 210,
+    }
+  }
+
+  #[tokio::test]
+  async fn select_established_baseline_is_none_before_anything_is_pinned() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_baseline(&pool).await;
+
+    assert_eq!(
+      select_established_baseline_from_pool(&pool).await.unwrap(),
+      None
+    );
+  }
+
+  #[tokio::test]
+  async fn insert_then_select_round_trips_the_established_baseline() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_baseline(&pool).await;
+
+    insert_established_baseline_from_pool(&pool, &baseline(42.5), Utc::now())
+      .await
+      .unwrap();
+
+    assert_eq!(
+      select_established_baseline_from_pool(&pool).await.unwrap(),
+      Some(baseline(42.5))
+    );
+  }
+
+  #[tokio::test]
+  async fn a_second_insert_never_replaces_the_pinned_baseline() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_baseline(&pool).await;
+    insert_established_baseline_from_pool(&pool, &baseline(42.5), Utc::now())
+      .await
+      .unwrap();
+
+    // A later establishment - derived once the original rollup rows aged
+    // out - must be ignored, not overwrite the reference.
+    insert_established_baseline_from_pool(&pool, &baseline(70.0), Utc::now())
+      .await
+      .unwrap();
+
+    assert_eq!(
+      select_established_baseline_from_pool(&pool).await.unwrap(),
+      Some(baseline(42.5))
+    );
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(1) FROM cooling_baseline")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+    assert_eq!(rows, 1, "the baseline table holds exactly one row");
+  }
+}

--- a/core/src/infrastructure/database/cooling_daily_summary.rs
+++ b/core/src/infrastructure/database/cooling_daily_summary.rs
@@ -154,6 +154,107 @@ pub(crate) async fn select_daily_idle_samples_from_pool(
   Ok(rows.into_iter().map(DailyIdleSample::from).collect())
 }
 
+/// Every summarized day's full band breakdown, oldest first, for Cooling
+/// Insight's long-range trend and load-band comparison queries (#2017).
+/// Reads the whole table - see [`select_daily_idle_samples`] for why that
+/// is cheap enough not to need a bounded `WHERE date >= ...` clause.
+pub async fn select_all_daily_cooling_summaries()
+-> Result<Vec<DailyCoolingSummary>, sqlx::Error> {
+  let pool = db::get_pool().await?;
+  select_all_daily_cooling_summaries_from_pool(&pool).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, sqlx::FromRow)]
+struct DailyCoolingSummaryRow {
+  date: NaiveDate,
+  idle_cpu_temperature_avg: Option<f64>,
+  idle_cpu_temperature_max: Option<f64>,
+  idle_cpu_temperature_min: Option<f64>,
+  idle_sample_minutes: i64,
+  low_cpu_temperature_avg: Option<f64>,
+  low_cpu_temperature_max: Option<f64>,
+  low_cpu_temperature_min: Option<f64>,
+  low_sample_minutes: i64,
+  mid_cpu_temperature_avg: Option<f64>,
+  mid_cpu_temperature_max: Option<f64>,
+  mid_cpu_temperature_min: Option<f64>,
+  mid_sample_minutes: i64,
+  high_cpu_temperature_avg: Option<f64>,
+  high_cpu_temperature_max: Option<f64>,
+  high_cpu_temperature_min: Option<f64>,
+  high_sample_minutes: i64,
+  coverage_minutes: i64,
+}
+
+impl From<DailyCoolingSummaryRow> for DailyCoolingSummary {
+  fn from(row: DailyCoolingSummaryRow) -> Self {
+    fn band(
+      avg: Option<f64>,
+      max: Option<f64>,
+      min: Option<f64>,
+      minutes: i64,
+    ) -> BandSummary {
+      BandSummary {
+        avg: avg.map(|v| v as f32),
+        max: max.map(|v| v as f32),
+        min: min.map(|v| v as f32),
+        // Same defensive clamp as `select_daily_idle_samples`: the
+        // column is `NOT NULL DEFAULT 0` and only ever written from a
+        // `u32`.
+        sample_minutes: minutes.max(0) as u32,
+      }
+    }
+
+    Self {
+      date: row.date,
+      coverage_minutes: row.coverage_minutes.max(0) as u32,
+      idle: band(
+        row.idle_cpu_temperature_avg,
+        row.idle_cpu_temperature_max,
+        row.idle_cpu_temperature_min,
+        row.idle_sample_minutes,
+      ),
+      low: band(
+        row.low_cpu_temperature_avg,
+        row.low_cpu_temperature_max,
+        row.low_cpu_temperature_min,
+        row.low_sample_minutes,
+      ),
+      mid: band(
+        row.mid_cpu_temperature_avg,
+        row.mid_cpu_temperature_max,
+        row.mid_cpu_temperature_min,
+        row.mid_sample_minutes,
+      ),
+      high: band(
+        row.high_cpu_temperature_avg,
+        row.high_cpu_temperature_max,
+        row.high_cpu_temperature_min,
+        row.high_sample_minutes,
+      ),
+    }
+  }
+}
+
+async fn select_all_daily_cooling_summaries_from_pool(
+  pool: &SqlitePool,
+) -> Result<Vec<DailyCoolingSummary>, sqlx::Error> {
+  let rows = sqlx::query_as::<_, DailyCoolingSummaryRow>(
+    "SELECT date,
+       idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+       low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+       mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+       high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+       coverage_minutes
+     FROM cooling_daily_summary
+     ORDER BY date ASC",
+  )
+  .fetch_all(pool)
+  .await?;
+
+  Ok(rows.into_iter().map(DailyCoolingSummary::from).collect())
+}
+
 pub async fn upsert(summary: &DailyCoolingSummary) -> Result<(), sqlx::Error> {
   let pool = db::get_pool().await?;
   upsert_from_pool(&pool, summary).await
@@ -532,6 +633,103 @@ mod tests {
       min: None,
       sample_minutes: 0,
     }
+  }
+
+  async fn insert_full_summary_row(
+    pool: &SqlitePool,
+    date: &str,
+    idle: BandSummary,
+    low: BandSummary,
+    mid: BandSummary,
+    high: BandSummary,
+    coverage_minutes: i64,
+  ) {
+    sqlx::query(
+      "INSERT INTO cooling_daily_summary (
+         date,
+         idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+         low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+         mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+         high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+         coverage_minutes
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)",
+    )
+    .bind(date)
+    .bind(idle.avg)
+    .bind(idle.max)
+    .bind(idle.min)
+    .bind(idle.sample_minutes as i64)
+    .bind(low.avg)
+    .bind(low.max)
+    .bind(low.min)
+    .bind(low.sample_minutes as i64)
+    .bind(mid.avg)
+    .bind(mid.max)
+    .bind(mid.min)
+    .bind(mid.sample_minutes as i64)
+    .bind(high.avg)
+    .bind(high.max)
+    .bind(high.min)
+    .bind(high.sample_minutes as i64)
+    .bind(coverage_minutes)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  #[tokio::test]
+  async fn select_all_daily_cooling_summaries_returns_every_band_in_ascending_date_order()
+  {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+    // Inserted out of order to verify the `ORDER BY date ASC` clause.
+    insert_full_summary_row(
+      &pool,
+      "2026-08-20",
+      full_band(30.0, 600),
+      full_band(40.0, 300),
+      empty_band(),
+      full_band(70.0, 100),
+      1000,
+    )
+    .await;
+    insert_full_summary_row(
+      &pool,
+      "2026-08-10",
+      full_band(28.0, 1440),
+      empty_band(),
+      empty_band(),
+      empty_band(),
+      1440,
+    )
+    .await;
+
+    let summaries = select_all_daily_cooling_summaries_from_pool(&pool)
+      .await
+      .unwrap();
+
+    assert_eq!(
+      summaries.iter().map(|s| s.date).collect::<Vec<_>>(),
+      vec![date(2026, 8, 10), date(2026, 8, 20)]
+    );
+    assert_eq!(summaries[1].idle, full_band(30.0, 600));
+    assert_eq!(summaries[1].low, full_band(40.0, 300));
+    assert_eq!(summaries[1].mid, empty_band());
+    assert_eq!(summaries[1].high, full_band(70.0, 100));
+    assert_eq!(summaries[1].coverage_minutes, 1000);
+  }
+
+  #[tokio::test]
+  async fn select_all_daily_cooling_summaries_is_empty_for_an_empty_rollup() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_cooling_daily_summary(&pool).await;
+
+    assert_eq!(
+      select_all_daily_cooling_summaries_from_pool(&pool)
+        .await
+        .unwrap(),
+      Vec::new()
+    );
   }
 
   #[tokio::test]

--- a/core/src/infrastructure/database/cooling_daily_summary.rs
+++ b/core/src/infrastructure/database/cooling_daily_summary.rs
@@ -138,7 +138,7 @@ impl From<DailyIdleRow> for DailyIdleSample {
   }
 }
 
-async fn select_daily_idle_samples_from_pool(
+pub(crate) async fn select_daily_idle_samples_from_pool(
   pool: &SqlitePool,
 ) -> Result<Vec<DailyIdleSample>, sqlx::Error> {
   // `date` is stored as "%Y-%m-%d", which sorts lexicographically the

--- a/core/src/infrastructure/database/cooling_daily_summary.rs
+++ b/core/src/infrastructure/database/cooling_daily_summary.rs
@@ -236,7 +236,7 @@ impl From<DailyCoolingSummaryRow> for DailyCoolingSummary {
   }
 }
 
-async fn select_all_daily_cooling_summaries_from_pool(
+pub(crate) async fn select_all_daily_cooling_summaries_from_pool(
   pool: &SqlitePool,
 ) -> Result<Vec<DailyCoolingSummary>, sqlx::Error> {
   let rows = sqlx::query_as::<_, DailyCoolingSummaryRow>(

--- a/core/src/infrastructure/database/mod.rs
+++ b/core/src/infrastructure/database/mod.rs
@@ -8,6 +8,7 @@
 //! read / write that Core executes goes through this module.
 
 pub mod archive_queries;
+pub mod cooling_baseline;
 pub mod cooling_daily_summary;
 pub mod db;
 pub mod gpu_archive;

--- a/core/src/persistence/cooling_band_comparison.rs
+++ b/core/src/persistence/cooling_band_comparison.rs
@@ -1,0 +1,437 @@
+//! Cooling Insight load-band comparison: for each CPU-load band
+//! (idle/low/mid/high), the baseline window's temperature versus the
+//! recent window's temperature, with sample counts (#2017).
+//!
+//! The baseline window is the same calendar range that established the
+//! idle cooling baseline (see
+//! [`crate::persistence::cooling_baseline`]) - reusing it keeps every
+//! band's "baseline" anchored to the same period rather than each band
+//! silently picking its own qualifying days. When no baseline is
+//! established yet, there is no such window, so every band reports
+//! [`BaselineState::Establishing`](crate::persistence::cooling_baseline::BaselineState::Establishing)
+//! rather than a partial comparison.
+
+use chrono::{Duration, NaiveDate};
+
+use crate::persistence::cooling_baseline::{
+  BaselineState, COOLING_BASELINE_RECENT_WINDOW_DAYS,
+};
+use crate::persistence::cooling_rollup::{BandSummary, CpuLoadBand, DailyCoolingSummary};
+
+/// Minimum sample minutes a band's window must carry before that band's
+/// comparison is meaningful. Applied independently to the baseline side
+/// and the recent side of each band - a band comparable on one side but
+/// not the other is still not comparable overall (DP-02: no delta
+/// computed from a handful of minutes as if it were a measurement).
+pub const COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES: u32 = 30;
+
+/// One band's sample-minute-weighted temperature over some date window.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct BandWindowSummary {
+  pub temperature_avg: Option<f32>,
+  pub sample_minutes: u32,
+}
+
+impl BandWindowSummary {
+  fn is_comparable(&self) -> bool {
+    self.sample_minutes >= COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES
+  }
+}
+
+/// One [`CpuLoadBand`]'s baseline-vs-recent comparison.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BandComparison {
+  pub band: CpuLoadBand,
+  pub baseline: BandWindowSummary,
+  pub recent: BandWindowSummary,
+  /// Whether both windows carry enough evidence for `recent` minus
+  /// `baseline` to mean anything. `false` means present "not comparable"
+  /// rather than a number, even though both fields above still carry
+  /// whatever (insufficient) data was found.
+  pub comparable: bool,
+}
+
+/// Cooling Insight's load-band comparison, gated by the same baseline
+/// lifecycle as [`crate::persistence::cooling_baseline::CoolingBaseline`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum CoolingBandComparison {
+  Establishing {
+    qualifying_days: u32,
+    required_days: u32,
+  },
+  Established {
+    baseline_window_start_date: NaiveDate,
+    baseline_window_end_date: NaiveDate,
+    recent_window_start_date: NaiveDate,
+    recent_window_end_date: NaiveDate,
+    bands: [BandComparison; 4],
+  },
+}
+
+/// Derive the load-band comparison from every completed day's rollup row
+/// and the current baseline lifecycle state.
+///
+/// `window_end_date` is the most recent completed local day (yesterday),
+/// matching [`crate::persistence::cooling_baseline::derive_cooling_baseline`].
+pub fn derive_band_comparison(
+  days: &[DailyCoolingSummary],
+  baseline_state: BaselineState,
+  window_end_date: NaiveDate,
+) -> CoolingBandComparison {
+  let (baseline_start, baseline_end) = match baseline_state {
+    BaselineState::Establishing {
+      qualifying_days,
+      required_days,
+    } => {
+      return CoolingBandComparison::Establishing {
+        qualifying_days,
+        required_days,
+      };
+    }
+    BaselineState::Established {
+      window_start_date,
+      window_end_date,
+      ..
+    } => (window_start_date, window_end_date),
+  };
+
+  let recent_start =
+    window_end_date - Duration::days(COOLING_BASELINE_RECENT_WINDOW_DAYS as i64 - 1);
+
+  let bands = [
+    CpuLoadBand::Idle,
+    CpuLoadBand::Low,
+    CpuLoadBand::Mid,
+    CpuLoadBand::High,
+  ]
+  .map(|band| {
+    let baseline = band_window_summary(days, band, baseline_start, baseline_end);
+    let recent = band_window_summary(days, band, recent_start, window_end_date);
+    let comparable = baseline.is_comparable() && recent.is_comparable();
+    BandComparison {
+      band,
+      baseline,
+      recent,
+      comparable,
+    }
+  });
+
+  CoolingBandComparison::Established {
+    baseline_window_start_date: baseline_start,
+    baseline_window_end_date: baseline_end,
+    recent_window_start_date: recent_start,
+    recent_window_end_date: window_end_date,
+    bands,
+  }
+}
+
+fn band_summary_for(day: &DailyCoolingSummary, band: CpuLoadBand) -> &BandSummary {
+  match band {
+    CpuLoadBand::Idle => &day.idle,
+    CpuLoadBand::Low => &day.low,
+    CpuLoadBand::Mid => &day.mid,
+    CpuLoadBand::High => &day.high,
+  }
+}
+
+/// Sample-minute-weighted average temperature for `band` across
+/// `[start, end]` (inclusive). Mirrors
+/// `cooling_baseline::weighted_idle_temperature`'s weighting rule, just
+/// generalized to any band instead of only idle.
+fn band_window_summary(
+  days: &[DailyCoolingSummary],
+  band: CpuLoadBand,
+  start: NaiveDate,
+  end: NaiveDate,
+) -> BandWindowSummary {
+  let mut weighted_sum = 0.0f64;
+  let mut sample_minutes: u64 = 0;
+
+  for day in days.iter().filter(|d| d.date >= start && d.date <= end) {
+    let summary = band_summary_for(day, band);
+    let Some(avg) = summary.avg else { continue };
+    weighted_sum += avg as f64 * summary.sample_minutes as f64;
+    sample_minutes += summary.sample_minutes as u64;
+  }
+
+  BandWindowSummary {
+    temperature_avg: (sample_minutes > 0)
+      .then(|| (weighted_sum / sample_minutes as f64) as f32),
+    sample_minutes: sample_minutes as u32,
+  }
+}
+
+fn to_idle_sample(
+  day: &DailyCoolingSummary,
+) -> crate::persistence::cooling_baseline::DailyIdleSample {
+  crate::persistence::cooling_baseline::DailyIdleSample {
+    date: day.date,
+    idle_temperature_avg: day.idle.avg,
+    idle_sample_minutes: day.idle.sample_minutes,
+  }
+}
+
+/// [`derive_band_comparison`] over the whole `cooling_daily_summary`
+/// table, deriving the baseline lifecycle state from the same rows
+/// (their idle-band projection) instead of a second query.
+pub async fn load_cooling_band_comparison() -> Result<CoolingBandComparison, sqlx::Error>
+{
+  use crate::infrastructure::database;
+  use crate::persistence::cooling_baseline::derive_baseline_state;
+
+  let days =
+    database::cooling_daily_summary::select_all_daily_cooling_summaries().await?;
+  let idle_samples: Vec<_> = days.iter().map(to_idle_sample).collect();
+  let baseline_state = derive_baseline_state(&idle_samples);
+  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+
+  Ok(derive_band_comparison(&days, baseline_state, yesterday))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::persistence::cooling_baseline::COOLING_BASELINE_QUALIFYING_IDLE_MINUTES;
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  fn band(avg: f32, minutes: u32) -> BandSummary {
+    BandSummary {
+      avg: Some(avg),
+      max: Some(avg + 1.0),
+      min: Some(avg - 1.0),
+      sample_minutes: minutes,
+    }
+  }
+
+  fn empty_band() -> BandSummary {
+    BandSummary::default()
+  }
+
+  fn established_baseline(start: NaiveDate, end: NaiveDate) -> BaselineState {
+    BaselineState::Established {
+      idle_temperature_avg: 35.0,
+      window_start_date: start,
+      window_end_date: end,
+      sample_minutes: 210,
+    }
+  }
+
+  #[test]
+  fn an_unestablished_baseline_reports_establishing_for_every_band() {
+    let result = derive_band_comparison(
+      &[],
+      BaselineState::Establishing {
+        qualifying_days: 2,
+        required_days: 7,
+      },
+      date(2026, 8, 20),
+    );
+
+    assert_eq!(
+      result,
+      CoolingBandComparison::Establishing {
+        qualifying_days: 2,
+        required_days: 7,
+      }
+    );
+  }
+
+  #[test]
+  fn each_band_is_weighted_by_its_own_sample_minutes_in_each_window() {
+    let baseline_start = date(2026, 8, 1);
+    let baseline_end = date(2026, 8, 7);
+    let recent_end = date(2026, 8, 20);
+    let recent_start =
+      recent_end - Duration::days(COOLING_BASELINE_RECENT_WINDOW_DAYS as i64 - 1);
+
+    let days = vec![
+      DailyCoolingSummary {
+        date: baseline_start,
+        coverage_minutes: 1440,
+        idle: band(30.0, 60),
+        low: band(40.0, 30),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+      DailyCoolingSummary {
+        date: baseline_end,
+        coverage_minutes: 1440,
+        idle: band(32.0, 60),
+        low: band(42.0, 90),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+      DailyCoolingSummary {
+        date: recent_start,
+        coverage_minutes: 1440,
+        idle: band(50.0, 60),
+        low: empty_band(),
+        mid: empty_band(),
+        high: band(70.0, 40),
+      },
+      DailyCoolingSummary {
+        date: recent_end,
+        coverage_minutes: 1440,
+        idle: band(52.0, 60),
+        low: empty_band(),
+        mid: empty_band(),
+        high: band(72.0, 20),
+      },
+    ];
+
+    let result = derive_band_comparison(
+      &days,
+      established_baseline(baseline_start, baseline_end),
+      recent_end,
+    );
+
+    match result {
+      CoolingBandComparison::Established {
+        baseline_window_start_date,
+        baseline_window_end_date,
+        recent_window_start_date,
+        recent_window_end_date,
+        bands,
+      } => {
+        assert_eq!(baseline_window_start_date, baseline_start);
+        assert_eq!(baseline_window_end_date, baseline_end);
+        assert_eq!(recent_window_start_date, recent_start);
+        assert_eq!(recent_window_end_date, recent_end);
+
+        let idle = bands.iter().find(|b| b.band == CpuLoadBand::Idle).unwrap();
+        assert_eq!(idle.baseline.sample_minutes, 120);
+        assert!((idle.baseline.temperature_avg.unwrap() - 31.0).abs() < 0.001);
+        assert_eq!(idle.recent.sample_minutes, 120);
+        assert!((idle.recent.temperature_avg.unwrap() - 51.0).abs() < 0.001);
+        assert!(idle.comparable);
+
+        let low = bands.iter().find(|b| b.band == CpuLoadBand::Low).unwrap();
+        assert_eq!(low.baseline.sample_minutes, 120);
+        let expected_low = (40.0 * 30.0 + 42.0 * 90.0) / 120.0;
+        assert!((low.baseline.temperature_avg.unwrap() - expected_low).abs() < 0.001);
+        assert_eq!(low.recent.sample_minutes, 0);
+        assert_eq!(low.recent.temperature_avg, None);
+        assert!(!low.comparable, "no recent low-band evidence at all");
+
+        let mid = bands.iter().find(|b| b.band == CpuLoadBand::Mid).unwrap();
+        assert_eq!(mid.baseline.sample_minutes, 0);
+        assert_eq!(mid.recent.sample_minutes, 0);
+        assert!(!mid.comparable);
+
+        let high = bands.iter().find(|b| b.band == CpuLoadBand::High).unwrap();
+        assert_eq!(high.baseline.sample_minutes, 0);
+        assert_eq!(high.recent.sample_minutes, 60);
+        assert!(
+          !high.comparable,
+          "recent evidence exists but the baseline side has none"
+        );
+      }
+      other => panic!("expected an established comparison, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn a_band_at_exactly_the_minimum_sample_minutes_on_both_sides_is_comparable() {
+    let baseline_start = date(2026, 8, 1);
+    let baseline_end = date(2026, 8, 1);
+    let recent_end = date(2026, 8, 20);
+    let recent_start =
+      recent_end - Duration::days(COOLING_BASELINE_RECENT_WINDOW_DAYS as i64 - 1);
+
+    let days = vec![
+      DailyCoolingSummary {
+        date: baseline_start,
+        coverage_minutes: 1440,
+        idle: band(30.0, COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES),
+        low: empty_band(),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+      DailyCoolingSummary {
+        date: recent_start,
+        coverage_minutes: 1440,
+        idle: band(50.0, COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES),
+        low: empty_band(),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+    ];
+
+    let result = derive_band_comparison(
+      &days,
+      established_baseline(baseline_start, baseline_end),
+      recent_end,
+    );
+
+    let CoolingBandComparison::Established { bands, .. } = result else {
+      panic!("expected an established comparison");
+    };
+    let idle = bands.iter().find(|b| b.band == CpuLoadBand::Idle).unwrap();
+    assert!(idle.comparable);
+  }
+
+  #[test]
+  fn a_band_one_minute_short_on_either_side_is_not_comparable() {
+    let baseline_start = date(2026, 8, 1);
+    let baseline_end = date(2026, 8, 1);
+    let recent_end = date(2026, 8, 20);
+    let recent_start =
+      recent_end - Duration::days(COOLING_BASELINE_RECENT_WINDOW_DAYS as i64 - 1);
+    let short = COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES - 1;
+
+    let days = vec![
+      DailyCoolingSummary {
+        date: baseline_start,
+        coverage_minutes: 1440,
+        idle: band(30.0, short),
+        low: empty_band(),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+      DailyCoolingSummary {
+        date: recent_start,
+        coverage_minutes: 1440,
+        idle: band(50.0, COOLING_BAND_COMPARISON_MINIMUM_SAMPLE_MINUTES),
+        low: empty_band(),
+        mid: empty_band(),
+        high: empty_band(),
+      },
+    ];
+
+    let result = derive_band_comparison(
+      &days,
+      established_baseline(baseline_start, baseline_end),
+      recent_end,
+    );
+
+    let CoolingBandComparison::Established { bands, .. } = result else {
+      panic!("expected an established comparison");
+    };
+    let idle = bands.iter().find(|b| b.band == CpuLoadBand::Idle).unwrap();
+    assert!(!idle.comparable);
+  }
+
+  #[test]
+  fn to_idle_sample_projects_only_the_idle_band() {
+    let day = DailyCoolingSummary {
+      date: date(2026, 8, 1),
+      coverage_minutes: 1440,
+      idle: band(30.0, COOLING_BASELINE_QUALIFYING_IDLE_MINUTES),
+      low: band(40.0, 300),
+      mid: empty_band(),
+      high: empty_band(),
+    };
+
+    let sample = to_idle_sample(&day);
+
+    assert_eq!(sample.date, day.date);
+    assert_eq!(sample.idle_temperature_avg, Some(30.0));
+    assert_eq!(
+      sample.idle_sample_minutes,
+      COOLING_BASELINE_QUALIFYING_IDLE_MINUTES
+    );
+  }
+}

--- a/core/src/persistence/cooling_band_comparison.rs
+++ b/core/src/persistence/cooling_band_comparison.rs
@@ -172,20 +172,35 @@ fn to_idle_sample(
 }
 
 /// [`derive_band_comparison`] over the whole `cooling_daily_summary`
-/// table, deriving the baseline lifecycle state from the same rows
-/// (their idle-band projection) instead of a second query.
-pub async fn load_cooling_band_comparison() -> Result<CoolingBandComparison, sqlx::Error>
-{
+/// table, resolving the baseline lifecycle state through
+/// [`crate::persistence::cooling_baseline::resolve_baseline_state_from_pool`]
+/// (their idle-band projection, so no second query) rather than
+/// re-deriving it - the pinned baseline row must win once one exists, or
+/// this comparison would silently drift once the rollup rows the
+/// original establishment came from age out.
+pub(crate) async fn load_cooling_band_comparison_from_pool(
+  pool: &sqlx::SqlitePool,
+  today: NaiveDate,
+) -> Result<CoolingBandComparison, sqlx::Error> {
   use crate::infrastructure::database;
-  use crate::persistence::cooling_baseline::derive_baseline_state;
+  use crate::persistence::cooling_baseline::resolve_baseline_state_from_pool;
 
   let days =
-    database::cooling_daily_summary::select_all_daily_cooling_summaries().await?;
+    database::cooling_daily_summary::select_all_daily_cooling_summaries_from_pool(pool)
+      .await?;
   let idle_samples: Vec<_> = days.iter().map(to_idle_sample).collect();
-  let baseline_state = derive_baseline_state(&idle_samples);
-  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+  let baseline_state = resolve_baseline_state_from_pool(pool, &idle_samples).await?;
+  let yesterday = today - Duration::days(1);
 
   Ok(derive_band_comparison(&days, baseline_state, yesterday))
+}
+
+/// [`load_cooling_band_comparison_from_pool`] against Core's process-wide
+/// pool.
+pub async fn load_cooling_band_comparison() -> Result<CoolingBandComparison, sqlx::Error>
+{
+  let pool = crate::infrastructure::database::db::get_pool().await?;
+  load_cooling_band_comparison_from_pool(&pool, chrono::Local::now().date_naive()).await
 }
 
 #[cfg(test)]
@@ -433,5 +448,141 @@ mod tests {
       sample.idle_sample_minutes,
       COOLING_BASELINE_QUALIFYING_IDLE_MINUTES
     );
+  }
+
+  // ── pinned baseline (DB-backed) ──
+
+  mod pinned_baseline {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn setup_tables(pool: &SqlitePool) {
+      sqlx::query(
+        "CREATE TABLE cooling_daily_summary (
+          date TEXT PRIMARY KEY,
+          idle_cpu_temperature_avg REAL,
+          idle_cpu_temperature_max REAL,
+          idle_cpu_temperature_min REAL,
+          idle_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          low_cpu_temperature_avg REAL,
+          low_cpu_temperature_max REAL,
+          low_cpu_temperature_min REAL,
+          low_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          mid_cpu_temperature_avg REAL,
+          mid_cpu_temperature_max REAL,
+          mid_cpu_temperature_min REAL,
+          mid_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          high_cpu_temperature_avg REAL,
+          high_cpu_temperature_max REAL,
+          high_cpu_temperature_min REAL,
+          high_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          coverage_minutes INTEGER NOT NULL
+        )",
+      )
+      .execute(pool)
+      .await
+      .unwrap();
+      sqlx::query(
+        "CREATE TABLE cooling_baseline (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          window_start_date TEXT NOT NULL,
+          window_end_date TEXT NOT NULL,
+          idle_temperature_avg REAL NOT NULL,
+          sample_minutes INTEGER NOT NULL,
+          established_at TEXT NOT NULL
+        )",
+      )
+      .execute(pool)
+      .await
+      .unwrap();
+    }
+
+    async fn insert_idle_day(
+      pool: &SqlitePool,
+      date: NaiveDate,
+      temperature: f32,
+      minutes: u32,
+    ) {
+      sqlx::query(
+        "INSERT INTO cooling_daily_summary
+           (date, idle_cpu_temperature_avg, idle_sample_minutes, coverage_minutes)
+         VALUES ($1, $2, $3, 1440)",
+      )
+      .bind(date.format("%Y-%m-%d").to_string())
+      .bind(temperature)
+      .bind(minutes as i64)
+      .execute(pool)
+      .await
+      .unwrap();
+    }
+
+    async fn insert_establishing_days(
+      pool: &SqlitePool,
+      start: NaiveDate,
+      temperature: f32,
+    ) {
+      use crate::persistence::cooling_baseline::{
+        COOLING_BASELINE_QUALIFYING_IDLE_MINUTES,
+        COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
+      };
+      for offset in 0..COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS {
+        insert_idle_day(
+          pool,
+          start + Duration::days(offset as i64),
+          temperature,
+          COOLING_BASELINE_QUALIFYING_IDLE_MINUTES,
+        )
+        .await;
+      }
+    }
+
+    #[tokio::test]
+    async fn the_baseline_window_does_not_drift_when_its_source_rows_are_deleted() {
+      // Same regression as cooling_baseline's own pinning test, but for
+      // the band comparison's loader: it must resolve the pinned row
+      // through the shared resolver instead of re-deriving from whatever
+      // `cooling_daily_summary` rows currently exist.
+      let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+      setup_tables(&pool).await;
+      let start = date(2026, 8, 1);
+      insert_establishing_days(&pool, start, 42.0).await;
+
+      let established = load_cooling_band_comparison_from_pool(&pool, date(2026, 8, 20))
+        .await
+        .unwrap();
+      let CoolingBandComparison::Established {
+        baseline_window_start_date,
+        ..
+      } = established
+      else {
+        panic!("expected an established comparison");
+      };
+      assert_eq!(baseline_window_start_date, start);
+
+      // Age out the rows the baseline was derived from, and record a
+      // hotter stretch that would establish a different window if the
+      // pinned row were ignored.
+      sqlx::query("DELETE FROM cooling_daily_summary")
+        .execute(&pool)
+        .await
+        .unwrap();
+      insert_establishing_days(&pool, date(2027, 6, 1), 70.0).await;
+
+      let after_cleanup =
+        load_cooling_band_comparison_from_pool(&pool, date(2027, 6, 20))
+          .await
+          .unwrap();
+      let CoolingBandComparison::Established {
+        baseline_window_start_date,
+        ..
+      } = after_cleanup
+      else {
+        panic!("expected an established comparison");
+      };
+      assert_eq!(
+        baseline_window_start_date, start,
+        "the pinned baseline window must not drift when its source rows are deleted"
+      );
+    }
   }
 }

--- a/core/src/persistence/cooling_baseline.rs
+++ b/core/src/persistence/cooling_baseline.rs
@@ -335,12 +335,24 @@ pub(crate) async fn resolve_baseline_state_from_pool(
     None => {
       let derived = derive_baseline_state(days);
       if let Some(baseline) = EstablishedBaseline::from_state(&derived) {
-        database::cooling_baseline::insert_established_baseline_from_pool(
+        // Pinning is write-once bookkeeping (`INSERT OR IGNORE`), not
+        // part of the answer: a transient write failure (e.g.
+        // SQLITE_BUSY while the rollup worker holds the database) must
+        // not turn a valid derivation into a read error. The pin is
+        // simply retried on the next resolution.
+        if let Err(e) = database::cooling_baseline::insert_established_baseline_from_pool(
           pool,
           &baseline,
           chrono::Utc::now(),
         )
-        .await?;
+        .await
+        {
+          crate::log_error!(
+            "Failed to pin the established cooling baseline; retrying on the next resolution",
+            "persistence::cooling_baseline::resolve_baseline_state_from_pool",
+            Some(e.to_string())
+          );
+        }
       }
       Ok(derived)
     }
@@ -380,6 +392,23 @@ pub(crate) async fn load_cooling_baseline_from_pool(
 pub async fn load_cooling_baseline() -> Result<CoolingBaseline, sqlx::Error> {
   let pool = crate::infrastructure::database::db::get_pool().await?;
   load_cooling_baseline_from_pool(&pool, chrono::Local::now().date_naive()).await
+}
+
+/// Resolve — and, on first establishment, pin — the baseline in the
+/// background. The rollup worker calls this after every catch-up pass,
+/// so establishment never depends on Cooling Insight being opened
+/// before retention cleanup erases the establishment-window rows. The
+/// `scheduledDataDeletion` cleanup itself only runs after a successful
+/// catch-up, which orders it after this call too. Failures are logged
+/// and retried on the next pass.
+pub(crate) async fn ensure_baseline_pinned() {
+  if let Err(e) = load_cooling_baseline().await {
+    crate::log_error!(
+      "Failed to resolve the cooling baseline after a rollup catch-up",
+      "persistence::cooling_baseline::ensure_baseline_pinned",
+      Some(e.to_string())
+    );
+  }
 }
 
 #[cfg(test)]

--- a/core/src/persistence/cooling_baseline.rs
+++ b/core/src/persistence/cooling_baseline.rs
@@ -2,26 +2,35 @@
 //! when it is not doing anything, used later as the reference that recent
 //! idle temperatures are compared against (#1666 Phase 1 MVP).
 //!
-//! The baseline is *derived on read* from `cooling_daily_summary` (see
-//! [`crate::persistence::cooling_rollup`]) rather than stored in a table
-//! of its own. Two properties of the rollup make that work:
+//! The baseline is *established by derivation, then pinned*: it is
+//! derived from `cooling_daily_summary` (see
+//! [`crate::persistence::cooling_rollup`]) only while it has not been
+//! established yet, and the first derivation that reaches
+//! [`BaselineState::Established`] is written once into the single-row
+//! `cooling_baseline` table. Every later read returns that pinned row.
 //!
-//! - The rollup already expresses "idle" per completed local day: the
-//!   [`CpuLoadBand::Idle`](crate::persistence::cooling_rollup::CpuLoadBand)
-//!   band's `sample_minutes` is exactly how many one-minute samples that
-//!   day spent in the idle band. "Sustained low load" therefore becomes a
-//!   per-day minimum ([`COOLING_BASELINE_QUALIFYING_IDLE_MINUTES`])
-//!   instead of a separate run-length scan over one-minute archive rows.
-//! - The baseline is defined as the *first*
-//!   [`COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS`] qualifying days, which
-//!   never change once they are in the past, so the derived value is
-//!   stable across reads without being pinned into a row.
+//! Deriving expresses the idle requirement cheaply: the rollup already
+//! records, per completed local day, how many one-minute samples that day
+//! spent in the
+//! [`CpuLoadBand::Idle`](crate::persistence::cooling_rollup::CpuLoadBand)
+//! band, so "low load sustained for a minimum duration" becomes a per-day
+//! minimum ([`COOLING_BASELINE_QUALIFYING_IDLE_MINUTES`]) instead of a
+//! run-length scan over one-minute archive rows.
 //!
-//! Deriving also makes the explicit-reset requirement fall out for free:
-//! the Insights data reset clears `cooling_daily_summary`, and the
-//! baseline goes with it. A dedicated baseline table would instead need
-//! its own reset path, its own migration, and a stored lifecycle state
-//! that could drift out of sync with the rollup it was computed from.
+//! Pinning is what keeps it *stable*. The baseline is defined as the
+//! first [`COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS`] qualifying days,
+//! which never change once they are in the past - but the rows recording
+//! them do: `cooling_daily_summary` is cleaned up after
+//! [`COOLING_DAILY_SUMMARY_RETENTION_DAYS`](crate::persistence::cooling_rollup::COOLING_DAILY_SUMMARY_RETENTION_DAYS).
+//! Re-deriving forever would therefore let "the first N qualifying days"
+//! silently advance as the original days aged out, drifting the very
+//! reference that deltas are measured against (or regressing an
+//! established baseline to `Establishing` once fewer than N days
+//! remained). Writing the value down at establishment time is what makes
+//! the reference outlive the rows it was computed from.
+//!
+//! The recent window and its comparability are still derived on every
+//! read: those describe the present, not the fixed reference.
 
 use chrono::{Duration, NaiveDate};
 
@@ -102,6 +111,51 @@ pub enum BaselineState {
     window_end_date: NaiveDate,
     sample_minutes: u32,
   },
+}
+
+/// The established baseline as pinned into `cooling_baseline`: the value
+/// together with the collection period it was computed from.
+///
+/// Written exactly once, the first time the derivation reaches
+/// [`BaselineState::Established`], so the reference outlives the
+/// `cooling_daily_summary` rows it was derived from (see the module
+/// docs).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EstablishedBaseline {
+  pub idle_temperature_avg: f32,
+  pub window_start_date: NaiveDate,
+  pub window_end_date: NaiveDate,
+  pub sample_minutes: u32,
+}
+
+impl EstablishedBaseline {
+  /// The record to pin for `state`, or `None` while still establishing -
+  /// nothing is written before the baseline exists.
+  pub fn from_state(state: &BaselineState) -> Option<Self> {
+    match *state {
+      BaselineState::Established {
+        idle_temperature_avg,
+        window_start_date,
+        window_end_date,
+        sample_minutes,
+      } => Some(Self {
+        idle_temperature_avg,
+        window_start_date,
+        window_end_date,
+        sample_minutes,
+      }),
+      BaselineState::Establishing { .. } => None,
+    }
+  }
+
+  pub fn into_state(self) -> BaselineState {
+    BaselineState::Established {
+      idle_temperature_avg: self.idle_temperature_avg,
+      window_start_date: self.window_start_date,
+      window_end_date: self.window_end_date,
+      sample_minutes: self.sample_minutes,
+    }
+  }
 }
 
 /// Trailing-window idle summary: how much idle evidence the recent past
@@ -258,30 +312,64 @@ fn weighted_idle_temperature<'a>(
   })
 }
 
-/// [`derive_cooling_baseline`] over the whole `cooling_daily_summary`
-/// table.
+/// Load the cooling baseline, pinning it the first time it establishes.
 ///
-/// Reads every row - at most
-/// [`COOLING_DAILY_SUMMARY_RETENTION_DAYS`](crate::persistence::cooling_rollup::COOLING_DAILY_SUMMARY_RETENTION_DAYS)
-/// of them, three narrow columns each - which is cheap enough that
-/// caching the result, or pinning it into a dedicated row, would only add
-/// state to keep in sync with the rollup it is derived from.
-pub async fn load_cooling_baseline() -> Result<CoolingBaseline, sqlx::Error> {
+/// Reads the pinned row first: once established, the baseline is a fixed
+/// reference, and re-deriving it would let it drift as the rollup rows it
+/// came from age out (see the module docs). Only while nothing is pinned
+/// does this derive from the rollup, and that derivation is written back
+/// as soon as it reaches [`BaselineState::Established`].
+///
+/// The recent window is always derived - it describes the present, not
+/// the fixed reference.
+pub(crate) async fn load_cooling_baseline_from_pool(
+  pool: &sqlx::SqlitePool,
+  today: NaiveDate,
+) -> Result<CoolingBaseline, sqlx::Error> {
   use crate::infrastructure::database;
 
-  let days = database::cooling_daily_summary::select_daily_idle_samples().await?;
+  let days =
+    database::cooling_daily_summary::select_daily_idle_samples_from_pool(pool).await?;
   // The rollup only ever summarizes completed local days, so the newest
   // day that can carry a row is yesterday. Anchoring the recent window
   // to the calendar (not to the newest row present) is what makes a long
   // gap in usage report "not comparable" instead of presenting a stale
   // reading as recent.
-  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
-  Ok(derive_cooling_baseline(&days, yesterday))
+  let recent = summarize_recent_idle(&days, today - Duration::days(1));
+
+  let state = match database::cooling_baseline::select_established_baseline_from_pool(
+    pool,
+  )
+  .await?
+  {
+    Some(pinned) => pinned.into_state(),
+    None => {
+      let derived = derive_baseline_state(&days);
+      if let Some(baseline) = EstablishedBaseline::from_state(&derived) {
+        database::cooling_baseline::insert_established_baseline_from_pool(
+          pool,
+          &baseline,
+          chrono::Utc::now(),
+        )
+        .await?;
+      }
+      derived
+    }
+  };
+
+  Ok(CoolingBaseline { state, recent })
+}
+
+/// [`load_cooling_baseline_from_pool`] against Core's process-wide pool.
+pub async fn load_cooling_baseline() -> Result<CoolingBaseline, sqlx::Error> {
+  let pool = crate::infrastructure::database::db::get_pool().await?;
+  load_cooling_baseline_from_pool(&pool, chrono::Local::now().date_naive()).await
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+  use sqlx::SqlitePool;
 
   fn date(y: i32, m: u32, d: u32) -> NaiveDate {
     NaiveDate::from_ymd_opt(y, m, d).unwrap()
@@ -528,24 +616,159 @@ mod tests {
     );
   }
 
-  #[test]
-  fn clearing_the_rollup_returns_the_baseline_to_establishing() {
-    // The Insights data reset deletes every `cooling_daily_summary` row;
-    // with the baseline derived from those rows, re-establishment
-    // restarts from whatever is recorded afterwards.
-    let established = qualifying_days(
-      date(2026, 8, 1),
-      COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
-      42.0,
+  // ── establish-then-persist (DB-backed) ──
+
+  async fn setup_tables(pool: &SqlitePool) {
+    sqlx::query(
+      "CREATE TABLE cooling_daily_summary (
+        date TEXT PRIMARY KEY,
+        idle_cpu_temperature_avg REAL,
+        idle_cpu_temperature_max REAL,
+        idle_cpu_temperature_min REAL,
+        idle_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        low_cpu_temperature_avg REAL,
+        low_cpu_temperature_max REAL,
+        low_cpu_temperature_min REAL,
+        low_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        mid_cpu_temperature_avg REAL,
+        mid_cpu_temperature_max REAL,
+        mid_cpu_temperature_min REAL,
+        mid_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        high_cpu_temperature_avg REAL,
+        high_cpu_temperature_max REAL,
+        high_cpu_temperature_min REAL,
+        high_sample_minutes INTEGER NOT NULL DEFAULT 0,
+        coverage_minutes INTEGER NOT NULL
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+      "CREATE TABLE cooling_baseline (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        window_start_date TEXT NOT NULL,
+        window_end_date TEXT NOT NULL,
+        idle_temperature_avg REAL NOT NULL,
+        sample_minutes INTEGER NOT NULL,
+        established_at TEXT NOT NULL
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  async fn insert_idle_day(
+    pool: &SqlitePool,
+    date: NaiveDate,
+    temperature: f32,
+    minutes: u32,
+  ) {
+    sqlx::query(
+      "INSERT INTO cooling_daily_summary
+         (date, idle_cpu_temperature_avg, idle_sample_minutes, coverage_minutes)
+       VALUES ($1, $2, $3, 1440)",
+    )
+    .bind(date.format("%Y-%m-%d").to_string())
+    .bind(temperature)
+    .bind(minutes as i64)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  /// Record `COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS` qualifying days
+  /// starting at `start`, enough to establish the baseline.
+  async fn insert_establishing_days(
+    pool: &SqlitePool,
+    start: NaiveDate,
+    temperature: f32,
+  ) {
+    for offset in 0..COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS {
+      insert_idle_day(
+        pool,
+        start + Duration::days(offset as i64),
+        temperature,
+        COOLING_BASELINE_QUALIFYING_IDLE_MINUTES,
+      )
+      .await;
+    }
+  }
+
+  #[tokio::test]
+  async fn the_baseline_survives_the_rollup_rows_it_was_derived_from_being_deleted() {
+    // The regression this whole design exists for: the rollup is cleaned
+    // up after COOLING_DAILY_SUMMARY_RETENTION_DAYS, so the days the
+    // baseline was established from eventually disappear. Once pinned,
+    // the reference must not move when that happens - neither drifting to
+    // a later set of qualifying days nor regressing to Establishing.
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_tables(&pool).await;
+    let start = date(2026, 8, 1);
+    insert_establishing_days(&pool, start, 42.0).await;
+
+    let established = load_cooling_baseline_from_pool(&pool, date(2026, 8, 20))
+      .await
+      .unwrap();
+    assert!(
+      matches!(
+        established.state,
+        BaselineState::Established {
+          idle_temperature_avg: 42.0,
+          ..
+        }
+      ),
+      "expected an established baseline, got {:?}",
+      established.state
     );
+
+    // Age out every row the baseline was derived from, and record a
+    // hotter stretch of days that would establish a different value.
+    sqlx::query("DELETE FROM cooling_daily_summary")
+      .execute(&pool)
+      .await
+      .unwrap();
+    insert_establishing_days(&pool, date(2027, 6, 1), 70.0).await;
+
+    let after_cleanup = load_cooling_baseline_from_pool(&pool, date(2027, 6, 20))
+      .await
+      .unwrap();
+
+    assert_eq!(
+      after_cleanup.state, established.state,
+      "the pinned baseline must not drift when its source rows are deleted"
+    );
+  }
+
+  #[tokio::test]
+  async fn clearing_the_rollup_and_the_pinned_row_returns_the_baseline_to_establishing() {
+    // The Insights data reset clears both tables. Only then does the
+    // baseline go back to establishing and re-derive from whatever is
+    // recorded afterwards.
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_tables(&pool).await;
+    insert_establishing_days(&pool, date(2026, 8, 1), 42.0).await;
     assert!(matches!(
-      derive_baseline_state(&established),
+      load_cooling_baseline_from_pool(&pool, date(2026, 8, 20))
+        .await
+        .unwrap()
+        .state,
       BaselineState::Established { .. }
     ));
 
-    let after_reset: Vec<DailyIdleSample> = Vec::new();
+    for table in ["cooling_daily_summary", "cooling_baseline"] {
+      sqlx::query(&format!("DELETE FROM {table}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
     assert_eq!(
-      derive_baseline_state(&after_reset),
+      load_cooling_baseline_from_pool(&pool, date(2026, 8, 20))
+        .await
+        .unwrap()
+        .state,
       BaselineState::Establishing {
         qualifying_days: 0,
         required_days: COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
@@ -554,13 +777,12 @@ mod tests {
 
     // Days recorded after the reset establish a fresh baseline at the new
     // temperature rather than restoring the old one.
-    let re_established = qualifying_days(
-      date(2026, 10, 1),
-      COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
-      55.0,
-    );
+    insert_establishing_days(&pool, date(2026, 10, 1), 55.0).await;
     assert_eq!(
-      derive_baseline_state(&re_established),
+      load_cooling_baseline_from_pool(&pool, date(2026, 10, 20))
+        .await
+        .unwrap()
+        .state,
       BaselineState::Established {
         idle_temperature_avg: 55.0,
         window_start_date: date(2026, 10, 1),
@@ -570,6 +792,59 @@ mod tests {
           * COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
       }
     );
+  }
+
+  #[tokio::test]
+  async fn a_baseline_still_establishing_is_not_pinned_yet() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_tables(&pool).await;
+    for offset in 0..(COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS - 1) {
+      insert_idle_day(
+        &pool,
+        date(2026, 8, 1) + Duration::days(offset as i64),
+        42.0,
+        COOLING_BASELINE_QUALIFYING_IDLE_MINUTES,
+      )
+      .await;
+    }
+
+    let baseline = load_cooling_baseline_from_pool(&pool, date(2026, 8, 20))
+      .await
+      .unwrap();
+
+    assert_eq!(
+      baseline.state,
+      BaselineState::Establishing {
+        qualifying_days: COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS - 1,
+        required_days: COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS,
+      }
+    );
+    let pinned: i64 = sqlx::query_scalar("SELECT COUNT(1) FROM cooling_baseline")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+    assert_eq!(pinned, 0, "nothing may be pinned before establishment");
+  }
+
+  #[tokio::test]
+  async fn the_recent_window_still_tracks_the_present_after_the_baseline_is_pinned() {
+    // Pinning fixes the reference, not the comparison: recent idle must
+    // keep following current data.
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup_tables(&pool).await;
+    insert_establishing_days(&pool, date(2026, 8, 1), 42.0).await;
+    load_cooling_baseline_from_pool(&pool, date(2026, 8, 20))
+      .await
+      .unwrap();
+
+    insert_idle_day(&pool, date(2026, 9, 10), 61.0, 120).await;
+    let baseline = load_cooling_baseline_from_pool(&pool, date(2026, 9, 11))
+      .await
+      .unwrap();
+
+    assert_eq!(baseline.recent.idle_temperature_avg, Some(61.0));
+    assert_eq!(baseline.recent.sample_minutes, 120);
+    assert!(baseline.recent.is_comparable());
   }
 
   // ── recent idle window ──

--- a/core/src/persistence/cooling_baseline.rs
+++ b/core/src/persistence/cooling_baseline.rs
@@ -312,6 +312,41 @@ fn weighted_idle_temperature<'a>(
   })
 }
 
+/// Resolve the baseline lifecycle state for any Cooling Insight query:
+/// the pinned row if one exists, otherwise derive it from `days` and pin
+/// it the moment it reaches [`BaselineState::Established`].
+///
+/// Every loader that needs the baseline state (the baseline card itself,
+/// the band comparison, the baseline delta, ...) must go through this
+/// function rather than calling [`derive_baseline_state`] directly -
+/// otherwise it silently ignores the pinned row and drifts as the
+/// `cooling_daily_summary` rows the original establishment was derived
+/// from age out (see the module docs). Keeping the write-back in this one
+/// place is what keeps that guarantee from depending on every call site
+/// remembering it.
+pub(crate) async fn resolve_baseline_state_from_pool(
+  pool: &sqlx::SqlitePool,
+  days: &[DailyIdleSample],
+) -> Result<BaselineState, sqlx::Error> {
+  use crate::infrastructure::database;
+
+  match database::cooling_baseline::select_established_baseline_from_pool(pool).await? {
+    Some(pinned) => Ok(pinned.into_state()),
+    None => {
+      let derived = derive_baseline_state(days);
+      if let Some(baseline) = EstablishedBaseline::from_state(&derived) {
+        database::cooling_baseline::insert_established_baseline_from_pool(
+          pool,
+          &baseline,
+          chrono::Utc::now(),
+        )
+        .await?;
+      }
+      Ok(derived)
+    }
+  }
+}
+
 /// Load the cooling baseline, pinning it the first time it establishes.
 ///
 /// Reads the pinned row first: once established, the baseline is a fixed
@@ -336,26 +371,7 @@ pub(crate) async fn load_cooling_baseline_from_pool(
   // gap in usage report "not comparable" instead of presenting a stale
   // reading as recent.
   let recent = summarize_recent_idle(&days, today - Duration::days(1));
-
-  let state = match database::cooling_baseline::select_established_baseline_from_pool(
-    pool,
-  )
-  .await?
-  {
-    Some(pinned) => pinned.into_state(),
-    None => {
-      let derived = derive_baseline_state(&days);
-      if let Some(baseline) = EstablishedBaseline::from_state(&derived) {
-        database::cooling_baseline::insert_established_baseline_from_pool(
-          pool,
-          &baseline,
-          chrono::Utc::now(),
-        )
-        .await?;
-      }
-      derived
-    }
-  };
+  let state = resolve_baseline_state_from_pool(pool, &days).await?;
 
   Ok(CoolingBaseline { state, recent })
 }

--- a/core/src/persistence/cooling_baseline_delta.rs
+++ b/core/src/persistence/cooling_baseline_delta.rs
@@ -1,0 +1,404 @@
+//! Cooling Insight baseline delta: how far the trailing 7-day idle
+//! temperature average has drifted from the established baseline, and
+//! whether that drift has been sustained long enough to call out (#2017,
+//! thresholds from #1666).
+//!
+//! The threshold defaults live here, behind this module's boundary, so
+//! the frontend never re-derives "how much warmer counts as a mild
+//! rise" - it only renders the [`CoolingDeltaObservation`] Core already
+//! decided.
+
+use chrono::{Duration, NaiveDate};
+
+use crate::persistence::cooling_baseline::{
+  BaselineState, DailyIdleSample, RecentIdleSummary, summarize_recent_idle,
+};
+
+/// Consecutive trailing-window days a delta must stay at or above
+/// [`COOLING_DELTA_MILD_RISE_THRESHOLD`] before the rise counts as
+/// "sustained" rather than a single noisy day.
+pub const COOLING_DELTA_SUSTAIN_DAYS: u32 = 3;
+
+/// Delta (degrees Celsius, recent minus baseline) at or above which a
+/// sustained rise is reported as mild.
+pub const COOLING_DELTA_MILD_RISE_THRESHOLD: f32 = 5.0;
+
+/// Delta (degrees Celsius) at or above which a sustained rise is
+/// reported as large instead of mild.
+pub const COOLING_DELTA_LARGE_RISE_THRESHOLD: f32 = 10.0;
+
+/// Cooling Insight's read of the current idle-temperature drift.
+///
+/// `Establishing` and `NotComparable` both withhold a verdict on the
+/// drift itself - they differ in *why*: no baseline exists yet, versus a
+/// baseline exists but the recent window does not carry enough idle
+/// evidence to compare against it (see
+/// [`RecentIdleSummary::is_comparable`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoolingDeltaObservation {
+  Establishing,
+  NotComparable,
+  WithinRange,
+  SustainedMildRise,
+  SustainedLargeRise,
+}
+
+/// One trailing-7-day-window's delta against the baseline, ending on
+/// `date`. Part of the series a sustained-rise verdict was computed
+/// from, returned so the UI can render "n days in a row" without
+/// recomputing it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DailyDelta {
+  pub date: NaiveDate,
+  pub delta: f32,
+}
+
+/// Everything Cooling Insight needs to render the baseline delta card.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoolingBaselineDelta {
+  pub baseline_state: BaselineState,
+  pub recent: RecentIdleSummary,
+  /// `recent.idle_temperature_avg - baseline`, or `None` whenever
+  /// `observation` is `Establishing` or `NotComparable`.
+  pub delta: Option<f32>,
+  pub observation: CoolingDeltaObservation,
+  /// The trailing-window deltas actually examined to reach
+  /// `sustained_days`, oldest first, ending at the same day `recent`
+  /// covers. Empty when `observation` is `Establishing` or
+  /// `NotComparable`.
+  pub daily_deltas: Vec<DailyDelta>,
+  pub sustained_days: u32,
+}
+
+/// Derive the baseline delta from every summarized day's idle-band
+/// facts and the current baseline lifecycle state.
+///
+/// `window_end_date` is the most recent completed local day (yesterday),
+/// matching [`crate::persistence::cooling_baseline::derive_cooling_baseline`].
+pub fn derive_baseline_delta(
+  days: &[DailyIdleSample],
+  baseline_state: BaselineState,
+  window_end_date: NaiveDate,
+) -> CoolingBaselineDelta {
+  let recent = summarize_recent_idle(days, window_end_date);
+
+  let Some(baseline_temperature) = established_temperature(baseline_state) else {
+    return CoolingBaselineDelta {
+      baseline_state,
+      recent,
+      delta: None,
+      observation: CoolingDeltaObservation::Establishing,
+      daily_deltas: Vec::new(),
+      sustained_days: 0,
+    };
+  };
+
+  if !recent.is_comparable() {
+    return CoolingBaselineDelta {
+      baseline_state,
+      recent,
+      delta: None,
+      observation: CoolingDeltaObservation::NotComparable,
+      daily_deltas: Vec::new(),
+      sustained_days: 0,
+    };
+  }
+
+  // `recent.is_comparable()` guarantees an average is present.
+  let delta = recent.idle_temperature_avg.unwrap() - baseline_temperature;
+  let (daily_deltas, sustained_days) =
+    trailing_daily_deltas(days, baseline_temperature, window_end_date);
+  let observation = classify_observation(delta, sustained_days);
+
+  CoolingBaselineDelta {
+    baseline_state,
+    recent,
+    delta: Some(delta),
+    observation,
+    daily_deltas,
+    sustained_days,
+  }
+}
+
+fn established_temperature(state: BaselineState) -> Option<f32> {
+  match state {
+    BaselineState::Established {
+      idle_temperature_avg,
+      ..
+    } => Some(idle_temperature_avg),
+    BaselineState::Establishing { .. } => None,
+  }
+}
+
+fn classify_observation(delta: f32, sustained_days: u32) -> CoolingDeltaObservation {
+  if sustained_days < COOLING_DELTA_SUSTAIN_DAYS {
+    return CoolingDeltaObservation::WithinRange;
+  }
+  if delta >= COOLING_DELTA_LARGE_RISE_THRESHOLD {
+    CoolingDeltaObservation::SustainedLargeRise
+  } else if delta >= COOLING_DELTA_MILD_RISE_THRESHOLD {
+    CoolingDeltaObservation::SustainedMildRise
+  } else {
+    CoolingDeltaObservation::WithinRange
+  }
+}
+
+/// Walk backward day by day from `window_end_date`, recomputing the
+/// trailing 7-day idle average at each day and comparing it against
+/// `baseline_temperature`. Stops (without including that day) at the
+/// first day whose trailing window is not comparable, and stops
+/// (including that day) at the first day whose delta drops below
+/// [`COOLING_DELTA_MILD_RISE_THRESHOLD`] - the walk only needs to go far
+/// enough to explain `sustained_days`, not the whole rollup history.
+///
+/// Returned oldest-first, so the series reads left-to-right as a
+/// timeline.
+fn trailing_daily_deltas(
+  days: &[DailyIdleSample],
+  baseline_temperature: f32,
+  window_end_date: NaiveDate,
+) -> (Vec<DailyDelta>, u32) {
+  let mut series = Vec::new();
+  let mut sustained_days = 0u32;
+  let mut cursor = window_end_date;
+
+  loop {
+    let window = summarize_recent_idle(days, cursor);
+    if !window.is_comparable() {
+      break;
+    }
+    // `is_comparable()` guarantees an average is present.
+    let delta = window.idle_temperature_avg.unwrap() - baseline_temperature;
+    let sustained = delta >= COOLING_DELTA_MILD_RISE_THRESHOLD;
+    series.push(DailyDelta {
+      date: cursor,
+      delta,
+    });
+    if !sustained {
+      break;
+    }
+    sustained_days += 1;
+    cursor -= Duration::days(1);
+  }
+
+  series.reverse();
+  (series, sustained_days)
+}
+
+/// [`derive_baseline_delta`] over the whole `cooling_daily_summary`
+/// table.
+pub async fn load_cooling_baseline_delta() -> Result<CoolingBaselineDelta, sqlx::Error> {
+  use crate::infrastructure::database;
+  use crate::persistence::cooling_baseline::derive_baseline_state;
+
+  let days = database::cooling_daily_summary::select_daily_idle_samples().await?;
+  let baseline_state = derive_baseline_state(&days);
+  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+
+  Ok(derive_baseline_delta(&days, baseline_state, yesterday))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::persistence::cooling_baseline::{
+    COOLING_BASELINE_COMPARABLE_IDLE_MINUTES, COOLING_BASELINE_RECENT_WINDOW_DAYS,
+  };
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  fn day(date: NaiveDate, temperature: f32, minutes: u32) -> DailyIdleSample {
+    DailyIdleSample {
+      date,
+      idle_temperature_avg: Some(temperature),
+      idle_sample_minutes: minutes,
+    }
+  }
+
+  fn established(baseline_temperature: f32) -> BaselineState {
+    BaselineState::Established {
+      idle_temperature_avg: baseline_temperature,
+      window_start_date: date(2026, 1, 1),
+      window_end_date: date(2026, 1, 7),
+      sample_minutes: 210,
+    }
+  }
+
+  /// `count` consecutive days ending at `end`, each carrying a full
+  /// comparable window's worth of idle minutes at `temperature`.
+  fn days_ending_at(
+    end: NaiveDate,
+    count: i64,
+    temperature: f32,
+  ) -> Vec<DailyIdleSample> {
+    (0..count)
+      .map(|offset| {
+        day(
+          end - Duration::days(offset),
+          temperature,
+          // One full comparable day's worth on its own is enough for
+          // every 7-day trailing window in this range to be comparable.
+          COOLING_BASELINE_COMPARABLE_IDLE_MINUTES,
+        )
+      })
+      .collect()
+  }
+
+  // ── establishing / not comparable ──
+
+  #[test]
+  fn an_unestablished_baseline_reports_establishing_with_no_delta() {
+    let state = BaselineState::Establishing {
+      qualifying_days: 3,
+      required_days: 7,
+    };
+    let result = derive_baseline_delta(&[], state, date(2026, 8, 20));
+
+    assert_eq!(result.observation, CoolingDeltaObservation::Establishing);
+    assert_eq!(result.delta, None);
+    assert_eq!(result.sustained_days, 0);
+    assert!(result.daily_deltas.is_empty());
+  }
+
+  #[test]
+  fn an_established_baseline_without_recent_idle_evidence_is_not_comparable() {
+    let result = derive_baseline_delta(&[], established(30.0), date(2026, 8, 20));
+
+    assert_eq!(result.observation, CoolingDeltaObservation::NotComparable);
+    assert_eq!(result.delta, None);
+    assert_eq!(result.sustained_days, 0);
+    assert!(result.daily_deltas.is_empty());
+  }
+
+  // ── delta threshold boundaries (single recent day, no sustain yet) ──
+
+  #[test]
+  fn a_delta_below_five_degrees_is_within_range_even_if_sustained() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 10, 34.9);
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert!((result.delta.unwrap() - 4.9).abs() < 0.001);
+    assert_eq!(result.observation, CoolingDeltaObservation::WithinRange);
+  }
+
+  #[test]
+  fn a_single_day_at_a_five_degree_rise_is_not_yet_sustained() {
+    let end = date(2026, 8, 20);
+    // Only one comparable day exists; the day before has no history at
+    // all, so the walk can only confirm a one-day streak - short of the
+    // 3-day sustain requirement, even though today's own delta clears
+    // the rise threshold.
+    let days = vec![day(
+      end,
+      35.0,
+      COOLING_BASELINE_COMPARABLE_IDLE_MINUTES * COOLING_BASELINE_RECENT_WINDOW_DAYS,
+    )];
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert!((result.delta.unwrap() - 5.0).abs() < 0.001);
+    assert_eq!(result.sustained_days, 1);
+    assert_eq!(result.observation, CoolingDeltaObservation::WithinRange);
+  }
+
+  // ── sustain-length boundary ──
+
+  #[test]
+  fn two_sustained_days_are_not_yet_enough_to_report_a_rise() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 2, 35.0);
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 2);
+    assert_eq!(result.observation, CoolingDeltaObservation::WithinRange);
+  }
+
+  #[test]
+  fn three_sustained_days_at_a_mild_rise_report_sustained_mild_rise() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 3, 35.0);
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 3);
+    assert_eq!(
+      result.observation,
+      CoolingDeltaObservation::SustainedMildRise
+    );
+  }
+
+  // ── mild vs large boundary ──
+
+  #[test]
+  fn a_sustained_delta_just_under_ten_degrees_is_a_mild_rise() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 5, 39.9);
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert!((result.delta.unwrap() - 9.9).abs() < 0.001);
+    assert_eq!(
+      result.observation,
+      CoolingDeltaObservation::SustainedMildRise
+    );
+  }
+
+  #[test]
+  fn a_sustained_delta_at_exactly_ten_degrees_is_a_large_rise() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 5, 40.0);
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert!((result.delta.unwrap() - 10.0).abs() < 0.001);
+    assert_eq!(
+      result.observation,
+      CoolingDeltaObservation::SustainedLargeRise
+    );
+  }
+
+  // ── daily delta series ──
+
+  #[test]
+  fn the_daily_delta_series_is_oldest_first_and_stops_where_the_streak_breaks() {
+    let end = date(2026, 8, 20);
+    // `end`'s own 7-day trailing window mixes both days (they are one
+    // day apart), so its average is pulled up by the heavily-weighted
+    // hot day but still shows the cooler day's influence; `end - 1`'s
+    // window contains only the cooler day and reads its temperature
+    // directly. Weights are chosen so the mixed window still clears the
+    // sustained-rise threshold while the cooler-only window does not,
+    // giving a clean one-day streak to assert on.
+    let days = vec![
+      day(end, 60.0, 6 * COOLING_BASELINE_COMPARABLE_IDLE_MINUTES),
+      day(
+        end - Duration::days(1),
+        20.0,
+        COOLING_BASELINE_COMPARABLE_IDLE_MINUTES,
+      ),
+    ];
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 1);
+    let dates: Vec<_> = result.daily_deltas.iter().map(|d| d.date).collect();
+    assert_eq!(dates, vec![end - Duration::days(1), end]);
+    // The older, cooler-only window reads a negative delta...
+    assert!((result.daily_deltas[0].delta - (-10.0)).abs() < 0.001);
+    // ...while the newer, mixed window still clears the rise threshold.
+    assert!(result.daily_deltas[1].delta >= COOLING_DELTA_MILD_RISE_THRESHOLD);
+  }
+
+  #[test]
+  fn the_daily_delta_series_stops_when_history_runs_out() {
+    let end = date(2026, 8, 20);
+    // Only 2 comparable days exist at all; the walk cannot look further
+    // back than that, so it stops there rather than treating missing
+    // history as a broken streak or looping forever.
+    let days = days_ending_at(end, 2, 35.0);
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 2);
+    assert_eq!(result.daily_deltas.len(), 2);
+  }
+}

--- a/core/src/persistence/cooling_baseline_delta.rs
+++ b/core/src/persistence/cooling_baseline_delta.rs
@@ -104,11 +104,18 @@ pub fn derive_baseline_delta(
     };
   }
 
-  // `recent.is_comparable()` guarantees an average is present.
-  let delta = recent.idle_temperature_avg.unwrap() - baseline_temperature;
-  let (daily_deltas, sustained_days) =
+  let (daily_deltas, mild_sustained_days, large_sustained_days) =
     trailing_daily_deltas(days, baseline_temperature, window_end_date);
-  let observation = classify_observation(delta, sustained_days);
+  let (observation, sustained_days) =
+    classify_observation(mild_sustained_days, large_sustained_days);
+  // `recent.is_comparable()` guarantees an average is present. This is
+  // the same quantity `trailing_daily_deltas` computes for `cursor ==
+  // window_end_date` (when that day has its own rollup row), kept as a
+  // direct computation here so a day recent enough to be "comparable" as
+  // a trailing window, but too sparse to itself carry an idle-sample row
+  // exactly on `window_end_date` (see `has_idle_sample_on`), still gets a
+  // reported delta - only the sustain streak requires a same-day row.
+  let delta = recent.idle_temperature_avg.unwrap() - baseline_temperature;
 
   CoolingBaselineDelta {
     baseline_state,
@@ -130,72 +137,136 @@ fn established_temperature(state: BaselineState) -> Option<f32> {
   }
 }
 
-fn classify_observation(delta: f32, sustained_days: u32) -> CoolingDeltaObservation {
-  if sustained_days < COOLING_DELTA_SUSTAIN_DAYS {
-    return CoolingDeltaObservation::WithinRange;
-  }
-  if delta >= COOLING_DELTA_LARGE_RISE_THRESHOLD {
-    CoolingDeltaObservation::SustainedLargeRise
-  } else if delta >= COOLING_DELTA_MILD_RISE_THRESHOLD {
-    CoolingDeltaObservation::SustainedMildRise
+/// Classify the observation from the two independently-counted streaks
+/// [`trailing_daily_deltas`] returns, and report the streak length that
+/// backs the returned observation (so the UI's "n days in a row" always
+/// matches what actually triggered it).
+///
+/// A large rise requires [`COOLING_DELTA_SUSTAIN_DAYS`] consecutive days
+/// at or above [`COOLING_DELTA_LARGE_RISE_THRESHOLD`] specifically - not
+/// merely a mild-or-above streak whose *most recent* day happens to have
+/// crossed the large threshold. Two days at +7 followed by a today at
+/// +10 is a 3-day mild streak, not a 3-day large one.
+fn classify_observation(
+  mild_sustained_days: u32,
+  large_sustained_days: u32,
+) -> (CoolingDeltaObservation, u32) {
+  if large_sustained_days >= COOLING_DELTA_SUSTAIN_DAYS {
+    (
+      CoolingDeltaObservation::SustainedLargeRise,
+      large_sustained_days,
+    )
+  } else if mild_sustained_days >= COOLING_DELTA_SUSTAIN_DAYS {
+    (
+      CoolingDeltaObservation::SustainedMildRise,
+      mild_sustained_days,
+    )
   } else {
-    CoolingDeltaObservation::WithinRange
+    (CoolingDeltaObservation::WithinRange, mild_sustained_days)
   }
+}
+
+/// Whether `date` itself has a rollup row carrying idle-band evidence.
+///
+/// Required before a cursor day may extend either streak in
+/// [`trailing_daily_deltas`]: without it, a single real day's minutes can
+/// still appear (weighted) inside several different 7-day trailing
+/// windows a few calendar days apart, since those windows overlap. Only
+/// gating on window comparability would let that overlap alone report
+/// several "sustained" days from one real observation - exactly the
+/// streak the day itself never spanned (DP-02).
+fn has_idle_sample_on(days: &[DailyIdleSample], date: NaiveDate) -> bool {
+  days
+    .iter()
+    .any(|day| day.date == date && day.idle_sample_minutes > 0)
 }
 
 /// Walk backward day by day from `window_end_date`, recomputing the
 /// trailing 7-day idle average at each day and comparing it against
-/// `baseline_temperature`. Stops (without including that day) at the
-/// first day whose trailing window is not comparable, and stops
-/// (including that day) at the first day whose delta drops below
-/// [`COOLING_DELTA_MILD_RISE_THRESHOLD`] - the walk only needs to go far
-/// enough to explain `sustained_days`, not the whole rollup history.
+/// `baseline_temperature`. A day only extends either streak - and is
+/// only added to the series - when it carries its own rollup row (see
+/// [`has_idle_sample_on`]); the walk stops there otherwise, since an
+/// unobserved day cannot be counted as part of a sustained trend. It
+/// also stops (including that day) at the first day whose delta drops
+/// below [`COOLING_DELTA_MILD_RISE_THRESHOLD`] - the walk only needs to
+/// go far enough to explain the streak lengths, not the whole rollup
+/// history.
 ///
-/// Returned oldest-first, so the series reads left-to-right as a
-/// timeline.
+/// Returns `(daily_deltas, mild_sustained_days, large_sustained_days)`.
+/// `daily_deltas` is oldest first, so the series reads left-to-right as a
+/// timeline. `mild_sustained_days` counts the streak at
+/// [`COOLING_DELTA_MILD_RISE_THRESHOLD`] or above; `large_sustained_days`
+/// counts the streak at [`COOLING_DELTA_LARGE_RISE_THRESHOLD`] or above,
+/// and stops growing (without ending the walk) the first time a day
+/// falls below the large threshold while still at or above the mild one.
 fn trailing_daily_deltas(
   days: &[DailyIdleSample],
   baseline_temperature: f32,
   window_end_date: NaiveDate,
-) -> (Vec<DailyDelta>, u32) {
+) -> (Vec<DailyDelta>, u32, u32) {
   let mut series = Vec::new();
-  let mut sustained_days = 0u32;
+  let mut mild_sustained_days = 0u32;
+  let mut large_sustained_days = 0u32;
+  let mut large_streak_intact = true;
   let mut cursor = window_end_date;
 
   loop {
+    if !has_idle_sample_on(days, cursor) {
+      break;
+    }
     let window = summarize_recent_idle(days, cursor);
     if !window.is_comparable() {
       break;
     }
     // `is_comparable()` guarantees an average is present.
     let delta = window.idle_temperature_avg.unwrap() - baseline_temperature;
-    let sustained = delta >= COOLING_DELTA_MILD_RISE_THRESHOLD;
+    let is_mild = delta >= COOLING_DELTA_MILD_RISE_THRESHOLD;
     series.push(DailyDelta {
       date: cursor,
       delta,
     });
-    if !sustained {
+    if !is_mild {
       break;
     }
-    sustained_days += 1;
+    mild_sustained_days += 1;
+    if large_streak_intact && delta >= COOLING_DELTA_LARGE_RISE_THRESHOLD {
+      large_sustained_days += 1;
+    } else {
+      large_streak_intact = false;
+    }
     cursor -= Duration::days(1);
   }
 
   series.reverse();
-  (series, sustained_days)
+  (series, mild_sustained_days, large_sustained_days)
 }
 
 /// [`derive_baseline_delta`] over the whole `cooling_daily_summary`
-/// table.
-pub async fn load_cooling_baseline_delta() -> Result<CoolingBaselineDelta, sqlx::Error> {
+/// table, resolving the baseline lifecycle state through
+/// [`crate::persistence::cooling_baseline::resolve_baseline_state_from_pool`]
+/// rather than re-deriving it - the pinned baseline row must win once one
+/// exists, or this delta would silently drift once the rollup rows the
+/// original establishment came from age out.
+pub(crate) async fn load_cooling_baseline_delta_from_pool(
+  pool: &sqlx::SqlitePool,
+  today: NaiveDate,
+) -> Result<CoolingBaselineDelta, sqlx::Error> {
   use crate::infrastructure::database;
-  use crate::persistence::cooling_baseline::derive_baseline_state;
+  use crate::persistence::cooling_baseline::resolve_baseline_state_from_pool;
 
-  let days = database::cooling_daily_summary::select_daily_idle_samples().await?;
-  let baseline_state = derive_baseline_state(&days);
-  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+  let days =
+    database::cooling_daily_summary::select_daily_idle_samples_from_pool(pool).await?;
+  let baseline_state = resolve_baseline_state_from_pool(pool, &days).await?;
+  let yesterday = today - Duration::days(1);
 
   Ok(derive_baseline_delta(&days, baseline_state, yesterday))
+}
+
+/// [`load_cooling_baseline_delta_from_pool`] against Core's process-wide
+/// pool.
+pub async fn load_cooling_baseline_delta() -> Result<CoolingBaselineDelta, sqlx::Error> {
+  let pool = crate::infrastructure::database::db::get_pool().await?;
+  load_cooling_baseline_delta_from_pool(&pool, chrono::Local::now().date_naive()).await
 }
 
 #[cfg(test)]
@@ -400,5 +471,227 @@ mod tests {
 
     assert_eq!(result.sustained_days, 2);
     assert_eq!(result.daily_deltas.len(), 2);
+  }
+
+  // ── gap days must not inflate the streak via window overlap ──
+
+  #[test]
+  fn a_single_real_day_does_not_inflate_the_streak_through_overlapping_windows() {
+    // Regression: a real day's minutes can appear (weighted) in several
+    // different 7-day trailing windows a few calendar days apart, since
+    // those windows overlap. Before requiring the cursor day to carry
+    // its own rollup row, walking backward from `end` through
+    // `end - 6` would all land on windows that still contain this one
+    // real day 3 days back, reporting several "sustained" days from a
+    // single observation.
+    let end = date(2026, 8, 20);
+    let real_day = end - Duration::days(3);
+    let days = vec![day(real_day, 60.0, 1440)];
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 0);
+    assert_eq!(result.observation, CoolingDeltaObservation::WithinRange);
+    assert!(result.daily_deltas.is_empty());
+  }
+
+  #[test]
+  fn a_gap_immediately_before_the_most_recent_day_still_stops_the_streak() {
+    // `end` itself has no rollup row (e.g. the app was not running
+    // yesterday); a real day 2 days back must not let the walk treat
+    // `end` as part of an ongoing streak.
+    let end = date(2026, 8, 20);
+    let days = vec![day(end - Duration::days(2), 60.0, 1440)];
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.sustained_days, 0);
+    assert!(result.daily_deltas.is_empty());
+  }
+
+  // ── mild vs large streaks are counted independently ──
+
+  #[test]
+  fn two_days_at_a_large_rise_followed_by_a_milder_third_day_report_sustained_mild_rise()
+  {
+    // Two consecutive days whose trailing window average clears the
+    // large threshold, then (going further back) a third day whose
+    // trailing window is only mild: the *mild* streak reaches 3 days,
+    // but the *large* streak stops at 2 - the large threshold must not
+    // be granted on the strength of a 3-day streak that only mostly
+    // cleared it.
+    let end = date(2026, 8, 20);
+    // Chosen so each cursor's 7-day trailing window (which accumulates
+    // every real row already seen, since all three days sit within 7
+    // days of each other) averages out to the target delta at that
+    // cursor: end-2 alone -> +7, end-1 blended with end-2 -> +10, end
+    // blended with both -> +10.
+    let days = vec![
+      day(
+        end - Duration::days(2),
+        37.0,
+        COOLING_BASELINE_COMPARABLE_IDLE_MINUTES,
+      ),
+      day(
+        end - Duration::days(1),
+        43.0,
+        COOLING_BASELINE_COMPARABLE_IDLE_MINUTES,
+      ),
+      day(end, 40.0, COOLING_BASELINE_COMPARABLE_IDLE_MINUTES),
+    ];
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(
+      result.observation,
+      CoolingDeltaObservation::SustainedMildRise
+    );
+    assert_eq!(result.sustained_days, 3);
+  }
+
+  #[test]
+  fn three_consecutive_days_at_a_large_rise_report_sustained_large_rise() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 3, 40.0);
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(
+      result.observation,
+      CoolingDeltaObservation::SustainedLargeRise
+    );
+    assert_eq!(result.sustained_days, 3);
+  }
+
+  #[test]
+  fn two_large_rise_days_are_not_yet_enough_for_a_large_verdict() {
+    let end = date(2026, 8, 20);
+    let days = days_ending_at(end, 2, 45.0);
+
+    let result = derive_baseline_delta(&days, established(30.0), end);
+
+    assert_eq!(result.observation, CoolingDeltaObservation::WithinRange);
+    assert_eq!(result.sustained_days, 2);
+  }
+
+  // ── pinned baseline (DB-backed) ──
+
+  mod pinned_baseline {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn setup_tables(pool: &SqlitePool) {
+      sqlx::query(
+        "CREATE TABLE cooling_daily_summary (
+          date TEXT PRIMARY KEY,
+          idle_cpu_temperature_avg REAL,
+          idle_cpu_temperature_max REAL,
+          idle_cpu_temperature_min REAL,
+          idle_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          low_cpu_temperature_avg REAL,
+          low_cpu_temperature_max REAL,
+          low_cpu_temperature_min REAL,
+          low_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          mid_cpu_temperature_avg REAL,
+          mid_cpu_temperature_max REAL,
+          mid_cpu_temperature_min REAL,
+          mid_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          high_cpu_temperature_avg REAL,
+          high_cpu_temperature_max REAL,
+          high_cpu_temperature_min REAL,
+          high_sample_minutes INTEGER NOT NULL DEFAULT 0,
+          coverage_minutes INTEGER NOT NULL
+        )",
+      )
+      .execute(pool)
+      .await
+      .unwrap();
+      sqlx::query(
+        "CREATE TABLE cooling_baseline (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          window_start_date TEXT NOT NULL,
+          window_end_date TEXT NOT NULL,
+          idle_temperature_avg REAL NOT NULL,
+          sample_minutes INTEGER NOT NULL,
+          established_at TEXT NOT NULL
+        )",
+      )
+      .execute(pool)
+      .await
+      .unwrap();
+    }
+
+    async fn insert_idle_day(
+      pool: &SqlitePool,
+      date: NaiveDate,
+      temperature: f32,
+      minutes: u32,
+    ) {
+      sqlx::query(
+        "INSERT INTO cooling_daily_summary
+           (date, idle_cpu_temperature_avg, idle_sample_minutes, coverage_minutes)
+         VALUES ($1, $2, $3, 1440)",
+      )
+      .bind(date.format("%Y-%m-%d").to_string())
+      .bind(temperature)
+      .bind(minutes as i64)
+      .execute(pool)
+      .await
+      .unwrap();
+    }
+
+    async fn insert_establishing_days(
+      pool: &SqlitePool,
+      start: NaiveDate,
+      temperature: f32,
+    ) {
+      use crate::persistence::cooling_baseline::COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS;
+      for offset in 0..COOLING_BASELINE_REQUIRED_QUALIFYING_DAYS {
+        insert_idle_day(
+          pool,
+          start + Duration::days(offset as i64),
+          temperature,
+          COOLING_BASELINE_COMPARABLE_IDLE_MINUTES,
+        )
+        .await;
+      }
+    }
+
+    #[tokio::test]
+    async fn the_baseline_temperature_does_not_drift_when_its_source_rows_are_deleted() {
+      // Same regression as cooling_baseline's own pinning test, but for
+      // the delta loader: it must resolve the pinned row through the
+      // shared resolver instead of re-deriving from whatever
+      // `cooling_daily_summary` rows currently exist.
+      let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+      setup_tables(&pool).await;
+      insert_establishing_days(&pool, date(2026, 8, 1), 42.0).await;
+      // A comparable recent window so the delta actually gets computed.
+      insert_idle_day(&pool, date(2026, 8, 19), 42.0, 120).await;
+
+      let established = load_cooling_baseline_delta_from_pool(&pool, date(2026, 8, 20))
+        .await
+        .unwrap();
+      assert_eq!(established.delta, Some(0.0));
+
+      // Age out the rows the baseline was derived from, and record a
+      // hotter stretch that would establish a different baseline value
+      // if the pinned row were ignored.
+      sqlx::query("DELETE FROM cooling_daily_summary")
+        .execute(&pool)
+        .await
+        .unwrap();
+      insert_establishing_days(&pool, date(2027, 6, 1), 70.0).await;
+      insert_idle_day(&pool, date(2027, 6, 19), 42.0, 120).await;
+
+      let after_cleanup = load_cooling_baseline_delta_from_pool(&pool, date(2027, 6, 20))
+        .await
+        .unwrap();
+      assert_eq!(
+        after_cleanup.delta,
+        Some(0.0),
+        "the pinned baseline must not drift when its source rows are deleted"
+      );
+    }
   }
 }

--- a/core/src/persistence/cooling_rollup.rs
+++ b/core/src/persistence/cooling_rollup.rs
@@ -418,6 +418,14 @@ async fn catch_up_cooling_rollup() -> Result<(), sqlx::Error> {
     roll_up_day(date).await?;
   }
 
+  // Resolve (and, once established, pin) the baseline right after the
+  // rollup advances, so establishment happens in the background rather
+  // than only when Cooling Insight is read — otherwise a user who never
+  // opens the view before retention cleanup erases the
+  // establishment-window rows would get a drifted baseline pinned on
+  // their first read.
+  crate::persistence::cooling_baseline::ensure_baseline_pinned().await;
+
   Ok(())
 }
 

--- a/core/src/persistence/cooling_trend.rs
+++ b/core/src/persistence/cooling_trend.rs
@@ -14,14 +14,26 @@
 
 use chrono::{Duration, NaiveDate};
 
-use crate::persistence::cooling_rollup::DailyCoolingSummary;
+use crate::persistence::cooling_rollup::{
+  COOLING_DAILY_SUMMARY_RETENTION_DAYS, DailyCoolingSummary,
+};
+
+/// Upper bound for a requested trend window, matching the rollup's own
+/// retention: no window can show more days than the table can hold.
+/// Clamping here also keeps the `NaiveDate` arithmetic below safely
+/// inside chrono's supported range for any `u32` the IPC boundary lets
+/// through, instead of panicking on an oversized request.
+pub const COOLING_TREND_MAX_DAYS: u32 = COOLING_DAILY_SUMMARY_RETENTION_DAYS;
 
 /// First local day of the trailing `days`-day window ending at (and
-/// including) `window_end_date`. `days == 0` degenerates to a
+/// including) `window_end_date`. `days` is clamped to
+/// `1..=`[`COOLING_TREND_MAX_DAYS`]: `days == 0` degenerates to a
 /// single-day window at `window_end_date`, matching `days == 1`, rather
-/// than producing a start date after the end date.
+/// than producing a start date after the end date, and an oversized
+/// request degenerates to the widest window the rollup can back.
 pub fn trend_window_start_date(days: u32, window_end_date: NaiveDate) -> NaiveDate {
-  window_end_date - Duration::days(days.saturating_sub(1) as i64)
+  let days = days.clamp(1, COOLING_TREND_MAX_DAYS);
+  window_end_date - Duration::days((days - 1) as i64)
 }
 
 /// The subset of `days` whose date falls within `[start, end]`
@@ -97,6 +109,18 @@ mod tests {
   fn a_one_day_window_starts_and_ends_on_the_same_day() {
     let end = date(2026, 8, 29);
     assert_eq!(trend_window_start_date(1, end), end);
+  }
+
+  #[test]
+  fn an_oversized_request_clamps_to_the_retention_window_instead_of_panicking() {
+    let end = date(2026, 8, 29);
+    // u32::MAX days would push the NaiveDate arithmetic outside chrono's
+    // supported range; the clamp degrades it to the widest window the
+    // rollup can back.
+    assert_eq!(
+      trend_window_start_date(u32::MAX, end),
+      trend_window_start_date(COOLING_TREND_MAX_DAYS, end)
+    );
   }
 
   #[test]

--- a/core/src/persistence/cooling_trend.rs
+++ b/core/src/persistence/cooling_trend.rs
@@ -1,0 +1,152 @@
+//! Cooling Insight long-range trend: per-day CPU temperature summaries
+//! from the daily rollup (`cooling_daily_summary`), for the 90-day and
+//! 1-year Cooling Insight windows (#2017).
+//!
+//! Periods of 30 days and below keep using the existing bucketed
+//! `archive_queries` (see `get_data_archive_series`) - this module exists
+//! only for the longer windows the one-minute Hardware Archive cannot
+//! reach without extending `hardwareArchive.retentionDays`.
+//!
+//! A day the rollup has no row for is simply absent from the returned
+//! list: the caller renders that as a gap, never as a zeroed day (see
+//! `crate::persistence::cooling_rollup::summarize_day`, which is why a
+//! dayless row can never exist in the table to begin with).
+
+use chrono::{Duration, NaiveDate};
+
+use crate::persistence::cooling_rollup::DailyCoolingSummary;
+
+/// First local day of the trailing `days`-day window ending at (and
+/// including) `window_end_date`. `days == 0` degenerates to a
+/// single-day window at `window_end_date`, matching `days == 1`, rather
+/// than producing a start date after the end date.
+pub fn trend_window_start_date(days: u32, window_end_date: NaiveDate) -> NaiveDate {
+  window_end_date - Duration::days(days.saturating_sub(1) as i64)
+}
+
+/// The subset of `days` whose date falls within `[start, end]`
+/// (inclusive), preserving input order. Days the rollup never produced a
+/// row for are simply not present in `days` and stay absent from the
+/// result - this never fills a gap with a synthesized entry.
+pub fn days_in_window(
+  days: &[DailyCoolingSummary],
+  start: NaiveDate,
+  end: NaiveDate,
+) -> Vec<DailyCoolingSummary> {
+  days
+    .iter()
+    .filter(|day| day.date >= start && day.date <= end)
+    .cloned()
+    .collect()
+}
+
+/// [`days_in_window`] over the trailing `days`-day window ending
+/// yesterday (the most recent local day the rollup can have summarized).
+pub async fn load_cooling_trend(
+  days: u32,
+) -> Result<Vec<DailyCoolingSummary>, sqlx::Error> {
+  use crate::infrastructure::database;
+
+  let all_days =
+    database::cooling_daily_summary::select_all_daily_cooling_summaries().await?;
+  let yesterday = chrono::Local::now().date_naive() - Duration::days(1);
+  let start = trend_window_start_date(days, yesterday);
+
+  Ok(days_in_window(&all_days, start, yesterday))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::persistence::cooling_rollup::BandSummary;
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  fn empty_band() -> BandSummary {
+    BandSummary::default()
+  }
+
+  fn day(date: NaiveDate, coverage_minutes: u32) -> DailyCoolingSummary {
+    DailyCoolingSummary {
+      date,
+      coverage_minutes,
+      idle: empty_band(),
+      low: empty_band(),
+      mid: empty_band(),
+      high: empty_band(),
+    }
+  }
+
+  // ── trend_window_start_date ──
+
+  #[test]
+  fn a_ninety_day_window_starts_eighty_nine_days_before_the_end() {
+    let end = date(2026, 8, 29);
+    assert_eq!(trend_window_start_date(90, end), end - Duration::days(89));
+  }
+
+  #[test]
+  fn a_one_year_window_starts_three_hundred_sixty_four_days_before_the_end() {
+    let end = date(2026, 8, 29);
+    assert_eq!(trend_window_start_date(365, end), end - Duration::days(364));
+  }
+
+  #[test]
+  fn a_one_day_window_starts_and_ends_on_the_same_day() {
+    let end = date(2026, 8, 29);
+    assert_eq!(trend_window_start_date(1, end), end);
+  }
+
+  #[test]
+  fn a_zero_day_window_does_not_start_after_the_end() {
+    let end = date(2026, 8, 29);
+    assert_eq!(trend_window_start_date(0, end), end);
+  }
+
+  // ── days_in_window ──
+
+  #[test]
+  fn days_outside_the_window_are_excluded() {
+    let start = date(2026, 8, 1);
+    let end = date(2026, 8, 10);
+    let days = vec![
+      day(start - Duration::days(1), 100),
+      day(start, 100),
+      day(end, 100),
+      day(end + Duration::days(1), 100),
+    ];
+
+    let result = days_in_window(&days, start, end);
+
+    assert_eq!(
+      result.iter().map(|d| d.date).collect::<Vec<_>>(),
+      vec![start, end]
+    );
+  }
+
+  #[test]
+  fn a_gap_in_the_rollup_stays_absent_rather_than_being_filled() {
+    let start = date(2026, 8, 1);
+    let end = date(2026, 8, 5);
+    // Day 3 was never rolled up (e.g. the app was not running).
+    let days = vec![day(date(2026, 8, 1), 100), day(date(2026, 8, 5), 100)];
+
+    let result = days_in_window(&days, start, end);
+
+    assert_eq!(result.len(), 2, "only the two present days should appear");
+    assert_eq!(
+      result.iter().map(|d| d.date).collect::<Vec<_>>(),
+      vec![date(2026, 8, 1), date(2026, 8, 5)]
+    );
+  }
+
+  #[test]
+  fn an_empty_rollup_yields_an_empty_trend() {
+    assert_eq!(
+      days_in_window(&[], date(2026, 8, 1), date(2026, 8, 10)),
+      Vec::new()
+    );
+  }
+}

--- a/core/src/persistence/mod.rs
+++ b/core/src/persistence/mod.rs
@@ -11,8 +11,11 @@
 
 pub mod archive;
 pub mod archive_data;
+pub mod cooling_band_comparison;
 pub mod cooling_baseline;
+pub mod cooling_baseline_delta;
 pub mod cooling_rollup;
+pub mod cooling_trend;
 pub mod preflight;
 pub mod storage_health;
 

--- a/src-tauri/src/commands/cooling_insight.rs
+++ b/src-tauri/src/commands/cooling_insight.rs
@@ -1,0 +1,53 @@
+//! Cooling Insight query commands (#2017): long-range trend, load-band
+//! comparison, and baseline delta. Every judgment - qualifying windows,
+//! comparability thresholds, and the delta observation classification -
+//! is decided in `hardviz_core::persistence`; these commands only fetch
+//! and convert to the wire DTOs in `crate::models::cooling_insight`.
+//!
+//! Periods of 30 days and below keep using `get_data_archive_series`
+//! (see `commands::hardware`) - these commands exist only for the
+//! 90-day and 1-year windows the daily rollup backs.
+
+use crate::models::cooling_insight::{
+  CoolingBandComparison, CoolingBaselineDelta, CoolingDailyTrendPoint,
+};
+use tauri::command;
+
+///
+/// ## Get the long-range cooling trend (90-day / 1-year)
+///
+#[command]
+#[specta::specta]
+pub async fn get_cooling_trend(days: u32) -> Result<Vec<CoolingDailyTrendPoint>, String> {
+  use crate::services::cooling_insight_service;
+
+  cooling_insight_service::fetch_cooling_trend(days)
+    .await
+    .map(|days| days.into_iter().map(Into::into).collect())
+}
+
+///
+/// ## Get the per-load-band baseline-vs-recent cooling comparison
+///
+#[command]
+#[specta::specta]
+pub async fn get_cooling_band_comparison() -> Result<CoolingBandComparison, String> {
+  use crate::services::cooling_insight_service;
+
+  cooling_insight_service::fetch_cooling_band_comparison()
+    .await
+    .map(Into::into)
+}
+
+///
+/// ## Get the idle cooling baseline delta and its observation state
+///
+#[command]
+#[specta::specta]
+pub async fn get_cooling_baseline_delta() -> Result<CoolingBaselineDelta, String> {
+  use crate::services::cooling_insight_service;
+
+  cooling_insight_service::fetch_cooling_baseline_delta()
+    .await
+    .map(Into::into)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod background_image;
+pub mod cooling_insight;
 pub mod external_component_guidance;
 pub mod hardware;
 pub mod settings;

--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -148,6 +148,20 @@ pub fn get_migrations() -> Vec<SchemaMigration> {
         );
       "#,
     },
+    SchemaMigration {
+      version: 12,
+      description: "create_cooling_baseline",
+      sql: r#"
+        CREATE TABLE cooling_baseline (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          window_start_date TEXT NOT NULL,
+          window_end_date TEXT NOT NULL,
+          idle_temperature_avg REAL NOT NULL,
+          sample_minutes INTEGER NOT NULL,
+          established_at TEXT NOT NULL
+        );
+      "#,
+    },
   ]
 }
 
@@ -269,14 +283,33 @@ mod tests {
   }
 
   #[test]
+  fn migration_v12_creates_the_single_row_cooling_baseline_table() {
+    let migrations = get_migrations();
+    let v12 = migrations
+      .iter()
+      .find(|m| m.version == 12)
+      .expect("Version 12 up migration must exist");
+    assert!(v12.sql.contains("CREATE TABLE cooling_baseline"));
+    // The established baseline is a single row. The CHECK constraint is
+    // what makes the insert idempotent: a second establishment can never
+    // add a competing row, so the value cannot drift once pinned.
+    assert!(v12.sql.contains("id INTEGER PRIMARY KEY CHECK (id = 1)"));
+    assert!(v12.sql.contains("window_start_date TEXT NOT NULL"));
+    assert!(v12.sql.contains("window_end_date TEXT NOT NULL"));
+    assert!(v12.sql.contains("idle_temperature_avg REAL NOT NULL"));
+    assert!(v12.sql.contains("sample_minutes INTEGER NOT NULL"));
+    assert!(v12.sql.contains("established_at TEXT NOT NULL"));
+  }
+
+  #[test]
   fn max_migration_version() {
-    assert_eq!(get_max_migration_version(), 11);
+    assert_eq!(get_max_migration_version(), 12);
   }
 
   #[test]
   fn migration_count() {
     let migrations = get_migrations();
-    assert_eq!(migrations.len(), 11);
+    assert_eq!(migrations.len(), 12);
   }
 
   #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod workers;
 mod _tests;
 
 use commands::background_image;
+use commands::cooling_insight;
 use commands::external_component_guidance;
 use commands::hardware;
 use commands::settings;
@@ -99,6 +100,9 @@ fn build_specta_builder() -> Builder<Wry> {
       hardware::get_process_stats,
       hardware::get_process_stats_in_period,
       hardware::get_gpu_archive_names,
+      cooling_insight::get_cooling_trend,
+      cooling_insight::get_cooling_band_comparison,
+      cooling_insight::get_cooling_baseline_delta,
       settings::commands::get_settings,
       settings::commands::set_language,
       settings::commands::set_theme,

--- a/src-tauri/src/models/cooling_insight.rs
+++ b/src-tauri/src/models/cooling_insight.rs
@@ -1,0 +1,574 @@
+//! Wire-format mirrors of Cooling Insight's Core-owned query results
+//! (#2017). Core keeps deriving every threshold, weighted average, and
+//! lifecycle state; these types only carry the already-decided result
+//! across IPC, following the manual `From` conversion pattern used by
+//! `models::archive_history` rather than the ADR 0009 build-time
+//! generator (these are not mirrors of `core/src/models/hardware.rs`).
+//!
+//! Dates cross the wire as `"%Y-%m-%d"` strings, matching how
+//! `cooling_daily_summary.date` is already stored and compared in Core.
+
+use chrono::NaiveDate;
+use hardviz_core::persistence::cooling_band_comparison::{
+  BandComparison as CoreBandComparison, BandWindowSummary as CoreBandWindowSummary,
+  CoolingBandComparison as CoreCoolingBandComparison,
+};
+use hardviz_core::persistence::cooling_baseline::{
+  BaselineState as CoreBaselineState, RecentIdleSummary as CoreRecentIdleSummary,
+};
+use hardviz_core::persistence::cooling_baseline_delta::{
+  CoolingBaselineDelta as CoreCoolingBaselineDelta,
+  CoolingDeltaObservation as CoreCoolingDeltaObservation, DailyDelta as CoreDailyDelta,
+};
+use hardviz_core::persistence::cooling_rollup::{
+  BandSummary as CoreBandSummary, CpuLoadBand as CoreCpuLoadBand,
+  DailyCoolingSummary as CoreDailyCoolingSummary,
+};
+use serde::Serialize;
+use specta::Type;
+
+fn format_date(date: NaiveDate) -> String {
+  date.format("%Y-%m-%d").to_string()
+}
+
+/// One CPU-load band's temperature summary for a single day.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingBandTemperature {
+  pub avg: Option<f32>,
+  pub max: Option<f32>,
+  pub min: Option<f32>,
+  pub sample_minutes: u32,
+}
+
+impl From<CoreBandSummary> for CoolingBandTemperature {
+  fn from(value: CoreBandSummary) -> Self {
+    Self {
+      avg: value.avg,
+      max: value.max,
+      min: value.min,
+      sample_minutes: value.sample_minutes,
+    }
+  }
+}
+
+/// One day's `cooling_daily_summary` row, for the 90-day/1-year Cooling
+/// Insight trend. A date the rollup has no row for is simply absent from
+/// the response array - never a zero-filled entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingDailyTrendPoint {
+  pub date: String,
+  pub coverage_minutes: u32,
+  pub idle: CoolingBandTemperature,
+  pub low: CoolingBandTemperature,
+  pub mid: CoolingBandTemperature,
+  pub high: CoolingBandTemperature,
+}
+
+impl From<CoreDailyCoolingSummary> for CoolingDailyTrendPoint {
+  fn from(value: CoreDailyCoolingSummary) -> Self {
+    Self {
+      date: format_date(value.date),
+      coverage_minutes: value.coverage_minutes,
+      idle: value.idle.into(),
+      low: value.low.into(),
+      mid: value.mid.into(),
+      high: value.high.into(),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum CoolingLoadBand {
+  Idle,
+  Low,
+  Mid,
+  High,
+}
+
+impl From<CoreCpuLoadBand> for CoolingLoadBand {
+  fn from(value: CoreCpuLoadBand) -> Self {
+    match value {
+      CoreCpuLoadBand::Idle => Self::Idle,
+      CoreCpuLoadBand::Low => Self::Low,
+      CoreCpuLoadBand::Mid => Self::Mid,
+      CoreCpuLoadBand::High => Self::High,
+    }
+  }
+}
+
+/// One band's weighted-average temperature and sample coverage over a
+/// date window (either the baseline window or the recent window).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingBandWindowSummary {
+  pub temperature_avg: Option<f32>,
+  pub sample_minutes: u32,
+}
+
+impl From<CoreBandWindowSummary> for CoolingBandWindowSummary {
+  fn from(value: CoreBandWindowSummary) -> Self {
+    Self {
+      temperature_avg: value.temperature_avg,
+      sample_minutes: value.sample_minutes,
+    }
+  }
+}
+
+/// One CPU-load band's baseline-vs-recent comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingBandComparisonEntry {
+  pub band: CoolingLoadBand,
+  pub baseline: CoolingBandWindowSummary,
+  pub recent: CoolingBandWindowSummary,
+  pub comparable: bool,
+}
+
+impl From<CoreBandComparison> for CoolingBandComparisonEntry {
+  fn from(value: CoreBandComparison) -> Self {
+    Self {
+      band: value.band.into(),
+      baseline: value.baseline.into(),
+      recent: value.recent.into(),
+      comparable: value.comparable,
+    }
+  }
+}
+
+/// Cooling Insight's load-band comparison, gated by the same baseline
+/// lifecycle as [`CoolingBaselineState`]: no comparison exists yet while
+/// the baseline is still establishing.
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(
+  tag = "status",
+  rename_all = "camelCase",
+  rename_all_fields = "camelCase"
+)]
+pub enum CoolingBandComparison {
+  Establishing {
+    qualifying_days: u32,
+    required_days: u32,
+  },
+  Established {
+    baseline_window_start_date: String,
+    baseline_window_end_date: String,
+    recent_window_start_date: String,
+    recent_window_end_date: String,
+    bands: Vec<CoolingBandComparisonEntry>,
+  },
+}
+
+impl From<CoreCoolingBandComparison> for CoolingBandComparison {
+  fn from(value: CoreCoolingBandComparison) -> Self {
+    match value {
+      CoreCoolingBandComparison::Establishing {
+        qualifying_days,
+        required_days,
+      } => Self::Establishing {
+        qualifying_days,
+        required_days,
+      },
+      CoreCoolingBandComparison::Established {
+        baseline_window_start_date,
+        baseline_window_end_date,
+        recent_window_start_date,
+        recent_window_end_date,
+        bands,
+      } => Self::Established {
+        baseline_window_start_date: format_date(baseline_window_start_date),
+        baseline_window_end_date: format_date(baseline_window_end_date),
+        recent_window_start_date: format_date(recent_window_start_date),
+        recent_window_end_date: format_date(recent_window_end_date),
+        bands: bands.into_iter().map(Into::into).collect(),
+      },
+    }
+  }
+}
+
+/// Lifecycle of the idle cooling baseline (see
+/// `hardviz_core::persistence::cooling_baseline::BaselineState`).
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(
+  tag = "status",
+  rename_all = "camelCase",
+  rename_all_fields = "camelCase"
+)]
+pub enum CoolingBaselineState {
+  Establishing {
+    qualifying_days: u32,
+    required_days: u32,
+  },
+  Established {
+    idle_temperature_avg: f32,
+    window_start_date: String,
+    window_end_date: String,
+    sample_minutes: u32,
+  },
+}
+
+impl From<CoreBaselineState> for CoolingBaselineState {
+  fn from(value: CoreBaselineState) -> Self {
+    match value {
+      CoreBaselineState::Establishing {
+        qualifying_days,
+        required_days,
+      } => Self::Establishing {
+        qualifying_days,
+        required_days,
+      },
+      CoreBaselineState::Established {
+        idle_temperature_avg,
+        window_start_date,
+        window_end_date,
+        sample_minutes,
+      } => Self::Established {
+        idle_temperature_avg,
+        window_start_date: format_date(window_start_date),
+        window_end_date: format_date(window_end_date),
+        sample_minutes,
+      },
+    }
+  }
+}
+
+/// The trailing recent-window idle summary the baseline is compared
+/// against.
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingRecentIdleSummary {
+  pub window_start_date: String,
+  pub window_end_date: String,
+  pub idle_temperature_avg: Option<f32>,
+  pub sample_minutes: u32,
+}
+
+impl From<CoreRecentIdleSummary> for CoolingRecentIdleSummary {
+  fn from(value: CoreRecentIdleSummary) -> Self {
+    Self {
+      window_start_date: format_date(value.window_start_date),
+      window_end_date: format_date(value.window_end_date),
+      idle_temperature_avg: value.idle_temperature_avg,
+      sample_minutes: value.sample_minutes,
+    }
+  }
+}
+
+/// Cooling Insight's read of the current idle-temperature drift. The
+/// frontend renders this enum as-is; the +5/+10 degC thresholds and the
+/// 3-day sustain requirement stay behind Core's boundary (#1666).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub enum CoolingDeltaObservation {
+  Establishing,
+  NotComparable,
+  WithinRange,
+  SustainedMildRise,
+  SustainedLargeRise,
+}
+
+impl From<CoreCoolingDeltaObservation> for CoolingDeltaObservation {
+  fn from(value: CoreCoolingDeltaObservation) -> Self {
+    match value {
+      CoreCoolingDeltaObservation::Establishing => Self::Establishing,
+      CoreCoolingDeltaObservation::NotComparable => Self::NotComparable,
+      CoreCoolingDeltaObservation::WithinRange => Self::WithinRange,
+      CoreCoolingDeltaObservation::SustainedMildRise => Self::SustainedMildRise,
+      CoreCoolingDeltaObservation::SustainedLargeRise => Self::SustainedLargeRise,
+    }
+  }
+}
+
+/// One trailing-7-day-window delta against the baseline, ending on
+/// `date`.
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingDailyDelta {
+  pub date: String,
+  pub delta: f32,
+}
+
+impl From<CoreDailyDelta> for CoolingDailyDelta {
+  fn from(value: CoreDailyDelta) -> Self {
+    Self {
+      date: format_date(value.date),
+      delta: value.delta,
+    }
+  }
+}
+
+/// Cooling Insight's baseline delta card: the current drift, its
+/// classification, and the daily series that classification was derived
+/// from.
+#[derive(Debug, Clone, PartialEq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CoolingBaselineDelta {
+  pub baseline: CoolingBaselineState,
+  pub recent: CoolingRecentIdleSummary,
+  pub delta: Option<f32>,
+  pub observation: CoolingDeltaObservation,
+  pub daily_deltas: Vec<CoolingDailyDelta>,
+  pub sustained_days: u32,
+}
+
+impl From<CoreCoolingBaselineDelta> for CoolingBaselineDelta {
+  fn from(value: CoreCoolingBaselineDelta) -> Self {
+    Self {
+      baseline: value.baseline_state.into(),
+      recent: value.recent.into(),
+      delta: value.delta,
+      observation: value.observation.into(),
+      daily_deltas: value.daily_deltas.into_iter().map(Into::into).collect(),
+      sustained_days: value.sustained_days,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use hardviz_core::persistence::cooling_rollup::CpuLoadBand;
+
+  fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+  }
+
+  #[test]
+  fn a_core_daily_cooling_summary_carries_its_date_as_an_iso_string() {
+    let core = CoreDailyCoolingSummary {
+      date: date(2026, 8, 5),
+      coverage_minutes: 1440,
+      idle: CoreBandSummary::default(),
+      low: CoreBandSummary::default(),
+      mid: CoreBandSummary::default(),
+      high: CoreBandSummary::default(),
+    };
+
+    let wire: CoolingDailyTrendPoint = core.into();
+
+    assert_eq!(wire.date, "2026-08-05");
+  }
+
+  // `rename_all` on a tagged enum only renames variant tags, not the
+  // fields inside struct variants - that needs `rename_all_fields` too.
+  // These assert on the actual serialized JSON (not just the Rust
+  // struct), since a `PartialEq` comparison against another Rust value
+  // would not have caught the enum's fields serializing as snake_case.
+
+  #[test]
+  fn an_established_baseline_state_serializes_its_fields_as_camel_case() {
+    let wire = CoolingBaselineState::Established {
+      idle_temperature_avg: 32.5,
+      window_start_date: "2026-01-01".to_string(),
+      window_end_date: "2026-01-07".to_string(),
+      sample_minutes: 210,
+    };
+
+    let json = serde_json::to_value(&wire).unwrap();
+
+    assert_eq!(json["status"], "established");
+    assert_eq!(json["idleTemperatureAvg"], 32.5);
+    assert_eq!(json["windowStartDate"], "2026-01-01");
+    assert_eq!(json["windowEndDate"], "2026-01-07");
+    assert_eq!(json["sampleMinutes"], 210);
+    assert!(
+      json.get("idle_temperature_avg").is_none(),
+      "must not also serialize the snake_case field name"
+    );
+  }
+
+  #[test]
+  fn an_established_band_comparison_serializes_its_fields_as_camel_case() {
+    let wire = CoolingBandComparison::Established {
+      baseline_window_start_date: "2026-01-01".to_string(),
+      baseline_window_end_date: "2026-01-07".to_string(),
+      recent_window_start_date: "2026-08-14".to_string(),
+      recent_window_end_date: "2026-08-20".to_string(),
+      bands: Vec::new(),
+    };
+
+    let json = serde_json::to_value(&wire).unwrap();
+
+    assert_eq!(json["status"], "established");
+    assert_eq!(json["baselineWindowStartDate"], "2026-01-01");
+    assert_eq!(json["recentWindowEndDate"], "2026-08-20");
+    assert!(
+      json.get("baseline_window_start_date").is_none(),
+      "must not also serialize the snake_case field name"
+    );
+  }
+
+  #[test]
+  fn an_establishing_baseline_state_carries_its_progress_through() {
+    let core = CoreBaselineState::Establishing {
+      qualifying_days: 3,
+      required_days: 7,
+    };
+
+    let wire: CoolingBaselineState = core.into();
+
+    assert_eq!(
+      wire,
+      CoolingBaselineState::Establishing {
+        qualifying_days: 3,
+        required_days: 7,
+      }
+    );
+  }
+
+  #[test]
+  fn an_established_baseline_state_formats_its_window_dates() {
+    let core = CoreBaselineState::Established {
+      idle_temperature_avg: 32.5,
+      window_start_date: date(2026, 1, 1),
+      window_end_date: date(2026, 1, 7),
+      sample_minutes: 210,
+    };
+
+    let wire: CoolingBaselineState = core.into();
+
+    assert_eq!(
+      wire,
+      CoolingBaselineState::Established {
+        idle_temperature_avg: 32.5,
+        window_start_date: "2026-01-01".to_string(),
+        window_end_date: "2026-01-07".to_string(),
+        sample_minutes: 210,
+      }
+    );
+  }
+
+  #[test]
+  fn cpu_load_bands_map_one_to_one() {
+    assert_eq!(
+      CoolingLoadBand::from(CpuLoadBand::Idle),
+      CoolingLoadBand::Idle
+    );
+    assert_eq!(
+      CoolingLoadBand::from(CpuLoadBand::Low),
+      CoolingLoadBand::Low
+    );
+    assert_eq!(
+      CoolingLoadBand::from(CpuLoadBand::Mid),
+      CoolingLoadBand::Mid
+    );
+    assert_eq!(
+      CoolingLoadBand::from(CpuLoadBand::High),
+      CoolingLoadBand::High
+    );
+  }
+
+  #[test]
+  fn an_established_band_comparison_formats_every_window_date() {
+    let core = CoreCoolingBandComparison::Established {
+      baseline_window_start_date: date(2026, 1, 1),
+      baseline_window_end_date: date(2026, 1, 7),
+      recent_window_start_date: date(2026, 8, 14),
+      recent_window_end_date: date(2026, 8, 20),
+      bands: [
+        CoreBandComparison {
+          band: CpuLoadBand::Idle,
+          baseline: CoreBandWindowSummary {
+            temperature_avg: Some(30.0),
+            sample_minutes: 210,
+          },
+          recent: CoreBandWindowSummary {
+            temperature_avg: Some(35.0),
+            sample_minutes: 210,
+          },
+          comparable: true,
+        },
+        CoreBandComparison {
+          band: CpuLoadBand::Low,
+          baseline: CoreBandWindowSummary::default(),
+          recent: CoreBandWindowSummary::default(),
+          comparable: false,
+        },
+        CoreBandComparison {
+          band: CpuLoadBand::Mid,
+          baseline: CoreBandWindowSummary::default(),
+          recent: CoreBandWindowSummary::default(),
+          comparable: false,
+        },
+        CoreBandComparison {
+          band: CpuLoadBand::High,
+          baseline: CoreBandWindowSummary::default(),
+          recent: CoreBandWindowSummary::default(),
+          comparable: false,
+        },
+      ],
+    };
+
+    let wire: CoolingBandComparison = core.into();
+
+    match wire {
+      CoolingBandComparison::Established {
+        baseline_window_start_date,
+        baseline_window_end_date,
+        recent_window_start_date,
+        recent_window_end_date,
+        bands,
+      } => {
+        assert_eq!(baseline_window_start_date, "2026-01-01");
+        assert_eq!(baseline_window_end_date, "2026-01-07");
+        assert_eq!(recent_window_start_date, "2026-08-14");
+        assert_eq!(recent_window_end_date, "2026-08-20");
+        assert_eq!(bands.len(), 4);
+        assert_eq!(bands[0].band, CoolingLoadBand::Idle);
+        assert!(bands[0].comparable);
+      }
+      other => panic!("expected an established comparison, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn a_baseline_delta_carries_the_daily_series_with_formatted_dates() {
+    let core = CoreCoolingBaselineDelta {
+      baseline_state: CoreBaselineState::Established {
+        idle_temperature_avg: 30.0,
+        window_start_date: date(2026, 1, 1),
+        window_end_date: date(2026, 1, 7),
+        sample_minutes: 210,
+      },
+      recent: CoreRecentIdleSummary {
+        window_start_date: date(2026, 8, 14),
+        window_end_date: date(2026, 8, 20),
+        idle_temperature_avg: Some(37.0),
+        sample_minutes: 210,
+      },
+      delta: Some(7.0),
+      observation: CoreCoolingDeltaObservation::SustainedMildRise,
+      daily_deltas: vec![
+        CoreDailyDelta {
+          date: date(2026, 8, 18),
+          delta: 5.5,
+        },
+        CoreDailyDelta {
+          date: date(2026, 8, 19),
+          delta: 6.5,
+        },
+        CoreDailyDelta {
+          date: date(2026, 8, 20),
+          delta: 7.0,
+        },
+      ],
+      sustained_days: 3,
+    };
+
+    let wire: CoolingBaselineDelta = core.into();
+
+    assert_eq!(wire.observation, CoolingDeltaObservation::SustainedMildRise);
+    assert_eq!(wire.sustained_days, 3);
+    assert_eq!(wire.delta, Some(7.0));
+    assert_eq!(
+      wire
+        .daily_deltas
+        .iter()
+        .map(|d| d.date.clone())
+        .collect::<Vec<_>>(),
+      vec!["2026-08-18", "2026-08-19", "2026-08-20"]
+    );
+  }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive_history;
 pub mod background_image;
+pub mod cooling_insight;
 pub mod external_component_guidance;
 pub mod hardware;
 pub mod hardware_archive;

--- a/src-tauri/src/services/cooling_insight_service.rs
+++ b/src-tauri/src/services/cooling_insight_service.rs
@@ -1,0 +1,27 @@
+//! Thin service wrapping Cooling Insight's Core-owned query functions
+//! (#2017). Mirrors `archive_history_service`: each function just calls
+//! into `hardviz_core::persistence` and maps a `sqlx::Error` into the
+//! `String` shape the command layer's `Result<T, String>` uses.
+
+use hardviz_core::persistence::cooling_band_comparison::{self, CoolingBandComparison};
+use hardviz_core::persistence::cooling_baseline_delta::{self, CoolingBaselineDelta};
+use hardviz_core::persistence::cooling_rollup::DailyCoolingSummary;
+use hardviz_core::persistence::cooling_trend;
+
+pub async fn fetch_cooling_trend(days: u32) -> Result<Vec<DailyCoolingSummary>, String> {
+  cooling_trend::load_cooling_trend(days)
+    .await
+    .map_err(|e| format!("Failed to load cooling trend: {e}"))
+}
+
+pub async fn fetch_cooling_band_comparison() -> Result<CoolingBandComparison, String> {
+  cooling_band_comparison::load_cooling_band_comparison()
+    .await
+    .map_err(|e| format!("Failed to load cooling band comparison: {e}"))
+}
+
+pub async fn fetch_cooling_baseline_delta() -> Result<CoolingBaselineDelta, String> {
+  cooling_baseline_delta::load_cooling_baseline_delta()
+    .await
+    .map_err(|e| format!("Failed to load cooling baseline delta: {e}"))
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod archive_history_service;
 pub mod background_image_service;
+pub mod cooling_insight_service;
 pub mod external_component_guidance_service;
 pub mod gpu_service;
 pub mod hardware_service;

--- a/src/rspc/bindings.ts
+++ b/src/rspc/bindings.ts
@@ -124,6 +124,12 @@ export const commands = {
 	getProcessStatsInPeriod: (start: string, end: string) => typedError<ProcessStatRecord[], string>(__TAURI_INVOKE("get_process_stats_in_period", { start, end })),
 	// ## Get GPU names that have archive records
 	getGpuArchiveNames: () => typedError<string[], string>(__TAURI_INVOKE("get_gpu_archive_names")),
+	// ## Get the long-range cooling trend (90-day / 1-year)
+	getCoolingTrend: (days: number) => typedError<CoolingDailyTrendPoint[], string>(__TAURI_INVOKE("get_cooling_trend", { days })),
+	// ## Get the per-load-band baseline-vs-recent cooling comparison
+	getCoolingBandComparison: () => typedError<CoolingBandComparison, string>(__TAURI_INVOKE("get_cooling_band_comparison")),
+	// ## Get the idle cooling baseline delta and its observation state
+	getCoolingBaselineDelta: () => typedError<CoolingBaselineDelta, string>(__TAURI_INVOKE("get_cooling_baseline_delta")),
 	getSettings: () => typedError<ClientSettings_Serialize, string>(__TAURI_INVOKE("get_settings")),
 	setLanguage: (newLanguage: string) => typedError<null, string>(__TAURI_INVOKE("set_language", { newLanguage })),
 	setTheme: (newTheme: Theme) => typedError<null, string>(__TAURI_INVOKE("set_theme", { newTheme })),
@@ -361,6 +367,101 @@ export type ClientSettings_Serialize = {
 	externalComponentGuidance: ExternalComponentGuidanceSettings,
 	elevatedStartupMode: boolean,
 	trayWidget: TrayWidgetSettings_Serialize,
+};
+
+/**
+ *  Cooling Insight's load-band comparison, gated by the same baseline
+ *  lifecycle as [`CoolingBaselineState`]: no comparison exists yet while
+ *  the baseline is still establishing.
+ */
+export type CoolingBandComparison = { status: "establishing"; qualifyingDays: number; requiredDays: number } | { status: "established"; baselineWindowStartDate: string; baselineWindowEndDate: string; recentWindowStartDate: string; recentWindowEndDate: string; bands: CoolingBandComparisonEntry[] };
+
+// One CPU-load band's baseline-vs-recent comparison.
+export type CoolingBandComparisonEntry = {
+	band: CoolingLoadBand,
+	baseline: CoolingBandWindowSummary,
+	recent: CoolingBandWindowSummary,
+	comparable: boolean,
+};
+
+// One CPU-load band's temperature summary for a single day.
+export type CoolingBandTemperature = {
+	avg: number | null,
+	max: number | null,
+	min: number | null,
+	sampleMinutes: number,
+};
+
+/**
+ *  One band's weighted-average temperature and sample coverage over a
+ *  date window (either the baseline window or the recent window).
+ */
+export type CoolingBandWindowSummary = {
+	temperatureAvg: number | null,
+	sampleMinutes: number,
+};
+
+/**
+ *  Cooling Insight's baseline delta card: the current drift, its
+ *  classification, and the daily series that classification was derived
+ *  from.
+ */
+export type CoolingBaselineDelta = {
+	baseline: CoolingBaselineState,
+	recent: CoolingRecentIdleSummary,
+	delta: number | null,
+	observation: CoolingDeltaObservation,
+	dailyDeltas: CoolingDailyDelta[],
+	sustainedDays: number,
+};
+
+/**
+ *  Lifecycle of the idle cooling baseline (see
+ *  `hardviz_core::persistence::cooling_baseline::BaselineState`).
+ */
+export type CoolingBaselineState = { status: "establishing"; qualifyingDays: number; requiredDays: number } | { status: "established"; idleTemperatureAvg: number; windowStartDate: string; windowEndDate: string; sampleMinutes: number };
+
+/**
+ *  One trailing-7-day-window delta against the baseline, ending on
+ *  `date`.
+ */
+export type CoolingDailyDelta = {
+	date: string,
+	delta: number,
+};
+
+/**
+ *  One day's `cooling_daily_summary` row, for the 90-day/1-year Cooling
+ *  Insight trend. A date the rollup has no row for is simply absent from
+ *  the response array - never a zero-filled entry.
+ */
+export type CoolingDailyTrendPoint = {
+	date: string,
+	coverageMinutes: number,
+	idle: CoolingBandTemperature,
+	low: CoolingBandTemperature,
+	mid: CoolingBandTemperature,
+	high: CoolingBandTemperature,
+};
+
+/**
+ *  Cooling Insight's read of the current idle-temperature drift. The
+ *  frontend renders this enum as-is; the +5/+10 degC thresholds and the
+ *  3-day sustain requirement stay behind Core's boundary (#1666).
+ */
+export type CoolingDeltaObservation = "establishing" | "notComparable" | "withinRange" | "sustainedMildRise" | "sustainedLargeRise";
+
+export type CoolingLoadBand = "idle" | "low" | "mid" | "high";
+
+/**
+ *  The trailing recent-window idle summary the baseline is compared
+ *  against.
+ */
+export type CoolingRecentIdleSummary = {
+	windowStartDate: string,
+	windowEndDate: string,
+	idleTemperatureAvg: number | null,
+	sampleMinutes: number,
 };
 
 export type CpuInfo = {


### PR DESCRIPTION
## Summary

> **Scope note:** #2028 (the Cooling Insight query commands) was stacked on this branch and auto-merged **into it**, so this PR now delivers three things as one unit: the baseline persistence fix, the #2017 query surface, and the review fixes from #2028's threads. The commit history keeps them separate (`e37bdacd` / `151a4520` / `623cefda`).

### 1. `fix(core)`: persist the cooling baseline once established (`e37bdacd`)

- the derive-on-read baseline from #2026 breaks once the 400-day rollup retention slides past the establishment days: the "first 7 qualifying days" silently move, so the supposedly stable reference drifts — or degrades back to `establishing`
- **establish-then-persist**: when the derivation first reaches `Established`, the value and its collection window are written once to a new single-row `cooling_baseline` table (migration v12, `INSERT OR IGNORE`); reads prefer the pinned row; the recent 7-day window stays derived — it describes the present, not the fixed reference
- the core regression test establishes at one temperature, deletes every source rollup row, records seven **hotter** qualifying days, and asserts the established state is unchanged (fails on the derive-on-read code)
- reset semantics now have teeth: a future Insights data reset must delete `cooling_baseline` together with `cooling_daily_summary`

### 2. `feat(app)`: Cooling Insight query commands (#2028, `151a4520`)

- `getCoolingTrend(days)` — per-day band summaries, idle series, and coverage from the daily rollup for the 90-day / 1-year windows; absent days stay absent; ≤ 30-day windows keep using `getDataArchiveSeries`
- `getCoolingBandComparison()` — baseline window vs recent 7 days per load band, each side independently guarded by a 30-idle-minute threshold; thin bands return `comparable: false`, an unestablished baseline returns the `establishing` variant
- `getCoolingBaselineDelta()` — trailing 7-day idle average vs baseline with the observation state decided in Core (`establishing` / `notComparable` / `withinRange` / `sustainedMildRise` / `sustainedLargeRise`; +5/+10 °C thresholds, 3-day sustain, all Core constants), plus the daily delta series for "n days in a row" rendering
- wire DTOs per ADR 0009; `src/rspc/bindings.ts` regenerated, never hand-edited

### 3. `fix(core)`: #2028 review fixes (`623cefda`)

- **streak gating**: a day only extends a sustained streak when it has its own rollup row with idle samples — windows over unobserved days no longer re-count the same samples, so one real day can never read as a multi-day streak (DP-02)
- **large-rise integrity**: mild and large streaks are counted independently; `sustainedLargeRise` now requires 3 consecutive days at ≥ +10 °C, and `sustained_days` reports the streak matching the returned observation
- **pinned-baseline integration**: baseline state resolution is centralized in `resolve_baseline_state_from_pool` (pinned row first, establish-then-persist write-back), used by the baseline, band-comparison, and delta loaders alike — the delta/band queries can no longer drift by re-deriving while a pinned baseline exists

## Related Issues

Relates to #1666, #2016, #2017
Follow-up to #2026 and #2028 review findings (chatgpt-codex-connector)

## Type of Change

- [x] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (Core/App persistence and query surface; the UI lands in #2018–#2020)

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- `cargo test -p hardviz-core --lib` → 451 passed, 0 failed (includes the persistence regression, streak-gating, large-boundary, and pinned-baseline tests)
- `cargo test -p hardware_visualizer --lib migration` → v12 green
- `cargo tauri-fmt` applied; `cargo tauri-lint` → 0 warnings
- bindings verified byte-identical after the review fixes (no wire shape change)

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cooling Insights with long-range daily temperature trends.
  * Added comparisons across idle, low, medium, and high CPU-load bands.
  * Added baseline temperature drift tracking, including daily changes and sustained-rise indicators.
  * Cooling baselines are established from qualifying data and remain consistent for meaningful comparisons.
* **Bug Fixes**
  * Improved handling of incomplete data, missing days, and insufficient samples to avoid misleading results.
  * Limited trend requests to the available retention period.
* **Data & Reliability**
  * Added persistent baseline storage and reset-safe behavior.
  * Baseline saving failures no longer interrupt insight retrieval and can retry later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->