### PR TITLE
ci: keep required CodeQL configurations on pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,25 +22,7 @@ on:
 permissions: read-all
 
 jobs:
-  detect-rust-changes:
-    name: Detect Rust source changes
-    runs-on: ubuntu-slim
-    permissions:
-      pull-requests: read
-    outputs:
-      rust: ${{ steps.changes.outputs.rust }}
-    steps:
-      - name: Detect Rust source changes
-        id: changes
-        if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        with:
-          filters: |
-            rust:
-              - '**/*.rs'
-
   analyze:
-    needs: detect-rust-changes
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -62,15 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The develop ruleset compares every CodeQL category with each pull
+        # request. Keep Rust present even when a pull request changes no Rust.
         language: [actions, javascript-typescript, rust]
         build-mode: [none]
-        # Rust analysis takes about nine minutes in this repository. Run it
-        # after changes land on develop and on pull requests that modify Rust.
-        run_rust:
-          - ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') || needs.detect-rust-changes.outputs.rust == 'true' }}
-        exclude:
-          - language: rust
-            run_rust: false
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -109,6 +109,7 @@ shared enforcement surface.
 - [Make navigation levels explicit](make-navigation-levels-explicit.md)
 - [Separate release integrity from vulnerability exposure](separate-release-integrity-from-vulnerability-exposure.md)
 - [Deliver pull requests through review](deliver-pull-requests-through-review.md)
+- [Keep required CodeQL configurations present on pull requests](keep-required-codeql-configurations-on-pull-requests.md)
 - [Keep shared system refresh ownership explicit](keep-shared-system-refresh-ownership-explicit.md)
 - [Keep CPU power sampling independent](keep-independent-cpu-power-sampler.md)
 - [Read id producers before identity UI](read-id-producers-before-identity-ui.md)

--- a/docs/agents/lessons/keep-required-codeql-configurations-on-pull-requests.md
+++ b/docs/agents/lessons/keep-required-codeql-configurations-on-pull-requests.md
@@ -1,0 +1,27 @@
+---
+id: LRN-20260905-keep-required-codeql-configurations
+status: promoted
+cause_status: confirmed
+scope: .github/workflows/codeql.yml and develop code-scanning merge protection
+trigger: changing CodeQL language matrices, job conditions, or path filters
+failure_signature: an approved pull request with a successful Merge Gate remains blocked by CodeQL reporting 1 configuration not found for /language:rust
+root_cause: develop had a Rust CodeQL analysis category that a condition excluded from the pull request, so required code-scanning protection could not compare all base configurations
+guardrail: .github/workflows/codeql.yml keeps every configured CodeQL language present on pull requests and explains why Rust must not be path-filtered
+canonical_refs: .github/workflows/codeql.yml
+verification: on a non-Rust pull request and a Rust-changing pull request, confirm Analyze (rust) and the aggregate CodeQL check succeed; run actionlint and npm run check:agent-guidance
+evidence: "Issue #2080; PR #2079 check 101265371495 reproduced the missing Rust category; PR #2076 demonstrated a complete non-Rust analysis; PR #2070 run 33948618970 demonstrated successful Rust-changing analysis"
+revalidate_when: the develop ruleset stops requiring CodeQL, or GitHub supports per-category merge policy or safe reuse of base analyses for omitted pull-request categories
+---
+
+# Keep Required CodeQL Configurations Present On Pull Requests
+
+Required code-scanning protection compares each CodeQL configuration on the
+target branch with the pull request analysis. A path filter that omits Rust
+from a non-Rust pull request does not mean the Rust configuration is unchanged;
+it means the comparison has no pull request result and cannot satisfy the
+required policy.
+
+Keep all languages configured on `develop` in every pull request analysis.
+Accept the additional Rust analysis time while CodeQL is a required merge gate.
+Changing that trade-off requires changing the ruleset policy explicitly, not
+silently removing one required configuration from selected pull requests.

--- a/docs/agents/lessons/keep-required-codeql-configurations-on-pull-requests.md
+++ b/docs/agents/lessons/keep-required-codeql-configurations-on-pull-requests.md
@@ -8,7 +8,7 @@ failure_signature: an approved pull request with a successful Merge Gate remains
 root_cause: develop had a Rust CodeQL analysis category that a condition excluded from the pull request, so required code-scanning protection could not compare all base configurations
 guardrail: .github/workflows/codeql.yml keeps every configured CodeQL language present on pull requests and explains why Rust must not be path-filtered
 canonical_refs: .github/workflows/codeql.yml
-verification: on a non-Rust pull request and a Rust-changing pull request, confirm Analyze (rust) and the aggregate CodeQL check succeed; run actionlint and npm run check:agent-guidance
+verification: on a non-Rust pull request and a Rust-changing pull request, confirm /language:rust is present in the CodeQL comparison, Analyze (rust) and the aggregate CodeQL check succeed, and the develop merge gate passes; run actionlint and npm run check:agent-guidance
 evidence: "Issue #2080; PR #2079 check 101265371495 reproduced the missing Rust category; PR #2076 demonstrated a complete non-Rust analysis; PR #2070 run 33948618970 demonstrated successful Rust-changing analysis"
 revalidate_when: the develop ruleset stops requiring CodeQL, or GitHub supports per-category merge policy or safe reuse of base analyses for omitted pull-request categories
 ---


### PR DESCRIPTION
## Summary

- remove the Rust path-detection job and conditional matrix exclusion introduced by #2077
- keep `actions`, `javascript-typescript`, and `rust` CodeQL configurations present on every pull request
- record why required CodeQL categories must not be path-filtered while the develop ruleset requires CodeQL

This fixes the regression reproduced by documentation-only PR #2079: develop had `/language:rust`, but the pull request omitted it, so GitHub could not compare all required configurations and kept the pull request blocked.

The chosen trade-off is to accept the roughly seven-to-nine-minute Rust job on every pull request. Complete required-configuration coverage takes priority over reducing analysis minutes. This PR does not change the repository ruleset; changing that policy requires separate maintainer authorization.

## Related Issues

Closes #2080.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] `actionlint -no-color .github/workflows/codeql.yml`
- [x] Parse the workflow and assert that `analyze` is the only job and its matrix contains exactly `actions`, `javascript-typescript`, and `rust` with `build-mode: none`
- [x] `npm run check:agent-guidance`
- [x] `git diff --check`
- [x] Confirm a Rust-changing PR still succeeds: PR #2070, CodeQL run `33948618970`
- [x] Confirm this non-Rust PR produces a successful `Analyze (rust)` job and aggregate `CodeQL` result

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`actionlint`, agent-guidance validation, and `git diff --check`; application lint/format is not applicable)
- [ ] Tests pass (`npm test` / `cargo tauri-test`) — not applicable to a workflow and agent-guidance-only change
- [x] No new warnings or errors — live CodeQL succeeded without missing configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code-scanning workflows so Rust analysis runs consistently on all pull requests, including those without Rust changes.
  * Improved reliability when required code-scanning checks compare branch configurations.

* **Documentation**
  * Added guidance for keeping required code-scanning configurations present on pull requests.
  * Documented verification steps, failure symptoms, evidence, and revalidation criteria for code-scanning configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
