### PR TITLE
fix(config): exclude generated trees from the vite dev watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -108,8 +108,19 @@ export default defineConfig(async ({ mode }) => ({
     port: 1520,
     strictPort: true,
     watch: {
-      // 3. tell vite to ignore Rust sources and build artifacts
-      ignored: ["**/src-tauri/**", "**/target/**"],
+      // 3. tell vite to ignore Rust sources, build artifacts, and
+      //    generated trees that churn during test runs - .claude holds
+      //    AI-agent worktrees whose coverage output was observed
+      //    triggering full page reloads into a live dev session, and
+      //    the repo's own vitest coverage / Playwright test-results
+      //    reproduce the same pattern at the repo root.
+      ignored: [
+        "**/src-tauri/**",
+        "**/target/**",
+        "**/.claude/**",
+        "**/coverage/**",
+        "**/test-results/**",
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Excludes non-source generated trees from the dev server's file watcher, so background work no longer reloads a running verification session.

- **observed harm**: while the maintainer was verifying #2054 on a live `tauri:dev` session, a parallel AI-agent worktree's test run rewrote `.claude/worktrees/agent-*/coverage/index.html` and vite fired a full page reload into the running app (`[vite] (client) page reload .claude/worktrees/...`)
- `server.watch.ignored` gains `**/.claude/**` (agent worktrees and config — never app source), plus `**/coverage/**` and `**/test-results/**`: both are `.gitignore`d generated output, and the repo's own `npm test` (vitest `--coverage`, default html reporter into `coverage/`) and Playwright (`test-results/output`) write exactly the same kind of churning HTML at the repo root, reproducing the same reload pattern without any agent involved
- build-only outputs (`dist/` etc.) are deliberately not added — they don't churn during a watch session

## Related Issues

Tooling annoyance found during #2044 on-hardware verification; no tracked issue.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A (dev-server watch configuration)

## Test Plan

- [ ] Manual testing
- [x] Unit tests

- `npm run build` (tsc && vite build) → success
- `npm test -- --run` → 844 passed; `npm run lint:ci` clean

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development file-watching exclusions to ignore Claude configuration, coverage reports, test results, Rust sources, and build artifacts.
  * Reduces unnecessary reloads while working with generated or non-application files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->