### PR TITLE
ci: scan Rust with CodeQL in pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,13 +46,6 @@ jobs:
       matrix:
         language: [actions, javascript-typescript, rust]
         build-mode: [none]
-        # Rust analysis takes about nine minutes in this repository, so run it
-        # only after changes land on develop instead of delaying pull requests.
-        is_develop_push:
-          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        exclude:
-          - language: rust
-            is_develop_push: false
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## Summary

- run Rust CodeQL analysis for pull requests as well as branch and scheduled scans
- remove the event-derived matrix exclusion that left `/language:rust` missing from pull request analyses
- restore complete CodeQL comparisons required by the develop code-scanning ruleset

The develop branch contains a Rust CodeQL configuration after #2074, but pull request runs omitted that configuration. GitHub therefore could not compare Rust alerts introduced by a pull request and returned a neutral `1 configuration not found` result.

## Related Issues

Follow-up to #2074.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] `actionlint -no-color .github/workflows/codeql.yml`
- [x] Parse the workflow and assert that the analysis matrix contains only `actions`, `javascript-typescript`, and `rust`, all with `build-mode: none`
- [x] `git diff --check`
- [x] Confirm this PR produces a successful `Analyze (rust)` job and a complete CodeQL result

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`actionlint` and `git diff --check`; application lint/format is not applicable)
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — not applicable to a workflow-only change
- [x] No new warnings or errors