### PR TITLE
ci: analyze Rust with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,13 +44,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
+        language: [actions, javascript-typescript, rust]
+        build-mode: [none]
+        # Rust analysis takes about nine minutes in this repository, so run it
+        # only after changes land on develop instead of delaying pull requests.
+        is_develop_push:
+          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        exclude:
           - language: rust
-            build-mode: none
+            is_develop_push: false
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,9 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+          - language: rust
+            build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
## Summary

- add Rust to the existing CodeQL Advanced language matrix
- use the generally available build-free `none` mode
- include Rust only for pushes to `refs/heads/develop`, so pull requests and scheduled runs continue to analyze only Actions and JavaScript/TypeScript

GitHub made Rust analysis generally available in CodeQL 2.23.3. This repository already runs advanced CodeQL analysis, but its matrix currently covers only GitHub Actions and JavaScript/TypeScript, leaving the Rust workspace unscanned.

Rust analysis took 9m05s in this PR. Restricting it to the post-merge `develop` push adds the coverage without delaying every pull request.

## Related Issues

None. This is a focused CI configuration update.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] `git diff --check`
- [x] Confirm Rust analysis succeeds with `build-mode: none` (`Analyze (rust)`, 9m05s on commit `321fdf4`)
- [x] Confirm the gated PR run creates only `Analyze (actions)` and `Analyze (javascript-typescript)`, with no Rust job (commit `4e75c2a`)

The positive `refs/heads/develop` push condition will run for the first time after merge; the PR run verifies the complementary exclusion path.

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`) — not applicable to a workflow-only change
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — not applicable to a workflow-only change
- [x] No new warnings or errors

References:

- https://github.blog/changelog/2025-10-14-codeql-scanning-rust-and-c-c-without-builds-is-now-generally-available/
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations#excluding-matrix-configurations
