### PR TITLE
feat(core): environmental sensor provider and ambient temperature archive

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,6 +186,20 @@ _Avoid_: Healthy fan, connected fan
 A fan-speed reading that cannot be trusted for display because the reported value is outside the accepted reading shape.
 _Avoid_: Failed fan, broken fan
 
+### Environmental Sensors
+
+**Ambient Temperature Reading**:
+A room-temperature observation, optionally carrying relative humidity, taken by an environmental sensor outside the machine and used to explain machine temperatures.
+_Avoid_: CPU temperature, motherboard temperature, thermal zone, weather data
+
+**Ambient Sensor Connection State**:
+Whether a registered environmental sensor is currently delivering Ambient Temperature Readings, shown together with when it last succeeded.
+_Avoid_: Sensor availability, pairing status, device health
+
+**Ambient Reading Freshness Window**:
+How recently an Ambient Temperature Reading must have been observed to stand for the archive minute being written; an older reading leaves that minute without ambient data instead of repeating a past value.
+_Avoid_: Polling interval, sample rate, Retention Period
+
 ### Sensor Availability
 
 **External Component Guidance**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -192,9 +192,9 @@ _Avoid_: Failed fan, broken fan
 A room-temperature observation, optionally carrying relative humidity, taken by an environmental sensor outside the machine and used to explain machine temperatures.
 _Avoid_: CPU temperature, motherboard temperature, thermal zone, weather data
 
-**Ambient Sensor Connection State**:
-Whether a registered environmental sensor is currently delivering Ambient Temperature Readings, shown together with when it last succeeded.
-_Avoid_: Sensor availability, pairing status, device health
+**Ambient Sensor Availability**:
+Whether an environmental sensor's readings are currently arriving, reported as available, stale, or never received, together with when it last succeeded.
+_Avoid_: Connection state, pairing status, link status, device health
 
 **Ambient Reading Freshness Window**:
 How recently an Ambient Temperature Reading must have been observed to stand for the archive minute being written; an older reading leaves that minute without ambient data instead of repeating a past value.

--- a/core/src/infrastructure/database/ambient_archive.rs
+++ b/core/src/infrastructure/database/ambient_archive.rs
@@ -1,0 +1,187 @@
+//! `AMBIENT_ARCHIVE` writes (#2043).
+//!
+//! Row-per-source: one archive minute holds one row per ambient Sensor
+//! Source Label that produced a fresh reading, and none at all for a
+//! minute with no usable reading. Nothing here fills a gap.
+//!
+//! Same `_from_pool` split the cooling tables use: the public `async fn`s
+//! resolve Core's process-wide pool via [`db::get_pool`] and delegate to a
+//! variant taking an explicit `SqlitePool`, so the SQL is testable against
+//! an in-memory database.
+
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+
+use super::db;
+use crate::persistence::archive_data::AmbientData;
+
+pub async fn insert(
+  rows: Vec<AmbientData>,
+  timestamp: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+  if rows.is_empty() {
+    return Ok(());
+  }
+
+  let pool = db::get_pool().await?;
+  insert_from_pool(&pool, rows, timestamp).await
+}
+
+/// Every row of one archive minute shares the tick's `timestamp` rather
+/// than each reading's own observation time, so an ambient row lines up
+/// with the `DATA_ARCHIVE` row for the same minute the way every other
+/// archive table does. The freshness window is what bounds how far the
+/// observation may trail the tick.
+pub(crate) async fn insert_from_pool(
+  pool: &SqlitePool,
+  rows: Vec<AmbientData>,
+  timestamp: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+  let mut tx = pool.begin().await?;
+
+  for row in rows {
+    sqlx::query(
+      "INSERT INTO AMBIENT_ARCHIVE (source, temperature, humidity, timestamp)
+       VALUES ($1, $2, $3, $4)",
+    )
+    .bind(&row.source)
+    .bind(row.temperature)
+    .bind(row.humidity)
+    .bind(timestamp)
+    .execute(&mut *tx)
+    .await?;
+  }
+
+  tx.commit().await?;
+  Ok(())
+}
+
+/// Ambient rows age out on the same `hardwareArchive.retentionDays`
+/// window as the hardware archive rows they explain, so a retained minute
+/// never loses its ambient context while the CPU side survives.
+pub async fn delete_old_data(retention_days: u32) -> Result<(), sqlx::Error> {
+  let pool = db::get_pool().await?;
+  delete_old_data_from_pool(&pool, retention_days).await
+}
+
+pub(crate) async fn delete_old_data_from_pool(
+  pool: &SqlitePool,
+  retention_days: u32,
+) -> Result<(), sqlx::Error> {
+  sqlx::query("DELETE FROM AMBIENT_ARCHIVE WHERE timestamp < $1")
+    .bind(Utc::now() - chrono::Duration::days(retention_days as i64))
+    .execute(pool)
+    .await?;
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  async fn setup(pool: &SqlitePool) {
+    sqlx::query(
+      "CREATE TABLE AMBIENT_ARCHIVE (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        temperature REAL NOT NULL,
+        humidity REAL,
+        timestamp DATETIME NOT NULL
+      )",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  fn at(input: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(input)
+      .unwrap()
+      .with_timezone(&Utc)
+  }
+
+  fn row(source: &str, temperature: f32, humidity: Option<f32>) -> AmbientData {
+    AmbientData {
+      source: source.to_string(),
+      temperature,
+      humidity,
+    }
+  }
+
+  async fn stored(pool: &SqlitePool) -> Vec<(String, f64, Option<f64>, DateTime<Utc>)> {
+    sqlx::query_as(
+      "SELECT source, temperature, humidity, timestamp
+       FROM AMBIENT_ARCHIVE ORDER BY source",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap()
+  }
+
+  #[tokio::test]
+  async fn each_ambient_source_gets_its_own_row_for_the_same_minute() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup(&pool).await;
+    let tick = at("2026-08-30T12:00:00Z");
+
+    insert_from_pool(
+      &pool,
+      vec![
+        row("Living Room", 24.5, Some(48.0)),
+        row("Desk", 26.0, None),
+      ],
+      tick,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+      stored(&pool).await,
+      vec![
+        ("Desk".to_string(), 26.0, None, tick),
+        ("Living Room".to_string(), 24.5, Some(48.0), tick),
+      ]
+    );
+  }
+
+  #[tokio::test]
+  async fn a_minute_with_no_usable_reading_writes_no_row() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup(&pool).await;
+
+    insert_from_pool(&pool, vec![], at("2026-08-30T12:00:00Z"))
+      .await
+      .unwrap();
+
+    assert!(stored(&pool).await.is_empty());
+  }
+
+  #[tokio::test]
+  async fn retention_deletes_rows_past_the_window_and_keeps_the_rest() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    setup(&pool).await;
+    let now = Utc::now();
+
+    insert_from_pool(
+      &pool,
+      vec![row("Old", 20.0, None)],
+      now - chrono::Duration::days(31),
+    )
+    .await
+    .unwrap();
+    insert_from_pool(
+      &pool,
+      vec![row("Recent", 25.0, None)],
+      now - chrono::Duration::days(2),
+    )
+    .await
+    .unwrap();
+
+    delete_old_data_from_pool(&pool, 30).await.unwrap();
+
+    let remaining = stored(&pool).await;
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].0, "Recent");
+  }
+}

--- a/core/src/infrastructure/database/mod.rs
+++ b/core/src/infrastructure/database/mod.rs
@@ -7,6 +7,7 @@
 //! the ordered migration definitions and hands them to the runner. Every
 //! read / write that Core executes goes through this module.
 
+pub mod ambient_archive;
 pub mod archive_queries;
 pub mod cooling_baseline;
 pub mod cooling_daily_summary;

--- a/core/src/infrastructure/providers/environmental.rs
+++ b/core/src/infrastructure/providers/environmental.rs
@@ -1,0 +1,461 @@
+//! Environmental (ambient) sensor abstraction (#2043).
+//!
+//! Ambient room temperature is an explanatory input for Cooling Insight,
+//! never a required one: a +6 °C summer drift and a genuine cooling
+//! degradation look identical without it. Core owns the shape of an
+//! ambient reading and the freshness rule that decides whether a reading
+//! may represent a given archive minute; concrete transports (BLE, USB,
+//! or anything else) live behind [`EnvironmentalSensorProvider`] and are
+//! registered from outside this module. No vendor type appears here.
+//!
+//! Providers are polled, not awaited. Every transport in scope pushes
+//! readings on its own cadence (a BLE advertisement arrives when the
+//! device chooses to send one), so a provider caches its latest sample
+//! and the archive tick reads that cache without blocking on I/O.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::log_warn;
+
+/// How old an ambient reading may be and still represent the minute
+/// currently being archived.
+///
+/// Five minutes. Indoor air temperature is a slow signal: under normal
+/// occupancy and HVAC behavior a room moves well under 1 °C in five
+/// minutes, which is inside the accuracy an ambient sensor reports in
+/// the first place, so a five-minute-old sample still describes the
+/// current minute honestly. It is also many multiples of a BLE
+/// advertisement interval (seconds to tens of seconds), so ordinary
+/// packet loss or a missed scan window does not punch holes in the
+/// archive. A sensor that genuinely stops reporting therefore stops
+/// producing rows within five minutes instead of freezing its last value
+/// across hours of history.
+pub const AMBIENT_READING_MAX_AGE_SECONDS: i64 = 5 * 60;
+
+/// One ambient environment sample.
+///
+/// `temperature_celsius` is the raw hardware fact in degrees Celsius;
+/// presentation units belong at the App boundary. `humidity_percent` is
+/// optional because a temperature-only sensor is a legitimate ambient
+/// source. `source` is the Sensor Source Label recorded with the reading.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnvironmentalReading {
+  pub temperature_celsius: f32,
+  pub humidity_percent: Option<f32>,
+  pub timestamp: DateTime<Utc>,
+  pub source: String,
+}
+
+/// Whether a provider's transport is currently delivering readings.
+///
+/// Deliberately two states: "configured but never seen a reading" is
+/// `Disconnected` with no last reading timestamp, so the data-state panel
+/// can tell that apart from a link that dropped after working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentalConnectionState {
+  /// The transport is up and further readings are expected.
+  Connected,
+  /// The provider is registered but its transport is not delivering
+  /// (adapter off, device out of range, permission refused, never paired).
+  Disconnected,
+}
+
+/// Per-provider state for the Phase 4 data-state panel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnvironmentalProviderState {
+  /// Sensor Source Label identifying the provider.
+  pub source: String,
+  pub connection: EnvironmentalConnectionState,
+  /// Timestamp of the newest reading the provider holds, or `None` when
+  /// it has never produced one. Not filtered by freshness - the panel
+  /// wants to show how stale the last success is, not hide it.
+  pub last_reading_at: Option<DateTime<Utc>>,
+}
+
+/// A source of ambient environment readings.
+///
+/// Implementations cache whatever their transport last delivered and
+/// answer from that cache; nothing here may block on I/O, because the
+/// hardware-archive tick calls it inline.
+pub trait EnvironmentalSensorProvider: Send + Sync {
+  /// Sensor Source Label identifying this provider. Readings it returns
+  /// are expected to carry the same label.
+  fn source(&self) -> &str;
+
+  /// The newest reading held, or `None` when the provider has never
+  /// observed one. Freshness is judged by the caller, not here.
+  fn latest_reading(&self) -> Option<EnvironmentalReading>;
+
+  /// Whether the transport is currently delivering readings.
+  fn connection_state(&self) -> EnvironmentalConnectionState;
+}
+
+/// The set of environmental providers this process collects from.
+///
+/// Built once at startup and then read-only, so it is shared as an
+/// `Arc`. With no provider registered every method is trivially empty and
+/// the archive tick writes no ambient rows - ambient data stays optional.
+#[derive(Default, Clone)]
+pub struct EnvironmentalSensorRegistry {
+  providers: Vec<Arc<dyn EnvironmentalSensorProvider>>,
+}
+
+impl EnvironmentalSensorRegistry {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn register(&mut self, provider: Arc<dyn EnvironmentalSensorProvider>) {
+    self.providers.push(provider);
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.providers.is_empty()
+  }
+
+  /// Readings that may represent the minute ending at `now`, one per
+  /// source.
+  ///
+  /// A reading is dropped rather than repaired: stale, unlabeled, or
+  /// non-finite readings produce no row at all, because a minute without
+  /// a usable ambient sample must stay absent instead of being zeroed or
+  /// interpolated (DP-02).
+  pub fn fresh_readings(&self, now: DateTime<Utc>) -> Vec<EnvironmentalReading> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut readings = Vec::new();
+
+    for provider in &self.providers {
+      let Some(reading) = provider
+        .latest_reading()
+        .and_then(|reading| normalize_reading(reading, now))
+      else {
+        continue;
+      };
+
+      // Row-per-source only stays joinable if one source contributes one
+      // row per minute. Two providers claiming the same label would
+      // otherwise double-count in every downstream rollup.
+      if !seen.insert(reading.source.clone()) {
+        log_warn!(
+          &format!(
+            "duplicate ambient Sensor Source Label `{}`; keeping the first provider's reading",
+            reading.source
+          ),
+          "providers::environmental::fresh_readings",
+          None::<&str>
+        );
+        continue;
+      }
+
+      readings.push(reading);
+    }
+
+    readings
+  }
+
+  /// Connection state and last-success timestamp for every registered
+  /// provider, in registration order.
+  pub fn provider_states(&self) -> Vec<EnvironmentalProviderState> {
+    self
+      .providers
+      .iter()
+      .map(|provider| EnvironmentalProviderState {
+        source: provider.source().to_string(),
+        connection: provider.connection_state(),
+        last_reading_at: provider.latest_reading().map(|reading| reading.timestamp),
+      })
+      .collect()
+  }
+}
+
+/// Normalize one reading for archiving, or `None` when it cannot honestly
+/// stand for the minute ending at `now`.
+fn normalize_reading(
+  reading: EnvironmentalReading,
+  now: DateTime<Utc>,
+) -> Option<EnvironmentalReading> {
+  let source = reading.source.trim();
+  // An ambient row is only meaningful attributed to a source: the table
+  // is row-per-source and every consumer selects by label.
+  if source.is_empty() || !reading.temperature_celsius.is_finite() {
+    return None;
+  }
+
+  // A reading stamped slightly ahead of `now` (host clock jitter between
+  // the transport callback and the archive tick) is still current, so the
+  // window is one-sided.
+  let age = now.signed_duration_since(reading.timestamp);
+  if age > Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS) {
+    return None;
+  }
+
+  Some(EnvironmentalReading {
+    temperature_celsius: reading.temperature_celsius,
+    // Humidity is an optional extra on an otherwise usable reading, so a
+    // garbage humidity value drops the field, never the row.
+    humidity_percent: reading.humidity_percent.filter(|value| value.is_finite()),
+    timestamp: reading.timestamp,
+    source: source.to_string(),
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Minimal provider used to drive the registry without any transport.
+  struct MockProvider {
+    source: String,
+    reading: Option<EnvironmentalReading>,
+    connection: EnvironmentalConnectionState,
+  }
+
+  impl MockProvider {
+    fn connected(source: &str, reading: EnvironmentalReading) -> Arc<Self> {
+      Arc::new(Self {
+        source: source.to_string(),
+        reading: Some(reading),
+        connection: EnvironmentalConnectionState::Connected,
+      })
+    }
+
+    fn silent(source: &str) -> Arc<Self> {
+      Arc::new(Self {
+        source: source.to_string(),
+        reading: None,
+        connection: EnvironmentalConnectionState::Disconnected,
+      })
+    }
+  }
+
+  impl EnvironmentalSensorProvider for MockProvider {
+    fn source(&self) -> &str {
+      &self.source
+    }
+
+    fn latest_reading(&self) -> Option<EnvironmentalReading> {
+      self.reading.clone()
+    }
+
+    fn connection_state(&self) -> EnvironmentalConnectionState {
+      self.connection
+    }
+  }
+
+  fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-08-30T12:00:00Z")
+      .unwrap()
+      .with_timezone(&Utc)
+  }
+
+  fn reading(source: &str, seconds_old: i64) -> EnvironmentalReading {
+    EnvironmentalReading {
+      temperature_celsius: 24.5,
+      humidity_percent: Some(48.0),
+      timestamp: now() - Duration::seconds(seconds_old),
+      source: source.to_string(),
+    }
+  }
+
+  // -- registry with no provider --
+
+  #[test]
+  fn an_empty_registry_produces_no_ambient_rows() {
+    let registry = EnvironmentalSensorRegistry::new();
+    assert!(registry.is_empty());
+    assert!(registry.fresh_readings(now()).is_empty());
+    assert!(registry.provider_states().is_empty());
+  }
+
+  // -- staleness --
+
+  #[test]
+  fn a_reading_inside_the_freshness_window_represents_the_minute() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected("Room", reading("Room", 90)));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 1);
+    assert_eq!(fresh[0].temperature_celsius, 24.5);
+    assert_eq!(fresh[0].humidity_percent, Some(48.0));
+  }
+
+  #[test]
+  fn a_reading_exactly_at_the_freshness_limit_is_still_accepted() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected(
+      "Room",
+      reading("Room", AMBIENT_READING_MAX_AGE_SECONDS),
+    ));
+
+    assert_eq!(registry.fresh_readings(now()).len(), 1);
+  }
+
+  #[test]
+  fn a_reading_past_the_freshness_limit_writes_no_row_rather_than_repeating() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected(
+      "Room",
+      reading("Room", AMBIENT_READING_MAX_AGE_SECONDS + 1),
+    ));
+
+    assert!(
+      registry.fresh_readings(now()).is_empty(),
+      "a stale sample must leave the minute absent, not carry a frozen value forward"
+    );
+  }
+
+  #[test]
+  fn a_reading_stamped_slightly_ahead_of_the_tick_is_accepted() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected("Room", reading("Room", -2)));
+
+    assert_eq!(registry.fresh_readings(now()).len(), 1);
+  }
+
+  // -- normalization --
+
+  #[test]
+  fn a_non_finite_temperature_writes_no_row() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut broken = reading("Room", 0);
+    broken.temperature_celsius = f32::NAN;
+    registry.register(MockProvider::connected("Room", broken));
+
+    assert!(registry.fresh_readings(now()).is_empty());
+  }
+
+  #[test]
+  fn a_non_finite_humidity_drops_only_the_humidity() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut partial = reading("Room", 0);
+    partial.humidity_percent = Some(f32::INFINITY);
+    registry.register(MockProvider::connected("Room", partial));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 1);
+    assert_eq!(fresh[0].temperature_celsius, 24.5);
+    assert_eq!(fresh[0].humidity_percent, None);
+  }
+
+  #[test]
+  fn a_temperature_only_reading_is_archived_without_humidity() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut dry = reading("Room", 0);
+    dry.humidity_percent = None;
+    registry.register(MockProvider::connected("Room", dry));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 1);
+    assert_eq!(fresh[0].humidity_percent, None);
+  }
+
+  #[test]
+  fn an_unlabeled_reading_writes_no_row() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut anonymous = reading("Room", 0);
+    anonymous.source = "   ".to_string();
+    registry.register(MockProvider::connected("Room", anonymous));
+
+    assert!(registry.fresh_readings(now()).is_empty());
+  }
+
+  #[test]
+  fn the_stored_source_label_is_trimmed() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut padded = reading("Room", 0);
+    padded.source = "  Living Room  ".to_string();
+    registry.register(MockProvider::connected("Room", padded));
+
+    assert_eq!(registry.fresh_readings(now())[0].source, "Living Room");
+  }
+
+  // -- multiple sources --
+
+  #[test]
+  fn each_source_contributes_its_own_row() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut desk = reading("Desk", 10);
+    desk.temperature_celsius = 26.0;
+    registry.register(MockProvider::connected("Room", reading("Room", 10)));
+    registry.register(MockProvider::connected("Desk", desk));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 2);
+    assert_eq!(fresh[0].source, "Room");
+    assert_eq!(fresh[1].source, "Desk");
+    assert_eq!(fresh[1].temperature_celsius, 26.0);
+  }
+
+  #[test]
+  fn one_stale_source_does_not_suppress_a_fresh_one() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected(
+      "Room",
+      reading("Room", AMBIENT_READING_MAX_AGE_SECONDS + 60),
+    ));
+    registry.register(MockProvider::connected("Desk", reading("Desk", 5)));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 1);
+    assert_eq!(fresh[0].source, "Desk");
+  }
+
+  #[test]
+  fn a_duplicated_source_label_contributes_only_one_row_per_minute() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected("Room", reading("Room", 5)));
+    let mut second = reading("Room", 5);
+    second.temperature_celsius = 31.0;
+    registry.register(MockProvider::connected("Room", second));
+
+    let fresh = registry.fresh_readings(now());
+    assert_eq!(fresh.len(), 1);
+    assert_eq!(fresh[0].temperature_celsius, 24.5);
+  }
+
+  // -- connection state --
+
+  #[test]
+  fn provider_states_report_connection_and_last_success() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected("Room", reading("Room", 30)));
+    registry.register(MockProvider::silent("Desk"));
+
+    assert_eq!(
+      registry.provider_states(),
+      vec![
+        EnvironmentalProviderState {
+          source: "Room".to_string(),
+          connection: EnvironmentalConnectionState::Connected,
+          last_reading_at: Some(now() - Duration::seconds(30)),
+        },
+        EnvironmentalProviderState {
+          source: "Desk".to_string(),
+          connection: EnvironmentalConnectionState::Disconnected,
+          last_reading_at: None,
+        },
+      ]
+    );
+  }
+
+  #[test]
+  fn provider_states_keep_reporting_a_last_success_that_is_now_stale() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::connected(
+      "Room",
+      reading("Room", AMBIENT_READING_MAX_AGE_SECONDS * 10),
+    ));
+
+    // The archive stops writing rows, but the panel must still be able to
+    // say how long ago the sensor last reported.
+    assert!(registry.fresh_readings(now()).is_empty());
+    assert_eq!(
+      registry.provider_states()[0].last_reading_at,
+      Some(now() - Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS * 10))
+    );
+  }
+}

--- a/core/src/infrastructure/providers/environmental.rs
+++ b/core/src/infrastructure/providers/environmental.rs
@@ -35,6 +35,21 @@ use crate::log_warn;
 /// across hours of history.
 pub const AMBIENT_READING_MAX_AGE_SECONDS: i64 = 5 * 60;
 
+/// How far ahead of the archive tick a reading may be stamped and still
+/// be believed.
+///
+/// Sixty seconds. Both stamps come from the same host - the transport
+/// callback records the observation, the archive tick reads it moments
+/// later - so the only legitimate future skew is clock jitter or a small
+/// adjustment in between, which is milliseconds in normal operation. A
+/// full archive interval of slack absorbs that with room to spare while
+/// still bounding the failure the window would otherwise have: without an
+/// upper bound, one reading stamped far into the future by a clock
+/// rewind, a bad NTP step, or a bogus device timestamp would count as
+/// fresh for as long as it stayed ahead of `now` - potentially days of
+/// identical rows. Past that bound the reading is refused instead.
+pub const AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS: i64 = 60;
+
 /// One ambient environment sample.
 ///
 /// `temperature_celsius` is the raw hardware fact in degrees Celsius;
@@ -57,16 +72,24 @@ pub struct EnvironmentalReading {
 /// is defined by observed readings alone: transport-specific causes
 /// (radio unavailable, scan not running, device out of range) stay inside
 /// the concrete provider and surface only as readings that stop arriving.
+///
+/// `Available` means exactly one thing: this source is eligible to have
+/// an ambient row written for the current archive minute. The panel and
+/// the archive read the same eligibility rule, so the panel can never
+/// call a source available while nothing is even being attempted for it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AmbientSensorAvailability {
-  /// A reading arrived inside the freshness window, so this source can
-  /// represent the current archive minute.
+  /// A usable reading arrived inside the freshness window, so this source
+  /// is eligible to represent the current archive minute.
   Available,
-  /// Readings arrived before, but the newest one is past the freshness
-  /// window. The archive stops writing rows for this source; the panel
-  /// still shows how long ago it last succeeded.
+  /// Usable readings arrived before, but the newest one is outside the
+  /// freshness window. The archive writes no row for this source; the
+  /// panel still shows how long ago it last succeeded.
   Stale,
-  /// No reading has ever arrived from this source.
+  /// Nothing usable is arriving: the source has never reported, or what
+  /// it reports cannot be archived (no Sensor Source Label, a non-finite
+  /// temperature, or a label another provider already claimed this
+  /// minute).
   Unavailable,
 }
 
@@ -74,12 +97,18 @@ pub enum AmbientSensorAvailability {
 /// arriving, and when did it last succeed.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnvironmentalProviderStatus {
-  /// Sensor Source Label identifying the provider.
+  /// Sensor Source Label the panel shows. Once a usable reading exists
+  /// this is that reading's normalized label - the same key the ambient
+  /// row is written under - so a status line and its archive rows can
+  /// never disagree about which source they describe. Before any usable
+  /// reading it falls back to the provider's own declared label.
   pub source: String,
   pub availability: AmbientSensorAvailability,
-  /// Timestamp of the newest reading the provider holds, or `None` when
-  /// it has never produced one. Not filtered by freshness - the panel
-  /// wants to show how stale the last success is, not hide it.
+  /// Timestamp of the newest *usable* reading, or `None` when none has
+  /// arrived. An unusable reading does not advance it: reporting a fresh
+  /// success the archive rejected would misdescribe the source. Not
+  /// filtered by freshness - the panel wants to show how stale the last
+  /// success is, not hide it.
   pub last_reading_at: Option<DateTime<Utc>>,
 }
 
@@ -133,94 +162,162 @@ impl EnvironmentalSensorRegistry {
   /// a usable ambient sample must stay absent instead of being zeroed or
   /// interpolated (DP-02).
   pub fn fresh_readings(&self, now: DateTime<Utc>) -> Vec<EnvironmentalReading> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut readings = Vec::new();
-
-    for provider in &self.providers {
-      let Some(reading) = provider
-        .latest_reading()
-        .and_then(|reading| normalize_reading(reading, now))
-      else {
-        continue;
-      };
-
-      // Row-per-source only stays joinable if one source contributes one
-      // row per minute. Two providers claiming the same label would
-      // otherwise double-count in every downstream rollup.
-      if !seen.insert(reading.source.clone()) {
-        log_warn!(
-          &format!(
-            "duplicate ambient Sensor Source Label `{}`; keeping the first provider's reading",
-            reading.source
-          ),
-          "providers::environmental::fresh_readings",
-          None::<&str>
-        );
-        continue;
-      }
-
-      readings.push(reading);
-    }
-
-    readings
+    self
+      .observe(now)
+      .into_iter()
+      .filter_map(|observation| observation.eligible)
+      .collect()
   }
 
   /// Availability and last-success timestamp for every registered
   /// provider as of `now`, in registration order.
   ///
-  /// Availability follows exactly the same freshness rule the archive
-  /// uses, so the panel can never claim a source is fine while the
-  /// archive is writing no rows for it.
+  /// Derived from the same evaluation [`Self::fresh_readings`] writes
+  /// from, so `Available` and "a row is attempted" cannot drift apart.
   pub fn provider_statuses(
     &self,
     now: DateTime<Utc>,
   ) -> Vec<EnvironmentalProviderStatus> {
     self
+      .observe(now)
+      .into_iter()
+      .map(|observation| observation.status)
+      .collect()
+  }
+
+  /// Evaluate every provider once for the minute ending at `now`.
+  ///
+  /// This is the single place the eligibility rule lives. Both public
+  /// readers project out of it, which is what makes "the panel says
+  /// Available" and "the archive attempts a row" the same condition by
+  /// construction rather than by two rules kept in sync by hand.
+  fn observe(&self, now: DateTime<Utc>) -> Vec<ProviderObservation> {
+    let mut claimed: HashSet<String> = HashSet::new();
+
+    self
       .providers
       .iter()
       .map(|provider| {
-        let last_reading_at = provider.latest_reading().map(|reading| reading.timestamp);
-        EnvironmentalProviderStatus {
-          source: provider.source().to_string(),
-          availability: match last_reading_at {
-            None => AmbientSensorAvailability::Unavailable,
-            Some(observed_at) if is_fresh(observed_at, now) => {
-              AmbientSensorAvailability::Available
-            }
-            Some(_) => AmbientSensorAvailability::Stale,
-          },
-          last_reading_at,
+        // An unusable reading is not a success, so it neither yields a row
+        // nor advances the last-success timestamp the panel shows.
+        let Some(reading) = provider.latest_reading().and_then(normalize_reading) else {
+          return ProviderObservation::unusable(provider.source());
+        };
+
+        if !is_fresh(reading.timestamp, now) {
+          return ProviderObservation::stale(reading);
         }
+
+        // Row-per-source only stays joinable if one source contributes one
+        // row per minute. Two providers claiming the same label would
+        // otherwise double-count in every downstream rollup, so the later
+        // one is reported as contributing nothing rather than silently
+        // looking healthy.
+        if !claimed.insert(reading.source.clone()) {
+          log_warn!(
+            &format!(
+              "duplicate ambient Sensor Source Label `{}`; keeping the first provider's reading",
+              reading.source
+            ),
+            "providers::environmental::observe",
+            None::<&str>
+          );
+          return ProviderObservation::unclaimable(reading);
+        }
+
+        ProviderObservation::available(reading)
       })
       .collect()
+  }
+}
+
+/// One provider's evaluated contribution to a single archive minute.
+struct ProviderObservation {
+  status: EnvironmentalProviderStatus,
+  /// The row to write, present exactly when the status is
+  /// [`AmbientSensorAvailability::Available`].
+  eligible: Option<EnvironmentalReading>,
+}
+
+impl ProviderObservation {
+  /// Nothing usable has ever arrived, so the provider's own declared
+  /// label is all there is to identify it by.
+  fn unusable(source: &str) -> Self {
+    Self {
+      status: EnvironmentalProviderStatus {
+        source: source.trim().to_string(),
+        availability: AmbientSensorAvailability::Unavailable,
+        last_reading_at: None,
+      },
+      eligible: None,
+    }
+  }
+
+  fn stale(reading: EnvironmentalReading) -> Self {
+    Self {
+      status: EnvironmentalProviderStatus {
+        source: reading.source,
+        availability: AmbientSensorAvailability::Stale,
+        last_reading_at: Some(reading.timestamp),
+      },
+      eligible: None,
+    }
+  }
+
+  /// A usable, fresh reading whose label another provider already claimed
+  /// this minute. It did read successfully, so the last-success timestamp
+  /// stands, but no row can be attributed to it.
+  fn unclaimable(reading: EnvironmentalReading) -> Self {
+    Self {
+      status: EnvironmentalProviderStatus {
+        source: reading.source,
+        availability: AmbientSensorAvailability::Unavailable,
+        last_reading_at: Some(reading.timestamp),
+      },
+      eligible: None,
+    }
+  }
+
+  fn available(reading: EnvironmentalReading) -> Self {
+    Self {
+      status: EnvironmentalProviderStatus {
+        // The normalized reading's label is the key the row is written
+        // under, so the status must report that same key.
+        source: reading.source.clone(),
+        availability: AmbientSensorAvailability::Available,
+        last_reading_at: Some(reading.timestamp),
+      },
+      eligible: Some(reading),
+    }
   }
 }
 
 /// Whether a reading observed at `observed_at` still stands for the
 /// minute ending at `now`.
 ///
-/// A reading stamped slightly ahead of `now` (host clock jitter between
-/// the transport callback and the archive tick) is still current, so the
-/// window is one-sided.
+/// Bounded on both sides. A reading stamped slightly ahead of `now` is
+/// ordinary host clock jitter between the transport callback and the
+/// archive tick, so a little skew is accepted; past
+/// [`AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS`] it is refused, because a
+/// reading stamped far into the future would otherwise stay "fresh" for
+/// as long as it led the clock.
 fn is_fresh(observed_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-  now.signed_duration_since(observed_at)
-    <= Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS)
+  let age = now.signed_duration_since(observed_at);
+  age <= Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS)
+    && age >= -Duration::seconds(AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS)
 }
 
-/// Normalize one reading for archiving, or `None` when it cannot honestly
-/// stand for the minute ending at `now`.
-fn normalize_reading(
-  reading: EnvironmentalReading,
-  now: DateTime<Utc>,
-) -> Option<EnvironmentalReading> {
+/// Normalize one reading's shape, or `None` when it could never be
+/// archived whatever its age.
+///
+/// Deliberately time-independent: freshness is a separate question, so
+/// that a well-formed but old reading can be reported as stale while a
+/// malformed one is reported as no reading at all.
+fn normalize_reading(reading: EnvironmentalReading) -> Option<EnvironmentalReading> {
   let source = reading.source.trim();
   // An ambient row is only meaningful attributed to a source: the table
   // is row-per-source and every consumer selects by label.
   if source.is_empty() || !reading.temperature_celsius.is_finite() {
-    return None;
-  }
-
-  if !is_fresh(reading.timestamp, now) {
     return None;
   }
 
@@ -341,6 +438,35 @@ mod tests {
     assert_eq!(registry.fresh_readings(now()).len(), 1);
   }
 
+  #[test]
+  fn a_reading_at_the_future_skew_limit_is_still_accepted() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::reporting(
+      "Room",
+      reading("Room", -AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS),
+    ));
+
+    assert_eq!(registry.fresh_readings(now()).len(), 1);
+  }
+
+  #[test]
+  fn a_reading_stamped_far_in_the_future_is_refused() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::reporting(
+      "Room",
+      reading("Room", -(AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS + 1)),
+    ));
+
+    assert!(
+      registry.fresh_readings(now()).is_empty(),
+      "a clock rewind must not leave one reading fresh for as long as it leads the clock"
+    );
+    assert_eq!(
+      registry.provider_statuses(now())[0].availability,
+      AmbientSensorAvailability::Stale
+    );
+  }
+
   // -- normalization --
 
   #[test]
@@ -393,9 +519,28 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut padded = reading("Room", 0);
     padded.source = "  Living Room  ".to_string();
-    registry.register(MockProvider::reporting("Room", padded));
+    registry.register(MockProvider::reporting("Living Room", padded));
 
     assert_eq!(registry.fresh_readings(now())[0].source, "Living Room");
+  }
+
+  // -- one source key for the row and its status --
+
+  /// A provider whose declared label disagrees with the label on the
+  /// reading it hands over must not split into two keys: the archive row
+  /// and the panel line have to describe the same source.
+  #[test]
+  fn the_archive_row_and_the_status_share_the_normalized_reading_label() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut relabeled = reading("Room", 30);
+    relabeled.source = "  Living Room  ".to_string();
+    registry.register(MockProvider::reporting("stale-provider-label", relabeled));
+
+    let row_label = registry.fresh_readings(now())[0].source.clone();
+    let status_label = registry.provider_statuses(now())[0].source.clone();
+
+    assert_eq!(row_label, "Living Room");
+    assert_eq!(status_label, row_label);
   }
 
   // -- multiple sources --
@@ -440,6 +585,29 @@ mod tests {
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
     assert_eq!(fresh[0].temperature_celsius, 24.5);
+  }
+
+  #[test]
+  fn a_provider_whose_label_was_already_claimed_is_not_reported_available() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::reporting("Room", reading("Room", 5)));
+    registry.register(MockProvider::reporting("Room", reading("Room", 5)));
+
+    let statuses = registry.provider_statuses(now());
+    assert_eq!(
+      statuses[0].availability,
+      AmbientSensorAvailability::Available
+    );
+    assert_eq!(
+      statuses[1].availability,
+      AmbientSensorAvailability::Unavailable,
+      "no row is written for the second provider, so it must not look healthy"
+    );
+    // It did read successfully, so the panel can still say when.
+    assert_eq!(
+      statuses[1].last_reading_at,
+      Some(now() - Duration::seconds(5))
+    );
   }
 
   // -- provider status --
@@ -512,5 +680,84 @@ mod tests {
       registry.provider_statuses(now())[0].availability,
       AmbientSensorAvailability::Available
     );
+  }
+
+  /// Regression: availability used to be derived from the raw reading's
+  /// timestamp alone, so a reading the archive rejects on shape still
+  /// reported as `Available` - "available but no row" by construction.
+  #[test]
+  fn an_unlabeled_but_fresh_reading_is_never_reported_available() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut anonymous = reading("Room", 5);
+    anonymous.source = "   ".to_string();
+    registry.register(MockProvider::reporting("Room", anonymous));
+
+    assert!(registry.fresh_readings(now()).is_empty());
+    assert_eq!(
+      registry.provider_statuses(now()),
+      vec![EnvironmentalProviderStatus {
+        source: "Room".to_string(),
+        availability: AmbientSensorAvailability::Unavailable,
+        last_reading_at: None,
+      }]
+    );
+  }
+
+  #[test]
+  fn a_fresh_reading_with_a_non_finite_temperature_is_never_reported_available() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut broken = reading("Room", 5);
+    broken.temperature_celsius = f32::NAN;
+    registry.register(MockProvider::reporting("Room", broken));
+
+    assert!(registry.fresh_readings(now()).is_empty());
+    let status = &registry.provider_statuses(now())[0];
+    assert_eq!(status.availability, AmbientSensorAvailability::Unavailable);
+    assert_eq!(
+      status.last_reading_at, None,
+      "a reading the archive rejected is not a success and must not be timestamped as one"
+    );
+  }
+
+  /// The invariant the whole status contract exists to protect, asserted
+  /// directly over a registry holding every rejection shape at once.
+  #[test]
+  fn available_is_reported_exactly_for_the_sources_that_get_a_row() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    let mut anonymous = reading("Anonymous", 5);
+    anonymous.source = "  ".to_string();
+    let mut broken = reading("Broken", 5);
+    broken.temperature_celsius = f32::NEG_INFINITY;
+
+    registry.register(MockProvider::reporting(
+      "Living Room",
+      reading("Living Room", 5),
+    ));
+    registry.register(MockProvider::silent("Never"));
+    registry.register(MockProvider::reporting("Anonymous", anonymous));
+    registry.register(MockProvider::reporting("Broken", broken));
+    registry.register(MockProvider::reporting(
+      "Quiet",
+      reading("Quiet", AMBIENT_READING_MAX_AGE_SECONDS + 1),
+    ));
+    registry.register(MockProvider::reporting("Desk", reading("Desk", 0)));
+
+    let archived: Vec<String> = registry
+      .fresh_readings(now())
+      .into_iter()
+      .map(|reading| reading.source)
+      .collect();
+    let available: Vec<String> = registry
+      .provider_statuses(now())
+      .into_iter()
+      .filter(|status| status.availability == AmbientSensorAvailability::Available)
+      .map(|status| status.source)
+      .collect();
+
+    assert_eq!(
+      archived,
+      vec!["Living Room".to_string(), "Desk".to_string()]
+    );
+    assert_eq!(available, archived);
   }
 }

--- a/core/src/infrastructure/providers/environmental.rs
+++ b/core/src/infrastructure/providers/environmental.rs
@@ -49,26 +49,34 @@ pub struct EnvironmentalReading {
   pub source: String,
 }
 
-/// Whether a provider's transport is currently delivering readings.
+/// Whether an ambient source's readings are arriving.
 ///
-/// Deliberately two states: "configured but never seen a reading" is
-/// `Disconnected` with no last reading timestamp, so the data-state panel
-/// can tell that apart from a link that dropped after working.
+/// Deliberately *not* a connection state. The first concrete provider
+/// listens to passive BLE advertisements and never establishes a
+/// connection, so a link concept has no shared meaning here. Availability
+/// is defined by observed readings alone: transport-specific causes
+/// (radio unavailable, scan not running, device out of range) stay inside
+/// the concrete provider and surface only as readings that stop arriving.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EnvironmentalConnectionState {
-  /// The transport is up and further readings are expected.
-  Connected,
-  /// The provider is registered but its transport is not delivering
-  /// (adapter off, device out of range, permission refused, never paired).
-  Disconnected,
+pub enum AmbientSensorAvailability {
+  /// A reading arrived inside the freshness window, so this source can
+  /// represent the current archive minute.
+  Available,
+  /// Readings arrived before, but the newest one is past the freshness
+  /// window. The archive stops writing rows for this source; the panel
+  /// still shows how long ago it last succeeded.
+  Stale,
+  /// No reading has ever arrived from this source.
+  Unavailable,
 }
 
-/// Per-provider state for the Phase 4 data-state panel.
+/// Per-provider status for the Phase 4 data-state panel: is the source
+/// arriving, and when did it last succeed.
 #[derive(Debug, Clone, PartialEq)]
-pub struct EnvironmentalProviderState {
+pub struct EnvironmentalProviderStatus {
   /// Sensor Source Label identifying the provider.
   pub source: String,
-  pub connection: EnvironmentalConnectionState,
+  pub availability: AmbientSensorAvailability,
   /// Timestamp of the newest reading the provider holds, or `None` when
   /// it has never produced one. Not filtered by freshness - the panel
   /// wants to show how stale the last success is, not hide it.
@@ -79,7 +87,11 @@ pub struct EnvironmentalProviderState {
 ///
 /// Implementations cache whatever their transport last delivered and
 /// answer from that cache; nothing here may block on I/O, because the
-/// hardware-archive tick calls it inline.
+/// hardware-archive tick calls it inline. The contract is deliberately
+/// two observations - who the source is and what it last reported -
+/// because every status the app shows is derived from those. A provider
+/// that internally knows *why* nothing is arriving keeps that reason to
+/// itself rather than widening this trait with a transport concept.
 pub trait EnvironmentalSensorProvider: Send + Sync {
   /// Sensor Source Label identifying this provider. Readings it returns
   /// are expected to carry the same label.
@@ -88,9 +100,6 @@ pub trait EnvironmentalSensorProvider: Send + Sync {
   /// The newest reading held, or `None` when the provider has never
   /// observed one. Freshness is judged by the caller, not here.
   fn latest_reading(&self) -> Option<EnvironmentalReading>;
-
-  /// Whether the transport is currently delivering readings.
-  fn connection_state(&self) -> EnvironmentalConnectionState;
 }
 
 /// The set of environmental providers this process collects from.
@@ -98,7 +107,7 @@ pub trait EnvironmentalSensorProvider: Send + Sync {
 /// Built once at startup and then read-only, so it is shared as an
 /// `Arc`. With no provider registered every method is trivially empty and
 /// the archive tick writes no ambient rows - ambient data stays optional.
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct EnvironmentalSensorRegistry {
   providers: Vec<Arc<dyn EnvironmentalSensorProvider>>,
 }
@@ -156,19 +165,46 @@ impl EnvironmentalSensorRegistry {
     readings
   }
 
-  /// Connection state and last-success timestamp for every registered
-  /// provider, in registration order.
-  pub fn provider_states(&self) -> Vec<EnvironmentalProviderState> {
+  /// Availability and last-success timestamp for every registered
+  /// provider as of `now`, in registration order.
+  ///
+  /// Availability follows exactly the same freshness rule the archive
+  /// uses, so the panel can never claim a source is fine while the
+  /// archive is writing no rows for it.
+  pub fn provider_statuses(
+    &self,
+    now: DateTime<Utc>,
+  ) -> Vec<EnvironmentalProviderStatus> {
     self
       .providers
       .iter()
-      .map(|provider| EnvironmentalProviderState {
-        source: provider.source().to_string(),
-        connection: provider.connection_state(),
-        last_reading_at: provider.latest_reading().map(|reading| reading.timestamp),
+      .map(|provider| {
+        let last_reading_at = provider.latest_reading().map(|reading| reading.timestamp);
+        EnvironmentalProviderStatus {
+          source: provider.source().to_string(),
+          availability: match last_reading_at {
+            None => AmbientSensorAvailability::Unavailable,
+            Some(observed_at) if is_fresh(observed_at, now) => {
+              AmbientSensorAvailability::Available
+            }
+            Some(_) => AmbientSensorAvailability::Stale,
+          },
+          last_reading_at,
+        }
       })
       .collect()
   }
+}
+
+/// Whether a reading observed at `observed_at` still stands for the
+/// minute ending at `now`.
+///
+/// A reading stamped slightly ahead of `now` (host clock jitter between
+/// the transport callback and the archive tick) is still current, so the
+/// window is one-sided.
+fn is_fresh(observed_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+  now.signed_duration_since(observed_at)
+    <= Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS)
 }
 
 /// Normalize one reading for archiving, or `None` when it cannot honestly
@@ -184,11 +220,7 @@ fn normalize_reading(
     return None;
   }
 
-  // A reading stamped slightly ahead of `now` (host clock jitter between
-  // the transport callback and the archive tick) is still current, so the
-  // window is one-sided.
-  let age = now.signed_duration_since(reading.timestamp);
-  if age > Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS) {
+  if !is_fresh(reading.timestamp, now) {
     return None;
   }
 
@@ -210,15 +242,13 @@ mod tests {
   struct MockProvider {
     source: String,
     reading: Option<EnvironmentalReading>,
-    connection: EnvironmentalConnectionState,
   }
 
   impl MockProvider {
-    fn connected(source: &str, reading: EnvironmentalReading) -> Arc<Self> {
+    fn reporting(source: &str, reading: EnvironmentalReading) -> Arc<Self> {
       Arc::new(Self {
         source: source.to_string(),
         reading: Some(reading),
-        connection: EnvironmentalConnectionState::Connected,
       })
     }
 
@@ -226,7 +256,6 @@ mod tests {
       Arc::new(Self {
         source: source.to_string(),
         reading: None,
-        connection: EnvironmentalConnectionState::Disconnected,
       })
     }
   }
@@ -238,10 +267,6 @@ mod tests {
 
     fn latest_reading(&self) -> Option<EnvironmentalReading> {
       self.reading.clone()
-    }
-
-    fn connection_state(&self) -> EnvironmentalConnectionState {
-      self.connection
     }
   }
 
@@ -267,7 +292,7 @@ mod tests {
     let registry = EnvironmentalSensorRegistry::new();
     assert!(registry.is_empty());
     assert!(registry.fresh_readings(now()).is_empty());
-    assert!(registry.provider_states().is_empty());
+    assert!(registry.provider_statuses(now()).is_empty());
   }
 
   // -- staleness --
@@ -275,7 +300,7 @@ mod tests {
   #[test]
   fn a_reading_inside_the_freshness_window_represents_the_minute() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected("Room", reading("Room", 90)));
+    registry.register(MockProvider::reporting("Room", reading("Room", 90)));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
@@ -286,7 +311,7 @@ mod tests {
   #[test]
   fn a_reading_exactly_at_the_freshness_limit_is_still_accepted() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected(
+    registry.register(MockProvider::reporting(
       "Room",
       reading("Room", AMBIENT_READING_MAX_AGE_SECONDS),
     ));
@@ -297,7 +322,7 @@ mod tests {
   #[test]
   fn a_reading_past_the_freshness_limit_writes_no_row_rather_than_repeating() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected(
+    registry.register(MockProvider::reporting(
       "Room",
       reading("Room", AMBIENT_READING_MAX_AGE_SECONDS + 1),
     ));
@@ -311,7 +336,7 @@ mod tests {
   #[test]
   fn a_reading_stamped_slightly_ahead_of_the_tick_is_accepted() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected("Room", reading("Room", -2)));
+    registry.register(MockProvider::reporting("Room", reading("Room", -2)));
 
     assert_eq!(registry.fresh_readings(now()).len(), 1);
   }
@@ -323,7 +348,7 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut broken = reading("Room", 0);
     broken.temperature_celsius = f32::NAN;
-    registry.register(MockProvider::connected("Room", broken));
+    registry.register(MockProvider::reporting("Room", broken));
 
     assert!(registry.fresh_readings(now()).is_empty());
   }
@@ -333,7 +358,7 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut partial = reading("Room", 0);
     partial.humidity_percent = Some(f32::INFINITY);
-    registry.register(MockProvider::connected("Room", partial));
+    registry.register(MockProvider::reporting("Room", partial));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
@@ -346,7 +371,7 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut dry = reading("Room", 0);
     dry.humidity_percent = None;
-    registry.register(MockProvider::connected("Room", dry));
+    registry.register(MockProvider::reporting("Room", dry));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
@@ -358,7 +383,7 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut anonymous = reading("Room", 0);
     anonymous.source = "   ".to_string();
-    registry.register(MockProvider::connected("Room", anonymous));
+    registry.register(MockProvider::reporting("Room", anonymous));
 
     assert!(registry.fresh_readings(now()).is_empty());
   }
@@ -368,7 +393,7 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut padded = reading("Room", 0);
     padded.source = "  Living Room  ".to_string();
-    registry.register(MockProvider::connected("Room", padded));
+    registry.register(MockProvider::reporting("Room", padded));
 
     assert_eq!(registry.fresh_readings(now())[0].source, "Living Room");
   }
@@ -380,8 +405,8 @@ mod tests {
     let mut registry = EnvironmentalSensorRegistry::new();
     let mut desk = reading("Desk", 10);
     desk.temperature_celsius = 26.0;
-    registry.register(MockProvider::connected("Room", reading("Room", 10)));
-    registry.register(MockProvider::connected("Desk", desk));
+    registry.register(MockProvider::reporting("Room", reading("Room", 10)));
+    registry.register(MockProvider::reporting("Desk", desk));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 2);
@@ -393,11 +418,11 @@ mod tests {
   #[test]
   fn one_stale_source_does_not_suppress_a_fresh_one() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected(
+    registry.register(MockProvider::reporting(
       "Room",
       reading("Room", AMBIENT_READING_MAX_AGE_SECONDS + 60),
     ));
-    registry.register(MockProvider::connected("Desk", reading("Desk", 5)));
+    registry.register(MockProvider::reporting("Desk", reading("Desk", 5)));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
@@ -407,45 +432,52 @@ mod tests {
   #[test]
   fn a_duplicated_source_label_contributes_only_one_row_per_minute() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected("Room", reading("Room", 5)));
+    registry.register(MockProvider::reporting("Room", reading("Room", 5)));
     let mut second = reading("Room", 5);
     second.temperature_celsius = 31.0;
-    registry.register(MockProvider::connected("Room", second));
+    registry.register(MockProvider::reporting("Room", second));
 
     let fresh = registry.fresh_readings(now());
     assert_eq!(fresh.len(), 1);
     assert_eq!(fresh[0].temperature_celsius, 24.5);
   }
 
-  // -- connection state --
+  // -- provider status --
 
   #[test]
-  fn provider_states_report_connection_and_last_success() {
+  fn a_source_with_readings_arriving_is_available_with_its_last_success() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected("Room", reading("Room", 30)));
-    registry.register(MockProvider::silent("Desk"));
+    registry.register(MockProvider::reporting("Room", reading("Room", 30)));
 
     assert_eq!(
-      registry.provider_states(),
-      vec![
-        EnvironmentalProviderState {
-          source: "Room".to_string(),
-          connection: EnvironmentalConnectionState::Connected,
-          last_reading_at: Some(now() - Duration::seconds(30)),
-        },
-        EnvironmentalProviderState {
-          source: "Desk".to_string(),
-          connection: EnvironmentalConnectionState::Disconnected,
-          last_reading_at: None,
-        },
-      ]
+      registry.provider_statuses(now()),
+      vec![EnvironmentalProviderStatus {
+        source: "Room".to_string(),
+        availability: AmbientSensorAvailability::Available,
+        last_reading_at: Some(now() - Duration::seconds(30)),
+      }]
     );
   }
 
   #[test]
-  fn provider_states_keep_reporting_a_last_success_that_is_now_stale() {
+  fn a_source_that_has_never_reported_is_unavailable() {
     let mut registry = EnvironmentalSensorRegistry::new();
-    registry.register(MockProvider::connected(
+    registry.register(MockProvider::silent("Desk"));
+
+    assert_eq!(
+      registry.provider_statuses(now()),
+      vec![EnvironmentalProviderStatus {
+        source: "Desk".to_string(),
+        availability: AmbientSensorAvailability::Unavailable,
+        last_reading_at: None,
+      }]
+    );
+  }
+
+  #[test]
+  fn a_source_that_went_quiet_is_stale_and_still_reports_its_last_success() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::reporting(
       "Room",
       reading("Room", AMBIENT_READING_MAX_AGE_SECONDS * 10),
     ));
@@ -454,8 +486,31 @@ mod tests {
     // say how long ago the sensor last reported.
     assert!(registry.fresh_readings(now()).is_empty());
     assert_eq!(
-      registry.provider_states()[0].last_reading_at,
-      Some(now() - Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS * 10))
+      registry.provider_statuses(now()),
+      vec![EnvironmentalProviderStatus {
+        source: "Room".to_string(),
+        availability: AmbientSensorAvailability::Stale,
+        last_reading_at: Some(
+          now() - Duration::seconds(AMBIENT_READING_MAX_AGE_SECONDS * 10)
+        ),
+      }]
+    );
+  }
+
+  #[test]
+  fn availability_uses_the_same_freshness_boundary_as_the_archive() {
+    let mut registry = EnvironmentalSensorRegistry::new();
+    registry.register(MockProvider::reporting(
+      "Room",
+      reading("Room", AMBIENT_READING_MAX_AGE_SECONDS),
+    ));
+
+    // The panel must never call a source available while the archive is
+    // writing no rows for it, so both read the same boundary.
+    assert_eq!(registry.fresh_readings(now()).len(), 1);
+    assert_eq!(
+      registry.provider_statuses(now())[0].availability,
+      AmbientSensorAvailability::Available
     );
   }
 }

--- a/core/src/infrastructure/providers/mod.rs
+++ b/core/src/infrastructure/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod environmental;
 pub mod smartctl;
 pub mod sysinfo_provider;
 

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -379,6 +379,12 @@ impl ArchiveTracker {
 
     self.dirty = false;
 
+    // Taken once at the top of the write cycle. The ambient rows are
+    // stamped with it rather than with a second `now()` read further
+    // down, so a write cycle that straddles a minute boundary cannot land
+    // its ambient rows in a different minute than the rest of the cycle.
+    let tick_timestamp = chrono::Utc::now();
+
     let cpu = StatsCalculator::compute_stats(self.cpu_history.iter().copied());
     let cpu_temperature = StatsCalculator::compute_stats(
       self.cpu_temperature_history.iter().copied().flatten(),
@@ -434,7 +440,6 @@ impl ArchiveTracker {
 
     // Ambient rows are keyed to the tick, not to each sensor's own
     // observation time, so they join the hardware row for this minute.
-    let tick_timestamp = chrono::Utc::now();
     let ambient = self.collect_ambient_data(tick_timestamp);
     if !ambient.is_empty()
       && let Err(e) = database::ambient_archive::insert(ambient, tick_timestamp).await

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -1222,8 +1222,7 @@ mod tests {
   mod ambient {
     use super::*;
     use crate::infrastructure::providers::environmental::{
-      AMBIENT_READING_MAX_AGE_SECONDS, EnvironmentalConnectionState,
-      EnvironmentalReading, EnvironmentalSensorProvider,
+      AMBIENT_READING_MAX_AGE_SECONDS, EnvironmentalReading, EnvironmentalSensorProvider,
     };
     use chrono::{DateTime, Utc};
 
@@ -1239,10 +1238,6 @@ mod tests {
 
       fn latest_reading(&self) -> Option<EnvironmentalReading> {
         self.reading.clone()
-      }
-
-      fn connection_state(&self) -> EnvironmentalConnectionState {
-        EnvironmentalConnectionState::Connected
       }
     }
 

--- a/core/src/persistence/archive.rs
+++ b/core/src/persistence/archive.rs
@@ -11,6 +11,7 @@
 //! cannot back-pressure sensor polling.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
 use tokio::runtime::Handle;
 use tokio::sync::broadcast::error::RecvError;
@@ -19,9 +20,10 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, MissedTickBehavior, interval};
 
 use crate::event_bus::EventBus;
+use crate::infrastructure::providers::environmental::EnvironmentalSensorRegistry;
 use crate::models::{MetricsSnapshot, ProcessSample};
 use crate::persistence::archive_data::{
-  GpuData, HardwareArchiveRow, HardwareData, ProcessStatData,
+  AmbientData, GpuData, HardwareArchiveRow, HardwareData, ProcessStatData,
 };
 use crate::{log_info, log_warn};
 
@@ -57,11 +59,24 @@ impl ArchiveController {
   /// `bus` immediately so no snapshots are missed between setup and the
   /// first tick.
   pub fn setup(bus: &EventBus, runtime: Handle) -> Self {
+    Self::setup_with_environmental_sensors(bus, runtime, Arc::default())
+  }
+
+  /// [`ArchiveController::setup`] with ambient sources attached (#2043).
+  ///
+  /// The registry rides the same one-minute tick as the hardware row, so
+  /// an ambient reading and the CPU temperature it explains land on the
+  /// same minute. An empty registry behaves exactly like [`Self::setup`].
+  pub fn setup_with_environmental_sensors(
+    bus: &EventBus,
+    runtime: Handle,
+    environmental_sensors: Arc<EnvironmentalSensorRegistry>,
+  ) -> Self {
     let (stop_tx, mut stop_rx) = watch::channel(false);
     let mut rx = bus.subscribe();
 
     let handle = runtime.spawn(async move {
-      let mut tracker = ArchiveTracker::new();
+      let mut tracker = ArchiveTracker::with_environmental_sensors(environmental_sensors);
       let mut ticker =
         interval(Duration::from_secs(HARDWARE_ARCHIVE_INTERVAL_SECONDS));
       ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -182,6 +197,14 @@ pub async fn cleanup_old_data(retention_days: u32) {
     );
   }
 
+  if let Err(e) = database::ambient_archive::delete_old_data(retention_days).await {
+    log_error!(
+      "Failed to delete old ambient archive data",
+      "persistence::archive::cleanup_old_data",
+      Some(e.to_string())
+    );
+  }
+
   crate::persistence::cooling_rollup::cleanup_old_data().await;
 }
 
@@ -233,11 +256,23 @@ struct ArchiveTracker {
   /// been ingested since the previous tick (e.g. shutdown lands within
   /// a fraction of a second after a scheduled write).
   dirty: bool,
+  /// Ambient sources polled on the archive tick. Empty on installs with
+  /// no environmental sensor, which then write no ambient rows at all.
+  environmental_sensors: Arc<EnvironmentalSensorRegistry>,
 }
 
 impl ArchiveTracker {
   fn new() -> Self {
     Self::default()
+  }
+
+  fn with_environmental_sensors(
+    environmental_sensors: Arc<EnvironmentalSensorRegistry>,
+  ) -> Self {
+    Self {
+      environmental_sensors,
+      ..Self::new()
+    }
   }
 
   fn is_dirty(&self) -> bool {
@@ -396,6 +431,35 @@ impl ArchiveTracker {
         Some(e.to_string())
       );
     }
+
+    // Ambient rows are keyed to the tick, not to each sensor's own
+    // observation time, so they join the hardware row for this minute.
+    let tick_timestamp = chrono::Utc::now();
+    let ambient = self.collect_ambient_data(tick_timestamp);
+    if !ambient.is_empty()
+      && let Err(e) = database::ambient_archive::insert(ambient, tick_timestamp).await
+    {
+      log_error!(
+        "Failed to insert ambient archive data",
+        "persistence::archive::write_archive",
+        Some(e.to_string())
+      );
+    }
+  }
+
+  /// The ambient rows for the minute ending at `now` - one per source
+  /// with a fresh reading, and none for a source that has gone quiet.
+  fn collect_ambient_data(&self, now: chrono::DateTime<chrono::Utc>) -> Vec<AmbientData> {
+    self
+      .environmental_sensors
+      .fresh_readings(now)
+      .into_iter()
+      .map(|reading| AmbientData {
+        source: reading.source,
+        temperature: reading.temperature_celsius,
+        humidity: reading.humidity_percent,
+      })
+      .collect()
   }
 
   fn collect_gpu_data(&self) -> Vec<GpuData> {
@@ -1151,6 +1215,112 @@ mod tests {
     assert_eq!(gpus[0].usage_max, Some(30.0));
     assert_eq!(gpus[0].temperature_avg, Some(50.0));
     assert_eq!(gpus[0].dedicated_memory_avg, Some(200));
+  }
+
+  // ── collect_ambient_data ──
+
+  mod ambient {
+    use super::*;
+    use crate::infrastructure::providers::environmental::{
+      AMBIENT_READING_MAX_AGE_SECONDS, EnvironmentalConnectionState,
+      EnvironmentalReading, EnvironmentalSensorProvider,
+    };
+    use chrono::{DateTime, Utc};
+
+    struct StubSensor {
+      source: String,
+      reading: Option<EnvironmentalReading>,
+    }
+
+    impl EnvironmentalSensorProvider for StubSensor {
+      fn source(&self) -> &str {
+        &self.source
+      }
+
+      fn latest_reading(&self) -> Option<EnvironmentalReading> {
+        self.reading.clone()
+      }
+
+      fn connection_state(&self) -> EnvironmentalConnectionState {
+        EnvironmentalConnectionState::Connected
+      }
+    }
+
+    fn tick() -> DateTime<Utc> {
+      DateTime::parse_from_rfc3339("2026-08-30T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+    }
+
+    fn sensor(
+      source: &str,
+      temperature: f32,
+      humidity: Option<f32>,
+      seconds_old: i64,
+    ) -> Arc<StubSensor> {
+      Arc::new(StubSensor {
+        source: source.to_string(),
+        reading: Some(EnvironmentalReading {
+          temperature_celsius: temperature,
+          humidity_percent: humidity,
+          timestamp: tick() - chrono::Duration::seconds(seconds_old),
+          source: source.to_string(),
+        }),
+      })
+    }
+
+    fn tracker(sensors: Vec<Arc<StubSensor>>) -> ArchiveTracker {
+      let mut registry = EnvironmentalSensorRegistry::new();
+      for sensor in sensors {
+        registry.register(sensor);
+      }
+      ArchiveTracker::with_environmental_sensors(Arc::new(registry))
+    }
+
+    #[test]
+    fn an_install_without_an_ambient_sensor_writes_no_ambient_rows() {
+      let tracker = ArchiveTracker::new();
+      assert!(tracker.collect_ambient_data(tick()).is_empty());
+    }
+
+    #[test]
+    fn every_fresh_ambient_source_becomes_its_own_row_for_the_tick() {
+      let tracker = tracker(vec![
+        sensor("Living Room", 24.5, Some(48.0), 30),
+        sensor("Desk", 26.0, None, 30),
+      ]);
+
+      assert_eq!(
+        tracker.collect_ambient_data(tick()),
+        vec![
+          AmbientData {
+            source: "Living Room".to_string(),
+            temperature: 24.5,
+            humidity: Some(48.0),
+          },
+          AmbientData {
+            source: "Desk".to_string(),
+            temperature: 26.0,
+            humidity: None,
+          },
+        ]
+      );
+    }
+
+    #[test]
+    fn a_sensor_that_went_quiet_leaves_the_minute_without_an_ambient_row() {
+      let tracker = tracker(vec![sensor(
+        "Living Room",
+        24.5,
+        Some(48.0),
+        AMBIENT_READING_MAX_AGE_SECONDS + 1,
+      )]);
+
+      assert!(
+        tracker.collect_ambient_data(tick()).is_empty(),
+        "a stale sensor must not keep writing its last value every minute"
+      );
+    }
   }
 
   #[test]

--- a/core/src/persistence/archive_data.rs
+++ b/core/src/persistence/archive_data.rs
@@ -37,6 +37,17 @@ pub struct GpuData {
   pub dedicated_memory_min: Option<i32>,
 }
 
+/// One ambient source's contribution to a single archive minute. The
+/// minute's timestamp is supplied by the writer, not carried per row -
+/// see [`crate::infrastructure::database::ambient_archive::insert_from_pool`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct AmbientData {
+  /// Sensor Source Label the reading is attributed to.
+  pub source: String,
+  pub temperature: f32,
+  pub humidity: Option<f32>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProcessStatData {
   pub pid: i32,

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -238,8 +238,18 @@ value across hours. A minute with no fresh reading has no ambient row, and one
 quiet sensor never suppresses another. Ambient rows carry the archive tick's
 timestamp so they join the Hardware Archive row for the same minute, and they
 age out on the same `hardwareArchive.retentionDays` cycle as the rows they
-explain. Provider connection state and last-success timestamps are exposed from
-the registry for the Cooling Insight data-state panel.
+explain.
+
+The provider contract is deliberately availability-based rather than
+connection-based: the first concrete provider reads passive BLE advertisements
+and never establishes a connection, so a link concept has no shared meaning.
+A provider reports only its Sensor Source Label and its latest reading; the
+registry derives Ambient Sensor Availability (available / stale / never
+received) and the last-success timestamp for the Cooling Insight data-state
+panel, using the same freshness window the archive writes by, so the panel can
+never call a source available while no rows are being written for it.
+Transport-specific causes such as an unavailable radio or a stopped scan stay
+inside the concrete provider and surface only as readings that stop arriving.
 
 Process Insight data is a sampled and ranked summary derived from realtime
 process observations. It is not a complete process audit log, and persistence

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -223,6 +223,24 @@ simplification from the period before close-to-tray/background execution was a
 supported app behavior, when the app was not expected to stay running
 continuously.
 
+Ambient Temperature Readings are archived beside those rows in
+`AMBIENT_ARCHIVE`, one row per ambient Sensor Source Label per minute, so more
+than one environmental sensor can contribute to the same minute. Core owns the
+`EnvironmentalSensorProvider` abstraction
+(`core/src/infrastructure/providers/environmental.rs`) and knows nothing about
+any vendor or transport: a provider caches whatever its transport last
+delivered, and the archive tick polls that cache without blocking. The Ambient
+Reading Freshness Window is five minutes
+(`environmental::AMBIENT_READING_MAX_AGE_SECONDS`) - long enough that ordinary
+BLE advertisement loss does not punch holes in the archive, short enough that a
+sensor which stops reporting stops producing rows instead of freezing its last
+value across hours. A minute with no fresh reading has no ambient row, and one
+quiet sensor never suppresses another. Ambient rows carry the archive tick's
+timestamp so they join the Hardware Archive row for the same minute, and they
+age out on the same `hardwareArchive.retentionDays` cycle as the rows they
+explain. Provider connection state and last-success timestamps are exposed from
+the registry for the Cooling Insight data-state panel.
+
 Process Insight data is a sampled and ranked summary derived from realtime
 process observations. It is not a complete process audit log, and persistence
 code should preserve that expectation unless a new feature explicitly changes

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -244,10 +244,18 @@ The provider contract is deliberately availability-based rather than
 connection-based: the first concrete provider reads passive BLE advertisements
 and never establishes a connection, so a link concept has no shared meaning.
 A provider reports only its Sensor Source Label and its latest reading; the
-registry derives Ambient Sensor Availability (available / stale / never
-received) and the last-success timestamp for the Cooling Insight data-state
-panel, using the same freshness window the archive writes by, so the panel can
-never call a source available while no rows are being written for it.
+registry derives Ambient Sensor Availability and the last-success timestamp for
+the Cooling Insight data-state panel. Both the panel status and the rows to
+write come from one evaluation per provider, so they share the same eligibility
+rule: `Available` means the archive will attempt a row for that source this
+minute, not that a row necessarily reached the database - the insert itself can
+still fail and is logged when it does. A reading that cannot be archived at all
+(no Sensor Source Label, a non-finite temperature, or a label another provider
+already claimed this minute) reports as unavailable and does not advance the
+last-success timestamp, so a "fresh success" the archive rejected is never
+shown. The freshness window is bounded in both directions: readings stamped
+more than `AMBIENT_READING_MAX_FUTURE_SKEW_SECONDS` (60 s) ahead of the tick are
+refused, so a clock rewind cannot leave one reading permanently fresh.
 Transport-specific causes such as an unavailable radio or a stopped scan stay
 inside the concrete provider and surface only as readings that stop arriving.
 

--- a/src-tauri/src/infrastructure/database/migration.rs
+++ b/src-tauri/src/infrastructure/database/migration.rs
@@ -189,6 +189,27 @@ pub fn get_migrations() -> Vec<SchemaMigration> {
         ALTER TABLE cooling_daily_summary ADD COLUMN power_sample_minutes INTEGER NOT NULL DEFAULT 0;
       "#,
     },
+    SchemaMigration {
+      version: 15,
+      description: "create_ambient_archive",
+      // Row-per-source (#2043): more than one ambient sensor in a room is
+      // plausible, and each one is a distinct Sensor Source Label rather
+      // than a column. `temperature` is NOT NULL because a row only
+      // exists when a fresh reading backs it - a minute with no usable
+      // ambient sample has no row at all, never a zeroed one (DP-02).
+      // `humidity` is nullable: temperature-only sensors are common.
+      sql: r#"
+        CREATE TABLE AMBIENT_ARCHIVE (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          source TEXT NOT NULL,
+          temperature REAL NOT NULL,
+          humidity REAL,
+          timestamp DATETIME NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_ambient_archive_timestamp ON AMBIENT_ARCHIVE(timestamp);
+      "#,
+    },
   ]
 }
 
@@ -365,14 +386,33 @@ mod tests {
   }
 
   #[test]
+  fn migration_v15_creates_the_row_per_source_ambient_archive_table() {
+    let migrations = get_migrations();
+    let v15 = migrations
+      .iter()
+      .find(|m| m.version == 15)
+      .expect("Version 15 up migration must exist");
+    assert!(v15.sql.contains("CREATE TABLE AMBIENT_ARCHIVE"));
+    // `source` identifies the row rather than being one column per
+    // sensor, so several ambient sources can share one minute.
+    assert!(v15.sql.contains("source TEXT NOT NULL"));
+    // A row exists only when a fresh reading backs it, so the temperature
+    // can never be a placeholder.
+    assert!(v15.sql.contains("temperature REAL NOT NULL"));
+    assert!(v15.sql.contains("humidity REAL"));
+    assert!(v15.sql.contains("timestamp DATETIME NOT NULL"));
+    assert!(v15.sql.contains("idx_ambient_archive_timestamp"));
+  }
+
+  #[test]
   fn max_migration_version() {
-    assert_eq!(get_max_migration_version(), 14);
+    assert_eq!(get_max_migration_version(), 15);
   }
 
   #[test]
   fn migration_count() {
     let migrations = get_migrations();
-    assert_eq!(migrations.len(), 14);
+    assert_eq!(migrations.len(), 15);
   }
 
   #[test]
@@ -558,5 +598,56 @@ mod tests {
     .execute(&pool)
     .await
     .expect("insert with the power columns must succeed after migrations");
+  }
+
+  /// The ambient archive (#2043) is row-per-source: the shipped migration
+  /// set must let two ambient sources share one minute, accept a
+  /// temperature-only sensor, and reject a row with no temperature.
+  #[tokio::test]
+  async fn shipped_migrations_create_ambient_archive_and_allow_row_per_source_insert() {
+    use hardviz_core::infrastructure::database::migrate;
+    use sqlx::sqlite::SqlitePool;
+
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let url = format!("sqlite:{}", file.path().to_string_lossy());
+    let pool = SqlitePool::connect(&url).await.unwrap();
+
+    migrate::run_on_pool(&pool, get_migrations())
+      .await
+      .expect("the shipped migration set must apply cleanly");
+
+    sqlx::query(
+      "INSERT INTO AMBIENT_ARCHIVE (source, temperature, humidity, timestamp) VALUES
+         ('Living Room', 24.5, 48.0, '2026-08-30T12:00:00Z'),
+         ('Desk', 26.0, NULL, '2026-08-30T12:00:00Z')",
+    )
+    .execute(&pool)
+    .await
+    .expect("two ambient sources must be able to share one archive minute");
+
+    let rows: Vec<(String, f64, Option<f64>)> = sqlx::query_as(
+      "SELECT source, temperature, humidity FROM AMBIENT_ARCHIVE ORDER BY source",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+      rows,
+      vec![
+        ("Desk".to_string(), 26.0, None),
+        ("Living Room".to_string(), 24.5, Some(48.0)),
+      ]
+    );
+
+    let without_temperature = sqlx::query(
+      "INSERT INTO AMBIENT_ARCHIVE (source, temperature, timestamp)
+       VALUES ('Broken', NULL, '2026-08-30T12:01:00Z')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+      without_temperature.is_err(),
+      "a minute without a usable ambient reading must have no row at all"
+    );
   }
 }


### PR DESCRIPTION
## Summary

Phase-4 foundation for #1666: a vendor-neutral environmental sensor abstraction and an ambient temperature archive, so Cooling Insight can later normalize CPU temperature against the air the PC actually ingests. Core-only — no UI, no wire changes, no concrete provider (that's #2044).

- **`EnvironmentalSensorProvider`** is deliberately minimal: `source()` (Sensor Source Label) + `latest_reading()` — a synchronous read of a value the transport pushes and caches, so a passive-BLE provider never blocks the archive tick. No vendor types anywhere in Core
- **Provider status, not connection state** (per the issue's review): the registry derives `Available` / `Stale` / `Unavailable` + last-successful-reading from the **same freshness predicate the archive uses**, so "no row was written but the panel says available" cannot happen by construction (pinned by tests). Transport-specific notions (radio state, scan windows) stay inside future concrete providers
- **`AMBIENT_ARCHIVE`** (migration v15): row-per-source `(source, temperature NOT NULL, humidity NULL, timestamp)` on the one-minute tick. `temperature NOT NULL` is DP-02 stated as schema — a minute only has a row when a fresh reading exists; nothing is zero-filled or interpolated. Rows are stamped with the tick time (joinable against the same minute's `DATA_ARCHIVE` row), with the freshness window bounding how far the observation may lag
- **Freshness window: 5 minutes** — slow-moving indoor air changes well under 1 °C in that span (inside consumer-sensor accuracy), it is many multiples of BLE advertisement intervals (normal packet loss doesn't punch archive holes), and a genuinely dead sensor stops producing rows within 5 minutes instead of freezing its last value. Rationale recorded in code and `docs/architecture/backend.md`
- Retention follows `hardwareArchive.retentionDays` in the existing cleanup cycle; `ArchiveController::setup()` delegates to an empty registry so App wiring is untouched until a provider exists

## Related Issues

Closes #2043
Relates to #1666 (Phase 4). Blocks #2044 (SwitchBot BLE provider) and #2045 (ambient-normalized rollups).

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

N/A (Core abstraction and persistence only; no UI changes)

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- `cargo tauri-test` → hardviz-core 577 + integration 2 + App 267 passed, 0 failed (+21: freshness boundaries incl. exactly-5-minutes and future-stamped readings, non-finite rejection, row-per-source multi-sensor minutes, one-stale-one-fresh independence, availability derivation sharing the archive predicate, persistence round-trips, retention, migration v15 schema assertions)
- `cargo tauri-fmt` / `cargo tauri-lint` clean; frontend and `bindings.ts` untouched
- `CONTEXT.md` gains the Ambient Temperature Reading / Ambient Sensor Availability / Ambient Reading Freshness Window vocabulary; `docs/architecture/backend.md` records the table shape and the availability contract's no-connection rationale

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting environmental sensor readings, including temperature and optional humidity from multiple sources.
  * Ambient readings are archived once per minute when fresh, with source information preserved.
  * Added sensor availability states for available, stale, and unavailable providers.
* **Bug Fixes**
  * Invalid, expired, duplicate, incomplete, or excessively future-dated readings are excluded from archived data.
  * Archived ambient data is automatically removed according to the configured retention period.
* **Documentation**
  * Documented environmental sensor freshness, availability, archival, and retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->