### PR TITLE
feat(core): collect experimental IT8728F temperatures

### DIFF
--- a/core/src/infrastructure/providers/windows/super_io_motherboard.rs
+++ b/core/src/infrastructure/providers/windows/super_io_motherboard.rs
@@ -25,6 +25,9 @@ pub(crate) const ITE_EXPERIMENTAL_FAILURE_PREFIX: &str =
   "Experimental IT8728F/EX motherboard temperature path failed";
 pub(crate) const ITE_EXPERIMENTAL_NON_COMPONENT_FAILURE_PREFIX: &str =
   "Experimental IT8728F/EX motherboard temperature path failed: hardware state";
+const ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT: &str = "configuration exit failed";
+const ITE_EC_AUTHORIZATION_PROBE_FAILURE_CONTEXT: &str =
+  "EC port authorization probe failed";
 
 const CHIP_ID_HIGH_REGISTER: u8 = 0x20;
 const CHIP_ID_LOW_REGISTER: u8 = 0x21;
@@ -412,14 +415,14 @@ impl<C: LpcIoOps> ActiveIteMotherboardSensors<C> {
         read_ite_ec_byte(client, discovered.ec_base, ITE_EC_CONFIGURATION_REGISTER)
           .map_err(|reason| {
             ite_experimental_failure(format!(
-              "EC port authorization probe failed: {reason}"
+              "{ITE_EC_AUTHORIZATION_PROBE_FAILURE_CONTEXT}: {reason}"
             ))
           })?;
         Ok(Some(discovered))
       }
       (Ok(None), Ok(())) => Ok(None),
       (Ok(Some(_)), Err(exit_error)) => Err(ite_experimental_failure(format!(
-        "configuration exit failed: {exit_error}"
+        "{ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT}: {exit_error}"
       ))),
       (Ok(None), Err(exit_error)) => Err(format!("ITE config exit failed: {exit_error}")),
       (Err(reason), Ok(())) => Err(reason),
@@ -738,8 +741,13 @@ fn ite_experimental_non_component_failure(reason: impl AsRef<str>) -> String {
 }
 
 fn is_retryable_init_error(reason: &str) -> bool {
+  let requires_ite_rediscovery = reason.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX)
+    && (reason.contains(ITE_EC_AUTHORIZATION_PROBE_FAILURE_CONTEXT)
+      || reason.contains(ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT));
+
   reason.contains("timed out waiting for mutex")
     || reason.contains("failed waiting for mutex")
+    || requires_ite_rediscovery
 }
 
 #[cfg(test)]
@@ -1154,9 +1162,19 @@ mod tests {
 
     assert!(error.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX));
     assert!(error.contains("EC port authorization probe failed"));
+    assert!(is_retryable_init_error(&error));
     assert_eq!(client.find_bars_calls.get(), 1);
     assert_eq!(client.config_exit_calls.get(), 1);
     assert_eq!(client.read_registers.borrow().as_slice(), &[0x00]);
+  }
+
+  #[test]
+  fn ite_configuration_exit_failure_requires_rediscovery() {
+    let error = ite_experimental_failure(format!(
+      "{ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT}: simulated exit failure"
+    ));
+
+    assert!(is_retryable_init_error(&error));
   }
 
   #[test]

--- a/core/src/infrastructure/providers/windows/super_io_motherboard.rs
+++ b/core/src/infrastructure/providers/windows/super_io_motherboard.rs
@@ -426,9 +426,9 @@ impl<C: LpcIoOps> ActiveIteMotherboardSensors<C> {
       ))),
       (Ok(None), Err(exit_error)) => Err(format!("ITE config exit failed: {exit_error}")),
       (Err(reason), Ok(())) => Err(reason),
-      (Err(reason), Err(exit_error)) => {
-        Err(format!("{reason}; exit failed: {exit_error}"))
-      }
+      (Err(reason), Err(exit_error)) => Err(format!(
+        "{reason}; {ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT}: {exit_error}"
+      )),
     }
   }
 
@@ -912,6 +912,7 @@ mod tests {
     channel_configuration: Cell<u8>,
     temperature_values: Cell<[u8; 3]>,
     failed_temperature_register: Cell<Option<u8>>,
+    fail_config_exit: Cell<bool>,
     selected_slot_calls: Cell<u32>,
     find_bars_calls: Cell<u32>,
     config_exit_calls: Cell<u32>,
@@ -935,6 +936,7 @@ mod tests {
         channel_configuration: Cell::new(0b0010_1000),
         temperature_values: Cell::new([25, 30, 35]),
         failed_temperature_register: Cell::new(None),
+        fail_config_exit: Cell::new(false),
         selected_slot_calls: Cell::new(0),
         find_bars_calls: Cell::new(0),
         config_exit_calls: Cell::new(0),
@@ -1059,6 +1061,9 @@ mod tests {
         }
         (0x02, 0x02) => {
           self.config_exit_calls.set(self.config_exit_calls.get() + 1);
+          if self.fail_config_exit.get() {
+            return Err("simulated ITE config exit failure".to_string());
+          }
         }
         _ => {}
       }
@@ -1175,6 +1180,20 @@ mod tests {
     ));
 
     assert!(is_retryable_init_error(&error));
+  }
+
+  #[test]
+  fn ite_discovery_and_configuration_exit_failure_requires_rediscovery() {
+    let client = FakeIteLpcIo::new();
+    client.activation.set(0x00);
+    client.fail_config_exit.set(true);
+
+    let error = ActiveIteMotherboardSensors::discover_slot(&client, 0).unwrap_err();
+
+    assert!(error.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX));
+    assert!(error.contains(ITE_CONFIGURATION_EXIT_FAILURE_CONTEXT));
+    assert!(is_retryable_init_error(&error));
+    assert_eq!(client.config_exit_calls.get(), 1);
   }
 
   #[test]

--- a/core/src/infrastructure/providers/windows/super_io_motherboard.rs
+++ b/core/src/infrastructure/providers/windows/super_io_motherboard.rs
@@ -1,13 +1,14 @@
 use std::sync::{Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::pawn_io::{ACCESS_ISABUS_MUTEX, NamedMutex, PawnIoClient, PawnIoModule};
 use crate::models::{
   MotherboardFanSpeed, MotherboardSensorSample, MotherboardTemperature,
 };
 use crate::utils::super_io::{
-  chip_id, decode_nuvoton_direct_rpm, decode_nuvoton_temperature_byte,
-  fan_speed_status_from_rpm, is_absent_id, slot_ports,
+  chip_id, decode_ite_temperature_byte, decode_nuvoton_direct_rpm,
+  decode_nuvoton_temperature_byte, fan_speed_status_from_rpm, is_absent_id,
+  is_ite_temperature_channel_eligible, is_plausible_ite_temperature, slot_ports,
 };
 use crate::{log_debug, log_warn};
 
@@ -15,13 +16,21 @@ const ISABUS_MUTEX_TIMEOUT: Duration = Duration::from_millis(50);
 const NUVOTON_NCT6799D_CHIP_ID: u16 = 0xD802;
 const NUVOTON_CHIP_LABEL: &str = "NCT6799D";
 const NUVOTON_SOURCE_LABEL: &str = "NCT6799D / Super I/O";
-pub(crate) const UNSUPPORTED_NUVOTON_HM_PATH_REASON: &str =
-  "No supported Nuvoton NCT6799D Super I/O hardware-monitor path found";
+const ITE_IT8728F_CHIP_ID: u16 = 0x8728;
+const ITE_CHIP_LABEL: &str = "IT8728F/EX";
+const ITE_SOURCE_LABEL: &str = "IT8728F/EX / Super I/O";
+pub(crate) const UNSUPPORTED_SUPER_IO_HM_PATH_REASON: &str =
+  "No supported Super I/O hardware-monitor path found";
+pub(crate) const ITE_EXPERIMENTAL_FAILURE_PREFIX: &str =
+  "Experimental IT8728F/EX motherboard temperature path failed";
+pub(crate) const ITE_EXPERIMENTAL_NON_COMPONENT_FAILURE_PREFIX: &str =
+  "Experimental IT8728F/EX motherboard temperature path failed: hardware state";
 
 const CHIP_ID_HIGH_REGISTER: u8 = 0x20;
 const CHIP_ID_LOW_REGISTER: u8 = 0x21;
 const LOGICAL_DEVICE_SELECT_REGISTER: u8 = 0x07;
 const NUVOTON_HARDWARE_MONITOR_LDN: u8 = 0x0B;
+const ITE_ENVIRONMENT_CONTROLLER_LDN: u8 = 0x04;
 const LDN_ACTIVATION_REGISTER: u8 = 0x30;
 const HM_BASE_HIGH_REGISTER: u8 = 0x60;
 const HM_BASE_LOW_REGISTER: u8 = 0x61;
@@ -30,6 +39,13 @@ const HM_INDEX_OFFSET: u16 = 0x05;
 const HM_DATA_OFFSET: u16 = 0x06;
 const HM_BANK_SELECT_REGISTER: u8 = 0x4E;
 const NUVOTON_BANK_4: u8 = 0x04;
+
+const ITE_EC_INDEX_OFFSET: u16 = 0x05;
+const ITE_EC_DATA_OFFSET: u16 = 0x06;
+const ITE_EC_CONFIGURATION_REGISTER: u8 = 0x00;
+const ITE_EC_CHANNEL_ENABLE_REGISTER: u8 = 0x51;
+const ITE_ABSENT_EC_BASE: u16 = 0x0FF8;
+const ITE_SAMPLE_MIN_INTERVAL: Duration = Duration::from_millis(1_500);
 
 const TEMPERATURE_REGISTERS: [(&str, u8); 6] = [
   ("SYSTIN", 0x90),
@@ -49,16 +65,23 @@ const FAN_RPM_REGISTERS: [(&str, u8, u8); 6] = [
   ("Fan 6", 0xCA, 0xCB),
 ];
 
+const ITE_TEMPERATURE_REGISTERS: [(&str, u8, u8); 3] = [
+  ("TMPIN1", 0x29, 1),
+  ("TMPIN2", 0x2A, 2),
+  ("TMPIN3", 0x2B, 3),
+];
+
 static MOTHERBOARD_SENSOR_SAMPLER: OnceLock<Mutex<MotherboardSensorSampler>> =
   OnceLock::new();
 
 /// Read live motherboard temperature and fan RPM values through the scoped
-/// Nuvoton normal-HM path.
+/// Nuvoton normal-HM or ITE Environment Controller path.
 ///
 /// Implemented from:
-/// - docs/specs/sensors/pawnio-interface.md revision 4
+/// - docs/specs/sensors/pawnio-interface.md revision 5
 /// - docs/specs/sensors/superio-access.md revision 3
 /// - docs/specs/sensors/superio-nuvoton-nct67xx.md revision 5
+/// - docs/specs/sensors/superio-ite-it86xx-it87xx.md revision 2
 ///
 /// No other external sensor implementation source was used.
 pub fn sample_motherboard_sensors() -> Result<MotherboardSensorSample, String> {
@@ -79,7 +102,7 @@ pub fn sample_motherboard_sensors() -> Result<MotherboardSensorSample, String> {
 }
 
 struct MotherboardSensorSampler {
-  active: Option<ActiveNuvotonMotherboardSensors<PawnIoClient>>,
+  active: Option<ActiveMotherboardSensors<PawnIoClient>>,
   unavailable_reason: Option<String>,
   retry_unavailable: bool,
   sample_failure_logged: bool,
@@ -104,7 +127,7 @@ impl MotherboardSensorSampler {
       let _ = self.try_open();
     }
 
-    let result = match self.active.as_ref() {
+    let result = match self.active.as_mut() {
       Some(active) => active.sample(),
       None => Err(
         self
@@ -129,7 +152,7 @@ impl MotherboardSensorSampler {
   }
 
   fn try_open(&mut self) -> Result<(), String> {
-    match ActiveNuvotonMotherboardSensors::open() {
+    match ActiveMotherboardSensors::open() {
       Ok(active) => {
         self.active = Some(active);
         self.unavailable_reason = None;
@@ -148,10 +171,7 @@ impl MotherboardSensorSampler {
 
   fn diagnostic_summary(&self) -> String {
     match &self.active {
-      Some(active) => format!(
-        "active chip={} slot={} hm_base=0x{:04X}",
-        active.chip_label, active.slot, active.hm_base
-      ),
+      Some(active) => active.diagnostic_summary(),
       None => format!(
         "unavailable retryable={} reason={}",
         self.retry_unavailable,
@@ -207,7 +227,22 @@ struct ActiveNuvotonMotherboardSensors<C: LpcIoOps> {
   source_label: &'static str,
 }
 
-impl ActiveNuvotonMotherboardSensors<PawnIoClient> {
+struct ActiveIteMotherboardSensors<C: LpcIoOps> {
+  client: C,
+  slot: u8,
+  ec_base: u16,
+  chip_label: &'static str,
+  source_label: &'static str,
+  last_attempt: Option<(Instant, Result<MotherboardSensorSample, String>)>,
+  partial_failure_logged: bool,
+}
+
+enum ActiveMotherboardSensors<C: LpcIoOps> {
+  Nuvoton(ActiveNuvotonMotherboardSensors<C>),
+  Ite(ActiveIteMotherboardSensors<C>),
+}
+
+impl ActiveMotherboardSensors<PawnIoClient> {
   fn open() -> Result<Self, String> {
     let (client, _discovery) =
       PawnIoClient::open(PawnIoModule::LpcIo).map_err(|error| error.reason)?;
@@ -216,15 +251,33 @@ impl ActiveNuvotonMotherboardSensors<PawnIoClient> {
     let mut last_error: Option<String> = None;
 
     for slot in [0_u8, 1] {
-      match Self::discover_slot(&client, slot) {
+      match ActiveNuvotonMotherboardSensors::discover_slot(&client, slot) {
         Ok(Some(discovered)) => {
-          return Ok(Self {
+          return Ok(Self::Nuvoton(ActiveNuvotonMotherboardSensors {
             client,
             slot: discovered.slot,
             hm_base: discovered.hm_base,
             chip_label: NUVOTON_CHIP_LABEL,
             source_label: NUVOTON_SOURCE_LABEL,
-          });
+          }));
+        }
+        Ok(None) => {}
+        Err(reason) => {
+          last_error = Some(reason);
+        }
+      }
+
+      match ActiveIteMotherboardSensors::discover_slot(&client, slot) {
+        Ok(Some(discovered)) => {
+          return Ok(Self::Ite(ActiveIteMotherboardSensors {
+            client,
+            slot: discovered.slot,
+            ec_base: discovered.ec_base,
+            chip_label: ITE_CHIP_LABEL,
+            source_label: ITE_SOURCE_LABEL,
+            last_attempt: None,
+            partial_failure_logged: false,
+          }));
         }
         Ok(None) => {}
         Err(reason) => {
@@ -233,13 +286,34 @@ impl ActiveNuvotonMotherboardSensors<PawnIoClient> {
       }
     }
 
-    Err(last_error.unwrap_or_else(|| UNSUPPORTED_NUVOTON_HM_PATH_REASON.to_string()))
+    Err(last_error.unwrap_or_else(|| UNSUPPORTED_SUPER_IO_HM_PATH_REASON.to_string()))
+  }
+}
+
+impl<C: LpcIoOps> ActiveMotherboardSensors<C> {
+  fn sample(&mut self) -> Result<MotherboardSensorSample, String> {
+    match self {
+      Self::Nuvoton(active) => active.sample(),
+      Self::Ite(active) => active.sample(),
+    }
   }
 
-  fn discover_slot(
-    client: &impl LpcIoOps,
-    slot: u8,
-  ) -> Result<Option<DetectedSlot>, String> {
+  fn diagnostic_summary(&self) -> String {
+    match self {
+      Self::Nuvoton(active) => format!(
+        "active chip={} slot={} hm_base=0x{:04X}",
+        active.chip_label, active.slot, active.hm_base
+      ),
+      Self::Ite(active) => format!(
+        "active chip={} slot={} ec_base=0x{:04X}",
+        active.chip_label, active.slot, active.ec_base
+      ),
+    }
+  }
+}
+
+impl<C: LpcIoOps> ActiveNuvotonMotherboardSensors<C> {
+  fn discover_slot(client: &C, slot: u8) -> Result<Option<DetectedSlot>, String> {
     let Some((index_port, _data_port)) = slot_ports(slot) else {
       return Ok(None);
     };
@@ -260,9 +334,7 @@ impl ActiveNuvotonMotherboardSensors<PawnIoClient> {
       }
     }
   }
-}
 
-impl<C: LpcIoOps> ActiveNuvotonMotherboardSensors<C> {
   fn sample(&self) -> Result<MotherboardSensorSample, String> {
     let _mutex = NamedMutex::acquire(ACCESS_ISABUS_MUTEX, ISABUS_MUTEX_TIMEOUT)?;
     self.sample_unlocked()
@@ -324,9 +396,188 @@ impl<C: LpcIoOps> ActiveNuvotonMotherboardSensors<C> {
   }
 }
 
+impl<C: LpcIoOps> ActiveIteMotherboardSensors<C> {
+  fn discover_slot(client: &C, slot: u8) -> Result<Option<DetectedIteSlot>, String> {
+    let Some((index_port, _data_port)) = slot_ports(slot) else {
+      return Ok(None);
+    };
+
+    client.select_lpc_slot(slot as u64)?;
+    enter_ite(client, slot, index_port)?;
+    let result = discover_ite_ec_base(client, slot);
+    let exit_result = exit_ite(client);
+
+    match (result, exit_result) {
+      (Ok(Some(discovered)), Ok(())) => {
+        read_ite_ec_byte(client, discovered.ec_base, ITE_EC_CONFIGURATION_REGISTER)
+          .map_err(|reason| {
+            ite_experimental_failure(format!(
+              "EC port authorization probe failed: {reason}"
+            ))
+          })?;
+        Ok(Some(discovered))
+      }
+      (Ok(None), Ok(())) => Ok(None),
+      (Ok(Some(_)), Err(exit_error)) => Err(ite_experimental_failure(format!(
+        "configuration exit failed: {exit_error}"
+      ))),
+      (Ok(None), Err(exit_error)) => Err(format!("ITE config exit failed: {exit_error}")),
+      (Err(reason), Ok(())) => Err(reason),
+      (Err(reason), Err(exit_error)) => {
+        Err(format!("{reason}; exit failed: {exit_error}"))
+      }
+    }
+  }
+
+  fn sample(&mut self) -> Result<MotherboardSensorSample, String> {
+    let now = Instant::now();
+    if let Some(cached) = self.cached_result(now) {
+      return cached;
+    }
+
+    let _mutex = NamedMutex::acquire(ACCESS_ISABUS_MUTEX, ISABUS_MUTEX_TIMEOUT)?;
+    let collected = self.collect_sample_unlocked();
+    self.finish_attempt(Instant::now(), collected)
+  }
+
+  #[cfg(test)]
+  fn sample_unlocked_at(
+    &mut self,
+    attempted_at: Instant,
+  ) -> Result<MotherboardSensorSample, String> {
+    if let Some(cached) = self.cached_result(attempted_at) {
+      return cached;
+    }
+
+    let collected = self.collect_sample_unlocked();
+    self.finish_attempt(attempted_at, collected)
+  }
+
+  fn finish_attempt(
+    &mut self,
+    completed_at: Instant,
+    collected: Result<(MotherboardSensorSample, Vec<String>), String>,
+  ) -> Result<MotherboardSensorSample, String> {
+    let result = match collected {
+      Ok((sample, partial_failures)) => {
+        if partial_failures.is_empty() {
+          self.partial_failure_logged = false;
+        } else if !self.partial_failure_logged {
+          self.partial_failure_logged = true;
+          log_warn!(
+            "experimental_ite_motherboard_sensor_partial_sample",
+            "windows::super_io_motherboard::ActiveIteMotherboardSensors::sample",
+            Some(partial_failures.join("; "))
+          );
+        }
+        Ok(sample)
+      }
+      Err(reason) => Err(ite_experimental_failure(reason)),
+    };
+
+    self.last_attempt = Some((completed_at, result.clone()));
+    result
+  }
+
+  fn cached_result(
+    &self,
+    now: Instant,
+  ) -> Option<Result<MotherboardSensorSample, String>> {
+    self
+      .last_attempt
+      .as_ref()
+      .and_then(|(attempted_at, result)| {
+        (now.saturating_duration_since(*attempted_at) < ITE_SAMPLE_MIN_INTERVAL)
+          .then(|| result.clone())
+      })
+  }
+
+  fn collect_sample_unlocked(
+    &self,
+  ) -> Result<(MotherboardSensorSample, Vec<String>), String> {
+    let monitoring_state = self.read_ec_byte(ITE_EC_CONFIGURATION_REGISTER)?;
+    if (monitoring_state & 0x01) == 0 {
+      return Err(ite_experimental_non_component_failure(
+        "Environment Controller monitoring is in standby",
+      ));
+    }
+    if (monitoring_state & 0x08) != 0 {
+      return Err(ite_experimental_non_component_failure(
+        "Environment Controller monitoring is stopped by INT_Clear",
+      ));
+    }
+
+    let channel_config = self.read_ec_byte(ITE_EC_CHANNEL_ENABLE_REGISTER)?;
+    let mut temperatures = Vec::new();
+    let mut partial_failures = Vec::new();
+    let mut eligible_channels = 0_usize;
+    let mut had_io_failure = false;
+
+    for (name, register, channel) in ITE_TEMPERATURE_REGISTERS {
+      if !is_ite_temperature_channel_eligible(channel_config, channel) {
+        continue;
+      }
+      eligible_channels += 1;
+
+      match self.read_ec_byte(register) {
+        Ok(raw) => {
+          let temperature = decode_ite_temperature_byte(raw);
+          if is_plausible_ite_temperature(temperature) {
+            temperatures.push(MotherboardTemperature {
+              name: name.to_string(),
+              temperature,
+              source: self.source_label.to_string(),
+            });
+          } else {
+            partial_failures.push(format!(
+              "{name} returned implausible raw value 0x{raw:02X} ({temperature} C)"
+            ));
+          }
+        }
+        Err(reason) => {
+          had_io_failure = true;
+          partial_failures.push(format!("{name} read failed: {reason}"));
+        }
+      }
+    }
+
+    if eligible_channels == 0 {
+      return Err(ite_experimental_non_component_failure(
+        "no eligible physical TMPIN channels are enabled",
+      ));
+    }
+    if temperatures.is_empty() {
+      let reason = format!("no usable TMPIN readings: {}", partial_failures.join("; "));
+      return if had_io_failure {
+        Err(reason)
+      } else {
+        Err(ite_experimental_non_component_failure(reason))
+      };
+    }
+
+    Ok((
+      MotherboardSensorSample {
+        temperatures,
+        fan_speeds: Vec::new(),
+      },
+      partial_failures,
+    ))
+  }
+
+  fn read_ec_byte(&self, register: u8) -> Result<u8, String> {
+    read_ite_ec_byte(&self.client, self.ec_base, register)
+  }
+}
+
 struct DetectedSlot {
   slot: u8,
   hm_base: u16,
+}
+
+#[derive(Debug)]
+struct DetectedIteSlot {
+  slot: u8,
+  ec_base: u16,
 }
 
 fn discover_nuvoton_hm_base(
@@ -364,6 +615,58 @@ fn discover_nuvoton_hm_base(
   Ok(Some(DetectedSlot { slot, hm_base }))
 }
 
+fn discover_ite_ec_base(
+  client: &impl LpcIoOps,
+  slot: u8,
+) -> Result<Option<DetectedIteSlot>, String> {
+  let id_high = client.superio_inb(CHIP_ID_HIGH_REGISTER)?;
+  let id_low = client.superio_inb(CHIP_ID_LOW_REGISTER)?;
+  if is_absent_id(id_high, id_low) {
+    return Ok(None);
+  }
+
+  let raw_chip_id = chip_id(id_high, id_low);
+  if raw_chip_id != ITE_IT8728F_CHIP_ID {
+    return Ok(None);
+  }
+
+  client
+    .superio_outb(
+      LOGICAL_DEVICE_SELECT_REGISTER,
+      ITE_ENVIRONMENT_CONTROLLER_LDN,
+    )
+    .map_err(|reason| {
+      ite_experimental_failure(format!("LDN selection failed: {reason}"))
+    })?;
+  let activation = client
+    .superio_inb(LDN_ACTIVATION_REGISTER)
+    .map_err(|reason| ite_experimental_failure(format!("CR30 read failed: {reason}")))?;
+  if (activation & 0x01) == 0 {
+    return Err(ite_experimental_non_component_failure(
+      "Environment Controller logical device is inactive",
+    ));
+  }
+
+  let base_high = client
+    .superio_inb(HM_BASE_HIGH_REGISTER)
+    .map_err(|reason| ite_experimental_failure(format!("CR60 read failed: {reason}")))?;
+  let base_low = client
+    .superio_inb(HM_BASE_LOW_REGISTER)
+    .map_err(|reason| ite_experimental_failure(format!("CR61 read failed: {reason}")))?;
+  let ec_base = ((base_high as u16 & 0x0F) << 8) | (base_low as u16 & 0xF8);
+  if !is_valid_ite_ec_base(base_high, base_low, ec_base) {
+    return Err(ite_experimental_non_component_failure(format!(
+      "invalid Environment Controller base from CR60/61=0x{base_high:02X}/0x{base_low:02X} (derived 0x{ec_base:04X})"
+    )));
+  }
+
+  client.find_lpc_bars().map_err(|reason| {
+    ite_experimental_failure(format!("LpcIO BAR discovery failed: {reason}"))
+  })?;
+
+  Ok(Some(DetectedIteSlot { slot, ec_base }))
+}
+
 fn enter_nuvoton(client: &impl LpcIoOps, index_port: u16) -> Result<(), String> {
   client.pio_outb(index_port, 0x87)?;
   client.pio_outb(index_port, 0x87)
@@ -373,8 +676,65 @@ fn exit_nuvoton(client: &impl LpcIoOps, index_port: u16) -> Result<(), String> {
   client.pio_outb(index_port, 0xAA)
 }
 
+fn enter_ite(client: &impl LpcIoOps, slot: u8, index_port: u16) -> Result<(), String> {
+  let final_key = match slot {
+    0 => 0x55,
+    1 => 0xAA,
+    _ => return Err(format!("unsupported Super I/O LpcIO slot {slot}")),
+  };
+
+  for value in [0x87, 0x01, 0x55, final_key] {
+    client.pio_outb(index_port, value)?;
+  }
+  Ok(())
+}
+
+fn exit_ite(client: &impl LpcIoOps) -> Result<(), String> {
+  client.superio_outb(0x02, 0x02)
+}
+
+fn read_ite_ec_byte(
+  client: &impl LpcIoOps,
+  ec_base: u16,
+  register: u8,
+) -> Result<u8, String> {
+  let index_port = ec_base
+    .checked_add(ITE_EC_INDEX_OFFSET)
+    .ok_or_else(|| format!("ITE EC index port overflows base 0x{ec_base:04X}"))?;
+  let data_port = ec_base
+    .checked_add(ITE_EC_DATA_OFFSET)
+    .ok_or_else(|| format!("ITE EC data port overflows base 0x{ec_base:04X}"))?;
+  client.pio_outb(index_port, register)?;
+  client.pio_inb(data_port)
+}
+
 fn is_valid_hm_base(base: u16) -> bool {
   base != 0x0000 && base != 0xFFFF && base <= u16::MAX - HM_DATA_OFFSET
+}
+
+fn is_valid_ite_ec_base(base_high: u8, base_low: u8, ec_base: u16) -> bool {
+  (base_high & 0xF0) == 0
+    && (base_low & 0x07) == 0
+    && (base_high, base_low) != (0xFF, 0xFF)
+    && ec_base != 0x0000
+    && ec_base != ITE_ABSENT_EC_BASE
+    && ec_base.checked_add(ITE_EC_DATA_OFFSET).is_some()
+}
+
+fn ite_experimental_failure(reason: impl AsRef<str>) -> String {
+  let reason = reason.as_ref();
+  if reason.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX) {
+    reason.to_string()
+  } else {
+    format!("{ITE_EXPERIMENTAL_FAILURE_PREFIX}: {reason}")
+  }
+}
+
+fn ite_experimental_non_component_failure(reason: impl AsRef<str>) -> String {
+  format!(
+    "{ITE_EXPERIMENTAL_NON_COMPONENT_FAILURE_PREFIX}: {}",
+    reason.as_ref()
+  )
 }
 
 fn is_retryable_init_error(reason: &str) -> bool {
@@ -535,6 +895,169 @@ mod tests {
     }
   }
 
+  struct FakeIteLpcIo {
+    chip_id_low: Cell<u8>,
+    activation: Cell<u8>,
+    base_high: Cell<u8>,
+    base_low: Cell<u8>,
+    ec_configuration: Cell<u8>,
+    channel_configuration: Cell<u8>,
+    temperature_values: Cell<[u8; 3]>,
+    failed_temperature_register: Cell<Option<u8>>,
+    selected_slot_calls: Cell<u32>,
+    find_bars_calls: Cell<u32>,
+    config_exit_calls: Cell<u32>,
+    ec_bars_authorized: Cell<bool>,
+    selected_ldn: Cell<Option<u8>>,
+    base_high_read: Cell<bool>,
+    base_low_read: Cell<bool>,
+    selected_ec_register: Cell<Option<u8>>,
+    read_registers: RefCell<Vec<u8>>,
+    config_port_writes: RefCell<Vec<(u16, u8)>>,
+  }
+
+  impl FakeIteLpcIo {
+    fn new() -> Self {
+      Self {
+        chip_id_low: Cell::new(0x28),
+        activation: Cell::new(0x01),
+        base_high: Cell::new(0x02),
+        base_low: Cell::new(0x90),
+        ec_configuration: Cell::new(0x01),
+        channel_configuration: Cell::new(0b0010_1000),
+        temperature_values: Cell::new([25, 30, 35]),
+        failed_temperature_register: Cell::new(None),
+        selected_slot_calls: Cell::new(0),
+        find_bars_calls: Cell::new(0),
+        config_exit_calls: Cell::new(0),
+        ec_bars_authorized: Cell::new(false),
+        selected_ldn: Cell::new(None),
+        base_high_read: Cell::new(false),
+        base_low_read: Cell::new(false),
+        selected_ec_register: Cell::new(None),
+        read_registers: RefCell::new(Vec::new()),
+        config_port_writes: RefCell::new(Vec::new()),
+      }
+    }
+
+    fn with_authorized_ec(channel_configuration: u8) -> Self {
+      let client = Self::new();
+      client.channel_configuration.set(channel_configuration);
+      client.ec_bars_authorized.set(true);
+      client
+        .selected_ldn
+        .set(Some(ITE_ENVIRONMENT_CONTROLLER_LDN));
+      client.base_high_read.set(true);
+      client.base_low_read.set(true);
+      client.config_exit_calls.set(1);
+      client
+    }
+
+    fn require_ec_bars(&self) -> Result<(), String> {
+      if self.ec_bars_authorized.get() {
+        Ok(())
+      } else {
+        Err("EC ports are not authorized".to_string())
+      }
+    }
+  }
+
+  impl LpcIoOps for FakeIteLpcIo {
+    fn select_lpc_slot(&self, _slot: u64) -> Result<(), String> {
+      self
+        .selected_slot_calls
+        .set(self.selected_slot_calls.get() + 1);
+      self.ec_bars_authorized.set(false);
+      Ok(())
+    }
+
+    fn find_lpc_bars(&self) -> Result<(), String> {
+      self.find_bars_calls.set(self.find_bars_calls.get() + 1);
+      if self.selected_ldn.get() != Some(ITE_ENVIRONMENT_CONTROLLER_LDN) {
+        return Err("find_lpc_bars called before ITE LDN 4 selection".to_string());
+      }
+      if !self.base_high_read.get() || !self.base_low_read.get() {
+        return Err("find_lpc_bars called before EC base discovery".to_string());
+      }
+      self.ec_bars_authorized.set(true);
+      Ok(())
+    }
+
+    fn pio_inb(&self, port: u16) -> Result<u8, String> {
+      if port != 0x0296 {
+        return Err(format!("unexpected EC data port 0x{port:04X}"));
+      }
+      self.require_ec_bars()?;
+      if self.config_exit_calls.get() == 0 {
+        return Err("EC read attempted before ITE config exit".to_string());
+      }
+
+      let register = self
+        .selected_ec_register
+        .get()
+        .ok_or_else(|| "EC index register was not selected".to_string())?;
+      self.read_registers.borrow_mut().push(register);
+      if self.failed_temperature_register.get() == Some(register) {
+        return Err(format!("simulated EC register 0x{register:02X} failure"));
+      }
+
+      match register {
+        ITE_EC_CONFIGURATION_REGISTER => Ok(self.ec_configuration.get()),
+        ITE_EC_CHANNEL_ENABLE_REGISTER => Ok(self.channel_configuration.get()),
+        0x29 => Ok(self.temperature_values.get()[0]),
+        0x2A => Ok(self.temperature_values.get()[1]),
+        0x2B => Ok(self.temperature_values.get()[2]),
+        _ => Err(format!("unexpected EC register 0x{register:02X}")),
+      }
+    }
+
+    fn pio_outb(&self, port: u16, value: u8) -> Result<(), String> {
+      match port {
+        0x0295 => {
+          self.require_ec_bars()?;
+          self.selected_ec_register.set(Some(value));
+          Ok(())
+        }
+        0x0296 => Err("ITE EC data port must remain read-only".to_string()),
+        0x002E | 0x004E => {
+          self.config_port_writes.borrow_mut().push((port, value));
+          Ok(())
+        }
+        _ => Ok(()),
+      }
+    }
+
+    fn superio_inb(&self, register: u8) -> Result<u8, String> {
+      match register {
+        CHIP_ID_HIGH_REGISTER => Ok(0x87),
+        CHIP_ID_LOW_REGISTER => Ok(self.chip_id_low.get()),
+        LDN_ACTIVATION_REGISTER => Ok(self.activation.get()),
+        HM_BASE_HIGH_REGISTER => {
+          self.base_high_read.set(true);
+          Ok(self.base_high.get())
+        }
+        HM_BASE_LOW_REGISTER => {
+          self.base_low_read.set(true);
+          Ok(self.base_low.get())
+        }
+        _ => Ok(0),
+      }
+    }
+
+    fn superio_outb(&self, register: u8, value: u8) -> Result<(), String> {
+      match (register, value) {
+        (LOGICAL_DEVICE_SELECT_REGISTER, value) => {
+          self.selected_ldn.set(Some(value));
+        }
+        (0x02, 0x02) => {
+          self.config_exit_calls.set(self.config_exit_calls.get() + 1);
+        }
+        _ => {}
+      }
+      Ok(())
+    }
+  }
+
   #[test]
   fn discover_slot_authorizes_hm_bars_after_base_discovery() {
     let client = FakeLpcIo::new();
@@ -571,6 +1094,192 @@ mod tests {
         0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6,
         0xC7, 0xC8, 0xC9, 0xCA, 0xCB
       ]
+    );
+  }
+
+  #[test]
+  fn ite_discovery_authorizes_ec_ports_only_after_config_exit() {
+    let client = FakeIteLpcIo::new();
+
+    let detected = ActiveIteMotherboardSensors::discover_slot(&client, 0)
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(detected.slot, 0);
+    assert_eq!(detected.ec_base, 0x0290);
+    assert_eq!(client.selected_slot_calls.get(), 1);
+    assert_eq!(client.find_bars_calls.get(), 1);
+    assert_eq!(client.config_exit_calls.get(), 1);
+    assert!(client.ec_bars_authorized.get());
+    assert_eq!(client.read_registers.borrow().as_slice(), &[0x00]);
+    assert_eq!(
+      client.config_port_writes.borrow().as_slice(),
+      &[
+        (0x002E, 0x87),
+        (0x002E, 0x01),
+        (0x002E, 0x55),
+        (0x002E, 0x55)
+      ]
+    );
+  }
+
+  #[test]
+  fn ite_discovery_uses_the_slot_one_entry_key() {
+    let client = FakeIteLpcIo::new();
+
+    let detected = ActiveIteMotherboardSensors::discover_slot(&client, 1)
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(detected.slot, 1);
+    assert_eq!(
+      client.config_port_writes.borrow().as_slice(),
+      &[
+        (0x004E, 0x87),
+        (0x004E, 0x01),
+        (0x004E, 0x55),
+        (0x004E, 0xAA)
+      ]
+    );
+  }
+
+  #[test]
+  fn ite_discovery_does_not_cache_when_the_post_exit_probe_fails() {
+    let client = FakeIteLpcIo::new();
+    client
+      .failed_temperature_register
+      .set(Some(ITE_EC_CONFIGURATION_REGISTER));
+
+    let error = ActiveIteMotherboardSensors::discover_slot(&client, 0).unwrap_err();
+
+    assert!(error.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX));
+    assert!(error.contains("EC port authorization probe failed"));
+    assert_eq!(client.find_bars_calls.get(), 1);
+    assert_eq!(client.config_exit_calls.get(), 1);
+    assert_eq!(client.read_registers.borrow().as_slice(), &[0x00]);
+  }
+
+  #[test]
+  fn ite_discovery_rejects_the_conflicting_8721_id() {
+    let client = FakeIteLpcIo::new();
+    client.chip_id_low.set(0x21);
+
+    let detected = ActiveIteMotherboardSensors::discover_slot(&client, 0).unwrap();
+
+    assert!(detected.is_none());
+    assert_eq!(client.find_bars_calls.get(), 0);
+    assert_eq!(client.config_exit_calls.get(), 1);
+    assert!(client.read_registers.borrow().is_empty());
+  }
+
+  #[test]
+  fn ite_discovery_rejects_invalid_raw_base_bits_before_bar_authorization() {
+    let client = FakeIteLpcIo::new();
+    client.base_high.set(0xF2);
+
+    let error = ActiveIteMotherboardSensors::discover_slot(&client, 0).unwrap_err();
+
+    assert!(error.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX));
+    assert!(error.contains("CR60/61=0xF2/0x90"));
+    assert_eq!(client.find_bars_calls.get(), 0);
+    assert_eq!(client.config_exit_calls.get(), 1);
+    assert!(client.read_registers.borrow().is_empty());
+  }
+
+  #[test]
+  fn ite_base_validation_rejects_alignment_reserved_bits_and_absent_value() {
+    assert!(is_valid_ite_ec_base(0x02, 0x90, 0x0290));
+    assert!(!is_valid_ite_ec_base(0xF2, 0x90, 0x0290));
+    assert!(!is_valid_ite_ec_base(0x02, 0x91, 0x0290));
+    assert!(!is_valid_ite_ec_base(0x00, 0x00, 0x0000));
+    assert!(!is_valid_ite_ec_base(0x0F, 0xF8, ITE_ABSENT_EC_BASE));
+  }
+
+  #[test]
+  fn ite_sample_keeps_successful_siblings_and_never_reads_fans() {
+    let client = FakeIteLpcIo::with_authorized_ec(0b0010_1010);
+    client.temperature_values.set([25, 30, 0x80]);
+    client.failed_temperature_register.set(Some(0x2A));
+    let mut active = ActiveIteMotherboardSensors {
+      client,
+      slot: 0,
+      ec_base: 0x0290,
+      chip_label: ITE_CHIP_LABEL,
+      source_label: ITE_SOURCE_LABEL,
+      last_attempt: None,
+      partial_failure_logged: false,
+    };
+
+    let sample = active.sample_unlocked_at(Instant::now()).unwrap();
+
+    assert_eq!(
+      sample.temperatures,
+      vec![MotherboardTemperature {
+        name: "TMPIN1".to_string(),
+        temperature: 25.0,
+        source: ITE_SOURCE_LABEL.to_string(),
+      }]
+    );
+    assert!(sample.fan_speeds.is_empty());
+    assert_eq!(
+      active.client.read_registers.borrow().as_slice(),
+      &[0x00, 0x51, 0x29, 0x2A, 0x2B]
+    );
+    assert!(!sample.temperatures[0].source.contains("Experimental"));
+  }
+
+  #[test]
+  fn ite_sample_stops_when_the_monitoring_state_is_not_running() {
+    let client = FakeIteLpcIo::with_authorized_ec(0b0000_1000);
+    client.ec_configuration.set(0x09);
+    let mut active = ActiveIteMotherboardSensors {
+      client,
+      slot: 0,
+      ec_base: 0x0290,
+      chip_label: ITE_CHIP_LABEL,
+      source_label: ITE_SOURCE_LABEL,
+      last_attempt: None,
+      partial_failure_logged: false,
+    };
+
+    let error = active.sample_unlocked_at(Instant::now()).unwrap_err();
+
+    assert!(error.starts_with(ITE_EXPERIMENTAL_FAILURE_PREFIX));
+    assert!(error.contains("stopped by INT_Clear"));
+    assert_eq!(active.client.read_registers.borrow().as_slice(), &[0x00]);
+  }
+
+  #[test]
+  fn ite_sample_reuses_the_last_result_inside_the_minimum_interval() {
+    let client = FakeIteLpcIo::with_authorized_ec(0b0000_1000);
+    let mut active = ActiveIteMotherboardSensors {
+      client,
+      slot: 0,
+      ec_base: 0x0290,
+      chip_label: ITE_CHIP_LABEL,
+      source_label: ITE_SOURCE_LABEL,
+      last_attempt: None,
+      partial_failure_logged: false,
+    };
+    let first_at = Instant::now();
+
+    let first = active.sample_unlocked_at(first_at).unwrap();
+    let cached = active
+      .sample_unlocked_at(first_at + Duration::from_secs(1))
+      .unwrap();
+
+    assert_eq!(cached, first);
+    assert_eq!(
+      active.client.read_registers.borrow().as_slice(),
+      &[0x00, 0x51, 0x29]
+    );
+
+    active
+      .sample_unlocked_at(first_at + ITE_SAMPLE_MIN_INTERVAL)
+      .unwrap();
+    assert_eq!(
+      active.client.read_registers.borrow().as_slice(),
+      &[0x00, 0x51, 0x29, 0x00, 0x51, 0x29]
     );
   }
 }

--- a/core/src/platform/windows/sensors.rs
+++ b/core/src/platform/windows/sensors.rs
@@ -30,7 +30,7 @@ pub fn sample_motherboard_sensors() -> MotherboardSensorCollection {
 
       let availability =
         if reason
-          == crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_NUVOTON_HM_PATH_REASON
+          == crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_SUPER_IO_HM_PATH_REASON
         {
           SensorAvailability::unsupported(reason.clone())
         } else {
@@ -50,7 +50,10 @@ fn motherboard_guidance_candidates_for_reason(
   reason: String,
 ) -> Vec<ExternalComponentGuidanceCandidate> {
   if reason
-    == crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_NUVOTON_HM_PATH_REASON
+    == crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_SUPER_IO_HM_PATH_REASON
+    || reason.starts_with(
+      crate::infrastructure::providers::windows::super_io_motherboard::ITE_EXPERIMENTAL_NON_COMPONENT_FAILURE_PREFIX,
+    )
   {
     return Vec::new();
   }
@@ -195,7 +198,7 @@ mod tests {
   #[test]
   fn motherboard_guidance_suppresses_unsupported_super_io_path() {
     let candidates = motherboard_guidance_candidates_for_reason(
-      crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_NUVOTON_HM_PATH_REASON
+      crate::infrastructure::providers::windows::super_io_motherboard::UNSUPPORTED_SUPER_IO_HM_PATH_REASON
         .to_string(),
     );
 
@@ -216,6 +219,30 @@ mod tests {
     assert_eq!(
       candidates[0].reason_kind,
       crate::models::ExternalComponentReasonKind::Permission
+    );
+  }
+
+  #[test]
+  fn motherboard_guidance_suppresses_experimental_ite_hardware_state_failure() {
+    let candidates = motherboard_guidance_candidates_for_reason(format!(
+      "{}: no eligible physical TMPIN channels are enabled",
+      crate::infrastructure::providers::windows::super_io_motherboard::ITE_EXPERIMENTAL_NON_COMPONENT_FAILURE_PREFIX
+    ));
+
+    assert!(candidates.is_empty());
+  }
+
+  #[test]
+  fn motherboard_guidance_remains_for_experimental_ite_runtime_failure() {
+    let candidates = motherboard_guidance_candidates_for_reason(format!(
+      "{}: EC port authorization probe failed: pawnio_execute ioctl_pio_inb failed",
+      crate::infrastructure::providers::windows::super_io_motherboard::ITE_EXPERIMENTAL_FAILURE_PREFIX
+    ));
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+      candidates[0].key,
+      crate::models::external_component_guidance::PAWNIO_MOTHERBOARD_SENSORS_KEY
     );
   }
 

--- a/core/src/utils/super_io.rs
+++ b/core/src/utils/super_io.rs
@@ -5,8 +5,12 @@
 //! mirroring [`crate::utils::thermal`]. The Windows `LpcIO` provider performs
 //! the actual port I/O and then uses these helpers to interpret the bytes.
 //!
-//! Implemented from docs/specs/sensors/superio-access.md (chip-id register and
-//! configuration-port facts). No other external sensor source was used.
+//! Implemented from:
+//! - `docs/specs/sensors/superio-access.md` revision 3
+//! - `docs/specs/sensors/superio-nuvoton-nct67xx.md` revision 5
+//! - `docs/specs/sensors/superio-ite-it86xx-it87xx.md` revision 2
+//!
+//! No other external sensor source was used.
 
 use crate::models::FanSpeedStatus;
 
@@ -53,6 +57,40 @@ pub const fn decode_nuvoton_temperature_byte(raw: u8) -> f32 {
 /// byte, unsigned RPM.
 pub const fn decode_nuvoton_direct_rpm(high: u8, low: u8) -> u32 {
   ((high as u32) << 8) | low as u32
+}
+
+/// Decode an IT8728F Environment Controller temperature byte as signed
+/// degrees C.
+///
+/// Implemented from `docs/specs/sensors/superio-ite-it86xx-it87xx.md`
+/// revision 2, scoped to exact chip id `0x8728` and generic TMPIN1-TMPIN3.
+pub const fn decode_ite_temperature_byte(raw: u8) -> f32 {
+  (raw as i8) as f32
+}
+
+/// Whether an IT8728F temperature is inside the revision 2 plausibility
+/// range. Zero is a valid reading for an enabled physical input.
+pub const fn is_plausible_ite_temperature(temperature: f32) -> bool {
+  temperature >= -55.0 && temperature <= 125.0
+}
+
+/// Whether one IT8728F TMPIN is an enabled physical temperature input.
+///
+/// `channel` is one-based (`1..=3`). A channel is eligible only when exactly
+/// one of its resistor/diode mode bits is set and the SST/PECI route does not
+/// target that TMPIN.
+pub const fn is_ite_temperature_channel_eligible(config: u8, channel: u8) -> bool {
+  let (resistor_bit, diode_bit) = match channel {
+    1 => (3, 0),
+    2 => (4, 1),
+    3 => (5, 2),
+    _ => return false,
+  };
+  let resistor_enabled = (config & (1 << resistor_bit)) != 0;
+  let diode_enabled = (config & (1 << diode_bit)) != 0;
+  let routed_external_channel = config >> 6;
+
+  resistor_enabled != diode_enabled && routed_external_channel != channel
 }
 
 /// Classify a direct RPM value for display.
@@ -113,6 +151,38 @@ mod tests {
     assert_eq!(decode_nuvoton_direct_rpm(0x0B, 0x08), 2824);
     assert_eq!(decode_nuvoton_direct_rpm(0x02, 0xE2), 738);
     assert_eq!(decode_nuvoton_direct_rpm(0x00, 0x00), 0);
+  }
+
+  #[test]
+  fn ite_temperature_byte_decodes_signed_celsius() {
+    assert_eq!(decode_ite_temperature_byte(0x7D), 125.0);
+    assert_eq!(decode_ite_temperature_byte(0x19), 25.0);
+    assert_eq!(decode_ite_temperature_byte(0x00), 0.0);
+    assert_eq!(decode_ite_temperature_byte(0xFF), -1.0);
+    assert_eq!(decode_ite_temperature_byte(0xC9), -55.0);
+  }
+
+  #[test]
+  fn ite_temperature_plausibility_keeps_zero_and_rejects_outside_bounds() {
+    assert!(is_plausible_ite_temperature(-55.0));
+    assert!(is_plausible_ite_temperature(0.0));
+    assert!(is_plausible_ite_temperature(125.0));
+    assert!(!is_plausible_ite_temperature(-56.0));
+    assert!(!is_plausible_ite_temperature(126.0));
+  }
+
+  #[test]
+  fn ite_temperature_channel_requires_one_physical_mode_and_no_external_route() {
+    assert!(is_ite_temperature_channel_eligible(0b0000_1000, 1));
+    assert!(is_ite_temperature_channel_eligible(0b0000_0010, 2));
+    assert!(is_ite_temperature_channel_eligible(0b0010_0000, 3));
+
+    assert!(!is_ite_temperature_channel_eligible(0, 1));
+    assert!(!is_ite_temperature_channel_eligible(0b0000_1001, 1));
+    assert!(!is_ite_temperature_channel_eligible(0b0100_1000, 1));
+    assert!(!is_ite_temperature_channel_eligible(0b1000_0010, 2));
+    assert!(!is_ite_temperature_channel_eligible(0b1110_0000, 3));
+    assert!(!is_ite_temperature_channel_eligible(0xFF, 4));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Add the clean-room, experimental IT8728F/EX (`0x8728`) motherboard-temperature provider on Windows.
- Validate the Super I/O configuration and environmental-controller gates before authorizing reads, then sample only the three documented temperature channels through the existing 1.5-second result cache.
- Preserve valid sibling temperatures when one channel is unavailable, exclude external SST/PECI inputs, and keep the path strictly read-only apart from the documented configuration-mode key sequence.
- Keep the successful source label user-facing and hardware-specific; identify the experimental status only when reporting failures.

No fan, voltage, control, telemetry, or outbound-network behavior is added. Hardware validation is intentionally deferred because no IT8728F test machine is available; the provider remains experimental as required by the pinned spec.

## Related Issues

Relates to #1635.

Follow-up implementation for the specs merged in #2036.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Clean-room provenance

```text
Implemented from docs/specs/sensors/superio-access.md revision 3 (commit a8c167b1a4a7dca6b48674f4eee01777f583332f).
Implemented from docs/specs/sensors/pawnio-interface.md revision 5 (commit 6e852236f0ec8db357c36b3ed12c213fd921e4a3).
Implemented from docs/specs/sensors/superio-ite-it86xx-it87xx.md revision 2 (commit 3b51504e4b7d50e8a3e21911bf2bd3d5677fea80).
No other external sensor documentation was used.
```

### Implementer attestation

- [x] This implementation references only `docs/specs/sensors/**` (at
      the revisions pinned above) and this repository.
- [x] Every spec document pinned above carries
      `Status: Implementation-ready (rev N)` at the pinned revision
      and has no unresolved `TODO(provenance)` markers (see "Status
      transition" in `docs/specs/sensors/README.md`).
- [x] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or any decompiled monitoring tool
      while writing this implementation (full prohibited-source list:
      `.agents/rules/clean-room-sensors.md`).
- [x] Register access added by this PR is read-only; the only writes
      are those the pinned specs document as required for reads
      (the Super I/O configuration-mode key sequence), and the ecosystem
      mutex conventions are honored.

### Reviewer attestation

Reviewers: copy the checklist below into your approval review
comment, with both boxes checked. Do not approve without it.

```markdown
- [ ] I reviewed this implementation only against
      `docs/specs/sensors/**`, this repository, and the pinned spec
      revision.
- [ ] I did not consult LibreHardwareMonitor, OpenHardwareMonitor,
      Linux kernel, lm-sensors, or decompiled monitoring tools while
      reviewing this implementation.
```

## Screenshots / Videos

Not applicable; this is a backend provider with no UI layout change.

## Test Plan

- [ ] Manual testing (no IT8728F/EX hardware available)
- [x] Unit tests

Validated locally on Windows:

- `cargo tauri-fmt`
- `cargo tauri-lint`
- `cargo tauri-test` with `APPDATA` redirected to a writable temporary directory (the sandbox cannot write the default roaming-profile path)
- `cargo test -p hardviz-core super_io --lib --quiet` (24 passed)
- `cargo test -p hardviz-core --quiet` (548 unit and 2 integration tests passed)
- `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental motherboard temperature monitoring for IT8728F hardware.
  * Improved detection across supported Super I/O monitoring paths.
  * Reports valid temperature readings while ignoring unusable or out-of-range sensor data.
  * Preserves available sensor readings when individual channels fail.

* **Bug Fixes**
  * Improved initialization reliability by retrying certain temporary hardware access failures.
  * Improved Windows fallback guidance for unsupported monitoring configurations.
  * Suppresses unnecessary guidance when no eligible physical temperature channels are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
