### PR TITLE
ci: scan Rust changes in pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,25 @@ on:
 permissions: read-all
 
 jobs:
+  detect-rust-changes:
+    name: Detect Rust source changes
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.changes.outputs.rust }}
+    steps:
+      - name: Detect Rust source changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+
   analyze:
+    needs: detect-rust-changes
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -46,13 +64,13 @@ jobs:
       matrix:
         language: [actions, javascript-typescript, rust]
         build-mode: [none]
-        # Rust analysis takes about nine minutes in this repository, so run it
-        # only after changes land on develop instead of delaying pull requests.
-        is_develop_push:
-          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+        # Rust analysis takes about nine minutes in this repository. Run it
+        # after changes land on develop and on pull requests that modify Rust.
+        run_rust:
+          - ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') || needs.detect-rust-changes.outputs.rust == 'true' }}
         exclude:
           - language: rust
-            is_develop_push: false
+            run_rust: false
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## Summary

- run Rust CodeQL after changes land on `develop`
- also run Rust CodeQL for pull requests that modify `**/*.rs`
- skip the roughly nine-minute Rust analysis for pull requests without Rust source changes

Follow-up to #2074.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

N/A

## Test Plan

- [x] Manual testing
- [ ] Unit tests

- `git diff --check`
- verify this workflow-only PR does not create an `Analyze (rust)` job
- verify the merged #2074 `develop` push completed `Analyze (rust)`

## Checklist

- [x] Self-reviewed the code
- [ ] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [ ] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code security checks to run Rust analysis when Rust files change or when updates are pushed to the development branch.
  - Preserved existing analysis behavior for other supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->