### PR TITLE
docs: record lossless Hardware Archive storage decision

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ documentation.
   [Japanese](user/external-components.ja.md)
 - [Windows sensor external components](architecture/windows-sensor-external-components.md)
 - [Architecture decision records](adr/)
+- [Lossless chunked Hardware Archive decision](adr/0019-lossless-chunked-hardware-archive.md)
 - [Sensor hardware specs (clean-room)](specs/sensors/)
 - [Frontend architecture](../src/README.md)
 - [Core crate guide](../core/README.md)

--- a/docs/adr/0018-cooling-daily-rollup-retention.md
+++ b/docs/adr/0018-cooling-daily-rollup-retention.md
@@ -7,3 +7,8 @@ The cooling daily rollup (`cooling_daily_summary`) is stored and retained separa
 This lets Cooling Insight show 90-day and 1-year CPU temperature trends without loading a year of per-minute archive rows and without extending how long the much larger one-minute Hardware Archive history has to be kept. It follows the same separation already established for Storage Health history (ADR 0004): a derived, long-lived summary can outlive the shorter-window raw data it is computed from.
 
 The rollup's own cleanup runs from the same `scheduledDataDeletion`-gated startup site as the Hardware Archive cleanup (`persistence::archive::cleanup_old_data`), so there is still exactly one place that decides whether startup deletion runs at all - only the retention window differs.
+
+For planned chunked storage, [ADR 0019](0019-lossless-chunked-hardware-archive.md)
+refines the startup-only cleanup trigger to cover long-lived sessions. The
+independent Retention Period and rollup-before-deletion dependency remain;
+this refinement does not claim that recurring cleanup is already implemented.

--- a/docs/adr/0019-lossless-chunked-hardware-archive.md
+++ b/docs/adr/0019-lossless-chunked-hardware-archive.md
@@ -1,0 +1,205 @@
+# Lossless Chunked Hardware Archive
+
+Status: accepted
+
+Tracking issue: [#2052](https://github.com/shm11C3/HardwareVisualizer/issues/2052).
+
+This records the product and architectural constraints agreed on 2026-09-01.
+It is a decision for planned work, not a claim that chunk storage is implemented.
+Concrete codecs, schema, migration lifecycle, and query numerical tolerances
+remain subject to the issue's design and benchmark gate.
+
+Implementation is planned to follow the current Cooling Insight scope tracked
+by [#1666](https://github.com/shm11C3/HardwareVisualizer/issues/1666). This is a
+sequencing plan, not a requirement for Cooling Insight to adopt chunked storage.
+Before starting #2052, refresh the table, retained-summary, baseline, and query
+inventory against the then-current implementation and benchmark that baseline.
+
+## Context
+
+Hardware Archive rows retain approximately one-minute summaries. Repeated
+timestamps, source labels, and process records make long Retention Periods an
+important storage workload. Process Stats is a required optimization target,
+not an optional follow-up to sensor compression; its actual contribution and
+the total improvement must be measured.
+
+The existing archive already contains summarized and ranked observations, not
+all original per-second readings or a complete process audit. Storage
+optimization must not reduce the information that was actually retained.
+
+## Decision
+
+### Keep SQLite and separate freshness from compaction
+
+Keep the realtime collector/EventBus path independent of database work.
+Persist each new archive interval in an append-oriented active tail and
+periodically finalize bounded windows into immutable, independently decodable,
+losslessly encoded chunks. Queries combine the tail, chunks, and any retained
+legacy representation in Core. Chunk duration determines neither history
+visibility nor the amount of recent history exposed to a crash.
+
+Process Stats conversion is mandatory for the first completed delivery.
+Optimize system, GPU, ambient, and fan archives wherever practical, recording
+each family's conversion decision. A separate process codec is acceptable;
+forcing every record into scalar sensor series is not required. Preserve
+non-converted families in their existing representation rather than dropping
+them. This work does not add sensor providers or change collection/ranking.
+
+Core owns codecs, persistence, queries, migration execution, and maintenance.
+App keeps database-path resolution, ordered migration definitions, Tauri
+lifecycle, typed IPC, and presentation conversion. The frontend owns
+interaction and rendering, not storage-format routing. This preserves
+[ADR 0002](0002-core-app-split.md).
+
+### Preserve samples exactly; assess query arithmetic separately
+
+A lossless round trip preserves stored values, timestamp precision, nullable
+fields, record presence and multiplicity, existing statistics, and attribution.
+Legacy records cannot be rounded onto a regular minute grid: actual write
+instants include delayed ticks and shutdown flushes. Do not narrow stored
+numeric values merely to match a convenient codec or current frontend type.
+
+Exact decoded-sample comparison is separate from the numerical criteria for
+derived query results. Those criteria must be defined before replacing the
+query path; tolerance must not excuse changed grouping, bucket/range boundaries,
+missing-data rules, or quantization of source samples. Metadata and rollups are
+accelerators, not replacements for retained samples. Partial-chunk queries
+must retain their exact requested range.
+
+Migration preserves the existing identity contract rather than repairing or
+inventing history:
+
+| Record family | Existing archived subject | Required preservation |
+| --- | --- | --- |
+| System | Metric and statistic columns in `DATA_ARCHIVE` | Keep average, minimum, maximum and nullability independently. |
+| GPU | `gpu_name` and optional `gpu_id` | Preserve existing name-based queries and already-combined same-name rows; do not reconstruct separate devices. |
+| Process | Per-observation `pid` and `process_name` | Preserve records and current tuple-based query grouping, not an inferred process lifetime. |
+| Fan | `source` copied from the live fan's `name` | Keep the archived label and real 0 RPM; do not substitute the live provider `source`. |
+| Ambient | Environmental Sensor Source Label in `source` | Keep source, temperature, optional humidity, and absent intervals. |
+
+These contracts come from the [archive producer](../../core/src/persistence/archive.rs),
+[stored record types](../../core/src/persistence/archive_data.rs), and
+[query owner](../../core/src/infrastructure/database/archive_queries.rs).
+Process queries currently average CPU/memory and take the maximum execution
+seconds and latest timestamp within the range; a name dictionary cannot turn
+those observations into an execution log.
+
+GPU ids must be retained as opaque values. Current live producers use
+`nvapi:<id>`, `pci:<bus>:<device>:<function>`, and
+`pdh:instance:<device_instance_id>` (fallback `pdh:<luid_high>:<luid_low>`) on
+[Windows](../../core/src/platform/windows/gpu.rs), `pci:<BDF>` (fallback
+`drm:card<n>`) on [Linux](../../core/src/platform/linux/gpu.rs), and
+`iokit:<name>` on [macOS](../../core/src/platform/macos/gpu.rs). These are not
+the inventory namespace; already-written legacy forms and absent ids remain
+as recorded. [ADR 0016](0016-gpu-attribution-on-the-performance-screen.md)
+explains the live/archive attribution boundary. No new physical-identity join
+or historical reverse translation is introduced by this decision.
+
+### Keep recent crash loss small, not proportional to chunk size
+
+The accepted runtime loss budget is on the order of the newest archive
+interval, approximately one minute, not zero loss under every power failure.
+Normal shutdown must flush pending observations and retain persisted tail
+samples. Restart must recover and finalize stale incomplete windows.
+
+Finalization and active-row removal must be atomic or recoverably equivalent,
+including concurrent reads and retries: neither sample loss nor double
+counting is acceptable. An interrupted finalization may revert to its active
+rows; it must not lose the older samples they represent. Migration must not
+turn a small recent loss window into loss of an existing archive.
+
+The [current pool policy](../../core/src/infrastructure/database/db.rs) uses
+WAL with `synchronous=NORMAL`. That setting alone does not establish a hard
+one-minute bound for OS crashes or power loss; verify the write/checkpoint
+strategy against the agreed target rather than asserting a guarantee from
+the pragma. Application crashes and OS/power failures require distinct tests.
+See [SQLite durability](https://sqlite.org/pragma.html#pragma_synchronous).
+
+### Expire whole chunks and preserve independent retention
+
+Delete a finalized chunk only once its latest actual sample has expired.
+Accept a small extension of physical retention rather than rewriting a
+boundary chunk or removing any unexpired sample. Bound elapsed chunk duration
+as well as sample count, so sparse sources cannot prolong retention
+indefinitely. With healthy maintenance enabled, extra retention is bounded
+by that duration plus the maintenance interval.
+
+Maintenance must also run in long-lived app sessions and preserve the user's
+`scheduledDataDeletion` choice; disabling deletion does not disable compaction.
+Required rollups must succeed before their source history is removed.
+Keep Hardware Archive, Cooling summary, and Storage Health Retention Periods
+separate. This refines the startup-only cleanup trigger in
+[ADR 0018](0018-cooling-daily-rollup-retention.md) for the planned storage,
+without changing its independent summary-retention decision or
+[ADR 0004](0004-separate-storage-health-history.md).
+
+### Render the readable remainder and report errors
+
+For a localized read/decode failure, return usable history with error
+information and render what can be read. Missing readings, absent rows and
+unreadable portions may all appear as chart gaps: a separate visual category
+for each is not required. Report the read error separately so incomplete
+coverage is not silently represented as a successful, complete result.
+
+Do not replace unavailable values with zero, interpolate through an unreadable
+chunk, or automatically delete its payload. Format/codec versions and
+corruption detection must prevent unrecognized or damaged payloads from being
+treated as valid readings. A whole-database failure still needs a recovery
+error; partial results are only possible when some history remains readable.
+
+### Migrate explicitly and preserve the whole database
+
+Offer optimization now or later and a settings entry point to return to it.
+Prefer conversion into a separate temporary database, validation, and a
+recoverable cutover while retaining the source as a recovery copy. Support
+years of existing data without waiting for default retention to expire.
+
+A whole-database replacement must preserve non-converted tables, Storage
+Health history, Cooling baseline data, and retained summaries whose source
+minute rows have already expired. Their schema need not be redesigned.
+Aggregate equality is not enough to validate migration: compare decoded
+samples against source records as well as coverage and database integrity.
+
+Check temporary capacity conservatively, stream conversion, and handle disk
+exhaustion and interruption without sacrificing original history. Account for
+[SQLite WAL state](https://sqlite.org/wal.html#the_wal_file). Define consistent
+source capture, concurrent writes, reader/writer shutdown, restart selection,
+and every cutover failure state before implementing file replacement. Merely
+renaming two files does not define recovery. Backup deletion needs a verified
+destination and an explicit policy.
+
+## Alternatives and consequences
+
+- Lossy rollups, quantization, and shortened retention violate the information
+  and user-intent contract. Query-only rollups remain useful.
+- RAM-only tails or hour-sized uncommitted writes make the loss/visibility
+  window too large. Persisting the active tail costs some temporary row overhead.
+- Whole-chunk deletion trades a bounded amount of extra retained data for
+  immutable payloads and cheaper maintenance.
+- Independent chunks add metadata and bounded random-access decode cost.
+  Measure total storage, CPU, and query behavior before selecting a format.
+- Copy/validate/switch migration needs extra disk space and recovery states,
+  but protects years of history from a failed conversion.
+- Process-specific encoding is allowed because process observations have a
+  different shape; shared storage infrastructure must not erase that meaning.
+- Partial display preserves useful results while an error explains unavailable
+  portions, without requiring a more complicated chart-gap vocabulary.
+
+## Deferred decisions
+
+The issue owns benchmark thresholds, codecs/chunk sizes, query numerical
+criteria, Later behavior, migration-time reads/writes and cutover pauses,
+resume/progress design, disk safety margin, maintenance cadence, and backup
+verification/deletion timing.
+
+Downgrade support remains on hold. An option to evaluate is an on-demand export
+into a separate legacy-compatible DB while preserving v2 as authoritative.
+This can include compatible post-migration observations without permanent
+dual writes. It is not an accepted implementation requirement: supported old
+schemas, unsupported metrics, extra space, safe file selection, and records
+created during subsequent old-version use all need a policy. A stale migration
+backup is not a lossless downgrade of current history, and automatic merging
+of old-version additions is not promised.
+
+The accepted constraints above can guide implementation planning without
+silently settling these open choices or claiming the new behavior is shipped.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,12 +12,12 @@ Every ADR carries one explicit status:
 
 - `proposed`: direction under evaluation; do not treat it as canonical shipped
   behavior without current code/product evidence.
-- `accepted`: the current decision. It can describe implemented direction that
-  has not yet appeared in a public release.
+- `accepted`: the current decision. The agreed direction may precede its
+  implementation or public release; the record must make that distinction clear.
 - `superseded`: historical context replaced by a newer ADR, which the record
   must link.
 
-ADR status describes decision maturity, not release status.
+ADR status describes decision maturity, not implementation or release status.
 
 ## Records
 
@@ -39,3 +39,4 @@ ADR status describes decision maturity, not release status.
 - [0016 GPU Attribution on the Performance Screen](0016-gpu-attribution-on-the-performance-screen.md)
 - [0017 Suspend Hidden Windows WebViews](0017-suspend-hidden-windows-webviews.md)
 - [0018 Cooling Daily Rollup Retention](0018-cooling-daily-rollup-retention.md)
+- [0019 Lossless Chunked Hardware Archive](0019-lossless-chunked-hardware-archive.md)

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -194,6 +194,12 @@ PawnIO and its CPU-specific module blobs, are documented in
 
 ### Persistence (`core/src/persistence/`, `src-tauri/src/infrastructure/`)
 
+This section describes the current row-based persistence implementation.
+[ADR 0019](../adr/0019-lossless-chunked-hardware-archive.md) records the accepted
+constraints for planned lossless chunked storage. Its persisted active tail,
+format migration, and recurring retention maintenance are not implemented by
+that decision; the startup flow and cleanup behavior below remain current.
+
 Persistence is split:
 
 - Core owns persistence workers and DB operations that are independent of Tauri.
@@ -363,9 +369,10 @@ with the write cycle's single tick instant so a fan reading and the hardware
 row folded from the same snapshots cannot land in adjacent buckets. The same
 rollup pass folds a completed day into one `cooling_fan_daily_summary` row per
 fan (`core/src/persistence/cooling_fan_rollup.rs`). Both are row-per-fan
-because how many fans a machine exposes is configuration-dependent, and both
-share the daily rollup's retention window. The three fan-reading meanings stay
-distinct end to end: an Inactive Fan Reading (0 RPM) is stored as the real
+because how many fans a machine exposes is configuration-dependent. The
+one-minute fan archive follows `hardwareArchive.retentionDays`; the daily fan
+summary follows the separate cooling daily rollup retention window. The three
+fan-reading meanings stay distinct end to end: an Inactive Fan Reading (0 RPM) is stored as the real
 observation it is, an Invalid Fan Reading is excluded, and a missing reading
 has no row - so a stopped fan is never confused with an unreadable one. There
 is no hourly fan projection, because no view reads a fan axis at that


### PR DESCRIPTION
## Summary

- Record ADR 0019 for the agreed lossless Hardware Archive storage direction, including mandatory Process Stats conversion, exact sample preservation, separately defined query tolerances, bounded recent crash loss, whole-chunk retention, explicit migration, and readable partial results with errors.
- Distinguish accepted architectural constraints from unimplemented codecs, schema, migration lifecycle, and runtime behavior. Downgrade support remains deferred.
- Plan implementation after the current Cooling Insight scope in #1666, with an inventory and benchmark refresh before starting #2052.
- Link the decision from the documentation indexes, existing retention ADR, and backend architecture. Correct the related fan-retention description: raw fan history follows Hardware Archive retention; daily summaries have their independent retention window.

This is a documentation-only PR. It does not implement chunked storage, change collection/query behavior, or complete the tracking issue.

## Related Issues

Refs #2052.

Related: #1666 (implementation sequencing only; chunked storage is not a prerequisite for the current Cooling Insight work).

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [x] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable: no UI changes.

## Test Plan

- [x] Manual testing: reviewed the complete documentation diff, relative links, current archive/query ownership, and the raw-vs-daily fan-retention distinction against the implementation.
- [x] Unit tests: `npm run test:agent-guidance` and `npm run test:agent-hooks`.
- [x] `npm run check:agent-guidance` — 20 lessons, 6 skills, 6 rules, and 19 ADRs validated.
- [x] `git diff --cached --check`.

Application runtime testing, application build/lint, and full JavaScript/Rust suites were not run because this PR changes only Markdown documentation.

## Checklist

- [x] Self-reviewed the code (documentation diff)
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`) — not run; documentation-only checks above passed.
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — not run; focused guidance and hook tests above passed.
- [x] No new warnings or errors in the checks run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record for lossless, chunked Hardware Archive storage.
  * Clarified that accepted architecture decisions may precede implementation or public release.
  * Documented current persistence limitations and distinguished planned storage capabilities.
  * Clarified separate retention periods for minute-level fan data and daily cooling summaries.
  * Documented that recurring retention maintenance and format migration are not yet implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->