### PR TITLE
chore: add G1 lossless archive benchmark and initial results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "core-foundation",
  "dirs 6.0.0",
  "dxgi",
+ "flate2",
  "futures",
  "getrandom 0.4.3",
  "hmac",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -83,4 +83,9 @@ libc = "0.2"
 core-foundation = "0.10.1"
 
 [dev-dependencies]
+flate2 = "1.1.9"
 tokio = { version = "1.52.3", features = ["macros", "rt"] }
+
+[[example]]
+name = "archive_format_benchmark"
+test = true

--- a/core/examples/archive_format_benchmark.rs
+++ b/core/examples/archive_format_benchmark.rs
@@ -1,7 +1,9 @@
 //! Standalone synthetic SQLite benchmark for the lossless archive experiment.
 //!
 //! The output directory must be new. This example never discovers or opens an
-//! application database and never reads local process or device data.
+//! application database and never imports application history, other-process
+//! data, or device readings. Its report records static host metadata and the
+//! benchmark process's own memory usage.
 
 #[path = "archive_format_benchmark/codec.rs"]
 mod codec;
@@ -275,17 +277,28 @@ fn command_output(program: &str, arguments: &[&str]) -> String {
     .unwrap_or_else(|| "unavailable".to_owned())
 }
 
-fn environment_report(output: &std::path::Path) -> EnvironmentReport {
-  let system = sysinfo::System::new_all();
-  let current_rss_bytes = sysinfo::get_current_pid()
-    .ok()
+fn environment_report(_output: &std::path::Path) -> EnvironmentReport {
+  let mut system = sysinfo::System::new();
+  system.refresh_cpu_list(sysinfo::CpuRefreshKind::nothing());
+  system.refresh_memory_specifics(sysinfo::MemoryRefreshKind::nothing().with_ram());
+  let current_pid = sysinfo::get_current_pid().ok();
+  if let Some(pid) = current_pid {
+    system.refresh_processes_specifics(
+      sysinfo::ProcessesToUpdate::Some(&[pid]),
+      false,
+      sysinfo::ProcessRefreshKind::nothing()
+        .with_memory()
+        .without_tasks(),
+    );
+  }
+  let current_rss_bytes = current_pid
     .and_then(|pid| system.process(pid))
     .map(|process| process.memory());
   #[cfg(target_os = "macos")]
-  let filesystem = command_output("stat", &["-f", "%T", output.to_str().unwrap_or("")]);
+  let filesystem = "unavailable".to_owned();
   #[cfg(target_os = "linux")]
   let filesystem =
-    command_output("stat", &["-f", "-c", "%T", output.to_str().unwrap_or("")]);
+    command_output("stat", &["-f", "-c", "%T", _output.to_str().unwrap_or("")]);
   #[cfg(not(any(target_os = "macos", target_os = "linux")))]
   let filesystem = "unavailable".to_owned();
   EnvironmentReport {

--- a/core/examples/archive_format_benchmark.rs
+++ b/core/examples/archive_format_benchmark.rs
@@ -1,0 +1,412 @@
+//! Standalone synthetic SQLite benchmark for the lossless archive experiment.
+//!
+//! The output directory must be new. This example never discovers or opens an
+//! application database and never reads local process or device data.
+
+#[path = "archive_format_benchmark/codec.rs"]
+mod codec;
+#[path = "archive_format_benchmark/database.rs"]
+mod database;
+
+use codec::{Compression, Layout};
+use database::{Benchmark, FileFootprint};
+use serde::Serialize;
+use std::{env, fs, path::PathBuf, process::Command, time::Duration};
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+type Result<T> = std::result::Result<T, Error>;
+
+const HELP: &str = r#"Usage:
+  cargo run -p hardviz-core --release --example archive_format_benchmark -- \
+    --output NEW_DIRECTORY [options]
+
+Options:
+  --minutes N                  represented duration (default: 1440)
+  --days N                     represented duration in days
+  --processes-per-minute N     rows per sampled minute (default: 15)
+  --chunk-minutes N            maximum represented minutes/chunk (default: 60)
+  --chunk-rows N               maximum rows/chunk, <= 4096 (default: 4096)
+  --repetitions N              measured query repetitions (default: 7)
+  --layout row|columnar        codec layout (default: columnar)
+  --compression none|deflate  compression (default: deflate)
+  --seed N                     deterministic seed (default: 2052)
+  --duty-cycle N               sample every N represented minutes (default: 1)
+  --group-cap N                maximum process groups/query (default: 100000)
+
+Duty cycle > 1 is reported as duty-cycled, not continuous history. Use the
+default duty cycle for continuous 24h/30d/1y/10y data."#;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Config {
+  output: PathBuf,
+  minutes: u64,
+  processes_per_minute: u32,
+  chunk_minutes: u64,
+  chunk_rows: usize,
+  repetitions: usize,
+  layout: Layout,
+  compression: Compression,
+  seed: u64,
+  duty_cycle: u64,
+  group_cap: usize,
+}
+
+impl Config {
+  fn parse() -> Result<Self> {
+    let mut config = Self {
+      output: PathBuf::new(),
+      minutes: 1_440,
+      processes_per_minute: 15,
+      chunk_minutes: 60,
+      chunk_rows: codec::MAX_ROWS,
+      repetitions: 7,
+      layout: Layout::Columnar,
+      compression: Compression::Deflate,
+      seed: 2052,
+      duty_cycle: 1,
+      group_cap: 100_000,
+    };
+    let mut args = env::args().skip(1);
+    while let Some(argument) = args.next() {
+      let value = args
+        .next()
+        .filter(|_| argument != "--help" && argument != "-h");
+      match argument.as_str() {
+        "--output" => config.output = value.ok_or("missing --output value")?.into(),
+        "--minutes" => {
+          config.minutes = value.ok_or("missing --minutes value")?.parse()?
+        }
+        "--days" => {
+          config.minutes = value
+            .ok_or("missing --days value")?
+            .parse::<u64>()?
+            .checked_mul(1_440)
+            .ok_or("duration overflow")?;
+        }
+        "--processes-per-minute" => {
+          config.processes_per_minute = value
+            .ok_or("missing --processes-per-minute value")?
+            .parse()?;
+        }
+        "--chunk-minutes" => {
+          config.chunk_minutes = value.ok_or("missing --chunk-minutes value")?.parse()?;
+        }
+        "--chunk-rows" => {
+          config.chunk_rows = value.ok_or("missing --chunk-rows value")?.parse()?;
+        }
+        "--repetitions" => {
+          config.repetitions = value.ok_or("missing --repetitions value")?.parse()?;
+        }
+        "--seed" => config.seed = value.ok_or("missing --seed value")?.parse()?,
+        "--duty-cycle" => {
+          config.duty_cycle = value.ok_or("missing --duty-cycle value")?.parse()?;
+        }
+        "--group-cap" => {
+          config.group_cap = value.ok_or("missing --group-cap value")?.parse()?;
+        }
+        "--layout" => {
+          config.layout = match value.ok_or("missing --layout value")?.as_str() {
+            "row" => Layout::Row,
+            "columnar" => Layout::Columnar,
+            other => return Err(format!("unknown layout {other:?}").into()),
+          };
+        }
+        "--compression" => {
+          config.compression = match value.ok_or("missing --compression value")?.as_str()
+          {
+            "none" => Compression::None,
+            "deflate" => Compression::Deflate,
+            other => return Err(format!("unknown compression {other:?}").into()),
+          };
+        }
+        "--help" | "-h" => {
+          println!("{HELP}");
+          std::process::exit(0);
+        }
+        other => return Err(format!("unknown argument {other:?}\n\n{HELP}").into()),
+      }
+    }
+    if config.output.as_os_str().is_empty() {
+      return Err("--output is required".into());
+    }
+    if config.minutes == 0
+      || config.processes_per_minute == 0
+      || config.chunk_minutes == 0
+      || config.chunk_rows == 0
+      || config.repetitions == 0
+      || config.duty_cycle == 0
+      || config.group_cap == 0
+    {
+      return Err("numeric controls must be positive".into());
+    }
+    if config.chunk_rows > codec::MAX_ROWS {
+      return Err(format!("--chunk-rows exceeds codec limit {}", codec::MAX_ROWS).into());
+    }
+    Ok(config)
+  }
+}
+
+#[derive(Serialize)]
+struct Report {
+  format: &'static str,
+  scope: &'static str,
+  workload: WorkloadReport,
+  format_candidate: FormatReport,
+  environment: EnvironmentReport,
+  sqlite: database::SqliteReport,
+  footprints: FootprintReport,
+  timings_ms: TimingReport,
+  correctness: database::CorrectnessReport,
+  limitations: [&'static str; 6],
+}
+
+#[derive(Serialize)]
+struct WorkloadReport {
+  source: &'static str,
+  represented_minutes: u64,
+  sampled_minutes: u64,
+  sampling_mode: &'static str,
+  duty_cycle: u64,
+  processes_per_sampled_minute: u32,
+  numeric_shape: &'static str,
+  process_rows: i64,
+  ambient_rows: i64,
+  seed: u64,
+}
+
+#[derive(Serialize)]
+struct FormatReport {
+  layout: &'static str,
+  compression: &'static str,
+  chunk_minutes: u64,
+  chunk_rows: usize,
+  chunks: i64,
+  encoded_bytes: i64,
+  decoded_value_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct EnvironmentReport {
+  os: &'static str,
+  architecture: &'static str,
+  logical_cpus: usize,
+  cpu_brand: String,
+  total_memory_bytes: u64,
+  current_rss_bytes: Option<u64>,
+  peak_rss_bytes: Option<u64>,
+  rustc_version: String,
+  git_commit: String,
+  filesystem: String,
+}
+
+#[derive(Serialize)]
+struct FootprintReport {
+  relational_baseline: FileFootprint,
+  chunked_before_reclamation: FileFootprint,
+  chunked_after_vacuum: FileFootprint,
+  before_reclamation_reduction_percent: f64,
+  after_vacuum_reduction_percent: f64,
+  vacuum_wall_ms: f64,
+}
+
+#[derive(Serialize)]
+struct TimingReport {
+  fixture_seed_batch: Timing,
+  production_shaped_minute_append: Timing,
+  source_scan: Timing,
+  encode: Timing,
+  decode: Timing,
+  chunk_insert_and_tail_delete: Timing,
+  finalize_total: Timing,
+  process_query_baseline: Timing,
+  process_query_chunked: Timing,
+  ambient_raw_query_baseline: Timing,
+  ambient_raw_query_chunked: Timing,
+}
+
+#[derive(Serialize)]
+struct Timing {
+  samples: usize,
+  p50_ms: f64,
+  p95_ms: f64,
+  p99_ms: f64,
+  max_ms: f64,
+}
+
+impl Timing {
+  fn from(values: &[Duration]) -> Self {
+    let mut micros: Vec<_> = values.iter().map(Duration::as_micros).collect();
+    micros.sort_unstable();
+    let at = |percent: usize| {
+      if micros.is_empty() {
+        0.0
+      } else {
+        let index = ((micros.len() - 1) * percent).div_ceil(100);
+        micros[index] as f64 / 1_000.0
+      }
+    };
+    Self {
+      samples: micros.len(),
+      p50_ms: at(50),
+      p95_ms: at(95),
+      p99_ms: at(99),
+      max_ms: micros.last().copied().unwrap_or(0) as f64 / 1_000.0,
+    }
+  }
+}
+
+fn reduction(baseline: &FileFootprint, candidate: &FileFootprint) -> f64 {
+  let baseline_bytes = baseline.database_bytes + baseline.wal_bytes;
+  let candidate_bytes = candidate.database_bytes + candidate.wal_bytes;
+  if baseline_bytes == 0 {
+    0.0
+  } else {
+    (1.0 - candidate_bytes as f64 / baseline_bytes as f64) * 100.0
+  }
+}
+
+fn command_output(program: &str, arguments: &[&str]) -> String {
+  Command::new(program)
+    .args(arguments)
+    .output()
+    .ok()
+    .filter(|output| output.status.success())
+    .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    .unwrap_or_else(|| "unavailable".to_owned())
+}
+
+fn environment_report(output: &std::path::Path) -> EnvironmentReport {
+  let system = sysinfo::System::new_all();
+  let current_rss_bytes = sysinfo::get_current_pid()
+    .ok()
+    .and_then(|pid| system.process(pid))
+    .map(|process| process.memory());
+  #[cfg(target_os = "macos")]
+  let filesystem = command_output("stat", &["-f", "%T", output.to_str().unwrap_or("")]);
+  #[cfg(target_os = "linux")]
+  let filesystem =
+    command_output("stat", &["-f", "-c", "%T", output.to_str().unwrap_or("")]);
+  #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+  let filesystem = "unavailable".to_owned();
+  EnvironmentReport {
+    os: env::consts::OS,
+    architecture: env::consts::ARCH,
+    logical_cpus: system.cpus().len(),
+    cpu_brand: system
+      .cpus()
+      .first()
+      .map(|cpu| cpu.brand().to_owned())
+      .unwrap_or_else(|| "unavailable".to_owned()),
+    total_memory_bytes: system.total_memory(),
+    current_rss_bytes,
+    peak_rss_bytes: None,
+    rustc_version: command_output("rustc", &["--version"]),
+    git_commit: command_output("git", &["rev-parse", "HEAD"]),
+    filesystem,
+  }
+}
+
+#[tokio::main]
+async fn main() {
+  if let Err(error) = run().await {
+    eprintln!("archive benchmark failed: {error}");
+    std::process::exit(1);
+  }
+}
+
+async fn run() -> Result<()> {
+  let config = Config::parse()?;
+  if config.output.exists() {
+    return Err(
+      format!(
+        "refusing existing output path {}; choose a new directory",
+        config.output.display()
+      )
+      .into(),
+    );
+  }
+  fs::create_dir(&config.output)?;
+
+  let mut benchmark = Benchmark::create(config.clone()).await?;
+  benchmark.seed().await?;
+  benchmark.finalize().await?;
+  benchmark.verify_and_query().await?;
+  if !benchmark.correctness.all_pass() {
+    return Err("one or more correctness checks failed".into());
+  }
+  let baseline = benchmark.baseline_footprint().await?;
+  let before = benchmark.candidate_footprint().await?;
+  let vacuum_started = std::time::Instant::now();
+  benchmark.vacuum_candidate().await?;
+  let vacuum_wall_ms = vacuum_started.elapsed().as_secs_f64() * 1_000.0;
+  let after = benchmark.candidate_footprint().await?;
+  let sqlite = benchmark.sqlite_report().await?;
+
+  let report = Report {
+    format: "hardviz-archive-g1-v1",
+    scope: "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+    workload: WorkloadReport {
+      source: "deterministic synthetic production-shaped rows",
+      represented_minutes: config.minutes,
+      sampled_minutes: config.minutes.div_ceil(config.duty_cycle),
+      sampling_mode: if config.duty_cycle == 1 {
+        "continuous"
+      } else {
+        "duty-cycled"
+      },
+      duty_cycle: config.duty_cycle,
+      processes_per_sampled_minute: config.processes_per_minute,
+      numeric_shape: "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+      process_rows: benchmark.process_rows,
+      ambient_rows: benchmark.ambient_rows,
+      seed: config.seed,
+    },
+    format_candidate: FormatReport {
+      layout: database::layout_name(config.layout),
+      compression: database::compression_name(config.compression),
+      chunk_minutes: config.chunk_minutes,
+      chunk_rows: config.chunk_rows,
+      chunks: benchmark.finalized.chunks,
+      encoded_bytes: benchmark.finalized.encoded_bytes,
+      decoded_value_bytes: benchmark.finalized.decoded_value_bytes,
+    },
+    environment: environment_report(&config.output),
+    sqlite,
+    footprints: FootprintReport {
+      before_reclamation_reduction_percent: reduction(&baseline, &before),
+      after_vacuum_reduction_percent: reduction(&baseline, &after),
+      relational_baseline: baseline,
+      chunked_before_reclamation: before,
+      chunked_after_vacuum: after,
+      vacuum_wall_ms,
+    },
+    timings_ms: TimingReport {
+      fixture_seed_batch: Timing::from(&benchmark.times.fixture_seed_batch),
+      production_shaped_minute_append: Timing::from(
+        &benchmark.times.production_minute_append,
+      ),
+      source_scan: Timing::from(&benchmark.times.source_scan),
+      encode: Timing::from(&benchmark.times.encode),
+      decode: Timing::from(&benchmark.times.decode),
+      chunk_insert_and_tail_delete: Timing::from(&benchmark.times.chunk_insert),
+      finalize_total: Timing::from(&benchmark.times.finalize),
+      process_query_baseline: Timing::from(&benchmark.times.process_baseline),
+      process_query_chunked: Timing::from(&benchmark.times.process_candidate),
+      ambient_raw_query_baseline: Timing::from(&benchmark.times.ambient_baseline),
+      ambient_raw_query_chunked: Timing::from(&benchmark.times.ambient_candidate),
+    },
+    correctness: benchmark.correctness.clone(),
+    limitations: [
+      "Synthetic data is not real-world workload evidence.",
+      "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+      "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+      "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+      "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+      "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness.",
+    ],
+  };
+  let json = serde_json::to_string_pretty(&report)?;
+  fs::write(config.output.join("report.json"), format!("{json}\n"))?;
+  println!("{json}");
+  Ok(())
+}

--- a/core/examples/archive_format_benchmark.rs
+++ b/core/examples/archive_format_benchmark.rs
@@ -173,6 +173,8 @@ struct WorkloadReport {
   numeric_shape: &'static str,
   process_rows: i64,
   ambient_rows: i64,
+  decoded_value_bytes: u64,
+  decoded_value_bytes_definition: &'static str,
   seed: u64,
 }
 
@@ -184,7 +186,8 @@ struct FormatReport {
   chunk_rows: usize,
   chunks: i64,
   encoded_bytes: i64,
-  decoded_value_bytes: u64,
+  finalized_decoded_value_bytes: u64,
+  retained_tail_decoded_value_bytes: u64,
 }
 
 #[derive(Serialize)]
@@ -354,9 +357,14 @@ async fn run() -> Result<()> {
   let vacuum_wall_ms = vacuum_started.elapsed().as_secs_f64() * 1_000.0;
   let after = benchmark.candidate_footprint().await?;
   let sqlite = benchmark.sqlite_report().await?;
+  let decoded_value_bytes = benchmark
+    .finalized
+    .finalized_decoded_value_bytes
+    .checked_add(benchmark.retained_tail_decoded_value_bytes)
+    .ok_or("full workload decoded value byte count overflow")?;
 
   let report = Report {
-    format: "hardviz-archive-g1-v1",
+    format: "hardviz-archive-g1-v2",
     scope: "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
     workload: WorkloadReport {
       source: "deterministic synthetic production-shaped rows",
@@ -372,6 +380,8 @@ async fn run() -> Result<()> {
       numeric_shape: "producer-range rows plus separately labeled exact i64/binary64 sentinels",
       process_rows: benchmark.process_rows,
       ambient_rows: benchmark.ambient_rows,
+      decoded_value_bytes,
+      decoded_value_bytes_definition: "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
       seed: config.seed,
     },
     format_candidate: FormatReport {
@@ -381,7 +391,8 @@ async fn run() -> Result<()> {
       chunk_rows: config.chunk_rows,
       chunks: benchmark.finalized.chunks,
       encoded_bytes: benchmark.finalized.encoded_bytes,
-      decoded_value_bytes: benchmark.finalized.decoded_value_bytes,
+      finalized_decoded_value_bytes: benchmark.finalized.finalized_decoded_value_bytes,
+      retained_tail_decoded_value_bytes: benchmark.retained_tail_decoded_value_bytes,
     },
     environment: environment_report(&config.output),
     sqlite,

--- a/core/examples/archive_format_benchmark/codec.rs
+++ b/core/examples/archive_format_benchmark/codec.rs
@@ -1,0 +1,847 @@
+//! Bounded codec candidates for the G1 benchmark experiment in issue #2052.
+//! This module gathers format evidence; its bytes are not a committed production format.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use flate2::{
+  Compression as FlateCompression, Decompress, FlushDecompress, Status,
+  write::DeflateEncoder,
+};
+use sha2::{Digest, Sha256};
+
+pub const MAX_ROWS: usize = 4_096;
+pub const MAX_COLUMNS: usize = 32;
+pub const MAX_DECODED_BYTES: usize = 4 * 1024 * 1024;
+
+const MAGIC: &[u8; 4] = b"HVA1";
+const VERSION: u8 = 1;
+const HEADER_WITHOUT_DIGEST_LEN: usize = 28;
+const DIGEST_LEN: usize = 32;
+const HEADER_LEN: usize = HEADER_WITHOUT_DIGEST_LEN + DIGEST_LEN;
+const MAX_CELLS: usize = MAX_ROWS * MAX_COLUMNS;
+const MAX_BODY_BYTES: usize = MAX_DECODED_BYTES + MAX_CELLS * 6 + MAX_COLUMNS * 3;
+const MAX_STORED_BYTES: usize = MAX_BODY_BYTES + 64 * 1024;
+
+const TAG_NULL: u8 = 0;
+const TAG_INTEGER: u8 = 1;
+const TAG_REAL: u8 = 2;
+const TAG_TEXT: u8 = 3;
+const TAG_BLOB: u8 = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Value {
+  Null,
+  Integer(i64),
+  Real(u64),
+  Text(Vec<u8>),
+  Blob(Vec<u8>),
+}
+
+pub type Record = Vec<Value>;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Layout {
+  Row,
+  Columnar,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Compression {
+  None,
+  Deflate,
+}
+
+pub fn encode(
+  records: &[Record],
+  layout: Layout,
+  compression: Compression,
+) -> Result<Vec<u8>, String> {
+  let (column_count, decoded_bytes) = validate_records(records)?;
+  let mut body = Vec::new();
+  match layout {
+    Layout::Row => encode_rows(records, &mut body),
+    Layout::Columnar => encode_columns(records, column_count, &mut body)?,
+  }
+  if body.len() > MAX_BODY_BYTES {
+    return Err("encoded body exceeds bounded framing limit".into());
+  }
+  let body_len = body.len();
+
+  let stored = match compression {
+    Compression::None => body,
+    Compression::Deflate => {
+      let mut encoder = DeflateEncoder::new(Vec::new(), FlateCompression::default());
+      encoder
+        .write_all(&body)
+        .map_err(|error| format!("deflate encode failed: {error}"))?;
+      encoder
+        .finish()
+        .map_err(|error| format!("deflate encode failed: {error}"))?
+    }
+  };
+  if stored.len() > MAX_STORED_BYTES {
+    return Err("stored payload exceeds bounded framing limit".into());
+  }
+
+  let mut header = Vec::with_capacity(HEADER_WITHOUT_DIGEST_LEN);
+  header.extend_from_slice(MAGIC);
+  header.push(VERSION);
+  header.push(layout_flag(layout));
+  header.push(compression_flag(compression));
+  header.push(0);
+  push_u32(&mut header, records.len(), "row count")?;
+  push_u32(&mut header, column_count, "column count")?;
+  push_u32(&mut header, decoded_bytes, "decoded byte count")?;
+  push_u32(&mut header, body_len, "body byte count")?;
+  push_u32(&mut header, stored.len(), "stored byte count")?;
+
+  let digest = digest(&header, &stored);
+  let mut framed = Vec::with_capacity(HEADER_LEN + stored.len());
+  framed.extend_from_slice(&header);
+  framed.extend_from_slice(&digest);
+  framed.extend_from_slice(&stored);
+  Ok(framed)
+}
+
+pub fn decode(payload: &[u8]) -> Result<Vec<Record>, String> {
+  if payload.len() < HEADER_LEN {
+    return Err("payload is truncated before the header ends".into());
+  }
+  if &payload[..4] != MAGIC {
+    return Err("unknown archive payload magic".into());
+  }
+  if payload[4] != VERSION {
+    return Err(format!(
+      "unsupported archive payload version {}",
+      payload[4]
+    ));
+  }
+  let layout = parse_layout(payload[5])?;
+  let compression = parse_compression(payload[6])?;
+  if payload[7] != 0 {
+    return Err("non-zero reserved header flags".into());
+  }
+
+  let row_count = header_u32(payload, 8)?;
+  let column_count = header_u32(payload, 12)?;
+  let declared_decoded_bytes = header_u32(payload, 16)?;
+  let body_len = header_u32(payload, 20)?;
+  let stored_len = header_u32(payload, 24)?;
+  if row_count > MAX_ROWS {
+    return Err(format!("row count exceeds {MAX_ROWS} row limit"));
+  }
+  if column_count > MAX_COLUMNS {
+    return Err(format!("column count exceeds {MAX_COLUMNS} column limit"));
+  }
+  if declared_decoded_bytes > MAX_DECODED_BYTES {
+    return Err(format!(
+      "declared decoded size exceeds {MAX_DECODED_BYTES} byte limit"
+    ));
+  }
+  if body_len > MAX_BODY_BYTES {
+    return Err("encoded body exceeds bounded framing limit".into());
+  }
+  if stored_len > MAX_STORED_BYTES {
+    return Err("stored payload exceeds bounded framing limit".into());
+  }
+  let expected_len = HEADER_LEN
+    .checked_add(stored_len)
+    .ok_or_else(|| "payload length overflows address space".to_owned())?;
+  if payload.len() != expected_len {
+    return Err(if payload.len() < expected_len {
+      "payload is truncated".into()
+    } else {
+      "payload has trailing bytes".into()
+    });
+  }
+
+  let expected_digest = &payload[HEADER_WITHOUT_DIGEST_LEN..HEADER_LEN];
+  let stored = &payload[HEADER_LEN..];
+  if digest(&payload[..HEADER_WITHOUT_DIGEST_LEN], stored) != expected_digest {
+    return Err("archive payload integrity check failed".into());
+  }
+
+  let body = match compression {
+    Compression::None => {
+      if stored.len() != body_len {
+        return Err("uncompressed body length does not match header".into());
+      }
+      stored.to_vec()
+    }
+    Compression::Deflate => inflate_bounded(stored, body_len)?,
+  };
+  let mut reader = Reader::new(&body);
+  let records = match layout {
+    Layout::Row => {
+      decode_rows(&mut reader, row_count, column_count, declared_decoded_bytes)?
+    }
+    Layout::Columnar => {
+      decode_columns(&mut reader, row_count, column_count, declared_decoded_bytes)?
+    }
+  };
+  if !reader.is_finished() {
+    return Err("decoded body has trailing bytes".into());
+  }
+  Ok(records)
+}
+
+fn validate_records(records: &[Record]) -> Result<(usize, usize), String> {
+  if records.len() > MAX_ROWS {
+    return Err(format!("record count exceeds {MAX_ROWS} row limit"));
+  }
+  let column_count = records.first().map_or(0, Vec::len);
+  if column_count > MAX_COLUMNS {
+    return Err(format!("record width exceeds {MAX_COLUMNS} column limit"));
+  }
+  let mut decoded_bytes = 0usize;
+  for record in records {
+    if record.len() != column_count {
+      return Err("records do not have a uniform column count".into());
+    }
+    for value in record {
+      let value_bytes = decoded_value_size(value)?;
+      decoded_bytes = decoded_bytes
+        .checked_add(value_bytes)
+        .ok_or_else(|| "decoded size overflows address space".to_owned())?;
+      if decoded_bytes > MAX_DECODED_BYTES {
+        return Err(format!(
+          "records exceed {MAX_DECODED_BYTES} decoded byte limit"
+        ));
+      }
+    }
+  }
+  Ok((column_count, decoded_bytes))
+}
+
+fn decoded_value_size(value: &Value) -> Result<usize, String> {
+  match value {
+    Value::Null => Ok(1),
+    Value::Integer(_) | Value::Real(_) => Ok(9),
+    Value::Text(bytes) | Value::Blob(bytes) => 1usize
+      .checked_add(bytes.len())
+      .ok_or_else(|| "decoded size overflows address space".to_owned()),
+  }
+}
+
+fn encode_rows(records: &[Record], output: &mut Vec<u8>) {
+  for record in records {
+    for value in record {
+      match value {
+        Value::Null => output.push(TAG_NULL),
+        Value::Integer(value) => {
+          output.push(TAG_INTEGER);
+          output.extend_from_slice(&value.to_le_bytes());
+        }
+        Value::Real(bits) => {
+          output.push(TAG_REAL);
+          output.extend_from_slice(&bits.to_le_bytes());
+        }
+        Value::Text(bytes) => {
+          output.push(TAG_TEXT);
+          write_varint(bytes.len() as u64, output);
+          output.extend_from_slice(bytes);
+        }
+        Value::Blob(bytes) => {
+          output.push(TAG_BLOB);
+          write_varint(bytes.len() as u64, output);
+          output.extend_from_slice(bytes);
+        }
+      }
+    }
+  }
+}
+
+fn encode_columns(
+  records: &[Record],
+  column_count: usize,
+  output: &mut Vec<u8>,
+) -> Result<(), String> {
+  for column in 0..column_count {
+    let mut dictionary = Vec::<Vec<u8>>::new();
+    let mut dictionary_ids = HashMap::<Vec<u8>, u32>::new();
+    for record in records {
+      output.push(tag(&record[column]));
+      if let Value::Text(bytes) = &record[column]
+        && !dictionary_ids.contains_key(bytes)
+      {
+        let id = u32::try_from(dictionary.len())
+          .map_err(|_| "text dictionary has too many entries".to_owned())?;
+        dictionary_ids.insert(bytes.clone(), id);
+        dictionary.push(bytes.clone());
+      }
+    }
+    write_varint(dictionary.len() as u64, output);
+    for entry in &dictionary {
+      write_varint(entry.len() as u64, output);
+      output.extend_from_slice(entry);
+    }
+
+    let mut previous_integer = 0i64;
+    let mut previous_real = 0u64;
+    for record in records {
+      match &record[column] {
+        Value::Null => {}
+        Value::Integer(value) => {
+          if let Some(delta) = value.checked_sub(previous_integer) {
+            output.push(0);
+            write_varint(zigzag_encode(delta), output);
+          } else {
+            output.push(1);
+            output.extend_from_slice(&value.to_le_bytes());
+          }
+          previous_integer = *value;
+        }
+        Value::Real(bits) => {
+          write_varint(*bits ^ previous_real, output);
+          previous_real = *bits;
+        }
+        Value::Text(bytes) => {
+          let id = dictionary_ids
+            .get(bytes)
+            .ok_or_else(|| "text dictionary construction failed".to_owned())?;
+          write_varint(u64::from(*id), output);
+        }
+        Value::Blob(bytes) => {
+          write_varint(bytes.len() as u64, output);
+          output.extend_from_slice(bytes);
+        }
+      }
+    }
+  }
+  Ok(())
+}
+
+fn decode_rows(
+  reader: &mut Reader<'_>,
+  row_count: usize,
+  column_count: usize,
+  declared_decoded_bytes: usize,
+) -> Result<Vec<Record>, String> {
+  let mut budget = DecodeBudget::new(declared_decoded_bytes);
+  let mut records = Vec::with_capacity(row_count);
+  for _ in 0..row_count {
+    let mut record = Vec::with_capacity(column_count);
+    for _ in 0..column_count {
+      let value = match reader.read_u8("value tag")? {
+        TAG_NULL => Value::Null,
+        TAG_INTEGER => Value::Integer(i64::from_le_bytes(reader.read_array("integer")?)),
+        TAG_REAL => Value::Real(u64::from_le_bytes(reader.read_array("real")?)),
+        TAG_TEXT => Value::Text(reader.read_sized_bytes("text")?),
+        TAG_BLOB => Value::Blob(reader.read_sized_bytes("blob")?),
+        unknown => return Err(format!("unknown value tag {unknown}")),
+      };
+      budget.add(&value)?;
+      record.push(value);
+    }
+    records.push(record);
+  }
+  budget.finish()?;
+  Ok(records)
+}
+
+fn decode_columns(
+  reader: &mut Reader<'_>,
+  row_count: usize,
+  column_count: usize,
+  declared_decoded_bytes: usize,
+) -> Result<Vec<Record>, String> {
+  let mut records = (0..row_count)
+    .map(|_| Vec::with_capacity(column_count))
+    .collect::<Vec<_>>();
+  let mut budget = DecodeBudget::new(declared_decoded_bytes);
+  for _ in 0..column_count {
+    let tags = reader.read_exact(row_count, "column type tags")?.to_vec();
+    for tag in &tags {
+      if *tag > TAG_BLOB {
+        return Err(format!("unknown value tag {tag}"));
+      }
+    }
+
+    let dictionary_count = reader.read_bounded_varint(MAX_ROWS, "dictionary count")?;
+    let mut dictionary = Vec::with_capacity(dictionary_count);
+    let mut dictionary_bytes = 0usize;
+    for _ in 0..dictionary_count {
+      let entry = reader.read_sized_bytes("dictionary entry")?;
+      dictionary_bytes = dictionary_bytes
+        .checked_add(entry.len())
+        .ok_or_else(|| "dictionary byte count overflows address space".to_owned())?;
+      if dictionary_bytes > declared_decoded_bytes {
+        return Err("text dictionary exceeds declared decoded size".into());
+      }
+      dictionary.push(entry);
+    }
+
+    let mut previous_integer = 0i64;
+    let mut previous_real = 0u64;
+    for (row, tag) in tags.into_iter().enumerate() {
+      let value = match tag {
+        TAG_NULL => Value::Null,
+        TAG_INTEGER => {
+          let value = match reader.read_u8("integer delta marker")? {
+            0 => {
+              let delta = zigzag_decode(reader.read_varint("integer delta")?);
+              previous_integer
+                .checked_add(delta)
+                .ok_or_else(|| "integer delta overflows i64".to_owned())?
+            }
+            1 => i64::from_le_bytes(reader.read_array("absolute integer")?),
+            marker => return Err(format!("unknown integer delta marker {marker}")),
+          };
+          previous_integer = value;
+          Value::Integer(value)
+        }
+        TAG_REAL => {
+          let bits = previous_real ^ reader.read_varint("real XOR")?;
+          previous_real = bits;
+          Value::Real(bits)
+        }
+        TAG_TEXT => {
+          let id = reader.read_bounded_varint(dictionary.len(), "text dictionary id")?;
+          let bytes = dictionary
+            .get(id)
+            .ok_or_else(|| "text dictionary id is out of range".to_owned())?
+            .clone();
+          Value::Text(bytes)
+        }
+        TAG_BLOB => Value::Blob(reader.read_sized_bytes("blob")?),
+        _ => unreachable!("tags were validated above"),
+      };
+      budget.add(&value)?;
+      records[row].push(value);
+    }
+  }
+  budget.finish()?;
+  Ok(records)
+}
+
+struct DecodeBudget {
+  expected: usize,
+  used: usize,
+}
+
+impl DecodeBudget {
+  fn new(expected: usize) -> Self {
+    Self { expected, used: 0 }
+  }
+
+  fn add(&mut self, value: &Value) -> Result<(), String> {
+    self.used = self
+      .used
+      .checked_add(decoded_value_size(value)?)
+      .ok_or_else(|| "decoded size overflows address space".to_owned())?;
+    if self.used > self.expected || self.used > MAX_DECODED_BYTES {
+      return Err("decoded records exceed declared decoded size".into());
+    }
+    Ok(())
+  }
+
+  fn finish(self) -> Result<(), String> {
+    if self.used != self.expected {
+      return Err("decoded record size does not match header".into());
+    }
+    Ok(())
+  }
+}
+
+struct Reader<'a> {
+  bytes: &'a [u8],
+  offset: usize,
+}
+
+impl<'a> Reader<'a> {
+  fn new(bytes: &'a [u8]) -> Self {
+    Self { bytes, offset: 0 }
+  }
+
+  fn read_u8(&mut self, what: &str) -> Result<u8, String> {
+    Ok(self.read_exact(1, what)?[0])
+  }
+
+  fn read_array<const N: usize>(&mut self, what: &str) -> Result<[u8; N], String> {
+    self
+      .read_exact(N, what)?
+      .try_into()
+      .map_err(|_| format!("invalid {what} width"))
+  }
+
+  fn read_exact(&mut self, len: usize, what: &str) -> Result<&'a [u8], String> {
+    let end = self
+      .offset
+      .checked_add(len)
+      .ok_or_else(|| format!("{what} length overflows address space"))?;
+    let bytes = self
+      .bytes
+      .get(self.offset..end)
+      .ok_or_else(|| format!("payload is truncated while reading {what}"))?;
+    self.offset = end;
+    Ok(bytes)
+  }
+
+  fn read_varint(&mut self, what: &str) -> Result<u64, String> {
+    let mut value = 0u64;
+    for index in 0..10 {
+      let byte = self.read_u8(what)?;
+      if index == 9 && byte > 1 {
+        return Err(format!("{what} varint overflows u64"));
+      }
+      value |= u64::from(byte & 0x7f) << (index * 7);
+      if byte & 0x80 == 0 {
+        return Ok(value);
+      }
+    }
+    Err(format!("{what} varint is too long"))
+  }
+
+  fn read_bounded_varint(&mut self, max: usize, what: &str) -> Result<usize, String> {
+    let value = self.read_varint(what)?;
+    let value =
+      usize::try_from(value).map_err(|_| format!("{what} exceeds address space"))?;
+    if value > max {
+      return Err(format!("{what} exceeds limit {max}"));
+    }
+    Ok(value)
+  }
+
+  fn read_sized_bytes(&mut self, what: &str) -> Result<Vec<u8>, String> {
+    let len = self.read_bounded_varint(MAX_DECODED_BYTES, &format!("{what} length"))?;
+    Ok(self.read_exact(len, what)?.to_vec())
+  }
+
+  fn is_finished(&self) -> bool {
+    self.offset == self.bytes.len()
+  }
+}
+
+fn inflate_bounded(stored: &[u8], expected_len: usize) -> Result<Vec<u8>, String> {
+  let output_limit = expected_len
+    .checked_add(1)
+    .ok_or_else(|| "inflated body length overflows address space".to_owned())?;
+  let mut body = vec![0; output_limit];
+  let mut decoder = Decompress::new(false);
+  let mut previous_in = 0;
+  let mut previous_out = 0;
+  loop {
+    let input_offset = decoder.total_in() as usize;
+    let output_offset = decoder.total_out() as usize;
+    let status = decoder
+      .decompress(
+        &stored[input_offset..],
+        &mut body[output_offset..],
+        FlushDecompress::Finish,
+      )
+      .map_err(|error| format!("deflate decode failed: {error}"))?;
+    if decoder.total_out() as usize > expected_len {
+      return Err("inflated body exceeds declared body length".into());
+    }
+    if status == Status::StreamEnd {
+      break;
+    }
+    if decoder.total_in() == previous_in && decoder.total_out() == previous_out {
+      return Err("deflate stream ended before its end marker".into());
+    }
+    previous_in = decoder.total_in();
+    previous_out = decoder.total_out();
+  }
+  if decoder.total_out() as usize != expected_len {
+    return Err("inflated body length does not match header".into());
+  }
+  if decoder.total_in() as usize != stored.len() {
+    return Err("deflate stream has trailing bytes".into());
+  }
+  body.truncate(expected_len);
+  Ok(body)
+}
+
+fn tag(value: &Value) -> u8 {
+  match value {
+    Value::Null => TAG_NULL,
+    Value::Integer(_) => TAG_INTEGER,
+    Value::Real(_) => TAG_REAL,
+    Value::Text(_) => TAG_TEXT,
+    Value::Blob(_) => TAG_BLOB,
+  }
+}
+
+fn zigzag_encode(value: i64) -> u64 {
+  ((value << 1) ^ (value >> 63)) as u64
+}
+
+fn zigzag_decode(value: u64) -> i64 {
+  ((value >> 1) as i64) ^ -((value & 1) as i64)
+}
+
+fn write_varint(mut value: u64, output: &mut Vec<u8>) {
+  while value >= 0x80 {
+    output.push((value as u8 & 0x7f) | 0x80);
+    value >>= 7;
+  }
+  output.push(value as u8);
+}
+
+fn push_u32(output: &mut Vec<u8>, value: usize, what: &str) -> Result<(), String> {
+  let value = u32::try_from(value).map_err(|_| format!("{what} exceeds u32"))?;
+  output.extend_from_slice(&value.to_le_bytes());
+  Ok(())
+}
+
+fn header_u32(payload: &[u8], offset: usize) -> Result<usize, String> {
+  let bytes: [u8; 4] = payload
+    .get(offset..offset + 4)
+    .ok_or_else(|| "payload is truncated in numeric header".to_owned())?
+    .try_into()
+    .map_err(|_| "invalid numeric header width".to_owned())?;
+  Ok(u32::from_le_bytes(bytes) as usize)
+}
+
+fn digest(header: &[u8], stored: &[u8]) -> [u8; DIGEST_LEN] {
+  let mut hasher = Sha256::new();
+  hasher.update(header);
+  hasher.update(stored);
+  hasher.finalize().into()
+}
+
+fn layout_flag(layout: Layout) -> u8 {
+  match layout {
+    Layout::Row => 0,
+    Layout::Columnar => 1,
+  }
+}
+
+fn compression_flag(compression: Compression) -> u8 {
+  match compression {
+    Compression::None => 0,
+    Compression::Deflate => 1,
+  }
+}
+
+fn parse_layout(flag: u8) -> Result<Layout, String> {
+  match flag {
+    0 => Ok(Layout::Row),
+    1 => Ok(Layout::Columnar),
+    _ => Err(format!("unknown layout flag {flag}")),
+  }
+}
+
+fn parse_compression(flag: u8) -> Result<Compression, String> {
+  match flag {
+    0 => Ok(Compression::None),
+    1 => Ok(Compression::Deflate),
+    _ => Err(format!("unknown compression flag {flag}")),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn resign(frame: &mut [u8]) {
+    let signed = digest(&frame[..HEADER_WITHOUT_DIGEST_LEN], &frame[HEADER_LEN..]);
+    frame[HEADER_WITHOUT_DIGEST_LEN..HEADER_LEN].copy_from_slice(&signed);
+  }
+
+  fn replace_stored(frame: &mut Vec<u8>, stored: &[u8], body_len: usize) {
+    frame.truncate(HEADER_LEN);
+    frame.extend_from_slice(stored);
+    frame[20..24].copy_from_slice(&(body_len as u32).to_le_bytes());
+    frame[24..28].copy_from_slice(&(stored.len() as u32).to_le_bytes());
+    resign(frame);
+  }
+
+  fn round_trip(records: &[Record]) {
+    for layout in [Layout::Row, Layout::Columnar] {
+      for compression in [Compression::None, Compression::Deflate] {
+        let encoded = encode(records, layout, compression).unwrap();
+        assert_eq!(decode(&encoded).unwrap(), records);
+      }
+    }
+  }
+
+  fn edge_records() -> Vec<Record> {
+    vec![
+      vec![
+        Value::Integer(i64::MIN),
+        Value::Real(f64::NAN.to_bits()),
+        Value::Text("温度🌡️".as_bytes().to_vec()),
+        Value::Blob(vec![0, 0xff, 0x80]),
+        Value::Null,
+      ],
+      vec![
+        Value::Integer(i64::MAX),
+        Value::Real((-0.0f64).to_bits()),
+        Value::Text(vec![0xff, 0, b'a']),
+        Value::Blob(Vec::new()),
+        Value::Integer(-1),
+      ],
+      vec![
+        Value::Integer(i64::MIN),
+        Value::Real(f64::INFINITY.to_bits()),
+        Value::Text("温度🌡️".as_bytes().to_vec()),
+        Value::Blob(vec![0, 0xff, 0x80]),
+        Value::Null,
+      ],
+    ]
+  }
+
+  #[test]
+  fn round_trips_storage_classes_and_exact_numeric_bits() {
+    round_trip(&edge_records());
+  }
+
+  #[test]
+  fn preserves_duplicate_and_empty_records() {
+    let duplicate = vec![Value::Null, Value::Text(b"same".to_vec())];
+    round_trip(&[duplicate.clone(), duplicate]);
+    round_trip(&[vec![], vec![], vec![]]);
+    round_trip(&[]);
+  }
+
+  #[test]
+  fn rejects_non_uniform_and_public_limits() {
+    assert!(
+      encode(&[vec![], vec![Value::Null]], Layout::Row, Compression::None).is_err()
+    );
+    assert!(encode(&vec![vec![]; MAX_ROWS + 1], Layout::Row, Compression::None).is_err());
+    assert!(
+      encode(
+        &[vec![Value::Null; MAX_COLUMNS + 1]],
+        Layout::Row,
+        Compression::None
+      )
+      .is_err()
+    );
+    assert!(
+      encode(
+        &[vec![Value::Blob(vec![0; MAX_DECODED_BYTES])]],
+        Layout::Row,
+        Compression::None
+      )
+      .is_err()
+    );
+  }
+
+  #[test]
+  fn accepts_exact_row_and_decoded_byte_limits() {
+    round_trip(&vec![vec![]; MAX_ROWS]);
+    round_trip(&[vec![Value::Blob(vec![0; MAX_DECODED_BYTES - 1])]]);
+  }
+
+  #[test]
+  fn rejects_corrupt_truncated_trailing_and_unknown_framing() {
+    let encoded =
+      encode(&edge_records(), Layout::Columnar, Compression::Deflate).unwrap();
+
+    let mut corrupt = encoded.clone();
+    *corrupt.last_mut().unwrap() ^= 1;
+    assert!(decode(&corrupt).is_err());
+    assert!(decode(&encoded[..encoded.len() - 1]).is_err());
+    let mut trailing = encoded.clone();
+    trailing.push(0);
+    assert!(decode(&trailing).is_err());
+
+    for offset in [4, 5, 6, 7] {
+      let mut unknown = encoded.clone();
+      unknown[offset] = 0xff;
+      assert!(decode(&unknown).is_err());
+    }
+  }
+
+  #[test]
+  fn rejects_adversarial_counts_and_lengths_before_allocation() {
+    let encoded = encode(&[vec![Value::Null]], Layout::Row, Compression::None).unwrap();
+    for (offset, value) in [
+      (8, (MAX_ROWS + 1) as u32),
+      (12, (MAX_COLUMNS + 1) as u32),
+      (16, (MAX_DECODED_BYTES + 1) as u32),
+      (20, (MAX_BODY_BYTES + 1) as u32),
+    ] {
+      let mut adversarial = encoded.clone();
+      adversarial[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+      assert!(decode(&adversarial).is_err());
+    }
+  }
+
+  #[test]
+  fn rejects_signed_invalid_dictionary_id() {
+    let mut encoded = encode(
+      &[vec![Value::Text(b"a".to_vec())]],
+      Layout::Columnar,
+      Compression::None,
+    )
+    .unwrap();
+    *encoded.last_mut().unwrap() = 1;
+    resign(&mut encoded);
+    assert!(decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn rejects_signed_overflowing_varint() {
+    let mut encoded =
+      encode(&[vec![Value::Real(0)]], Layout::Columnar, Compression::None).unwrap();
+    let body = [
+      TAG_REAL, 0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02,
+    ];
+    replace_stored(&mut encoded, &body, body.len());
+    assert!(decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn rejects_signed_decoded_byte_budget_overrun() {
+    let mut encoded =
+      encode(&[vec![Value::Null]], Layout::Row, Compression::None).unwrap();
+    encoded[16..20].copy_from_slice(&0u32.to_le_bytes());
+    resign(&mut encoded);
+    assert!(decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn rejects_deflate_expansion_past_global_limit() {
+    let mut encoder = DeflateEncoder::new(Vec::new(), FlateCompression::default());
+    encoder.write_all(&vec![0; MAX_BODY_BYTES + 1]).unwrap();
+    let compressed = encoder.finish().unwrap();
+
+    let mut encoded = encode(&[], Layout::Row, Compression::Deflate).unwrap();
+    replace_stored(&mut encoded, &compressed, MAX_BODY_BYTES);
+    assert!(decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn rejects_signed_truncated_deflate_stream() {
+    let mut encoded = encode(&[], Layout::Row, Compression::Deflate).unwrap();
+    encoded.pop();
+    let stored_len = encoded.len() - HEADER_LEN;
+    encoded[24..28].copy_from_slice(&(stored_len as u32).to_le_bytes());
+    resign(&mut encoded);
+    assert!(decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn row_encoding_has_stable_golden_bytes_without_digest() {
+    let encoded = encode(
+      &[vec![
+        Value::Null,
+        Value::Integer(-1),
+        Value::Real(0x3ff0_0000_0000_0000),
+        Value::Text(b"a".to_vec()),
+        Value::Blob(vec![0xff]),
+      ]],
+      Layout::Row,
+      Compression::None,
+    )
+    .unwrap();
+    assert_eq!(
+      &encoded[..HEADER_WITHOUT_DIGEST_LEN],
+      &[
+        b'H', b'V', b'A', b'1', 1, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 23, 0, 0, 0, 25, 0,
+        0, 0, 25, 0, 0, 0,
+      ]
+    );
+    assert_eq!(
+      &encoded[HEADER_LEN..],
+      &[
+        0, 1, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 2, 0, 0, 0, 0, 0, 0, 0xf0,
+        0x3f, 3, 1, b'a', 4, 1, 0xff,
+      ]
+    );
+  }
+}

--- a/core/examples/archive_format_benchmark/codec.rs
+++ b/core/examples/archive_format_benchmark/codec.rs
@@ -214,7 +214,9 @@ fn validate_records(records: &[Record]) -> Result<(usize, usize), String> {
   Ok((column_count, decoded_bytes))
 }
 
-fn decoded_value_size(value: &Value) -> Result<usize, String> {
+/// Counts a value's decoded type tag plus scalar payload or variable byte length.
+/// Frame, length-prefix, and dictionary bookkeeping bytes are excluded.
+pub(super) fn decoded_value_size(value: &Value) -> Result<usize, String> {
   match value {
     Value::Null => Ok(1),
     Value::Integer(_) | Value::Real(_) => Ok(9),
@@ -686,6 +688,24 @@ mod tests {
   #[test]
   fn round_trips_storage_classes_and_exact_numeric_bits() {
     round_trip(&edge_records());
+  }
+
+  #[test]
+  fn decoded_value_size_matches_mixed_storage_classes() -> Result<(), String> {
+    let values = [
+      Value::Null,
+      Value::Integer(i64::MIN),
+      Value::Real(f64::NAN.to_bits()),
+      Value::Text(b"abc".to_vec()),
+      Value::Blob(vec![0, 0xff]),
+    ];
+    let actual = values
+      .iter()
+      .map(decoded_value_size)
+      .sum::<Result<usize, _>>()?;
+
+    assert_eq!(actual, 26);
+    Ok(())
   }
 
   #[test]

--- a/core/examples/archive_format_benchmark/database.rs
+++ b/core/examples/archive_format_benchmark/database.rs
@@ -5,7 +5,7 @@ use super::{
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use sqlx::{
-  Connection, Row, SqliteConnection,
+  Connection, Row, Sqlite, SqliteConnection, Transaction, TypeInfo, ValueRef,
   sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteRow, SqliteSynchronous},
 };
 use std::{
@@ -46,7 +46,7 @@ pub(crate) struct Times {
 pub(crate) struct Finalized {
   pub chunks: i64,
   pub encoded_bytes: i64,
-  pub decoded_value_bytes: u64,
+  pub finalized_decoded_value_bytes: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -106,6 +106,7 @@ pub(crate) struct Benchmark {
   pub ambient_rows: i64,
   pub times: Times,
   pub finalized: Finalized,
+  pub retained_tail_decoded_value_bytes: u64,
   pub correctness: CorrectnessReport,
 }
 
@@ -139,6 +140,7 @@ impl Benchmark {
       ambient_rows: 0,
       times: Times::default(),
       finalized: Finalized::default(),
+      retained_tail_decoded_value_bytes: 0,
       correctness: CorrectnessReport {
         process_float_tolerance: "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
         ..CorrectnessReport::default()
@@ -187,7 +189,7 @@ impl Benchmark {
         if records.is_empty() {
           break;
         }
-        let decoded_value_bytes = value_bytes(&records);
+        let decoded_value_bytes = value_bytes(&records)?;
         let encode_started = Instant::now();
         let payload =
           codec::encode(&records, self.config.layout, self.config.compression)
@@ -214,7 +216,7 @@ impl Benchmark {
         self.times.finalize.push(finalize_started.elapsed());
         self.finalized.chunks += 1;
         self.finalized.encoded_bytes += i64::try_from(payload.len())?;
-        self.finalized.decoded_value_bytes += decoded_value_bytes;
+        self.finalized.finalized_decoded_value_bytes += decoded_value_bytes;
       }
     }
     checkpoint(candidate).await?;
@@ -224,6 +226,8 @@ impl Benchmark {
       .replace(replacement)
       .ok_or("candidate is not open")?;
     old.close().await?;
+    self.retained_tail_decoded_value_bytes =
+      tail_decoded_value_bytes(self.candidate.as_mut().unwrap()).await?;
     Ok(())
   }
 
@@ -544,30 +548,43 @@ async fn select_chunk(
 }
 
 fn row_record(family: &str, row: &SqliteRow) -> Result<Record> {
-  Ok(match family {
-    PROCESS => vec![
-      Value::Integer(row.try_get("id")?),
-      Value::Integer(row.try_get("pid")?),
-      Value::Text(row.try_get::<Vec<u8>, _>("process_name")?),
-      Value::Real(row.try_get::<f64, _>("cpu_usage")?.to_bits()),
-      Value::Integer(row.try_get("memory_usage")?),
-      Value::Integer(row.try_get("execution_sec")?),
-      Value::Text(row.try_get::<Vec<u8>, _>("timestamp")?),
+  let columns: &[&str] = match family {
+    PROCESS => &[
+      "id",
+      "pid",
+      "process_name",
+      "cpu_usage",
+      "memory_usage",
+      "execution_sec",
+      "timestamp",
     ],
-    AMBIENT => vec![
-      Value::Integer(row.try_get("id")?),
-      Value::Text(row.try_get::<Vec<u8>, _>("source")?),
-      Value::Real(row.try_get::<f64, _>("temperature")?.to_bits()),
-      match row.try_get::<Option<f64>, _>("humidity")? {
-        Some(value) => Value::Real(value.to_bits()),
-        None => Value::Null,
-      },
-      Value::Text(row.try_get::<Vec<u8>, _>("timestamp")?),
-    ],
+    AMBIENT => &["id", "source", "temperature", "humidity", "timestamp"],
     _ => return Err(format!("unknown family {family}").into()),
-  })
+  };
+  columns
+    .iter()
+    .map(|column| sqlite_value(row, column))
+    .collect()
 }
 
+fn sqlite_value(row: &SqliteRow, column: &str) -> Result<Value> {
+  let raw = row.try_get_raw(column)?;
+  if raw.is_null() {
+    return Ok(Value::Null);
+  }
+  match raw.type_info().name() {
+    "INTEGER" => Ok(Value::Integer(row.try_get(column)?)),
+    "REAL" => Ok(Value::Real(row.try_get::<f64, _>(column)?.to_bits())),
+    "TEXT" => Ok(Value::Text(row.try_get(column)?)),
+    "BLOB" => Ok(Value::Blob(row.try_get(column)?)),
+    storage_class => Err(
+      format!(
+        "unsupported SQLite runtime storage class {storage_class:?} at column {column:?}"
+      )
+      .into(),
+    ),
+  }
+}
 fn integer(record: &Record, index: usize) -> Result<i64> {
   match record.get(index) {
     Some(Value::Integer(value)) => Ok(*value),
@@ -589,16 +606,42 @@ fn text(record: &Record, index: usize) -> Result<&[u8]> {
   }
 }
 
-fn value_bytes(records: &[Record]) -> u64 {
-  records
-    .iter()
-    .flat_map(|record| record.iter())
-    .map(|value| match value {
-      Value::Null => 1,
-      Value::Integer(_) | Value::Real(_) => 9,
-      Value::Text(bytes) | Value::Blob(bytes) => 9 + bytes.len() as u64,
-    })
-    .sum()
+fn value_bytes(records: &[Record]) -> Result<u64> {
+  let mut total = 0_u64;
+  for value in records.iter().flat_map(|record| record.iter()) {
+    let bytes = codec::decoded_value_size(value).map_err(codec_error)?;
+    total = total
+      .checked_add(u64::try_from(bytes)?)
+      .ok_or("decoded value byte count overflow")?;
+  }
+  Ok(total)
+}
+
+async fn tail_decoded_value_bytes(db: &mut SqliteConnection) -> Result<u64> {
+  let mut total = 0_u64;
+  for family in [PROCESS, AMBIENT] {
+    let (table, _, _) = family_table(family);
+    let mut cursor = 0_i64;
+    loop {
+      let sql = format!("SELECT * FROM {table} WHERE id > ? ORDER BY id LIMIT 4096");
+      let rows = sqlx::query(&sql).bind(cursor).fetch_all(&mut *db).await?;
+      if rows.is_empty() {
+        break;
+      }
+      let records = rows
+        .iter()
+        .map(|row| row_record(family, row))
+        .collect::<Result<Vec<_>>>()?;
+      cursor = integer(
+        records.last().ok_or("tail batch was unexpectedly empty")?,
+        0,
+      )?;
+      total = total
+        .checked_add(value_bytes(&records)?)
+        .ok_or("decoded tail byte count overflow")?;
+    }
+  }
+  Ok(total)
 }
 
 fn update_digest(digest: &mut Sha256, record: &Record) {
@@ -726,7 +769,7 @@ async fn finalize_once(
     family,
     &records,
     &payload,
-    value_bytes(&records),
+    value_bytes(&records)?,
     config,
   )
   .await?;
@@ -758,7 +801,7 @@ async fn rollback_changed_selection(path: &Path, config: &Config) -> Result<bool
     PROCESS,
     &selected,
     &payload,
-    value_bytes(&selected),
+    value_bytes(&selected)?,
     config,
   )
   .await
@@ -1156,6 +1199,30 @@ async fn ambient_oracle(
   Ok((digest.finalize().to_vec(), count))
 }
 
+async fn insert_ambient_query_records(
+  tx: &mut Transaction<'_, Sqlite>,
+  records: &[Record],
+) -> Result<()> {
+  if records.is_empty() {
+    return Ok(());
+  }
+  let values = std::iter::repeat_n("(?, ?, ?)", records.len())
+    .collect::<Vec<_>>()
+    .join(",");
+  let sql = format!(
+    "INSERT INTO temp.ambient_query_records (id, timestamp, record_digest) VALUES {values}"
+  );
+  let mut insert = sqlx::query(&sql);
+  for record in records {
+    insert = insert
+      .bind(integer(record, 0)?)
+      .bind(String::from_utf8(text(record, 4)?.to_vec())?)
+      .bind(record_digest(record));
+  }
+  insert.execute(&mut **tx).await?;
+  Ok(())
+}
+
 async fn ambient_chunked(
   db: &mut SqliteConnection,
   start_ms: i64,
@@ -1186,17 +1253,8 @@ async fn ambient_chunked(
       break;
     };
     chunk_cursor = row.try_get("id")?;
-    for record in decode_chunk(&row, decode_timings).await? {
-      sqlx::query(
-        "INSERT INTO temp.ambient_query_records (id, timestamp, record_digest)
-         VALUES (?, ?, ?)",
-      )
-      .bind(integer(&record, 0)?)
-      .bind(String::from_utf8(text(&record, 4)?.to_vec())?)
-      .bind(record_digest(&record))
-      .execute(&mut *tx)
-      .await?;
-    }
+    let records = decode_chunk(&row, decode_timings).await?;
+    insert_ambient_query_records(&mut tx, &records).await?;
   }
   let mut tail_cursor = 0_i64;
   loop {
@@ -1213,19 +1271,15 @@ async fn ambient_chunked(
     if rows.is_empty() {
       break;
     }
-    for row in &rows {
-      let record = row_record(AMBIENT, row)?;
-      tail_cursor = integer(&record, 0)?;
-      sqlx::query(
-        "INSERT INTO temp.ambient_query_records (id, timestamp, record_digest)
-         VALUES (?, ?, ?)",
-      )
-      .bind(integer(&record, 0)?)
-      .bind(String::from_utf8(text(&record, 4)?.to_vec())?)
-      .bind(record_digest(&record))
-      .execute(&mut *tx)
-      .await?;
-    }
+    let records = rows
+      .iter()
+      .map(|row| row_record(AMBIENT, row))
+      .collect::<Result<Vec<_>>>()?;
+    tail_cursor = integer(
+      records.last().ok_or("tail batch was unexpectedly empty")?,
+      0,
+    )?;
+    insert_ambient_query_records(&mut tx, &records).await?;
   }
   let mut digest = Sha256::new();
   let mut count = 0_u64;
@@ -1425,6 +1479,45 @@ mod tests {
         .map(|row| row.get("detail"))
         .collect();
     assert_family_id_keyset_plan(&ambient_plan);
+  }
+
+  #[tokio::test]
+  async fn full_workload_decoded_value_bytes_do_not_depend_on_chunk_caps() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_output = temp.path().join("first");
+    let second_output = temp.path().join("second");
+    fs::create_dir(&first_output).unwrap();
+    fs::create_dir(&second_output).unwrap();
+
+    let mut first_config = config(first_output);
+    first_config.minutes = 67;
+    first_config.chunk_minutes = 30;
+    first_config.chunk_rows = 101;
+    let mut second_config = first_config.clone();
+    second_config.output = second_output;
+    second_config.chunk_minutes = 11;
+    second_config.chunk_rows = 47;
+
+    let mut first = Benchmark::create(first_config).await.unwrap();
+    first.seed().await.unwrap();
+    first.finalize().await.unwrap();
+    let first_bytes = first
+      .finalized
+      .finalized_decoded_value_bytes
+      .checked_add(first.retained_tail_decoded_value_bytes)
+      .unwrap();
+
+    let mut second = Benchmark::create(second_config).await.unwrap();
+    second.seed().await.unwrap();
+    second.finalize().await.unwrap();
+    let second_bytes = second
+      .finalized
+      .finalized_decoded_value_bytes
+      .checked_add(second.retained_tail_decoded_value_bytes)
+      .unwrap();
+
+    assert!(first_bytes > 0);
+    assert_eq!(first_bytes, second_bytes);
   }
 
   #[test]

--- a/core/examples/archive_format_benchmark/database.rs
+++ b/core/examples/archive_format_benchmark/database.rs
@@ -19,6 +19,13 @@ const PROCESS: &str = "process_stats";
 const AMBIENT: &str = "ambient_archive";
 const EPOCH_MS_SQL: &str = "(CAST(strftime('%s', timestamp) AS INTEGER) * 1000 + CAST(substr(strftime('%f', timestamp), 4, 3) AS INTEGER))";
 const SEED_BATCH_MINUTES: u64 = 128;
+const PROCESS_CHUNK_LOOP_SQL: &str =
+  "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
+   WHERE family = ? AND id > ? AND max_timestamp >= ? AND min_timestamp <= ?
+   ORDER BY id LIMIT 1";
+const AMBIENT_CHUNK_LOOP_SQL: &str =
+  "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
+   WHERE family = ? AND id > ? ORDER BY id LIMIT 1";
 
 #[derive(Default)]
 pub(crate) struct Times {
@@ -339,8 +346,9 @@ async fn create_schema(db: &mut SqliteConnection) -> Result<()> {
 async fn create_chunk_schema(db: &mut SqliteConnection) -> Result<()> {
   sqlx::query("CREATE TABLE ARCHIVE_CHUNKS (id INTEGER PRIMARY KEY AUTOINCREMENT, family TEXT NOT NULL, min_row_id INTEGER NOT NULL, max_row_id INTEGER NOT NULL, min_timestamp TEXT NOT NULL, max_timestamp TEXT NOT NULL, row_count INTEGER NOT NULL, layout TEXT NOT NULL, compression TEXT NOT NULL, decoded_value_bytes INTEGER NOT NULL, payload BLOB NOT NULL, digest BLOB NOT NULL)")
     .execute(&mut *db).await?;
-  sqlx::query("CREATE INDEX idx_archive_chunks_family_time ON ARCHIVE_CHUNKS(family, min_timestamp, max_timestamp)")
-    .execute(&mut *db).await?;
+  sqlx::query("CREATE INDEX idx_archive_chunks_family_id ON ARCHIVE_CHUNKS(family, id)")
+    .execute(&mut *db)
+    .await?;
   Ok(())
 }
 
@@ -990,17 +998,13 @@ async fn process_chunked_interleaved(
   let mut groups = HashMap::new();
   let mut cursor = 0_i64;
   loop {
-    let row = sqlx::query(
-      "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
-       WHERE family = ? AND id > ? AND max_timestamp >= ? AND min_timestamp <= ?
-       ORDER BY id LIMIT 1",
-    )
-    .bind(PROCESS)
-    .bind(cursor)
-    .bind(start)
-    .bind(end)
-    .fetch_optional(&mut *tx)
-    .await?;
+    let row = sqlx::query(PROCESS_CHUNK_LOOP_SQL)
+      .bind(PROCESS)
+      .bind(cursor)
+      .bind(start)
+      .bind(end)
+      .fetch_optional(&mut *tx)
+      .await?;
     let Some(row) = row else {
       break;
     };
@@ -1173,14 +1177,11 @@ async fn ambient_chunked(
   let mut tx = db.begin().await?;
   let mut chunk_cursor = 0_i64;
   loop {
-    let row = sqlx::query(
-      "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
-       WHERE family = ? AND id > ? ORDER BY id LIMIT 1",
-    )
-    .bind(AMBIENT)
-    .bind(chunk_cursor)
-    .fetch_optional(&mut *tx)
-    .await?;
+    let row = sqlx::query(AMBIENT_CHUNK_LOOP_SQL)
+      .bind(AMBIENT)
+      .bind(chunk_cursor)
+      .fetch_optional(&mut *tx)
+      .await?;
     let Some(row) = row else {
       break;
     };
@@ -1343,6 +1344,20 @@ mod contract_tests;
 mod tests {
   use super::*;
 
+  fn assert_family_id_keyset_plan(details: &[String]) {
+    let normalized = details.join(" ").to_ascii_lowercase().replace(' ', "");
+    assert!(
+      normalized.contains("idx_archive_chunks_family_id")
+        && normalized.contains("family=?")
+        && normalized.contains("id>?"),
+      "expected family/id keyset index, got {details:?}"
+    );
+    assert!(
+      !normalized.contains("tempb-tree"),
+      "keyset loop must not sort through a temporary B-tree: {details:?}"
+    );
+  }
+
   fn config(output: PathBuf) -> Config {
     Config {
       output,
@@ -1376,6 +1391,40 @@ mod tests {
     assert!(benchmark.correctness.concurrent_snapshot_before_or_after);
     assert!(benchmark.correctness.process_query_equivalent);
     assert!(benchmark.correctness.ambient_raw_range_equivalent);
+  }
+
+  #[tokio::test]
+  async fn process_and_ambient_chunk_loops_use_family_id_keyset_index() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut db = open(&temp.path().join("plan.sqlite3")).await.unwrap();
+    create_schema(&mut db).await.unwrap();
+    create_chunk_schema(&mut db).await.unwrap();
+
+    let process_plan: Vec<String> =
+      sqlx::query(&format!("EXPLAIN QUERY PLAN {PROCESS_CHUNK_LOOP_SQL}"))
+        .bind(PROCESS)
+        .bind(0_i64)
+        .bind("2026-01-01T00:00:00.000Z")
+        .bind("2026-01-02T00:00:00.000Z")
+        .fetch_all(&mut db)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get("detail"))
+        .collect();
+    assert_family_id_keyset_plan(&process_plan);
+
+    let ambient_plan: Vec<String> =
+      sqlx::query(&format!("EXPLAIN QUERY PLAN {AMBIENT_CHUNK_LOOP_SQL}"))
+        .bind(AMBIENT)
+        .bind(0_i64)
+        .fetch_all(&mut db)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get("detail"))
+        .collect();
+    assert_family_id_keyset_plan(&ambient_plan);
   }
 
   #[test]

--- a/core/examples/archive_format_benchmark/database.rs
+++ b/core/examples/archive_format_benchmark/database.rs
@@ -1,0 +1,1387 @@
+use super::{
+  Config, Error, Result,
+  codec::{self, Compression, Layout, Record, Value},
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use sqlx::{
+  Connection, Row, SqliteConnection,
+  sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteRow, SqliteSynchronous},
+};
+use std::{
+  collections::HashMap,
+  fs,
+  path::{Path, PathBuf},
+  time::{Duration, Instant},
+};
+
+const PROCESS: &str = "process_stats";
+const AMBIENT: &str = "ambient_archive";
+const EPOCH_MS_SQL: &str = "(CAST(strftime('%s', timestamp) AS INTEGER) * 1000 + CAST(substr(strftime('%f', timestamp), 4, 3) AS INTEGER))";
+const SEED_BATCH_MINUTES: u64 = 128;
+
+#[derive(Default)]
+pub(crate) struct Times {
+  pub fixture_seed_batch: Vec<Duration>,
+  pub production_minute_append: Vec<Duration>,
+  pub source_scan: Vec<Duration>,
+  pub encode: Vec<Duration>,
+  pub decode: Vec<Duration>,
+  pub chunk_insert: Vec<Duration>,
+  pub finalize: Vec<Duration>,
+  pub process_baseline: Vec<Duration>,
+  pub process_candidate: Vec<Duration>,
+  pub ambient_baseline: Vec<Duration>,
+  pub ambient_candidate: Vec<Duration>,
+}
+
+#[derive(Default)]
+pub(crate) struct Finalized {
+  pub chunks: i64,
+  pub encoded_bytes: i64,
+  pub decoded_value_bytes: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct CorrectnessReport {
+  exact_decoder_check: bool,
+  persisted_reopen_exact_records: bool,
+  process_query_equivalent: bool,
+  ambient_raw_range_equivalent: bool,
+  process_float_tolerance: &'static str,
+  precommit_changed_selection_rollback: bool,
+  postcommit_retry_exact_multiplicity: bool,
+  concurrent_snapshot_before_or_after: bool,
+  process_groups: usize,
+  ambient_range_rows: u64,
+}
+
+impl CorrectnessReport {
+  pub(crate) fn all_pass(&self) -> bool {
+    self.exact_decoder_check
+      && self.persisted_reopen_exact_records
+      && self.process_query_equivalent
+      && self.ambient_raw_range_equivalent
+      && self.precommit_changed_selection_rollback
+      && self.postcommit_retry_exact_multiplicity
+      && self.concurrent_snapshot_before_or_after
+  }
+}
+
+#[derive(Serialize)]
+pub(crate) struct FileFootprint {
+  pub database_bytes: u64,
+  pub wal_bytes: u64,
+  pub shm_bytes: u64,
+  page_size: i64,
+  page_count: i64,
+  freelist_pages: i64,
+  allocated_page_bytes: i64,
+  live_page_bytes: i64,
+  index_bytes: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct SqliteReport {
+  version: String,
+  journal_mode: String,
+  synchronous: i64,
+  compile_options: Vec<String>,
+}
+
+pub(crate) struct Benchmark {
+  config: Config,
+  baseline_path: PathBuf,
+  candidate_path: PathBuf,
+  baseline: SqliteConnection,
+  candidate: Option<SqliteConnection>,
+  pub process_rows: i64,
+  pub ambient_rows: i64,
+  pub times: Times,
+  pub finalized: Finalized,
+  pub correctness: CorrectnessReport,
+}
+
+pub(crate) fn layout_name(layout: Layout) -> &'static str {
+  match layout {
+    Layout::Row => "row",
+    Layout::Columnar => "columnar",
+  }
+}
+
+pub(crate) fn compression_name(compression: Compression) -> &'static str {
+  match compression {
+    Compression::None => "none",
+    Compression::Deflate => "deflate",
+  }
+}
+
+impl Benchmark {
+  pub async fn create(config: Config) -> Result<Self> {
+    let baseline_path = config.output.join("relational.sqlite3");
+    let candidate_path = config.output.join("chunked.sqlite3");
+    let mut baseline = open(&baseline_path).await?;
+    create_schema(&mut baseline).await?;
+    Ok(Self {
+      config,
+      baseline_path,
+      candidate_path,
+      baseline,
+      candidate: None,
+      process_rows: 0,
+      ambient_rows: 0,
+      times: Times::default(),
+      finalized: Finalized::default(),
+      correctness: CorrectnessReport {
+        process_float_tolerance: "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+        ..CorrectnessReport::default()
+      },
+    })
+  }
+
+  pub async fn seed(&mut self) -> Result<()> {
+    let sampled_minutes = self.config.minutes.div_ceil(self.config.duty_cycle);
+    let mut sampled = 0;
+    while sampled < sampled_minutes {
+      let batch_started = Instant::now();
+      let mut tx = self.baseline.begin().await?;
+      let batch_end = (sampled + SEED_BATCH_MINUTES).min(sampled_minutes);
+      while sampled < batch_end {
+        let minute = sampled * self.config.duty_cycle;
+        insert_minute(&mut tx, &self.config, minute).await?;
+        sampled += 1;
+      }
+      tx.commit().await?;
+      self.times.fixture_seed_batch.push(batch_started.elapsed());
+    }
+    checkpoint(&mut self.baseline).await?;
+    self.process_rows =
+      scalar(&mut self.baseline, "SELECT COUNT(*) FROM PROCESS_STATS").await?;
+    self.ambient_rows =
+      scalar(&mut self.baseline, "SELECT COUNT(*) FROM AMBIENT_ARCHIVE").await?;
+    measure_minute_append(&self.config, &mut self.times.production_minute_append).await?;
+    fs::copy(&self.baseline_path, &self.candidate_path)?;
+    let mut candidate = open(&self.candidate_path).await?;
+    create_chunk_schema(&mut candidate).await?;
+    self.candidate = Some(candidate);
+    Ok(())
+  }
+
+  pub async fn finalize(&mut self) -> Result<()> {
+    self.correctness.precommit_changed_selection_rollback =
+      rollback_changed_selection(&self.candidate_path, &self.config).await?;
+    let candidate = self.candidate.as_mut().ok_or("candidate is not open")?;
+    for family in [PROCESS, AMBIENT] {
+      loop {
+        let finalize_started = Instant::now();
+        let scan_started = Instant::now();
+        let records = select_chunk(candidate, family, &self.config).await?;
+        self.times.source_scan.push(scan_started.elapsed());
+        if records.is_empty() {
+          break;
+        }
+        let decoded_value_bytes = value_bytes(&records);
+        let encode_started = Instant::now();
+        let payload =
+          codec::encode(&records, self.config.layout, self.config.compression)
+            .map_err(codec_error)?;
+        self.times.encode.push(encode_started.elapsed());
+        let decode_started = Instant::now();
+        let decoded = codec::decode(&payload).map_err(codec_error)?;
+        self.times.decode.push(decode_started.elapsed());
+        if decoded != records {
+          return Err(format!("codec changed exact {family} records").into());
+        }
+        self.correctness.exact_decoder_check = true;
+        let insert_started = Instant::now();
+        persist_chunk(
+          candidate,
+          family,
+          &records,
+          &payload,
+          decoded_value_bytes,
+          &self.config,
+        )
+        .await?;
+        self.times.chunk_insert.push(insert_started.elapsed());
+        self.times.finalize.push(finalize_started.elapsed());
+        self.finalized.chunks += 1;
+        self.finalized.encoded_bytes += i64::try_from(payload.len())?;
+        self.finalized.decoded_value_bytes += decoded_value_bytes;
+      }
+    }
+    checkpoint(candidate).await?;
+    let replacement = open(&self.candidate_path).await?;
+    let old = self
+      .candidate
+      .replace(replacement)
+      .ok_or("candidate is not open")?;
+    old.close().await?;
+    Ok(())
+  }
+
+  pub async fn verify_and_query(&mut self) -> Result<()> {
+    let candidate = self.candidate.as_mut().ok_or("candidate is not open")?;
+    self.correctness.persisted_reopen_exact_records =
+      compare_persisted(&mut self.baseline, candidate, &mut self.times.decode).await?;
+
+    let before_rows = total_logical_rows(candidate, &mut self.times.decode).await?;
+    let retry = finalize_once(candidate, PROCESS, &self.config).await?;
+    let after_rows = total_logical_rows(candidate, &mut self.times.decode).await?;
+    self.correctness.postcommit_retry_exact_multiplicity =
+      retry == 0 && before_rows == after_rows;
+    self.correctness.concurrent_snapshot_before_or_after =
+      concurrent_snapshot(&self.candidate_path, &self.config).await?;
+
+    let start_minute = self.config.minutes / 2;
+    let end_minute = self.config.minutes.saturating_sub(1);
+    let start = timestamp(start_minute)?;
+    let end = timestamp(end_minute)?;
+    let start_ms = parse_timestamp(&start)?;
+    let end_ms = parse_timestamp(&end)?;
+    for _ in 0..self.config.repetitions {
+      let started = Instant::now();
+      let baseline = process_oracle(&mut self.baseline, &start, &end).await?;
+      self.times.process_baseline.push(started.elapsed());
+      let started = Instant::now();
+      let chunked = process_chunked(
+        candidate,
+        &start,
+        &end,
+        self.config.group_cap,
+        &mut self.times.decode,
+      )
+      .await?;
+      self.times.process_candidate.push(started.elapsed());
+      self.correctness.process_query_equivalent = compare_aggregates(&baseline, &chunked);
+      self.correctness.process_groups = baseline.len();
+
+      let started = Instant::now();
+      let baseline_ambient = ambient_oracle(&mut self.baseline, start_ms, end_ms).await?;
+      self.times.ambient_baseline.push(started.elapsed());
+      let started = Instant::now();
+      let chunked_ambient =
+        ambient_chunked(candidate, start_ms, end_ms, &mut self.times.decode).await?;
+      self.times.ambient_candidate.push(started.elapsed());
+      self.correctness.ambient_raw_range_equivalent = baseline_ambient == chunked_ambient;
+      self.correctness.ambient_range_rows = baseline_ambient.1;
+      if !self.correctness.process_query_equivalent
+        || !self.correctness.ambient_raw_range_equivalent
+      {
+        return Err("differential query comparison failed".into());
+      }
+    }
+    Ok(())
+  }
+
+  pub async fn baseline_footprint(&mut self) -> Result<FileFootprint> {
+    checkpoint(&mut self.baseline).await?;
+    footprint(&mut self.baseline, &self.baseline_path).await
+  }
+
+  pub async fn candidate_footprint(&mut self) -> Result<FileFootprint> {
+    let candidate = self.candidate.as_mut().ok_or("candidate is not open")?;
+    checkpoint(candidate).await?;
+    footprint(candidate, &self.candidate_path).await
+  }
+
+  pub async fn vacuum_candidate(&mut self) -> Result<()> {
+    let candidate = self.candidate.as_mut().ok_or("candidate is not open")?;
+    sqlx::query("VACUUM").execute(&mut *candidate).await?;
+    checkpoint(candidate).await
+  }
+
+  pub async fn sqlite_report(&mut self) -> Result<SqliteReport> {
+    let candidate = self.candidate.as_mut().ok_or("candidate is not open")?;
+    Ok(SqliteReport {
+      version: sqlx::query_scalar("SELECT sqlite_version()")
+        .fetch_one(&mut *candidate)
+        .await?,
+      journal_mode: sqlx::query_scalar("PRAGMA journal_mode")
+        .fetch_one(&mut *candidate)
+        .await?,
+      synchronous: sqlx::query_scalar("PRAGMA synchronous")
+        .fetch_one(&mut *candidate)
+        .await?,
+      compile_options: sqlx::query_scalar("PRAGMA compile_options")
+        .fetch_all(&mut *candidate)
+        .await?,
+    })
+  }
+}
+
+fn codec_error(message: String) -> Error {
+  message.into()
+}
+
+async fn open(path: &Path) -> Result<SqliteConnection> {
+  let options = SqliteConnectOptions::new()
+    .filename(path)
+    .create_if_missing(true)
+    .journal_mode(SqliteJournalMode::Wal)
+    .synchronous(SqliteSynchronous::Normal)
+    .busy_timeout(Duration::from_secs(30));
+  Ok(SqliteConnection::connect_with(&options).await?)
+}
+
+async fn create_schema(db: &mut SqliteConnection) -> Result<()> {
+  for ddl in [
+    "CREATE TABLE PROCESS_STATS (id INTEGER PRIMARY KEY AUTOINCREMENT, pid INTEGER NOT NULL, process_name TEXT NOT NULL, cpu_usage REAL NOT NULL, memory_usage INTEGER NOT NULL, execution_sec INTEGER NOT NULL, timestamp DATETIME NOT NULL)",
+    "CREATE INDEX idx_process_stats_timestamp ON PROCESS_STATS(timestamp)",
+    "CREATE TABLE AMBIENT_ARCHIVE (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, temperature REAL NOT NULL, humidity REAL, timestamp DATETIME NOT NULL)",
+    "CREATE INDEX idx_ambient_archive_timestamp ON AMBIENT_ARCHIVE(timestamp)",
+  ] {
+    sqlx::query(ddl).execute(&mut *db).await?;
+  }
+  Ok(())
+}
+
+async fn create_chunk_schema(db: &mut SqliteConnection) -> Result<()> {
+  sqlx::query("CREATE TABLE ARCHIVE_CHUNKS (id INTEGER PRIMARY KEY AUTOINCREMENT, family TEXT NOT NULL, min_row_id INTEGER NOT NULL, max_row_id INTEGER NOT NULL, min_timestamp TEXT NOT NULL, max_timestamp TEXT NOT NULL, row_count INTEGER NOT NULL, layout TEXT NOT NULL, compression TEXT NOT NULL, decoded_value_bytes INTEGER NOT NULL, payload BLOB NOT NULL, digest BLOB NOT NULL)")
+    .execute(&mut *db).await?;
+  sqlx::query("CREATE INDEX idx_archive_chunks_family_time ON ARCHIVE_CHUNKS(family, min_timestamp, max_timestamp)")
+    .execute(&mut *db).await?;
+  Ok(())
+}
+
+async fn measure_minute_append(
+  config: &Config,
+  timings: &mut Vec<Duration>,
+) -> Result<()> {
+  let path = config.output.join("append-probe.sqlite3");
+  let mut db = open(&path).await?;
+  create_schema(&mut db).await?;
+  for minute in 1..=config.repetitions as u64 {
+    let started = Instant::now();
+    let mut tx = db.begin().await?;
+    insert_minute(&mut tx, config, minute).await?;
+    tx.commit().await?;
+    timings.push(started.elapsed());
+  }
+  checkpoint(&mut db).await?;
+  db.close().await?;
+  fs::remove_file(path)?;
+  Ok(())
+}
+
+async fn insert_minute(
+  tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+  config: &Config,
+  minute: u64,
+) -> Result<()> {
+  let at = timestamp(minute)?;
+  for slot in 0..config.processes_per_minute {
+    let identity = (u64::from(slot) * 17 + minute / 31 + config.seed)
+      % (u64::from(config.processes_per_minute) * 3);
+    let name = match identity % 23 {
+      0 => format!("worker\0{identity}"),
+      1 => format!("描画-{identity}"),
+      _ => format!("process-{identity:05}"),
+    };
+    let random = mix(config.seed ^ minute.rotate_left(7) ^ u64::from(slot));
+    // Normal rows keep the current producer's f32/i32-shaped range. Separate
+    // sparse sentinel rows exercise exact i64 and binary64 storage classes.
+    let (cpu, memory, execution) = if minute == 0 && slot == 0 {
+      (
+        f64::from_bits(0x4009_21fb_5444_2d18),
+        i64::MAX - 2052,
+        i64::MAX - 17,
+      )
+    } else {
+      (
+        ((random & 0xffff) as f32 / 1_021.0) as f64,
+        i64::from(((random >> 9) % (8 * 1024 * 1024)) as i32),
+        i64::try_from((minute % 43_200).saturating_mul(60) + u64::from(slot))?,
+      )
+    };
+    sqlx::query("INSERT INTO PROCESS_STATS (pid, process_name, cpu_usage, memory_usage, execution_sec, timestamp) VALUES (?, ?, ?, ?, ?, ?)")
+      .bind(100_i64 + i64::try_from(identity)?)
+      .bind(name)
+      .bind(cpu)
+      .bind(memory)
+      .bind(execution)
+      .bind(&at)
+      .execute(&mut **tx)
+      .await?;
+  }
+  if minute.is_multiple_of(97) {
+    sqlx::query("INSERT INTO PROCESS_STATS (pid, process_name, cpu_usage, memory_usage, execution_sec, timestamp) VALUES (?, ?, ?, ?, ?, ?)")
+      .bind(777_i64).bind("duplicate-identity").bind(-0.0_f64)
+      .bind(i64::MIN + 2052).bind(i64::try_from(minute)?).bind(&at)
+      .execute(&mut **tx).await?;
+  }
+  for source_index in 0..2_u64 {
+    if (minute + source_index + config.seed).is_multiple_of(11) {
+      continue;
+    }
+    let source = if source_index == 0 {
+      "Desk"
+    } else {
+      "Living Room\0BLE"
+    };
+    let temperature = 18.0 + ((minute + source_index * 7) % 190) as f64 / 10.0;
+    let humidity = if (minute + source_index).is_multiple_of(5) {
+      None
+    } else {
+      Some(35.0 + (minute % 500) as f64 / 10.0)
+    };
+    sqlx::query("INSERT INTO AMBIENT_ARCHIVE (source, temperature, humidity, timestamp) VALUES (?, ?, ?, ?)")
+      .bind(source).bind(temperature).bind(humidity).bind(&at)
+      .execute(&mut **tx).await?;
+  }
+  Ok(())
+}
+
+fn mix(mut value: u64) -> u64 {
+  value ^= value >> 30;
+  value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+  value ^= value >> 27;
+  value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+  value ^ (value >> 31)
+}
+
+fn timestamp(minute: u64) -> Result<String> {
+  let millis = 1_767_225_600_000_i64
+    .checked_add(
+      i64::try_from(minute)?
+        .checked_mul(60_000)
+        .ok_or("timestamp overflow")?,
+    )
+    .ok_or("timestamp overflow")?;
+  Ok(
+    chrono::DateTime::from_timestamp_millis(millis)
+      .ok_or("timestamp out of range")?
+      .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+  )
+}
+
+fn parse_timestamp(value: &str) -> Result<i64> {
+  Ok(chrono::DateTime::parse_from_rfc3339(value)?.timestamp_millis())
+}
+
+async fn checkpoint(db: &mut SqliteConnection) -> Result<()> {
+  sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+    .execute(db)
+    .await?;
+  Ok(())
+}
+
+async fn scalar(db: &mut SqliteConnection, sql: &str) -> Result<i64> {
+  Ok(sqlx::query_scalar(sql).fetch_one(db).await?)
+}
+
+fn family_table(family: &str) -> (&'static str, usize, usize) {
+  match family {
+    PROCESS => ("PROCESS_STATS", 7, 6),
+    AMBIENT => ("AMBIENT_ARCHIVE", 5, 4),
+    _ => unreachable!("known benchmark family"),
+  }
+}
+
+async fn select_chunk(
+  db: &mut SqliteConnection,
+  family: &str,
+  config: &Config,
+) -> Result<Vec<Record>> {
+  let (table, _, timestamp_index) = family_table(family);
+  let newest: Option<String> =
+    sqlx::query_scalar(&format!("SELECT MAX(timestamp) FROM {table}"))
+      .fetch_one(&mut *db)
+      .await?;
+  let Some(newest) = newest else {
+    return Ok(Vec::new());
+  };
+  let newest_ms = parse_timestamp(&newest)?;
+  let tail_minutes = (config.chunk_minutes / 2).max(1);
+  let cutoff = chrono::DateTime::from_timestamp_millis(
+    newest_ms - i64::try_from(tail_minutes)?.saturating_mul(60_000),
+  )
+  .ok_or("invalid tail cutoff")?
+  .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+  let first: Option<String> = sqlx::query_scalar(&format!(
+    "SELECT MIN(timestamp) FROM {table} WHERE timestamp < ?"
+  ))
+  .bind(&cutoff)
+  .fetch_one(&mut *db)
+  .await?;
+  let Some(first) = first else {
+    return Ok(Vec::new());
+  };
+  let upper = chrono::DateTime::from_timestamp_millis(
+    parse_timestamp(&first)?
+      + i64::try_from(config.chunk_minutes)?.saturating_mul(60_000),
+  )
+  .ok_or("invalid chunk upper bound")?
+  .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+  .min(cutoff);
+  let rows = sqlx::query(&format!(
+    "SELECT * FROM {table} WHERE timestamp >= ? AND timestamp < ? ORDER BY id LIMIT ?"
+  ))
+  .bind(&first)
+  .bind(&upper)
+  .bind(i64::try_from(config.chunk_rows)?)
+  .fetch_all(&mut *db)
+  .await?;
+  let records = rows
+    .iter()
+    .map(|row| row_record(family, row))
+    .collect::<Result<Vec<_>>>()?;
+  if records
+    .iter()
+    .any(|record| record.get(timestamp_index).is_none())
+  {
+    return Err("record width mismatch".into());
+  }
+  Ok(records)
+}
+
+fn row_record(family: &str, row: &SqliteRow) -> Result<Record> {
+  Ok(match family {
+    PROCESS => vec![
+      Value::Integer(row.try_get("id")?),
+      Value::Integer(row.try_get("pid")?),
+      Value::Text(row.try_get::<Vec<u8>, _>("process_name")?),
+      Value::Real(row.try_get::<f64, _>("cpu_usage")?.to_bits()),
+      Value::Integer(row.try_get("memory_usage")?),
+      Value::Integer(row.try_get("execution_sec")?),
+      Value::Text(row.try_get::<Vec<u8>, _>("timestamp")?),
+    ],
+    AMBIENT => vec![
+      Value::Integer(row.try_get("id")?),
+      Value::Text(row.try_get::<Vec<u8>, _>("source")?),
+      Value::Real(row.try_get::<f64, _>("temperature")?.to_bits()),
+      match row.try_get::<Option<f64>, _>("humidity")? {
+        Some(value) => Value::Real(value.to_bits()),
+        None => Value::Null,
+      },
+      Value::Text(row.try_get::<Vec<u8>, _>("timestamp")?),
+    ],
+    _ => return Err(format!("unknown family {family}").into()),
+  })
+}
+
+fn integer(record: &Record, index: usize) -> Result<i64> {
+  match record.get(index) {
+    Some(Value::Integer(value)) => Ok(*value),
+    _ => Err(format!("expected integer at column {index}").into()),
+  }
+}
+
+fn real(record: &Record, index: usize) -> Result<f64> {
+  match record.get(index) {
+    Some(Value::Real(bits)) => Ok(f64::from_bits(*bits)),
+    _ => Err(format!("expected real at column {index}").into()),
+  }
+}
+
+fn text(record: &Record, index: usize) -> Result<&[u8]> {
+  match record.get(index) {
+    Some(Value::Text(value)) => Ok(value),
+    _ => Err(format!("expected text at column {index}").into()),
+  }
+}
+
+fn value_bytes(records: &[Record]) -> u64 {
+  records
+    .iter()
+    .flat_map(|record| record.iter())
+    .map(|value| match value {
+      Value::Null => 1,
+      Value::Integer(_) | Value::Real(_) => 9,
+      Value::Text(bytes) | Value::Blob(bytes) => 9 + bytes.len() as u64,
+    })
+    .sum()
+}
+
+fn update_digest(digest: &mut Sha256, record: &Record) {
+  digest.update((record.len() as u64).to_le_bytes());
+  for value in record {
+    match value {
+      Value::Null => digest.update([0]),
+      Value::Integer(value) => {
+        digest.update([1]);
+        digest.update(value.to_le_bytes());
+      }
+      Value::Real(bits) => {
+        digest.update([2]);
+        digest.update(bits.to_le_bytes());
+      }
+      Value::Text(bytes) => {
+        digest.update([3]);
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+      }
+      Value::Blob(bytes) => {
+        digest.update([4]);
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+      }
+    }
+  }
+}
+
+fn records_digest(records: &[Record]) -> Vec<u8> {
+  let mut digest = Sha256::new();
+  for record in records {
+    update_digest(&mut digest, record);
+  }
+  digest.finalize().to_vec()
+}
+
+async fn persist_chunk(
+  db: &mut SqliteConnection,
+  family: &str,
+  records: &[Record],
+  payload: &[u8],
+  decoded_value_bytes: u64,
+  config: &Config,
+) -> Result<()> {
+  let (table, _, timestamp_index) = family_table(family);
+  let min_id = records
+    .iter()
+    .map(|record| integer(record, 0))
+    .try_fold(i64::MAX, |current, value| {
+      Ok::<_, Error>(current.min(value?))
+    })?;
+  let max_id = records
+    .iter()
+    .map(|record| integer(record, 0))
+    .try_fold(i64::MIN, |current, value| {
+      Ok::<_, Error>(current.max(value?))
+    })?;
+  let min_timestamp = records
+    .iter()
+    .map(|record| text(record, timestamp_index))
+    .collect::<Result<Vec<_>>>()?
+    .into_iter()
+    .min()
+    .ok_or("empty chunk")?
+    .to_vec();
+  let max_timestamp = records
+    .iter()
+    .map(|record| text(record, timestamp_index))
+    .collect::<Result<Vec<_>>>()?
+    .into_iter()
+    .max()
+    .ok_or("empty chunk")?
+    .to_vec();
+  let mut tx = db.begin().await?;
+  sqlx::query("INSERT INTO ARCHIVE_CHUNKS (family, min_row_id, max_row_id, min_timestamp, max_timestamp, row_count, layout, compression, decoded_value_bytes, payload, digest) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+    .bind(family)
+    .bind(min_id)
+    .bind(max_id)
+    .bind(String::from_utf8(min_timestamp)?)
+    .bind(String::from_utf8(max_timestamp)?)
+    .bind(i64::try_from(records.len())?)
+    .bind(layout_name(config.layout))
+    .bind(compression_name(config.compression))
+    .bind(i64::try_from(decoded_value_bytes)?)
+    .bind(payload)
+    .bind(records_digest(records))
+    .execute(&mut *tx)
+    .await?;
+  let placeholders = std::iter::repeat_n("?", records.len())
+    .collect::<Vec<_>>()
+    .join(",");
+  let sql = format!("DELETE FROM {table} WHERE id IN ({placeholders})");
+  let mut delete = sqlx::query(&sql);
+  for record in records {
+    delete = delete.bind(integer(record, 0)?);
+  }
+  let deleted = delete.execute(&mut *tx).await?.rows_affected();
+  if deleted != records.len() as u64 {
+    return Err(
+      format!(
+        "selected {} {family} rows but deleted {deleted}",
+        records.len()
+      )
+      .into(),
+    );
+  }
+  tx.commit().await?;
+  Ok(())
+}
+
+async fn finalize_once(
+  db: &mut SqliteConnection,
+  family: &str,
+  config: &Config,
+) -> Result<usize> {
+  let records = select_chunk(db, family, config).await?;
+  if records.is_empty() {
+    return Ok(0);
+  }
+  let payload =
+    codec::encode(&records, config.layout, config.compression).map_err(codec_error)?;
+  persist_chunk(
+    db,
+    family,
+    &records,
+    &payload,
+    value_bytes(&records),
+    config,
+  )
+  .await?;
+  Ok(records.len())
+}
+
+async fn rollback_changed_selection(path: &Path, config: &Config) -> Result<bool> {
+  let probe = path.with_file_name("rollback-probe.sqlite3");
+  let mut db = open(&probe).await?;
+  create_schema(&mut db).await?;
+  create_chunk_schema(&mut db).await?;
+  let mut tx = db.begin().await?;
+  insert_minute(&mut tx, config, 0).await?;
+  insert_minute(&mut tx, config, config.chunk_minutes * 2).await?;
+  tx.commit().await?;
+  let selected = select_chunk(&mut db, PROCESS, config).await?;
+  let Some(first) = selected.first() else {
+    return Err("rollback probe did not produce an eligible selection".into());
+  };
+  sqlx::query("DELETE FROM PROCESS_STATS WHERE id = ?")
+    .bind(integer(first, 0)?)
+    .execute(&mut db)
+    .await?;
+  let remaining_before = scalar(&mut db, "SELECT COUNT(*) FROM PROCESS_STATS").await?;
+  let payload =
+    codec::encode(&selected, config.layout, config.compression).map_err(codec_error)?;
+  let failed = persist_chunk(
+    &mut db,
+    PROCESS,
+    &selected,
+    &payload,
+    value_bytes(&selected),
+    config,
+  )
+  .await
+  .is_err();
+  let result = failed
+    && scalar(&mut db, "SELECT COUNT(*) FROM PROCESS_STATS").await? == remaining_before
+    && scalar(&mut db, "SELECT COUNT(*) FROM ARCHIVE_CHUNKS").await? == 0;
+  db.close().await?;
+  fs::remove_file(probe)?;
+  Ok(result)
+}
+
+async fn decode_chunk(
+  row: &SqliteRow,
+  timings: &mut Vec<Duration>,
+) -> Result<Vec<Record>> {
+  let payload: Vec<u8> = row.try_get("payload")?;
+  let expected_digest: Vec<u8> = row.try_get("digest")?;
+  let expected_count: i64 = row.try_get("row_count")?;
+  let started = Instant::now();
+  let records = codec::decode(&payload).map_err(codec_error)?;
+  timings.push(started.elapsed());
+  if records.len() != usize::try_from(expected_count)?
+    || records_digest(&records) != expected_digest
+  {
+    return Err("persisted chunk count or digest mismatch".into());
+  }
+  Ok(records)
+}
+
+async fn compare_persisted(
+  baseline: &mut SqliteConnection,
+  candidate: &mut SqliteConnection,
+  decode_timings: &mut Vec<Duration>,
+) -> Result<bool> {
+  sqlx::query(
+    "CREATE TEMP TABLE IF NOT EXISTS verification_ids (
+       family TEXT NOT NULL, id INTEGER NOT NULL, PRIMARY KEY (family, id)
+     ) WITHOUT ROWID",
+  )
+  .execute(&mut *candidate)
+  .await?;
+  for family in [PROCESS, AMBIENT] {
+    let (table, _, _) = family_table(family);
+    sqlx::query("DELETE FROM temp.verification_ids WHERE family = ?")
+      .bind(family)
+      .execute(&mut *candidate)
+      .await?;
+    let mut candidate_tx = candidate.begin().await?;
+    let mut chunk_cursor = 0_i64;
+    let mut covered = 0_i64;
+    loop {
+      let row = sqlx::query("SELECT id, min_row_id, max_row_id, row_count, payload, digest FROM ARCHIVE_CHUNKS WHERE family = ? AND id > ? ORDER BY id LIMIT 1")
+        .bind(family).bind(chunk_cursor).fetch_optional(&mut *candidate_tx).await?;
+      let Some(row) = row else {
+        break;
+      };
+      chunk_cursor = row.try_get("id")?;
+      let records = decode_chunk(&row, decode_timings).await?;
+      let placeholders = std::iter::repeat_n("?", records.len())
+        .collect::<Vec<_>>()
+        .join(",");
+      let sql = format!("SELECT * FROM {table} WHERE id IN ({placeholders}) ORDER BY id");
+      let mut query = sqlx::query(&sql);
+      for record in &records {
+        query = query.bind(integer(record, 0)?);
+      }
+      let source_rows = query.fetch_all(&mut *baseline).await?;
+      let source = source_rows
+        .iter()
+        .map(|row| row_record(family, row))
+        .collect::<Result<Vec<_>>>()?;
+      if source != records {
+        return Ok(false);
+      }
+      let values = std::iter::repeat_n("(?, ?)", records.len())
+        .collect::<Vec<_>>()
+        .join(",");
+      let manifest_sql =
+        format!("INSERT INTO temp.verification_ids (family, id) VALUES {values}");
+      let mut manifest = sqlx::query(&manifest_sql);
+      for record in &records {
+        manifest = manifest.bind(family).bind(integer(record, 0)?);
+      }
+      if manifest.execute(&mut *candidate_tx).await.is_err() {
+        return Ok(false);
+      }
+      covered += i64::try_from(records.len())?;
+    }
+    let mut tail_cursor = 0_i64;
+    loop {
+      let candidate_rows = sqlx::query(&format!(
+        "SELECT * FROM {table} WHERE id > ? ORDER BY id LIMIT 4096"
+      ))
+      .bind(tail_cursor)
+      .fetch_all(&mut *candidate_tx)
+      .await?;
+      if candidate_rows.is_empty() {
+        break;
+      }
+      let candidate_records = candidate_rows
+        .iter()
+        .map(|row| row_record(family, row))
+        .collect::<Result<Vec<_>>>()?;
+      let ids = (
+        integer(candidate_records.first().unwrap(), 0)?,
+        integer(candidate_records.last().unwrap(), 0)?,
+      );
+      let placeholders = std::iter::repeat_n("?", candidate_records.len())
+        .collect::<Vec<_>>()
+        .join(",");
+      let sql = format!("SELECT * FROM {table} WHERE id IN ({placeholders}) ORDER BY id");
+      let mut query = sqlx::query(&sql);
+      for record in &candidate_records {
+        query = query.bind(integer(record, 0)?);
+      }
+      let source_rows = query.fetch_all(&mut *baseline).await?;
+      let source = source_rows
+        .iter()
+        .map(|row| row_record(family, row))
+        .collect::<Result<Vec<_>>>()?;
+      if source != candidate_records {
+        return Ok(false);
+      }
+      let values = std::iter::repeat_n("(?, ?)", candidate_records.len())
+        .collect::<Vec<_>>()
+        .join(",");
+      let manifest_sql =
+        format!("INSERT INTO temp.verification_ids (family, id) VALUES {values}");
+      let mut manifest = sqlx::query(&manifest_sql);
+      for record in &candidate_records {
+        manifest = manifest.bind(family).bind(integer(record, 0)?);
+      }
+      if manifest.execute(&mut *candidate_tx).await.is_err() {
+        return Ok(false);
+      }
+      tail_cursor = ids.1;
+      covered += i64::try_from(candidate_records.len())?;
+    }
+    let source_count = scalar(baseline, &format!("SELECT COUNT(*) FROM {table}")).await?;
+    let manifest_count: i64 =
+      sqlx::query_scalar("SELECT COUNT(*) FROM temp.verification_ids WHERE family = ?")
+        .bind(family)
+        .fetch_one(&mut *candidate_tx)
+        .await?;
+    if covered != source_count || manifest_count != source_count {
+      return Ok(false);
+    }
+    candidate_tx.commit().await?;
+  }
+  Ok(true)
+}
+
+async fn total_logical_rows(
+  candidate: &mut SqliteConnection,
+  timings: &mut Vec<Duration>,
+) -> Result<i64> {
+  let tail: i64 = sqlx::query_scalar(
+    "SELECT (SELECT COUNT(*) FROM PROCESS_STATS) + (SELECT COUNT(*) FROM AMBIENT_ARCHIVE)",
+  )
+  .fetch_one(&mut *candidate)
+  .await?;
+  let chunk_rows: i64 =
+    sqlx::query_scalar("SELECT COALESCE(SUM(row_count), 0) FROM ARCHIVE_CHUNKS")
+      .fetch_one(&mut *candidate)
+      .await?;
+  // Callers run this only after the bounded per-chunk digest validation.
+  let _ = timings;
+  Ok(tail + chunk_rows)
+}
+
+#[derive(Clone, Debug)]
+struct Aggregate {
+  pid: i64,
+  name: Vec<u8>,
+  cpu_sum: f64,
+  memory_sum: f64,
+  count: u64,
+  max_execution: i64,
+  latest: Vec<u8>,
+}
+
+async fn process_oracle(
+  db: &mut SqliteConnection,
+  start: &str,
+  end: &str,
+) -> Result<Vec<Aggregate>> {
+  let rows = sqlx::query(
+    "SELECT pid, process_name, AVG(cpu_usage) avg_cpu, AVG(memory_usage) avg_memory,
+            COUNT(*) sample_count, MAX(execution_sec) max_execution,
+            MAX(timestamp) latest
+     FROM PROCESS_STATS
+     WHERE timestamp BETWEEN ? AND ?
+     GROUP BY pid, process_name
+     ORDER BY pid, process_name",
+  )
+  .bind(start)
+  .bind(end)
+  .fetch_all(db)
+  .await?;
+  rows
+    .iter()
+    .map(|row| {
+      let count: i64 = row.try_get("sample_count")?;
+      Ok(Aggregate {
+        pid: row.try_get("pid")?,
+        name: row.try_get::<Vec<u8>, _>("process_name")?,
+        cpu_sum: row.try_get::<f64, _>("avg_cpu")? * count as f64,
+        memory_sum: row.try_get::<f64, _>("avg_memory")? * count as f64,
+        count: u64::try_from(count)?,
+        max_execution: row.try_get("max_execution")?,
+        latest: row.try_get::<Vec<u8>, _>("latest")?,
+      })
+    })
+    .collect()
+}
+
+async fn process_chunked(
+  db: &mut SqliteConnection,
+  start: &str,
+  end: &str,
+  group_cap: usize,
+  decode_timings: &mut Vec<Duration>,
+) -> Result<Vec<Aggregate>> {
+  process_chunked_interleaved(db, start, end, group_cap, decode_timings, None).await
+}
+
+async fn process_chunked_interleaved(
+  db: &mut SqliteConnection,
+  start: &str,
+  end: &str,
+  group_cap: usize,
+  decode_timings: &mut Vec<Duration>,
+  mut interleave: Option<(&mut SqliteConnection, &Config)>,
+) -> Result<Vec<Aggregate>> {
+  let mut tx = db.begin().await?;
+  let mut groups = HashMap::new();
+  let mut cursor = 0_i64;
+  loop {
+    let row = sqlx::query(
+      "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
+       WHERE family = ? AND id > ? AND max_timestamp >= ? AND min_timestamp <= ?
+       ORDER BY id LIMIT 1",
+    )
+    .bind(PROCESS)
+    .bind(cursor)
+    .bind(start)
+    .bind(end)
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(row) = row else {
+      break;
+    };
+    cursor = row.try_get("id")?;
+    for record in decode_chunk(&row, decode_timings).await? {
+      aggregate_process(
+        &mut groups,
+        &record,
+        start.as_bytes(),
+        end.as_bytes(),
+        group_cap,
+      )?;
+    }
+  }
+  if let Some((writer, config)) = interleave.as_mut() {
+    finalize_once(writer, PROCESS, config).await?;
+  }
+  let mut tail_cursor = 0_i64;
+  loop {
+    let rows = sqlx::query(
+      "SELECT * FROM PROCESS_STATS
+       WHERE timestamp BETWEEN ? AND ? AND id > ?
+       ORDER BY id LIMIT 4096",
+    )
+    .bind(start)
+    .bind(end)
+    .bind(tail_cursor)
+    .fetch_all(&mut *tx)
+    .await?;
+    if rows.is_empty() {
+      break;
+    }
+    for row in &rows {
+      let record = row_record(PROCESS, row)?;
+      tail_cursor = integer(&record, 0)?;
+      aggregate_process(
+        &mut groups,
+        &record,
+        start.as_bytes(),
+        end.as_bytes(),
+        group_cap,
+      )?;
+    }
+  }
+  let mut aggregates: Vec<_> = groups.into_values().collect();
+  aggregates.sort_by(|left, right| (left.pid, &left.name).cmp(&(right.pid, &right.name)));
+  tx.commit().await?;
+  Ok(aggregates)
+}
+
+fn aggregate_process(
+  groups: &mut HashMap<(i64, Vec<u8>), Aggregate>,
+  record: &Record,
+  start: &[u8],
+  end: &[u8],
+  group_cap: usize,
+) -> Result<()> {
+  let at = text(record, 6)?;
+  if at < start || at > end {
+    return Ok(());
+  }
+  let pid = integer(record, 1)?;
+  let name = text(record, 2)?.to_vec();
+  if !groups.contains_key(&(pid, name.clone())) && groups.len() == group_cap {
+    return Err(format!(
+      "Process Stats query exceeded explicit group cap {group_cap}; narrow the range or raise --group-cap"
+    )
+    .into());
+  }
+  let aggregate = groups
+    .entry((pid, name.clone()))
+    .or_insert_with(|| Aggregate {
+      pid,
+      name,
+      cpu_sum: 0.0,
+      memory_sum: 0.0,
+      count: 0,
+      max_execution: i64::MIN,
+      latest: Vec::new(),
+    });
+  aggregate.cpu_sum += real(record, 3)?;
+  aggregate.memory_sum += integer(record, 4)? as f64;
+  aggregate.count += 1;
+  aggregate.max_execution = aggregate.max_execution.max(integer(record, 5)?);
+  if at > aggregate.latest.as_slice() {
+    aggregate.latest = at.to_vec();
+  }
+  Ok(())
+}
+
+fn float_equal(reference: f64, actual: f64) -> bool {
+  if !reference.is_finite() || !actual.is_finite() {
+    return false;
+  }
+  if reference.to_bits() == actual.to_bits() {
+    return true;
+  }
+  (actual - reference).abs() <= (1e-9_f64).max(1e-12 * reference.abs())
+}
+
+fn compare_aggregates(reference: &[Aggregate], actual: &[Aggregate]) -> bool {
+  reference.len() == actual.len()
+    && reference.iter().zip(actual).all(|(left, right)| {
+      left.pid == right.pid
+        && left.name == right.name
+        && left.count == right.count
+        && left.max_execution == right.max_execution
+        && left.latest == right.latest
+        && float_equal(
+          left.cpu_sum / left.count as f64,
+          right.cpu_sum / right.count as f64,
+        )
+        && float_equal(
+          left.memory_sum / left.count as f64,
+          right.memory_sum / right.count as f64,
+        )
+    })
+}
+
+async fn ambient_oracle(
+  db: &mut SqliteConnection,
+  start_ms: i64,
+  end_ms: i64,
+) -> Result<(Vec<u8>, u64)> {
+  let mut digest = Sha256::new();
+  let mut count = 0_u64;
+  let mut cursor = 0_i64;
+  loop {
+    let rows = sqlx::query(&format!(
+      "SELECT * FROM AMBIENT_ARCHIVE
+       WHERE {EPOCH_MS_SQL} BETWEEN ? AND ? AND id > ?
+       ORDER BY id LIMIT 4096"
+    ))
+    .bind(start_ms)
+    .bind(end_ms)
+    .bind(cursor)
+    .fetch_all(&mut *db)
+    .await?;
+    if rows.is_empty() {
+      break;
+    }
+    for row in &rows {
+      let record = row_record(AMBIENT, row)?;
+      cursor = integer(&record, 0)?;
+      digest.update(record_digest(&record));
+      count += 1;
+    }
+  }
+  Ok((digest.finalize().to_vec(), count))
+}
+
+async fn ambient_chunked(
+  db: &mut SqliteConnection,
+  start_ms: i64,
+  end_ms: i64,
+  decode_timings: &mut Vec<Duration>,
+) -> Result<(Vec<u8>, u64)> {
+  // TEXT catalog bounds cannot prove membership for every valid timestamp
+  // spelling, so the experimental raw endpoint conservatively scans chunks.
+  sqlx::query(
+    "CREATE TEMP TABLE IF NOT EXISTS ambient_query_records (
+       id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL, record_digest BLOB NOT NULL
+     )",
+  )
+  .execute(&mut *db)
+  .await?;
+  sqlx::query("DELETE FROM temp.ambient_query_records")
+    .execute(&mut *db)
+    .await?;
+  let mut tx = db.begin().await?;
+  let mut chunk_cursor = 0_i64;
+  loop {
+    let row = sqlx::query(
+      "SELECT id, row_count, payload, digest FROM ARCHIVE_CHUNKS
+       WHERE family = ? AND id > ? ORDER BY id LIMIT 1",
+    )
+    .bind(AMBIENT)
+    .bind(chunk_cursor)
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(row) = row else {
+      break;
+    };
+    chunk_cursor = row.try_get("id")?;
+    for record in decode_chunk(&row, decode_timings).await? {
+      sqlx::query(
+        "INSERT INTO temp.ambient_query_records (id, timestamp, record_digest)
+         VALUES (?, ?, ?)",
+      )
+      .bind(integer(&record, 0)?)
+      .bind(String::from_utf8(text(&record, 4)?.to_vec())?)
+      .bind(record_digest(&record))
+      .execute(&mut *tx)
+      .await?;
+    }
+  }
+  let mut tail_cursor = 0_i64;
+  loop {
+    let rows = sqlx::query(&format!(
+      "SELECT * FROM AMBIENT_ARCHIVE
+       WHERE {EPOCH_MS_SQL} BETWEEN ? AND ? AND id > ?
+       ORDER BY id LIMIT 4096"
+    ))
+    .bind(start_ms)
+    .bind(end_ms)
+    .bind(tail_cursor)
+    .fetch_all(&mut *tx)
+    .await?;
+    if rows.is_empty() {
+      break;
+    }
+    for row in &rows {
+      let record = row_record(AMBIENT, row)?;
+      tail_cursor = integer(&record, 0)?;
+      sqlx::query(
+        "INSERT INTO temp.ambient_query_records (id, timestamp, record_digest)
+         VALUES (?, ?, ?)",
+      )
+      .bind(integer(&record, 0)?)
+      .bind(String::from_utf8(text(&record, 4)?.to_vec())?)
+      .bind(record_digest(&record))
+      .execute(&mut *tx)
+      .await?;
+    }
+  }
+  let mut digest = Sha256::new();
+  let mut count = 0_u64;
+  let mut cursor = 0_i64;
+  loop {
+    let rows = sqlx::query(&format!(
+      "SELECT id, record_digest FROM temp.ambient_query_records
+       WHERE {EPOCH_MS_SQL} BETWEEN ? AND ? AND id > ?
+       ORDER BY id LIMIT 4096"
+    ))
+    .bind(start_ms)
+    .bind(end_ms)
+    .bind(cursor)
+    .fetch_all(&mut *tx)
+    .await?;
+    if rows.is_empty() {
+      break;
+    }
+    for row in rows {
+      cursor = row.try_get("id")?;
+      digest.update(row.try_get::<Vec<u8>, _>("record_digest")?);
+      count += 1;
+    }
+  }
+  tx.commit().await?;
+  Ok((digest.finalize().to_vec(), count))
+}
+
+fn record_digest(record: &Record) -> Vec<u8> {
+  let mut digest = Sha256::new();
+  update_digest(&mut digest, record);
+  digest.finalize().to_vec()
+}
+
+async fn concurrent_snapshot(path: &Path, config: &Config) -> Result<bool> {
+  let source_path = path.with_file_name("snapshot-source.sqlite3");
+  let candidate_path = path.with_file_name("snapshot-candidate.sqlite3");
+  let mut source = open(&source_path).await?;
+  create_schema(&mut source).await?;
+  let mut sampled = 0;
+  while sampled <= config.chunk_minutes * 2 {
+    let mut tx = source.begin().await?;
+    let end = (sampled + 64).min(config.chunk_minutes * 2 + 1);
+    while sampled < end {
+      insert_minute(&mut tx, config, sampled).await?;
+      sampled += 1;
+    }
+    tx.commit().await?;
+  }
+  checkpoint(&mut source).await?;
+  fs::copy(&source_path, &candidate_path)?;
+  let mut writer = open(&candidate_path).await?;
+  create_chunk_schema(&mut writer).await?;
+  if finalize_once(&mut writer, PROCESS, config).await? == 0 {
+    return Err("snapshot probe could not create its initial chunk".into());
+  }
+  let mut reader = open(&candidate_path).await?;
+  let start = timestamp(0)?;
+  let end = timestamp(config.chunk_minutes * 2)?;
+  let reference = process_oracle(&mut source, &start, &end).await?;
+  let mut timings = Vec::new();
+  let actual = process_chunked_interleaved(
+    &mut reader,
+    &start,
+    &end,
+    config.group_cap,
+    &mut timings,
+    Some((&mut writer, config)),
+  )
+  .await?;
+  let result = compare_aggregates(&reference, &actual);
+  reader.close().await?;
+  writer.close().await?;
+  source.close().await?;
+  fs::remove_file(source_path)?;
+  fs::remove_file(candidate_path)?;
+  Ok(result)
+}
+
+async fn footprint(db: &mut SqliteConnection, path: &Path) -> Result<FileFootprint> {
+  let page_size = scalar(db, "PRAGMA page_size").await?;
+  let page_count = scalar(db, "PRAGMA page_count").await?;
+  let freelist_pages = scalar(db, "PRAGMA freelist_count").await?;
+  let index_bytes = sqlx::query_scalar::<_, Option<i64>>(
+    "SELECT SUM(pgsize) FROM dbstat
+     WHERE name IN (SELECT name FROM sqlite_schema WHERE type = 'index')",
+  )
+  .fetch_one(&mut *db)
+  .await
+  .ok()
+  .flatten();
+  Ok(FileFootprint {
+    database_bytes: file_size(path),
+    wal_bytes: file_size(&PathBuf::from(format!("{}-wal", path.display()))),
+    shm_bytes: file_size(&PathBuf::from(format!("{}-shm", path.display()))),
+    page_size,
+    page_count,
+    freelist_pages,
+    allocated_page_bytes: page_size.saturating_mul(page_count),
+    live_page_bytes: page_size.saturating_mul(page_count - freelist_pages),
+    index_bytes,
+  })
+}
+
+fn file_size(path: &Path) -> u64 {
+  fs::metadata(path)
+    .map(|metadata| metadata.len())
+    .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[path = "database_contract_tests.rs"]
+mod contract_tests;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn config(output: PathBuf) -> Config {
+    Config {
+      output,
+      minutes: 180,
+      processes_per_minute: 5,
+      chunk_minutes: 30,
+      chunk_rows: 101,
+      repetitions: 2,
+      layout: Layout::Columnar,
+      compression: Compression::Deflate,
+      seed: 9,
+      duty_cycle: 1,
+      group_cap: 10_000,
+    }
+  }
+
+  #[tokio::test]
+  async fn finalization_preserves_partial_chunks_tail_and_queries() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut benchmark = Benchmark::create(config(temp.path().to_path_buf()))
+      .await
+      .unwrap();
+    benchmark.seed().await.unwrap();
+    benchmark.finalize().await.unwrap();
+    benchmark.verify_and_query().await.unwrap();
+    assert!(benchmark.finalized.chunks > 2);
+    assert!(benchmark.correctness.exact_decoder_check);
+    assert!(benchmark.correctness.persisted_reopen_exact_records);
+    assert!(benchmark.correctness.precommit_changed_selection_rollback);
+    assert!(benchmark.correctness.postcommit_retry_exact_multiplicity);
+    assert!(benchmark.correctness.concurrent_snapshot_before_or_after);
+    assert!(benchmark.correctness.process_query_equivalent);
+    assert!(benchmark.correctness.ambient_raw_range_equivalent);
+  }
+
+  #[test]
+  fn derived_float_comparison_uses_the_ratified_tolerance() {
+    assert!(float_equal(10_000.0, 10_000.0 + 5e-9));
+    assert!(!float_equal(1.0, 1.0 + 1e-6));
+    assert!(!float_equal(f64::NAN, f64::NAN));
+  }
+}

--- a/core/examples/archive_format_benchmark/database_contract_tests.rs
+++ b/core/examples/archive_format_benchmark/database_contract_tests.rs
@@ -96,9 +96,16 @@ async fn persist_records(
   config: &Config,
 ) {
   let payload = codec::encode(records, config.layout, config.compression).unwrap();
-  persist_chunk(db, family, records, &payload, value_bytes(records), config)
-    .await
-    .unwrap();
+  persist_chunk(
+    db,
+    family,
+    records,
+    &payload,
+    value_bytes(records).unwrap(),
+    config,
+  )
+  .await
+  .unwrap();
 }
 
 #[tokio::test]
@@ -186,7 +193,7 @@ async fn changed_selection_rolls_back_chunk_and_other_deletes() {
       PROCESS,
       &selected,
       &payload,
-      value_bytes(&selected),
+      value_bytes(&selected).unwrap(),
       &config,
     )
     .await
@@ -202,6 +209,88 @@ async fn changed_selection_rolls_back_chunk_and_other_deletes() {
       .await
       .unwrap(),
     0
+  );
+}
+
+#[tokio::test]
+async fn row_record_preserves_runtime_storage_classes_bytes_and_bits() {
+  let temp = tempfile::tempdir().unwrap();
+  let mut db = open(&temp.path().join("storage-classes.sqlite3"))
+    .await
+    .unwrap();
+  create_schema(&mut db).await.unwrap();
+
+  sqlx::query(
+    "INSERT INTO PROCESS_STATS
+     (id, pid, process_name, cpu_usage, memory_usage, execution_sec, timestamp)
+     VALUES (1, x'0102', x'ff0061', 'cpu-text', x'0304', 3.25, x'32303236')",
+  )
+  .execute(&mut db)
+  .await
+  .unwrap();
+  let process_row = sqlx::query("SELECT * FROM PROCESS_STATS WHERE id = 1")
+    .fetch_one(&mut db)
+    .await
+    .unwrap();
+  let process_record = row_record(PROCESS, &process_row).unwrap();
+  assert_eq!(
+    process_record,
+    vec![
+      Value::Integer(1),
+      Value::Blob(vec![1, 2]),
+      Value::Blob(vec![0xff, 0, 0x61]),
+      Value::Text(b"cpu-text".to_vec()),
+      Value::Blob(vec![3, 4]),
+      Value::Real(3.25_f64.to_bits()),
+      Value::Blob(b"2026".to_vec()),
+    ]
+  );
+  assert!(integer(&process_record, 1).is_err());
+  assert!(real(&process_record, 3).is_err());
+  assert!(text(&process_record, 6).is_err());
+
+  sqlx::query(
+    "INSERT INTO AMBIENT_ARCHIVE
+     (id, source, temperature, humidity, timestamp)
+     VALUES (2, x'0506', x'0708', 'humidity-text', x'32303236')",
+  )
+  .execute(&mut db)
+  .await
+  .unwrap();
+  let exact_temperature = f64::from_bits(0x4009_21fb_5444_2d18);
+  sqlx::query(
+    "INSERT INTO AMBIENT_ARCHIVE
+     (id, source, temperature, humidity, timestamp) VALUES (3, ?, ?, NULL, ?)",
+  )
+  .bind("normal")
+  .bind(exact_temperature)
+  .bind("2026-01-01T00:00:00.000Z")
+  .execute(&mut db)
+  .await
+  .unwrap();
+  let ambient_rows = sqlx::query("SELECT * FROM AMBIENT_ARCHIVE ORDER BY id")
+    .fetch_all(&mut db)
+    .await
+    .unwrap();
+  assert_eq!(
+    row_record(AMBIENT, &ambient_rows[0]).unwrap(),
+    vec![
+      Value::Integer(2),
+      Value::Blob(vec![5, 6]),
+      Value::Blob(vec![7, 8]),
+      Value::Text(b"humidity-text".to_vec()),
+      Value::Blob(b"2026".to_vec()),
+    ]
+  );
+  assert_eq!(
+    row_record(AMBIENT, &ambient_rows[1]).unwrap(),
+    vec![
+      Value::Integer(3),
+      Value::Text(b"normal".to_vec()),
+      Value::Real(exact_temperature.to_bits()),
+      Value::Null,
+      Value::Text(b"2026-01-01T00:00:00.000Z".to_vec()),
+    ]
   );
 }
 

--- a/core/examples/archive_format_benchmark/database_contract_tests.rs
+++ b/core/examples/archive_format_benchmark/database_contract_tests.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+fn test_config(output: PathBuf) -> Config {
+  Config {
+    output,
+    minutes: 1,
+    processes_per_minute: 1,
+    chunk_minutes: 1,
+    chunk_rows: 64,
+    repetitions: 1,
+    layout: Layout::Columnar,
+    compression: Compression::None,
+    seed: 2052,
+    duty_cycle: 1,
+    group_cap: 64,
+  }
+}
+
+async fn databases(
+  temp: &tempfile::TempDir,
+) -> (SqliteConnection, SqliteConnection, Config) {
+  let config = test_config(temp.path().to_path_buf());
+  let mut baseline = open(&temp.path().join("baseline.sqlite3")).await.unwrap();
+  let mut candidate = open(&temp.path().join("candidate.sqlite3")).await.unwrap();
+  create_schema(&mut baseline).await.unwrap();
+  create_schema(&mut candidate).await.unwrap();
+  create_chunk_schema(&mut candidate).await.unwrap();
+  (baseline, candidate, config)
+}
+
+async fn insert_process(db: &mut SqliteConnection, id: i64, timestamp: &str) {
+  sqlx::query(
+    "INSERT INTO PROCESS_STATS
+     (id, pid, process_name, cpu_usage, memory_usage, execution_sec, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?)",
+  )
+  .bind(id)
+  .bind(1000 + id)
+  .bind(format!("process-{id}"))
+  .bind(id as f64 / 10.0)
+  .bind(4096 + id)
+  .bind(60 + id)
+  .bind(timestamp)
+  .execute(db)
+  .await
+  .unwrap();
+}
+
+async fn insert_ambient(
+  db: &mut SqliteConnection,
+  id: i64,
+  source: &str,
+  timestamp: &str,
+) {
+  sqlx::query(
+    "INSERT INTO AMBIENT_ARCHIVE
+     (id, source, temperature, humidity, timestamp) VALUES (?, ?, ?, ?, ?)",
+  )
+  .bind(id)
+  .bind(source)
+  .bind(20.0 + id as f64 / 10.0)
+  .bind(if id % 2 == 0 { Some(45.5) } else { None })
+  .bind(timestamp)
+  .execute(db)
+  .await
+  .unwrap();
+}
+
+async fn records_for_ids(
+  db: &mut SqliteConnection,
+  family: &str,
+  ids: &[i64],
+) -> Vec<Record> {
+  let (table, _, _) = family_table(family);
+  let placeholders = std::iter::repeat_n("?", ids.len())
+    .collect::<Vec<_>>()
+    .join(",");
+  let sql = format!("SELECT * FROM {table} WHERE id IN ({placeholders}) ORDER BY id");
+  let mut query = sqlx::query(&sql);
+  for id in ids {
+    query = query.bind(id);
+  }
+  query
+    .fetch_all(db)
+    .await
+    .unwrap()
+    .iter()
+    .map(|row| row_record(family, row).unwrap())
+    .collect()
+}
+
+async fn persist_records(
+  db: &mut SqliteConnection,
+  family: &str,
+  records: &[Record],
+  config: &Config,
+) {
+  let payload = codec::encode(records, config.layout, config.compression).unwrap();
+  persist_chunk(db, family, records, &payload, value_bytes(records), config)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn missing_persisted_chunk_fails_global_comparison() {
+  let temp = tempfile::tempdir().unwrap();
+  let (mut baseline, mut candidate, config) = databases(&temp).await;
+  for id in [1, 4, 9] {
+    let timestamp = format!("2026-01-01T00:0{id}:00.000Z");
+    insert_process(&mut baseline, id, &timestamp).await;
+    insert_process(&mut candidate, id, &timestamp).await;
+  }
+
+  let first = records_for_ids(&mut candidate, PROCESS, &[1, 4]).await;
+  persist_records(&mut candidate, PROCESS, &first, &config).await;
+  let second = records_for_ids(&mut candidate, PROCESS, &[9]).await;
+  persist_records(&mut candidate, PROCESS, &second, &config).await;
+  assert!(
+    compare_persisted(&mut baseline, &mut candidate, &mut Vec::new())
+      .await
+      .unwrap()
+  );
+
+  sqlx::query("DELETE FROM ARCHIVE_CHUNKS WHERE family = ? AND min_row_id = 1")
+    .bind(PROCESS)
+    .execute(&mut candidate)
+    .await
+    .unwrap();
+
+  assert!(
+    !compare_persisted(&mut baseline, &mut candidate, &mut Vec::new())
+      .await
+      .unwrap()
+  );
+}
+
+#[tokio::test]
+async fn duplicated_persisted_chunk_fails_global_comparison() {
+  let temp = tempfile::tempdir().unwrap();
+  let (mut baseline, mut candidate, config) = databases(&temp).await;
+  for id in [2, 8] {
+    let timestamp = format!("2026-01-01T00:0{id}:00.000Z");
+    insert_process(&mut baseline, id, &timestamp).await;
+    insert_process(&mut candidate, id, &timestamp).await;
+  }
+  let records = records_for_ids(&mut candidate, PROCESS, &[2, 8]).await;
+  persist_records(&mut candidate, PROCESS, &records, &config).await;
+
+  sqlx::query(
+    "INSERT INTO ARCHIVE_CHUNKS
+     (family, min_row_id, max_row_id, min_timestamp, max_timestamp, row_count,
+      layout, compression, decoded_value_bytes, payload, digest)
+     SELECT family, min_row_id, max_row_id, min_timestamp, max_timestamp, row_count,
+            layout, compression, decoded_value_bytes, payload, digest
+     FROM ARCHIVE_CHUNKS WHERE family = ?",
+  )
+  .bind(PROCESS)
+  .execute(&mut candidate)
+  .await
+  .unwrap();
+
+  assert!(
+    !compare_persisted(&mut baseline, &mut candidate, &mut Vec::new())
+      .await
+      .unwrap()
+  );
+}
+
+#[tokio::test]
+async fn changed_selection_rolls_back_chunk_and_other_deletes() {
+  let temp = tempfile::tempdir().unwrap();
+  let (_, mut candidate, config) = databases(&temp).await;
+  for id in [1, 5, 12] {
+    insert_process(&mut candidate, id, "2026-01-01T00:00:00.000Z").await;
+  }
+  let selected = records_for_ids(&mut candidate, PROCESS, &[1, 5, 12]).await;
+  sqlx::query("DELETE FROM PROCESS_STATS WHERE id = 5")
+    .execute(&mut candidate)
+    .await
+    .unwrap();
+  let payload = codec::encode(&selected, config.layout, config.compression).unwrap();
+
+  assert!(
+    persist_chunk(
+      &mut candidate,
+      PROCESS,
+      &selected,
+      &payload,
+      value_bytes(&selected),
+      &config,
+    )
+    .await
+    .is_err()
+  );
+  let ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM PROCESS_STATS ORDER BY id")
+    .fetch_all(&mut candidate)
+    .await
+    .unwrap();
+  assert_eq!(ids, vec![1, 12]);
+  assert_eq!(
+    scalar(&mut candidate, "SELECT COUNT(*) FROM ARCHIVE_CHUNKS")
+      .await
+      .unwrap(),
+    0
+  );
+}
+
+#[tokio::test]
+async fn ambient_endpoint_uses_sqlite_submillisecond_rounding_and_offsets() {
+  let temp = tempfile::tempdir().unwrap();
+  let (mut baseline, mut candidate, config) = databases(&temp).await;
+  let fixtures = [
+    (2, "utc", "2026-01-01T00:00:00.1239+00:00"),
+    (7, "offset", "2026-01-01T09:00:00.1239+09:00"),
+    (11, "outside", "2026-01-01T00:00:00.1229Z"),
+  ];
+  for (id, source, timestamp) in fixtures {
+    insert_ambient(&mut baseline, id, source, timestamp).await;
+    insert_ambient(&mut candidate, id, source, timestamp).await;
+  }
+  let records = records_for_ids(&mut candidate, AMBIENT, &[2, 7, 11]).await;
+  persist_records(&mut candidate, AMBIENT, &records, &config).await;
+
+  let endpoint: i64 = sqlx::query_scalar(&format!(
+    "SELECT {EPOCH_MS_SQL} FROM AMBIENT_ARCHIVE WHERE id = 2"
+  ))
+  .fetch_one(&mut baseline)
+  .await
+  .unwrap();
+  assert_eq!(endpoint, parse_timestamp(fixtures[0].2).unwrap() + 1);
+  let oracle = ambient_oracle(&mut baseline, endpoint, endpoint)
+    .await
+    .unwrap();
+  let chunked = ambient_chunked(&mut candidate, endpoint, endpoint, &mut Vec::new())
+    .await
+    .unwrap();
+  assert_eq!(oracle.1, 2);
+  assert_eq!(chunked, oracle);
+}
+
+#[tokio::test]
+async fn noncontiguous_ids_backwards_timestamps_and_duplicate_instants_remain_exact() {
+  let temp = tempfile::tempdir().unwrap();
+  let (mut baseline, mut candidate, config) = databases(&temp).await;
+  let fixtures = [
+    (2, "later-first", "2026-01-01T00:02:00.000Z"),
+    (7, "earlier-second", "2026-01-01T00:00:00.000Z"),
+    (11, "same-instant", "2026-01-01T09:00:00.000+09:00"),
+    (20, "middle-last", "2026-01-01T00:01:00.000Z"),
+  ];
+  for (id, source, timestamp) in fixtures {
+    insert_ambient(&mut baseline, id, source, timestamp).await;
+    insert_ambient(&mut candidate, id, source, timestamp).await;
+  }
+
+  let first = records_for_ids(&mut candidate, AMBIENT, &[2, 7]).await;
+  persist_records(&mut candidate, AMBIENT, &first, &config).await;
+  let second = records_for_ids(&mut candidate, AMBIENT, &[11, 20]).await;
+  persist_records(&mut candidate, AMBIENT, &second, &config).await;
+
+  assert!(
+    compare_persisted(&mut baseline, &mut candidate, &mut Vec::new())
+      .await
+      .unwrap()
+  );
+  let start_ms = parse_timestamp("2026-01-01T00:00:00.000Z").unwrap();
+  let end_ms = parse_timestamp("2026-01-01T00:01:00.000Z").unwrap();
+  let oracle = ambient_oracle(&mut baseline, start_ms, end_ms)
+    .await
+    .unwrap();
+  let chunked = ambient_chunked(&mut candidate, start_ms, end_ms, &mut Vec::new())
+    .await
+    .unwrap();
+  assert_eq!(oracle.1, 3);
+  assert_eq!(chunked, oracle);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ documentation.
 - [Hardware Archive migration lifecycle proposal](adr/0021-hardware-archive-migration-lifecycle.md)
 - [Hardware Archive storage design](development/hardware-archive-storage-design.md)
 - [Hardware Archive implementation slices](development/hardware-archive-implementation-plan.md)
+- [Hardware Archive G1 schema and query inventory](development/hardware-archive-g1-inventory.md)
 - [Relicense to GPL-3.0-or-later decision](adr/0020-relicense-to-gpl-3.0-or-later.md)
 - [Sensor hardware specs (clean-room)](specs/sensors/)
 - [Frontend architecture](../src/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ documentation.
 - [Hardware Archive storage design](development/hardware-archive-storage-design.md)
 - [Hardware Archive implementation slices](development/hardware-archive-implementation-plan.md)
 - [Hardware Archive G1 schema and query inventory](development/hardware-archive-g1-inventory.md)
+- [Hardware Archive G1 initial benchmark](development/hardware-archive-g1-benchmark.md)
 - [Relicense to GPL-3.0-or-later decision](adr/0020-relicense-to-gpl-3.0-or-later.md)
 - [Sensor hardware specs (clean-room)](specs/sensors/)
 - [Frontend architecture](../src/README.md)

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -117,5 +117,4 @@ shared enforcement surface.
 - [WebView2 suspension requires hiding the controller](webview2-suspend-requires-hidden-controller.md)
 - [Stabilize performance memory baselines](stabilize-perf-memory-baselines.md)
 - [Separate sensor support from recording coverage](separate-sensor-support-from-recording-coverage.md)
-
 - [Preserve SQLite timestamp membership](preserve-sqlite-timestamp-membership.md)

--- a/docs/agents/lessons/README.md
+++ b/docs/agents/lessons/README.md
@@ -117,3 +117,5 @@ shared enforcement surface.
 - [WebView2 suspension requires hiding the controller](webview2-suspend-requires-hidden-controller.md)
 - [Stabilize performance memory baselines](stabilize-perf-memory-baselines.md)
 - [Separate sensor support from recording coverage](separate-sensor-support-from-recording-coverage.md)
+
+- [Preserve SQLite timestamp membership](preserve-sqlite-timestamp-membership.md)

--- a/docs/agents/lessons/preserve-sqlite-timestamp-membership.md
+++ b/docs/agents/lessons/preserve-sqlite-timestamp-membership.md
@@ -1,0 +1,38 @@
+---
+id: LRN-20260905-preserve-sqlite-timestamp-membership
+status: promoted
+cause_status: confirmed
+scope: core/examples/archive_format_benchmark, core/src/infrastructure/database/archive_queries.rs
+trigger: replacing SQLite timestamp predicates with decoded archive reads
+failure_signature: a submillisecond row crosses an inclusive range endpoint after Rust timestamp conversion
+root_cause: SQLite strftime fractional-second conversion and chrono timestamp_millis do not use identical rounding
+guardrail: differential endpoint regression in the G1 database contract tests
+canonical_refs: core/examples/archive_format_benchmark/database_contract_tests.rs
+verification: cargo test -p hardviz-core --example archive_format_benchmark database::contract_tests::ambient_endpoint_uses_sqlite_submillisecond_rounding_and_offsets
+evidence: core/src/infrastructure/database/archive_queries.rs, core/examples/archive_format_benchmark/database.rs
+revalidate_when: SQLite or chrono changes, or an endpoint intentionally changes timestamp membership
+---
+
+# Preserve SQLite Timestamp Membership
+
+The G1 archive experiment initially converted decoded timestamps with
+`chrono::DateTime::timestamp_millis` while its relational oracle used the
+existing SQLite `strftime` expression. For
+`2026-01-01T00:00:00.1239+00:00`, the SQLite expression produces epoch millisecond
+`1767225600124`; the Rust conversion produces `1767225600123`. A range containing
+only the former millisecond includes the source row but excludes the decoded
+row under the replacement predicate. The equivalent `+09:00` spelling must
+have the same membership.
+
+The executable regression compares the relational and decoded paths at that
+endpoint and checks the expected two included records. The experiment applies
+the existing SQLite predicate to decoded timestamps in bounded batches backed
+by a temporary table. Its measured query cost includes that work; this is not
+a production query-performance claim.
+
+The durable contract is endpoint equivalence, not a new universal timestamp
+normalization rule. Preserve stored timestamp bytes and verify fractional
+precision, offsets, duplicate instants, and backward clock steps against the
+actual owning predicate before replacing it. Re-run the regression when the
+SQL expression, SQLite, chrono, or the storage reader changes. A future faster
+conversion needs the same differential evidence.

--- a/docs/development/benchmarks/hardware-archive-g1-2026-09-05.json
+++ b/docs/development/benchmarks/hardware-archive-g1-2026-09-05.json
@@ -1,7 +1,7 @@
 {
   "schema": "hardviz-g1-initial-measurements-v1",
   "measured_date": "2026-09-05",
-  "source_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+  "source_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
   "develop_baseline_commit": "838d08da16d60ead84df3ddb1501ca19a57f24fc",
   "external_host_metadata": {
     "macos_version": "26.6.2",
@@ -37,14 +37,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.62179320899304,
-        "user_seconds": 0.43357199999999996,
-        "system_seconds": 0.196427,
+        "wall_seconds": 0.9199028750008438,
+        "user_seconds": 0.406408,
+        "system_seconds": 0.162518,
         "maximum_resident_set_size_bytes": 30408704,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -56,6 +56,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -65,7 +67,8 @@
           "chunk_rows": 4096,
           "chunks": 48,
           "encoded_bytes": 1974520,
-          "decoded_value_bytes": 2303608
+          "finalized_decoded_value_bytes": 1924216,
+          "retained_tail_decoded_value_bytes": 42067
         },
         "environment": {
           "os": "macos",
@@ -73,10 +76,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 23019520,
+          "current_rss_bytes": 23232512,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -174,85 +177,85 @@
           },
           "before_reclamation_reduction_percent": -3.300330033003296,
           "after_vacuum_reduction_percent": 15.34653465346535,
-          "vacuum_wall_ms": 7.430334
+          "vacuum_wall_ms": 8.983
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.092,
-            "p95_ms": 13.721,
-            "p99_ms": 13.721,
-            "max_ms": 13.721
+            "p50_ms": 13.486,
+            "p95_ms": 23.71,
+            "p99_ms": 23.71,
+            "max_ms": 23.71
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.105,
-            "p95_ms": 0.124,
-            "p99_ms": 0.124,
-            "max_ms": 0.124
+            "p50_ms": 0.096,
+            "p95_ms": 0.113,
+            "p99_ms": 0.113,
+            "max_ms": 0.113
           },
           "source_scan": {
             "samples": 50,
-            "p50_ms": 0.137,
-            "p95_ms": 1.364,
-            "p99_ms": 1.756,
-            "max_ms": 1.756
+            "p50_ms": 0.159,
+            "p95_ms": 1.646,
+            "p99_ms": 1.769,
+            "max_ms": 1.769
           },
           "encode": {
             "samples": 48,
-            "p50_ms": 0.153,
-            "p95_ms": 0.348,
-            "p99_ms": 0.356,
-            "max_ms": 0.356
+            "p50_ms": 0.154,
+            "p95_ms": 0.319,
+            "p99_ms": 0.352,
+            "max_ms": 0.352
           },
           "decode": {
             "samples": 348,
-            "p50_ms": 0.051,
-            "p95_ms": 0.456,
-            "p99_ms": 0.471,
-            "max_ms": 0.481
+            "p50_ms": 0.043,
+            "p95_ms": 0.431,
+            "p99_ms": 0.465,
+            "max_ms": 0.503
           },
           "chunk_insert_and_tail_delete": {
             "samples": 48,
-            "p50_ms": 0.529,
-            "p95_ms": 1.053,
-            "p99_ms": 4.146,
-            "max_ms": 4.146
+            "p50_ms": 0.522,
+            "p95_ms": 1.006,
+            "p99_ms": 5.097,
+            "max_ms": 5.097
           },
           "finalize_total": {
             "samples": 48,
-            "p50_ms": 1.558,
-            "p95_ms": 3.257,
-            "p99_ms": 5.869,
-            "max_ms": 5.869
+            "p50_ms": 1.597,
+            "p95_ms": 3.44,
+            "p99_ms": 6.86,
+            "max_ms": 6.86
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.173,
-            "p95_ms": 3.345,
-            "p99_ms": 3.345,
-            "max_ms": 3.345
+            "p50_ms": 2.996,
+            "p95_ms": 3.062,
+            "p99_ms": 3.062,
+            "max_ms": 3.062
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 11.438,
-            "p95_ms": 11.655,
-            "p99_ms": 11.655,
-            "max_ms": 11.655
+            "p50_ms": 11.104,
+            "p95_ms": 11.221,
+            "p99_ms": 11.221,
+            "max_ms": 11.221
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.551,
-            "p95_ms": 2.708,
-            "p99_ms": 2.708,
-            "max_ms": 2.708
+            "p50_ms": 2.663,
+            "p95_ms": 2.723,
+            "p99_ms": 2.723,
+            "max_ms": 2.723
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 18.755,
-            "p95_ms": 19.36,
-            "p99_ms": 19.36,
-            "max_ms": 19.36
+            "p50_ms": 5.702,
+            "p95_ms": 5.983,
+            "p99_ms": 5.983,
+            "max_ms": 5.983
           }
         },
         "correctness": {
@@ -304,14 +307,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.5806848329957575,
-        "user_seconds": 0.417616,
-        "system_seconds": 0.190442,
+        "wall_seconds": 0.5001878750044852,
+        "user_seconds": 0.380806,
+        "system_seconds": 0.13888699999999998,
         "maximum_resident_set_size_bytes": 30425088,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -323,6 +326,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -332,7 +337,8 @@
           "chunk_rows": 4096,
           "chunks": 48,
           "encoded_bytes": 369127,
-          "decoded_value_bytes": 2303608
+          "finalized_decoded_value_bytes": 1924216,
+          "retained_tail_decoded_value_bytes": 42067
         },
         "environment": {
           "os": "macos",
@@ -340,10 +346,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 19922944,
+          "current_rss_bytes": 19906560,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -441,85 +447,85 @@
           },
           "before_reclamation_reduction_percent": -0.8250825082508184,
           "after_vacuum_reduction_percent": 79.86798679867987,
-          "vacuum_wall_ms": 1.4898330000000002
+          "vacuum_wall_ms": 1.8229170000000001
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.014,
-            "p95_ms": 13.479,
-            "p99_ms": 13.479,
-            "max_ms": 13.479
+            "p50_ms": 13.209,
+            "p95_ms": 13.397,
+            "p99_ms": 13.397,
+            "max_ms": 13.397
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.104,
-            "p95_ms": 0.123,
-            "p99_ms": 0.123,
-            "max_ms": 0.123
+            "p50_ms": 0.097,
+            "p95_ms": 0.122,
+            "p99_ms": 0.122,
+            "max_ms": 0.122
           },
           "source_scan": {
             "samples": 50,
-            "p50_ms": 0.155,
-            "p95_ms": 1.516,
-            "p99_ms": 1.65,
-            "max_ms": 1.65
+            "p50_ms": 0.146,
+            "p95_ms": 1.414,
+            "p99_ms": 1.865,
+            "max_ms": 1.865
           },
           "encode": {
             "samples": 48,
-            "p50_ms": 0.399,
-            "p95_ms": 0.967,
-            "p99_ms": 0.982,
-            "max_ms": 0.982
+            "p50_ms": 0.392,
+            "p95_ms": 0.928,
+            "p99_ms": 1.125,
+            "max_ms": 1.125
           },
           "decode": {
             "samples": 348,
-            "p50_ms": 0.037,
-            "p95_ms": 0.261,
-            "p99_ms": 0.276,
-            "max_ms": 0.291
+            "p50_ms": 0.038,
+            "p95_ms": 0.254,
+            "p99_ms": 0.273,
+            "max_ms": 0.311
           },
           "chunk_insert_and_tail_delete": {
             "samples": 48,
-            "p50_ms": 0.821,
-            "p95_ms": 1.005,
-            "p99_ms": 2.615,
-            "max_ms": 2.615
+            "p50_ms": 0.812,
+            "p95_ms": 1.071,
+            "p99_ms": 3.266,
+            "max_ms": 3.266
           },
           "finalize_total": {
             "samples": 48,
-            "p50_ms": 2.79,
-            "p95_ms": 3.615,
-            "p99_ms": 3.965,
-            "max_ms": 3.965
+            "p50_ms": 2.876,
+            "p95_ms": 3.598,
+            "p99_ms": 4.466,
+            "max_ms": 4.466
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.164,
-            "p95_ms": 3.334,
-            "p99_ms": 3.334,
-            "max_ms": 3.334
+            "p50_ms": 3.027,
+            "p95_ms": 3.105,
+            "p99_ms": 3.105,
+            "max_ms": 3.105
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 9.0,
-            "p95_ms": 9.322,
-            "p99_ms": 9.322,
-            "max_ms": 9.322
+            "p50_ms": 8.898,
+            "p95_ms": 9.4,
+            "p99_ms": 9.4,
+            "max_ms": 9.4
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.682,
-            "p95_ms": 2.736,
-            "p99_ms": 2.736,
-            "max_ms": 2.736
+            "p50_ms": 2.693,
+            "p95_ms": 2.907,
+            "p99_ms": 2.907,
+            "max_ms": 2.907
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 18.265,
-            "p95_ms": 18.902,
-            "p99_ms": 18.902,
-            "max_ms": 18.902
+            "p50_ms": 5.625,
+            "p95_ms": 5.917,
+            "p99_ms": 5.917,
+            "max_ms": 5.917
           }
         },
         "correctness": {
@@ -571,14 +577,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.554439542000182,
-        "user_seconds": 0.392685,
-        "system_seconds": 0.187127,
+        "wall_seconds": 0.4703112499846611,
+        "user_seconds": 0.354497,
+        "system_seconds": 0.137588,
         "maximum_resident_set_size_bytes": 30392320,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -590,6 +596,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -599,7 +607,8 @@
           "chunk_rows": 4096,
           "chunks": 48,
           "encoded_bytes": 724356,
-          "decoded_value_bytes": 2303608
+          "finalized_decoded_value_bytes": 1924216,
+          "retained_tail_decoded_value_bytes": 42067
         },
         "environment": {
           "os": "macos",
@@ -607,10 +616,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 20971520,
+          "current_rss_bytes": 21217280,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -708,85 +717,85 @@
           },
           "before_reclamation_reduction_percent": -1.320132013201314,
           "after_vacuum_reduction_percent": 65.67656765676568,
-          "vacuum_wall_ms": 2.31125
+          "vacuum_wall_ms": 2.4755
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.231,
-            "p95_ms": 13.7,
-            "p99_ms": 13.7,
-            "max_ms": 13.7
+            "p50_ms": 13.408,
+            "p95_ms": 13.757,
+            "p99_ms": 13.757,
+            "max_ms": 13.757
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.094,
-            "p95_ms": 0.11,
-            "p99_ms": 0.11,
-            "max_ms": 0.11
+            "p50_ms": 0.096,
+            "p95_ms": 0.113,
+            "p99_ms": 0.113,
+            "max_ms": 0.113
           },
           "source_scan": {
             "samples": 50,
-            "p50_ms": 0.132,
-            "p95_ms": 1.338,
-            "p99_ms": 1.799,
-            "max_ms": 1.799
+            "p50_ms": 0.137,
+            "p95_ms": 1.441,
+            "p99_ms": 1.778,
+            "max_ms": 1.778
           },
           "encode": {
             "samples": 48,
-            "p50_ms": 0.087,
-            "p95_ms": 0.198,
-            "p99_ms": 0.199,
-            "max_ms": 0.199
+            "p50_ms": 0.082,
+            "p95_ms": 0.18,
+            "p99_ms": 0.185,
+            "max_ms": 0.185
           },
           "decode": {
             "samples": 348,
-            "p50_ms": 0.036,
-            "p95_ms": 0.209,
-            "p99_ms": 0.215,
-            "max_ms": 0.226
+            "p50_ms": 0.037,
+            "p95_ms": 0.206,
+            "p99_ms": 0.216,
+            "max_ms": 0.225
           },
           "chunk_insert_and_tail_delete": {
             "samples": 48,
             "p50_ms": 0.833,
-            "p95_ms": 0.98,
-            "p99_ms": 3.143,
-            "max_ms": 3.143
+            "p95_ms": 1.028,
+            "p99_ms": 3.133,
+            "max_ms": 3.133
           },
           "finalize_total": {
             "samples": 48,
-            "p50_ms": 2.161,
-            "p95_ms": 2.736,
-            "p99_ms": 3.301,
-            "max_ms": 3.301
+            "p50_ms": 2.218,
+            "p95_ms": 2.843,
+            "p99_ms": 3.299,
+            "max_ms": 3.299
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.082,
-            "p95_ms": 3.153,
-            "p99_ms": 3.153,
-            "max_ms": 3.153
+            "p50_ms": 2.965,
+            "p95_ms": 3.09,
+            "p99_ms": 3.09,
+            "max_ms": 3.09
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 8.55,
-            "p95_ms": 8.615,
-            "p99_ms": 8.615,
-            "max_ms": 8.615
+            "p50_ms": 8.404,
+            "p95_ms": 8.51,
+            "p99_ms": 8.51,
+            "max_ms": 8.51
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.581,
-            "p95_ms": 2.677,
-            "p99_ms": 2.677,
-            "max_ms": 2.677
+            "p50_ms": 2.667,
+            "p95_ms": 2.731,
+            "p99_ms": 2.731,
+            "max_ms": 2.731
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 18.321,
-            "p95_ms": 18.851,
-            "p99_ms": 18.851,
-            "max_ms": 18.851
+            "p50_ms": 5.596,
+            "p95_ms": 5.815,
+            "p99_ms": 5.815,
+            "max_ms": 5.815
           }
         },
         "correctness": {
@@ -838,14 +847,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.5598732499929611,
-        "user_seconds": 0.395771,
-        "system_seconds": 0.190719,
+        "wall_seconds": 0.4694787920161616,
+        "user_seconds": 0.354493,
+        "system_seconds": 0.138122,
         "maximum_resident_set_size_bytes": 30408704,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -857,6 +866,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -866,7 +877,8 @@
           "chunk_rows": 4096,
           "chunks": 48,
           "encoded_bytes": 221234,
-          "decoded_value_bytes": 2303608
+          "finalized_decoded_value_bytes": 1924216,
+          "retained_tail_decoded_value_bytes": 42067
         },
         "environment": {
           "os": "macos",
@@ -874,10 +886,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 19742720,
+          "current_rss_bytes": 19988480,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -975,85 +987,85 @@
           },
           "before_reclamation_reduction_percent": -0.660066006600668,
           "after_vacuum_reduction_percent": 87.29372937293729,
-          "vacuum_wall_ms": 1.2342080000000002
+          "vacuum_wall_ms": 1.337416
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.343,
-            "p95_ms": 13.509,
-            "p99_ms": 13.509,
-            "max_ms": 13.509
+            "p50_ms": 13.206,
+            "p95_ms": 13.761,
+            "p99_ms": 13.761,
+            "max_ms": 13.761
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.101,
-            "p95_ms": 0.113,
-            "p99_ms": 0.113,
-            "max_ms": 0.113
+            "p50_ms": 0.104,
+            "p95_ms": 0.138,
+            "p99_ms": 0.138,
+            "max_ms": 0.138
           },
           "source_scan": {
             "samples": 50,
-            "p50_ms": 0.148,
-            "p95_ms": 1.491,
-            "p99_ms": 1.657,
-            "max_ms": 1.657
+            "p50_ms": 0.161,
+            "p95_ms": 1.338,
+            "p99_ms": 1.812,
+            "max_ms": 1.812
           },
           "encode": {
             "samples": 48,
-            "p50_ms": 0.204,
-            "p95_ms": 0.443,
-            "p99_ms": 0.456,
-            "max_ms": 0.456
+            "p50_ms": 0.203,
+            "p95_ms": 0.417,
+            "p99_ms": 0.426,
+            "max_ms": 0.426
           },
           "decode": {
             "samples": 348,
-            "p50_ms": 0.031,
+            "p50_ms": 0.032,
             "p95_ms": 0.17,
-            "p99_ms": 0.178,
-            "max_ms": 0.207
+            "p99_ms": 0.177,
+            "max_ms": 0.178
           },
           "chunk_insert_and_tail_delete": {
             "samples": 48,
-            "p50_ms": 0.808,
-            "p95_ms": 1.019,
-            "p99_ms": 2.996,
-            "max_ms": 2.996
+            "p50_ms": 0.807,
+            "p95_ms": 0.931,
+            "p99_ms": 3.433,
+            "max_ms": 3.433
           },
           "finalize_total": {
             "samples": 48,
-            "p50_ms": 2.328,
-            "p95_ms": 3.132,
-            "p99_ms": 3.327,
-            "max_ms": 3.327
+            "p50_ms": 2.403,
+            "p95_ms": 2.944,
+            "p99_ms": 3.61,
+            "max_ms": 3.61
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.124,
-            "p95_ms": 3.283,
-            "p99_ms": 3.283,
-            "max_ms": 3.283
+            "p50_ms": 2.967,
+            "p95_ms": 3.002,
+            "p99_ms": 3.002,
+            "max_ms": 3.002
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 8.111,
-            "p95_ms": 8.21,
-            "p99_ms": 8.21,
-            "max_ms": 8.21
+            "p50_ms": 7.867,
+            "p95_ms": 7.991,
+            "p99_ms": 7.991,
+            "max_ms": 7.991
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.579,
-            "p95_ms": 2.73,
-            "p99_ms": 2.73,
-            "max_ms": 2.73
+            "p50_ms": 2.65,
+            "p95_ms": 2.851,
+            "p99_ms": 2.851,
+            "max_ms": 2.851
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 18.617,
-            "p95_ms": 18.841,
-            "p99_ms": 18.841,
-            "max_ms": 18.841
+            "p50_ms": 5.515,
+            "p95_ms": 5.795,
+            "p99_ms": 5.795,
+            "max_ms": 5.795
           }
         },
         "correctness": {
@@ -1105,14 +1117,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.5707808749866672,
-        "user_seconds": 0.40356899999999996,
-        "system_seconds": 0.193,
-        "maximum_resident_set_size_bytes": 30425088,
+        "wall_seconds": 0.47992254100972787,
+        "user_seconds": 0.359771,
+        "system_seconds": 0.142045,
+        "maximum_resident_set_size_bytes": 30441472,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -1124,6 +1136,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -1133,7 +1147,8 @@
           "chunk_rows": 256,
           "chunks": 192,
           "encoded_bytes": 264300,
-          "decoded_value_bytes": 2341064
+          "finalized_decoded_value_bytes": 1955480,
+          "retained_tail_decoded_value_bytes": 10803
         },
         "environment": {
           "os": "macos",
@@ -1141,10 +1156,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 18055168,
+          "current_rss_bytes": 18251776,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -1242,85 +1257,85 @@
           },
           "before_reclamation_reduction_percent": -0.3300330033003229,
           "after_vacuum_reduction_percent": 80.36303630363037,
-          "vacuum_wall_ms": 1.6355
+          "vacuum_wall_ms": 1.345417
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.285,
-            "p95_ms": 13.615,
-            "p99_ms": 13.615,
-            "max_ms": 13.615
+            "p50_ms": 13.249,
+            "p95_ms": 13.653,
+            "p99_ms": 13.653,
+            "max_ms": 13.653
           },
           "production_shaped_minute_append": {
             "samples": 7,
             "p50_ms": 0.107,
-            "p95_ms": 0.116,
-            "p99_ms": 0.116,
-            "max_ms": 0.116
+            "p95_ms": 0.124,
+            "p99_ms": 0.124,
+            "max_ms": 0.124
           },
           "source_scan": {
             "samples": 194,
-            "p50_ms": 0.071,
-            "p95_ms": 0.292,
-            "p99_ms": 0.531,
-            "max_ms": 0.673
+            "p50_ms": 0.068,
+            "p95_ms": 0.309,
+            "p99_ms": 0.643,
+            "max_ms": 0.749
           },
           "encode": {
             "samples": 192,
-            "p50_ms": 0.057,
-            "p95_ms": 0.12,
-            "p99_ms": 0.13,
-            "max_ms": 0.131
+            "p50_ms": 0.056,
+            "p95_ms": 0.119,
+            "p99_ms": 0.128,
+            "max_ms": 0.136
           },
           "decode": {
             "samples": 1392,
-            "p50_ms": 0.014,
-            "p95_ms": 0.05,
+            "p50_ms": 0.012,
+            "p95_ms": 0.049,
             "p99_ms": 0.053,
-            "max_ms": 0.059
+            "max_ms": 0.065
           },
           "chunk_insert_and_tail_delete": {
             "samples": 192,
-            "p50_ms": 0.216,
-            "p95_ms": 0.306,
-            "p99_ms": 1.769,
-            "max_ms": 2.615
+            "p50_ms": 0.215,
+            "p95_ms": 0.298,
+            "p99_ms": 1.864,
+            "max_ms": 2.911
           },
           "finalize_total": {
             "samples": 192,
-            "p50_ms": 0.59,
-            "p95_ms": 0.776,
-            "p99_ms": 1.833,
-            "max_ms": 3.017
+            "p50_ms": 0.606,
+            "p95_ms": 0.788,
+            "p99_ms": 1.932,
+            "max_ms": 3.323
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.102,
-            "p95_ms": 3.171,
-            "p99_ms": 3.171,
-            "max_ms": 3.171
+            "p50_ms": 3.013,
+            "p95_ms": 3.047,
+            "p99_ms": 3.047,
+            "max_ms": 3.047
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 8.186,
-            "p95_ms": 8.286,
-            "p99_ms": 8.286,
-            "max_ms": 8.286
+            "p50_ms": 8.119,
+            "p95_ms": 8.153,
+            "p99_ms": 8.153,
+            "max_ms": 8.153
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.684,
-            "p95_ms": 2.734,
-            "p99_ms": 2.734,
-            "max_ms": 2.734
+            "p50_ms": 2.691,
+            "p95_ms": 2.786,
+            "p99_ms": 2.786,
+            "max_ms": 2.786
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 19.291,
-            "p95_ms": 19.359,
-            "p99_ms": 19.359,
-            "max_ms": 19.359
+            "p50_ms": 6.615,
+            "p95_ms": 6.733,
+            "p99_ms": 6.733,
+            "max_ms": 6.733
           }
         },
         "correctness": {
@@ -1372,14 +1387,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 0.6155702079995535,
-        "user_seconds": 0.430562,
-        "system_seconds": 0.213055,
+        "wall_seconds": 0.5197277090046555,
+        "user_seconds": 0.388775,
+        "system_seconds": 0.15981599999999999,
         "maximum_resident_set_size_bytes": 30392320,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -1391,6 +1406,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 21615,
           "ambient_rows": 2618,
+          "decoded_value_bytes": 1966283,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -1400,7 +1417,8 @@
           "chunk_rows": 4096,
           "chunks": 12,
           "encoded_bytes": 195207,
-          "decoded_value_bytes": 2156067
+          "finalized_decoded_value_bytes": 1800915,
+          "retained_tail_decoded_value_bytes": 165368
         },
         "environment": {
           "os": "macos",
@@ -1408,10 +1426,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 28655616,
+          "current_rss_bytes": 28803072,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -1509,85 +1527,85 @@
           },
           "before_reclamation_reduction_percent": -1.650165016501659,
           "after_vacuum_reduction_percent": 82.01320132013201,
-          "vacuum_wall_ms": 3.904084
+          "vacuum_wall_ms": 2.327166
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 12,
-            "p50_ms": 13.554,
-            "p95_ms": 13.944,
-            "p99_ms": 13.944,
-            "max_ms": 13.944
+            "p50_ms": 13.215,
+            "p95_ms": 13.393,
+            "p99_ms": 13.393,
+            "max_ms": 13.393
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.096,
-            "p95_ms": 0.123,
-            "p99_ms": 0.123,
-            "max_ms": 0.123
+            "p50_ms": 0.12,
+            "p95_ms": 0.139,
+            "p99_ms": 0.139,
+            "max_ms": 0.139
           },
           "source_scan": {
             "samples": 14,
-            "p50_ms": 0.516,
-            "p95_ms": 4.915,
-            "p99_ms": 4.915,
-            "max_ms": 4.915
+            "p50_ms": 0.506,
+            "p95_ms": 5.444,
+            "p99_ms": 5.444,
+            "max_ms": 5.444
           },
           "encode": {
             "samples": 12,
-            "p50_ms": 0.908,
-            "p95_ms": 1.872,
-            "p99_ms": 1.872,
-            "max_ms": 1.872
+            "p50_ms": 0.857,
+            "p95_ms": 1.826,
+            "p99_ms": 1.826,
+            "max_ms": 1.826
           },
           "decode": {
             "samples": 87,
-            "p50_ms": 0.077,
-            "p95_ms": 0.644,
-            "p99_ms": 0.744,
-            "max_ms": 0.744
+            "p50_ms": 0.074,
+            "p95_ms": 0.633,
+            "p99_ms": 0.713,
+            "max_ms": 0.713
           },
           "chunk_insert_and_tail_delete": {
             "samples": 12,
-            "p50_ms": 1.855,
-            "p95_ms": 3.6,
-            "p99_ms": 3.6,
-            "max_ms": 3.6
+            "p50_ms": 1.804,
+            "p95_ms": 3.676,
+            "p99_ms": 3.676,
+            "max_ms": 3.676
           },
           "finalize_total": {
             "samples": 12,
-            "p50_ms": 5.205,
-            "p95_ms": 11.072,
-            "p99_ms": 11.072,
-            "max_ms": 11.072
+            "p50_ms": 5.231,
+            "p95_ms": 11.709,
+            "p99_ms": 11.709,
+            "max_ms": 11.709
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 3.166,
-            "p95_ms": 3.253,
-            "p99_ms": 3.253,
-            "max_ms": 3.253
+            "p50_ms": 3.003,
+            "p95_ms": 3.13,
+            "p99_ms": 3.13,
+            "max_ms": 3.13
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 8.242,
-            "p95_ms": 8.384,
-            "p99_ms": 8.384,
-            "max_ms": 8.384
+            "p50_ms": 8.266,
+            "p95_ms": 8.405,
+            "p99_ms": 8.405,
+            "max_ms": 8.405
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 2.632,
-            "p95_ms": 2.685,
-            "p99_ms": 2.685,
-            "max_ms": 2.685
+            "p50_ms": 2.711,
+            "p95_ms": 2.781,
+            "p99_ms": 2.781,
+            "max_ms": 2.781
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 17.903,
-            "p95_ms": 18.098,
-            "p99_ms": 18.098,
-            "max_ms": 18.098
+            "p50_ms": 5.064,
+            "p95_ms": 5.521,
+            "p99_ms": 5.521,
+            "max_ms": 5.521
           }
         },
         "correctness": {
@@ -1639,14 +1657,14 @@
       "external_resources": {
         "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
         "exit_code": 0,
-        "wall_seconds": 15.005592832982074,
-        "user_seconds": 10.864864,
-        "system_seconds": 4.913524,
-        "maximum_resident_set_size_bytes": 30441472,
+        "wall_seconds": 12.528027750027832,
+        "user_seconds": 9.732918,
+        "system_seconds": 3.428201,
+        "maximum_resident_set_size_bytes": 30425088,
         "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -1658,6 +1676,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 648446,
           "ambient_rows": 78546,
+          "decoded_value_bytes": 58995685,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -1667,7 +1687,8 @@
           "chunk_rows": 4096,
           "chunks": 1440,
           "encoded_bytes": 6769222,
-          "decoded_value_bytes": 70576721
+          "finalized_decoded_value_bytes": 58953201,
+          "retained_tail_decoded_value_bytes": 42484
         },
         "environment": {
           "os": "macos",
@@ -1675,10 +1696,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 29704192,
+          "current_rss_bytes": 30081024,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -1776,85 +1797,85 @@
           },
           "before_reclamation_reduction_percent": -0.02169315038775821,
           "after_vacuum_reduction_percent": 90.41162752860784,
-          "vacuum_wall_ms": 25.234125
+          "vacuum_wall_ms": 25.368416
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 338,
-            "p50_ms": 13.146,
-            "p95_ms": 16.98,
-            "p99_ms": 17.86,
-            "max_ms": 18.551
+            "p50_ms": 13.12,
+            "p95_ms": 17.247,
+            "p99_ms": 18.474,
+            "max_ms": 18.898
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.116,
-            "p95_ms": 0.139,
-            "p99_ms": 0.139,
-            "max_ms": 0.139
+            "p50_ms": 0.113,
+            "p95_ms": 0.134,
+            "p99_ms": 0.134,
+            "max_ms": 0.134
           },
           "source_scan": {
             "samples": 1442,
-            "p50_ms": 0.223,
-            "p95_ms": 1.312,
-            "p99_ms": 1.492,
-            "max_ms": 2.573
+            "p50_ms": 0.189,
+            "p95_ms": 1.376,
+            "p99_ms": 1.548,
+            "max_ms": 2.067
           },
           "encode": {
             "samples": 1440,
-            "p50_ms": 0.199,
-            "p95_ms": 0.439,
-            "p99_ms": 0.452,
-            "max_ms": 0.787
+            "p50_ms": 0.196,
+            "p95_ms": 0.424,
+            "p99_ms": 0.433,
+            "max_ms": 0.459
           },
           "decode": {
             "samples": 10440,
-            "p50_ms": 0.03,
-            "p95_ms": 0.169,
+            "p50_ms": 0.027,
+            "p95_ms": 0.17,
             "p99_ms": 0.175,
-            "max_ms": 0.279
+            "max_ms": 0.329
           },
           "chunk_insert_and_tail_delete": {
             "samples": 1440,
-            "p50_ms": 0.814,
-            "p95_ms": 1.043,
-            "p99_ms": 4.007,
-            "max_ms": 5.172
+            "p50_ms": 0.792,
+            "p95_ms": 1.018,
+            "p99_ms": 4.229,
+            "max_ms": 5.628
           },
           "finalize_total": {
             "samples": 1440,
-            "p50_ms": 2.328,
-            "p95_ms": 2.91,
-            "p99_ms": 5.565,
-            "max_ms": 6.828
+            "p50_ms": 2.364,
+            "p95_ms": 2.927,
+            "p99_ms": 5.856,
+            "max_ms": 7.334
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 131.852,
-            "p95_ms": 134.36,
-            "p99_ms": 134.36,
-            "max_ms": 134.36
+            "p50_ms": 130.056,
+            "p95_ms": 136.601,
+            "p99_ms": 136.601,
+            "max_ms": 136.601
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 243.194,
-            "p95_ms": 244.489,
-            "p99_ms": 244.489,
-            "max_ms": 244.489
+            "p50_ms": 243.009,
+            "p95_ms": 244.865,
+            "p99_ms": 244.865,
+            "max_ms": 244.865
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 83.788,
-            "p95_ms": 85.041,
-            "p99_ms": 85.041,
-            "max_ms": 85.041
+            "p50_ms": 84.506,
+            "p95_ms": 85.561,
+            "p99_ms": 85.561,
+            "max_ms": 85.561
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 529.751,
-            "p95_ms": 536.85,
-            "p99_ms": 536.85,
-            "max_ms": 536.85
+            "p50_ms": 164.515,
+            "p95_ms": 165.447,
+            "p99_ms": 165.447,
+            "max_ms": 165.447
           }
         },
         "correctness": {
@@ -1904,19 +1925,16 @@
         "1"
       ],
       "external_resources": {
-        "method": "macOS /usr/bin/time -l; partial output",
-        "resource_wrapper_exit_code": 1,
-        "harness_exit_code": null,
-        "completed_harness_report": true,
-        "wall_seconds": 200.46,
-        "user_seconds": 135.45,
-        "system_seconds": 62.5,
-        "maximum_resident_set_size_bytes": null,
-        "swaps": null,
-        "error": "time: sysctl kern.clockrate: Operation not permitted"
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 169.1399844160187,
+        "user_seconds": 122.696711,
+        "system_seconds": 44.430684,
+        "maximum_resident_set_size_bytes": 33931264,
+        "swaps": 0
       },
       "report": {
-        "format": "hardviz-archive-g1-v1",
+        "format": "hardviz-archive-g1-v2",
         "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
         "workload": {
           "source": "deterministic synthetic production-shaped rows",
@@ -1928,6 +1946,8 @@
           "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
           "process_rows": 7889419,
           "ambient_rows": 955636,
+          "decoded_value_bytes": 717782731,
+          "decoded_value_bytes_definition": "type tag plus scalar payload or variable byte length across finalized chunks and retained tail; excludes framing and dictionary bookkeeping",
           "seed": 2052
         },
         "format_candidate": {
@@ -1937,7 +1957,8 @@
           "chunk_rows": 4096,
           "chunks": 17520,
           "encoded_bytes": 82424693,
-          "decoded_value_bytes": 859253037
+          "finalized_decoded_value_bytes": 717740493,
+          "retained_tail_decoded_value_bytes": 42238
         },
         "environment": {
           "os": "macos",
@@ -1945,10 +1966,10 @@
           "logical_cpus": 10,
           "cpu_brand": "Apple M4",
           "total_memory_bytes": 25769803776,
-          "current_rss_bytes": 30932992,
+          "current_rss_bytes": 31948800,
           "peak_rss_bytes": null,
           "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
-          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "git_commit": "f1de181f89054e52c42734ea69f276879e5cd389",
           "filesystem": "unavailable"
         },
         "sqlite": {
@@ -2046,85 +2067,85 @@
           },
           "before_reclamation_reduction_percent": -0.0017688392434767053,
           "after_vacuum_reduction_percent": 90.57871997948146,
-          "vacuum_wall_ms": 316.21137500000003
+          "vacuum_wall_ms": 404.285375
         },
         "timings_ms": {
           "fixture_seed_batch": {
             "samples": 4107,
-            "p50_ms": 13.419,
-            "p95_ms": 17.317,
-            "p99_ms": 18.095,
-            "max_ms": 28.766
+            "p50_ms": 13.351,
+            "p95_ms": 17.392,
+            "p99_ms": 18.353,
+            "max_ms": 39.303
           },
           "production_shaped_minute_append": {
             "samples": 7,
-            "p50_ms": 0.167,
-            "p95_ms": 1.332,
-            "p99_ms": 1.332,
-            "max_ms": 1.332
+            "p50_ms": 0.098,
+            "p95_ms": 0.138,
+            "p99_ms": 0.138,
+            "max_ms": 0.138
           },
           "source_scan": {
             "samples": 17522,
-            "p50_ms": 0.648,
-            "p95_ms": 1.32,
-            "p99_ms": 1.467,
-            "max_ms": 8.058
+            "p50_ms": 0.831,
+            "p95_ms": 1.419,
+            "p99_ms": 1.587,
+            "max_ms": 4.396
           },
           "encode": {
             "samples": 17520,
-            "p50_ms": 0.221,
-            "p95_ms": 0.442,
-            "p99_ms": 0.452,
-            "max_ms": 1.217
+            "p50_ms": 0.217,
+            "p95_ms": 0.437,
+            "p99_ms": 0.448,
+            "max_ms": 0.896
           },
           "decode": {
             "samples": 127020,
             "p50_ms": 0.028,
-            "p95_ms": 0.17,
-            "p99_ms": 0.175,
-            "max_ms": 0.82
+            "p95_ms": 0.171,
+            "p99_ms": 0.176,
+            "max_ms": 0.583
           },
           "chunk_insert_and_tail_delete": {
             "samples": 17520,
-            "p50_ms": 0.882,
-            "p95_ms": 1.085,
-            "p99_ms": 4.295,
-            "max_ms": 12.114
+            "p50_ms": 0.87,
+            "p95_ms": 1.078,
+            "p99_ms": 4.624,
+            "max_ms": 12.167
           },
           "finalize_total": {
             "samples": 17520,
-            "p50_ms": 2.452,
-            "p95_ms": 2.966,
-            "p99_ms": 5.905,
-            "max_ms": 12.291
+            "p50_ms": 2.529,
+            "p95_ms": 3.071,
+            "p99_ms": 6.367,
+            "max_ms": 13.996
           },
           "process_query_baseline": {
             "samples": 7,
-            "p50_ms": 2108.398,
-            "p95_ms": 2468.62,
-            "p99_ms": 2468.62,
-            "max_ms": 2468.62
+            "p50_ms": 2186.34,
+            "p95_ms": 2447.772,
+            "p99_ms": 2447.772,
+            "max_ms": 2447.772
           },
           "process_query_chunked": {
             "samples": 7,
-            "p50_ms": 2965.901,
-            "p95_ms": 2999.155,
-            "p99_ms": 2999.155,
-            "max_ms": 2999.155
+            "p50_ms": 2991.01,
+            "p95_ms": 2994.709,
+            "p99_ms": 2994.709,
+            "max_ms": 2994.709
           },
           "ambient_raw_query_baseline": {
             "samples": 7,
-            "p50_ms": 1514.669,
-            "p95_ms": 1572.645,
-            "p99_ms": 1572.645,
-            "max_ms": 1572.645
+            "p50_ms": 1278.139,
+            "p95_ms": 1340.537,
+            "p99_ms": 1340.537,
+            "max_ms": 1340.537
           },
           "ambient_raw_query_chunked": {
             "samples": 7,
-            "p50_ms": 6552.12,
-            "p95_ms": 6595.218,
-            "p99_ms": 6595.218,
-            "max_ms": 6595.218
+            "p50_ms": 2149.338,
+            "p95_ms": 2169.853,
+            "p99_ms": 2169.853,
+            "max_ms": 2169.853
           }
         },
         "correctness": {

--- a/docs/development/benchmarks/hardware-archive-g1-2026-09-05.json
+++ b/docs/development/benchmarks/hardware-archive-g1-2026-09-05.json
@@ -1,0 +1,2153 @@
+{
+  "schema": "hardviz-g1-initial-measurements-v1",
+  "measured_date": "2026-09-05",
+  "source_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+  "develop_baseline_commit": "838d08da16d60ead84df3ddb1501ca19a57f24fc",
+  "external_host_metadata": {
+    "macos_version": "26.6.2",
+    "macos_build": "25G83",
+    "filesystem": "APFS"
+  },
+  "query_policy": "One executable run per configuration; seven cache-primed repetitions after setup/validation, alternating baseline then candidate. No cache purge or independent cold/warm classification.",
+  "cases": [
+    {
+      "case": "24h-row-none",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-row-none",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "row",
+        "--compression",
+        "none",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.62179320899304,
+        "user_seconds": 0.43357199999999996,
+        "system_seconds": 0.196427,
+        "maximum_resident_set_size_bytes": 30408704,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "row",
+          "compression": "none",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 48,
+          "encoded_bytes": 1974520,
+          "decoded_value_bytes": 2303608
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 23019520,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2564096,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 626,
+            "freelist_pages": 111,
+            "allocated_page_bytes": 2564096,
+            "live_page_bytes": 2109440,
+            "index_bytes": 32768
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 2101248,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 513,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2101248,
+            "live_page_bytes": 2101248,
+            "index_bytes": 28672
+          },
+          "before_reclamation_reduction_percent": -3.300330033003296,
+          "after_vacuum_reduction_percent": 15.34653465346535,
+          "vacuum_wall_ms": 7.430334
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.092,
+            "p95_ms": 13.721,
+            "p99_ms": 13.721,
+            "max_ms": 13.721
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.105,
+            "p95_ms": 0.124,
+            "p99_ms": 0.124,
+            "max_ms": 0.124
+          },
+          "source_scan": {
+            "samples": 50,
+            "p50_ms": 0.137,
+            "p95_ms": 1.364,
+            "p99_ms": 1.756,
+            "max_ms": 1.756
+          },
+          "encode": {
+            "samples": 48,
+            "p50_ms": 0.153,
+            "p95_ms": 0.348,
+            "p99_ms": 0.356,
+            "max_ms": 0.356
+          },
+          "decode": {
+            "samples": 348,
+            "p50_ms": 0.051,
+            "p95_ms": 0.456,
+            "p99_ms": 0.471,
+            "max_ms": 0.481
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 48,
+            "p50_ms": 0.529,
+            "p95_ms": 1.053,
+            "p99_ms": 4.146,
+            "max_ms": 4.146
+          },
+          "finalize_total": {
+            "samples": 48,
+            "p50_ms": 1.558,
+            "p95_ms": 3.257,
+            "p99_ms": 5.869,
+            "max_ms": 5.869
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.173,
+            "p95_ms": 3.345,
+            "p99_ms": 3.345,
+            "max_ms": 3.345
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 11.438,
+            "p95_ms": 11.655,
+            "p99_ms": 11.655,
+            "max_ms": 11.655
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.551,
+            "p95_ms": 2.708,
+            "p99_ms": 2.708,
+            "max_ms": 2.708
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 18.755,
+            "p95_ms": 19.36,
+            "p99_ms": 19.36,
+            "max_ms": 19.36
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "24h-row-deflate",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-row-deflate",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "row",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.5806848329957575,
+        "user_seconds": 0.417616,
+        "system_seconds": 0.190442,
+        "maximum_resident_set_size_bytes": 30425088,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "row",
+          "compression": "deflate",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 48,
+          "encoded_bytes": 369127,
+          "decoded_value_bytes": 2303608
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 19922944,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2502656,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 611,
+            "freelist_pages": 487,
+            "allocated_page_bytes": 2502656,
+            "live_page_bytes": 507904,
+            "index_bytes": 32768
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 499712,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 122,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 499712,
+            "live_page_bytes": 499712,
+            "index_bytes": 28672
+          },
+          "before_reclamation_reduction_percent": -0.8250825082508184,
+          "after_vacuum_reduction_percent": 79.86798679867987,
+          "vacuum_wall_ms": 1.4898330000000002
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.014,
+            "p95_ms": 13.479,
+            "p99_ms": 13.479,
+            "max_ms": 13.479
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.104,
+            "p95_ms": 0.123,
+            "p99_ms": 0.123,
+            "max_ms": 0.123
+          },
+          "source_scan": {
+            "samples": 50,
+            "p50_ms": 0.155,
+            "p95_ms": 1.516,
+            "p99_ms": 1.65,
+            "max_ms": 1.65
+          },
+          "encode": {
+            "samples": 48,
+            "p50_ms": 0.399,
+            "p95_ms": 0.967,
+            "p99_ms": 0.982,
+            "max_ms": 0.982
+          },
+          "decode": {
+            "samples": 348,
+            "p50_ms": 0.037,
+            "p95_ms": 0.261,
+            "p99_ms": 0.276,
+            "max_ms": 0.291
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 48,
+            "p50_ms": 0.821,
+            "p95_ms": 1.005,
+            "p99_ms": 2.615,
+            "max_ms": 2.615
+          },
+          "finalize_total": {
+            "samples": 48,
+            "p50_ms": 2.79,
+            "p95_ms": 3.615,
+            "p99_ms": 3.965,
+            "max_ms": 3.965
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.164,
+            "p95_ms": 3.334,
+            "p99_ms": 3.334,
+            "max_ms": 3.334
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 9.0,
+            "p95_ms": 9.322,
+            "p99_ms": 9.322,
+            "max_ms": 9.322
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.682,
+            "p95_ms": 2.736,
+            "p99_ms": 2.736,
+            "max_ms": 2.736
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 18.265,
+            "p95_ms": 18.902,
+            "p99_ms": 18.902,
+            "max_ms": 18.902
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "24h-columnar-none",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-columnar-none",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "none",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.554439542000182,
+        "user_seconds": 0.392685,
+        "system_seconds": 0.187127,
+        "maximum_resident_set_size_bytes": 30392320,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "none",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 48,
+          "encoded_bytes": 724356,
+          "decoded_value_bytes": 2303608
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 20971520,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2514944,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 614,
+            "freelist_pages": 404,
+            "allocated_page_bytes": 2514944,
+            "live_page_bytes": 860160,
+            "index_bytes": 32768
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 851968,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 208,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 851968,
+            "live_page_bytes": 851968,
+            "index_bytes": 28672
+          },
+          "before_reclamation_reduction_percent": -1.320132013201314,
+          "after_vacuum_reduction_percent": 65.67656765676568,
+          "vacuum_wall_ms": 2.31125
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.231,
+            "p95_ms": 13.7,
+            "p99_ms": 13.7,
+            "max_ms": 13.7
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.094,
+            "p95_ms": 0.11,
+            "p99_ms": 0.11,
+            "max_ms": 0.11
+          },
+          "source_scan": {
+            "samples": 50,
+            "p50_ms": 0.132,
+            "p95_ms": 1.338,
+            "p99_ms": 1.799,
+            "max_ms": 1.799
+          },
+          "encode": {
+            "samples": 48,
+            "p50_ms": 0.087,
+            "p95_ms": 0.198,
+            "p99_ms": 0.199,
+            "max_ms": 0.199
+          },
+          "decode": {
+            "samples": 348,
+            "p50_ms": 0.036,
+            "p95_ms": 0.209,
+            "p99_ms": 0.215,
+            "max_ms": 0.226
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 48,
+            "p50_ms": 0.833,
+            "p95_ms": 0.98,
+            "p99_ms": 3.143,
+            "max_ms": 3.143
+          },
+          "finalize_total": {
+            "samples": 48,
+            "p50_ms": 2.161,
+            "p95_ms": 2.736,
+            "p99_ms": 3.301,
+            "max_ms": 3.301
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.082,
+            "p95_ms": 3.153,
+            "p99_ms": 3.153,
+            "max_ms": 3.153
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 8.55,
+            "p95_ms": 8.615,
+            "p99_ms": 8.615,
+            "max_ms": 8.615
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.581,
+            "p95_ms": 2.677,
+            "p99_ms": 2.677,
+            "max_ms": 2.677
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 18.321,
+            "p95_ms": 18.851,
+            "p99_ms": 18.851,
+            "max_ms": 18.851
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "24h-columnar-deflate",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-columnar-deflate",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.5598732499929611,
+        "user_seconds": 0.395771,
+        "system_seconds": 0.190719,
+        "maximum_resident_set_size_bytes": 30408704,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "deflate",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 48,
+          "encoded_bytes": 221234,
+          "decoded_value_bytes": 2303608
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 19742720,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2498560,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 610,
+            "freelist_pages": 531,
+            "allocated_page_bytes": 2498560,
+            "live_page_bytes": 323584,
+            "index_bytes": 32768
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 315392,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 77,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 315392,
+            "live_page_bytes": 315392,
+            "index_bytes": 28672
+          },
+          "before_reclamation_reduction_percent": -0.660066006600668,
+          "after_vacuum_reduction_percent": 87.29372937293729,
+          "vacuum_wall_ms": 1.2342080000000002
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.343,
+            "p95_ms": 13.509,
+            "p99_ms": 13.509,
+            "max_ms": 13.509
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.101,
+            "p95_ms": 0.113,
+            "p99_ms": 0.113,
+            "max_ms": 0.113
+          },
+          "source_scan": {
+            "samples": 50,
+            "p50_ms": 0.148,
+            "p95_ms": 1.491,
+            "p99_ms": 1.657,
+            "max_ms": 1.657
+          },
+          "encode": {
+            "samples": 48,
+            "p50_ms": 0.204,
+            "p95_ms": 0.443,
+            "p99_ms": 0.456,
+            "max_ms": 0.456
+          },
+          "decode": {
+            "samples": 348,
+            "p50_ms": 0.031,
+            "p95_ms": 0.17,
+            "p99_ms": 0.178,
+            "max_ms": 0.207
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 48,
+            "p50_ms": 0.808,
+            "p95_ms": 1.019,
+            "p99_ms": 2.996,
+            "max_ms": 2.996
+          },
+          "finalize_total": {
+            "samples": 48,
+            "p50_ms": 2.328,
+            "p95_ms": 3.132,
+            "p99_ms": 3.327,
+            "max_ms": 3.327
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.124,
+            "p95_ms": 3.283,
+            "p99_ms": 3.283,
+            "max_ms": 3.283
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 8.111,
+            "p95_ms": 8.21,
+            "p99_ms": 8.21,
+            "max_ms": 8.21
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.579,
+            "p95_ms": 2.73,
+            "p99_ms": 2.73,
+            "max_ms": 2.73
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 18.617,
+            "p95_ms": 18.841,
+            "p99_ms": 18.841,
+            "max_ms": 18.841
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "24h-columnar-deflate-15m",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-columnar-deflate-15m",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "15",
+        "--chunk-rows",
+        "256",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.5707808749866672,
+        "user_seconds": 0.40356899999999996,
+        "system_seconds": 0.193,
+        "maximum_resident_set_size_bytes": 30425088,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "deflate",
+          "chunk_minutes": 15,
+          "chunk_rows": 256,
+          "chunks": 192,
+          "encoded_bytes": 264300,
+          "decoded_value_bytes": 2341064
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 18055168,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2490368,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 608,
+            "freelist_pages": 486,
+            "allocated_page_bytes": 2490368,
+            "live_page_bytes": 499712,
+            "index_bytes": 28672
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 487424,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 119,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 487424,
+            "live_page_bytes": 487424,
+            "index_bytes": 20480
+          },
+          "before_reclamation_reduction_percent": -0.3300330033003229,
+          "after_vacuum_reduction_percent": 80.36303630363037,
+          "vacuum_wall_ms": 1.6355
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.285,
+            "p95_ms": 13.615,
+            "p99_ms": 13.615,
+            "max_ms": 13.615
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.107,
+            "p95_ms": 0.116,
+            "p99_ms": 0.116,
+            "max_ms": 0.116
+          },
+          "source_scan": {
+            "samples": 194,
+            "p50_ms": 0.071,
+            "p95_ms": 0.292,
+            "p99_ms": 0.531,
+            "max_ms": 0.673
+          },
+          "encode": {
+            "samples": 192,
+            "p50_ms": 0.057,
+            "p95_ms": 0.12,
+            "p99_ms": 0.13,
+            "max_ms": 0.131
+          },
+          "decode": {
+            "samples": 1392,
+            "p50_ms": 0.014,
+            "p95_ms": 0.05,
+            "p99_ms": 0.053,
+            "max_ms": 0.059
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 192,
+            "p50_ms": 0.216,
+            "p95_ms": 0.306,
+            "p99_ms": 1.769,
+            "max_ms": 2.615
+          },
+          "finalize_total": {
+            "samples": 192,
+            "p50_ms": 0.59,
+            "p95_ms": 0.776,
+            "p99_ms": 1.833,
+            "max_ms": 3.017
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.102,
+            "p95_ms": 3.171,
+            "p99_ms": 3.171,
+            "max_ms": 3.171
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 8.186,
+            "p95_ms": 8.286,
+            "p99_ms": 8.286,
+            "max_ms": 8.286
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.684,
+            "p95_ms": 2.734,
+            "p99_ms": 2.734,
+            "max_ms": 2.734
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 19.291,
+            "p95_ms": 19.359,
+            "p99_ms": 19.359,
+            "max_ms": 19.359
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "24h-columnar-deflate-240m",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-24h-columnar-deflate-240m",
+        "--minutes",
+        "1440",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "240",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 0.6155702079995535,
+        "user_seconds": 0.430562,
+        "system_seconds": 0.213055,
+        "maximum_resident_set_size_bytes": 30392320,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 1440,
+          "sampled_minutes": 1440,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 21615,
+          "ambient_rows": 2618,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "deflate",
+          "chunk_minutes": 240,
+          "chunk_rows": 4096,
+          "chunks": 12,
+          "encoded_bytes": 195207,
+          "decoded_value_bytes": 2156067
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 28655616,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 2482176,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 606,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 2482176,
+            "live_page_bytes": 2482176,
+            "index_bytes": 892928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 2523136,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 616,
+            "freelist_pages": 502,
+            "allocated_page_bytes": 2523136,
+            "live_page_bytes": 466944,
+            "index_bytes": 94208
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 446464,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 109,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 446464,
+            "live_page_bytes": 446464,
+            "index_bytes": 81920
+          },
+          "before_reclamation_reduction_percent": -1.650165016501659,
+          "after_vacuum_reduction_percent": 82.01320132013201,
+          "vacuum_wall_ms": 3.904084
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 12,
+            "p50_ms": 13.554,
+            "p95_ms": 13.944,
+            "p99_ms": 13.944,
+            "max_ms": 13.944
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.096,
+            "p95_ms": 0.123,
+            "p99_ms": 0.123,
+            "max_ms": 0.123
+          },
+          "source_scan": {
+            "samples": 14,
+            "p50_ms": 0.516,
+            "p95_ms": 4.915,
+            "p99_ms": 4.915,
+            "max_ms": 4.915
+          },
+          "encode": {
+            "samples": 12,
+            "p50_ms": 0.908,
+            "p95_ms": 1.872,
+            "p99_ms": 1.872,
+            "max_ms": 1.872
+          },
+          "decode": {
+            "samples": 87,
+            "p50_ms": 0.077,
+            "p95_ms": 0.644,
+            "p99_ms": 0.744,
+            "max_ms": 0.744
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 12,
+            "p50_ms": 1.855,
+            "p95_ms": 3.6,
+            "p99_ms": 3.6,
+            "max_ms": 3.6
+          },
+          "finalize_total": {
+            "samples": 12,
+            "p50_ms": 5.205,
+            "p95_ms": 11.072,
+            "p99_ms": 11.072,
+            "max_ms": 11.072
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 3.166,
+            "p95_ms": 3.253,
+            "p99_ms": 3.253,
+            "max_ms": 3.253
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 8.242,
+            "p95_ms": 8.384,
+            "p99_ms": 8.384,
+            "max_ms": 8.384
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2.632,
+            "p95_ms": 2.685,
+            "p99_ms": 2.685,
+            "max_ms": 2.685
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 17.903,
+            "p95_ms": 18.098,
+            "p99_ms": 18.098,
+            "max_ms": 18.098
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 1309
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "30d-columnar-deflate",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-30d-columnar-deflate",
+        "--minutes",
+        "43200",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "Python os.wait4 on macOS; ru_maxrss is bytes",
+        "exit_code": 0,
+        "wall_seconds": 15.005592832982074,
+        "user_seconds": 10.864864,
+        "system_seconds": 4.913524,
+        "maximum_resident_set_size_bytes": 30441472,
+        "swaps": 0
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 43200,
+          "sampled_minutes": 43200,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 648446,
+          "ambient_rows": 78546,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "deflate",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 1440,
+          "encoded_bytes": 6769222,
+          "decoded_value_bytes": 70576721
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 29704192,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 75526144,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 18439,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 75526144,
+            "live_page_bytes": 75526144,
+            "index_bytes": 27516928
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 75542528,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 18443,
+            "freelist_pages": 16670,
+            "allocated_page_bytes": 75542528,
+            "live_page_bytes": 7262208,
+            "index_bytes": 81920
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 7241728,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 1768,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 7241728,
+            "live_page_bytes": 7241728,
+            "index_bytes": 65536
+          },
+          "before_reclamation_reduction_percent": -0.02169315038775821,
+          "after_vacuum_reduction_percent": 90.41162752860784,
+          "vacuum_wall_ms": 25.234125
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 338,
+            "p50_ms": 13.146,
+            "p95_ms": 16.98,
+            "p99_ms": 17.86,
+            "max_ms": 18.551
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.116,
+            "p95_ms": 0.139,
+            "p99_ms": 0.139,
+            "max_ms": 0.139
+          },
+          "source_scan": {
+            "samples": 1442,
+            "p50_ms": 0.223,
+            "p95_ms": 1.312,
+            "p99_ms": 1.492,
+            "max_ms": 2.573
+          },
+          "encode": {
+            "samples": 1440,
+            "p50_ms": 0.199,
+            "p95_ms": 0.439,
+            "p99_ms": 0.452,
+            "max_ms": 0.787
+          },
+          "decode": {
+            "samples": 10440,
+            "p50_ms": 0.03,
+            "p95_ms": 0.169,
+            "p99_ms": 0.175,
+            "max_ms": 0.279
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 1440,
+            "p50_ms": 0.814,
+            "p95_ms": 1.043,
+            "p99_ms": 4.007,
+            "max_ms": 5.172
+          },
+          "finalize_total": {
+            "samples": 1440,
+            "p50_ms": 2.328,
+            "p95_ms": 2.91,
+            "p99_ms": 5.565,
+            "max_ms": 6.828
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 131.852,
+            "p95_ms": 134.36,
+            "p99_ms": 134.36,
+            "max_ms": 134.36
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 243.194,
+            "p95_ms": 244.489,
+            "p99_ms": 244.489,
+            "max_ms": 244.489
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 83.788,
+            "p95_ms": 85.041,
+            "p99_ms": 85.041,
+            "max_ms": 85.041
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 529.751,
+            "p95_ms": 536.85,
+            "p99_ms": 536.85,
+            "max_ms": 536.85
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 39274
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    },
+    {
+      "case": "1y-columnar-deflate",
+      "arguments": [
+        "--output",
+        "/tmp/hardviz-g1-1y-columnar-deflate",
+        "--minutes",
+        "525600",
+        "--processes-per-minute",
+        "15",
+        "--seed",
+        "2052",
+        "--repetitions",
+        "7",
+        "--layout",
+        "columnar",
+        "--compression",
+        "deflate",
+        "--chunk-minutes",
+        "60",
+        "--chunk-rows",
+        "4096",
+        "--duty-cycle",
+        "1"
+      ],
+      "external_resources": {
+        "method": "macOS /usr/bin/time -l; partial output",
+        "resource_wrapper_exit_code": 1,
+        "harness_exit_code": null,
+        "completed_harness_report": true,
+        "wall_seconds": 200.46,
+        "user_seconds": 135.45,
+        "system_seconds": 62.5,
+        "maximum_resident_set_size_bytes": null,
+        "swaps": null,
+        "error": "time: sysctl kern.clockrate: Operation not permitted"
+      },
+      "report": {
+        "format": "hardviz-archive-g1-v1",
+        "scope": "synthetic two-family experiment: PROCESS_STATS and AMBIENT_ARCHIVE",
+        "workload": {
+          "source": "deterministic synthetic production-shaped rows",
+          "represented_minutes": 525600,
+          "sampled_minutes": 525600,
+          "sampling_mode": "continuous",
+          "duty_cycle": 1,
+          "processes_per_sampled_minute": 15,
+          "numeric_shape": "producer-range rows plus separately labeled exact i64/binary64 sentinels",
+          "process_rows": 7889419,
+          "ambient_rows": 955636,
+          "seed": 2052
+        },
+        "format_candidate": {
+          "layout": "columnar",
+          "compression": "deflate",
+          "chunk_minutes": 60,
+          "chunk_rows": 4096,
+          "chunks": 17520,
+          "encoded_bytes": 82424693,
+          "decoded_value_bytes": 859253037
+        },
+        "environment": {
+          "os": "macos",
+          "architecture": "aarch64",
+          "logical_cpus": 10,
+          "cpu_brand": "Apple M4",
+          "total_memory_bytes": 25769803776,
+          "current_rss_bytes": 30932992,
+          "peak_rss_bytes": null,
+          "rustc_version": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+          "git_commit": "f4afeb9acc5b4c6a3206375db2b87b2b834fec2e",
+          "filesystem": "unavailable"
+        },
+        "sqlite": {
+          "version": "3.46.0",
+          "journal_mode": "wal",
+          "synchronous": 1,
+          "compile_options": [
+            "ATOMIC_INTRINSICS=1",
+            "COMPILER=clang-17.0.0",
+            "DEFAULT_AUTOVACUUM",
+            "DEFAULT_CACHE_SIZE=-2000",
+            "DEFAULT_FILE_FORMAT=4",
+            "DEFAULT_FOREIGN_KEYS",
+            "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+            "DEFAULT_MMAP_SIZE=0",
+            "DEFAULT_PAGE_SIZE=4096",
+            "DEFAULT_PCACHE_INITSZ=20",
+            "DEFAULT_RECURSIVE_TRIGGERS",
+            "DEFAULT_SECTOR_SIZE=4096",
+            "DEFAULT_SYNCHRONOUS=2",
+            "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+            "DEFAULT_WAL_SYNCHRONOUS=2",
+            "DEFAULT_WORKER_THREADS=0",
+            "DIRECT_OVERFLOW_READ",
+            "ENABLE_API_ARMOR",
+            "ENABLE_COLUMN_METADATA",
+            "ENABLE_DBSTAT_VTAB",
+            "ENABLE_FTS3",
+            "ENABLE_FTS3_PARENTHESIS",
+            "ENABLE_FTS5",
+            "ENABLE_LOAD_EXTENSION",
+            "ENABLE_MEMORY_MANAGEMENT",
+            "ENABLE_RTREE",
+            "ENABLE_STAT4",
+            "ENABLE_UNLOCK_NOTIFY",
+            "HAVE_ISNAN",
+            "MALLOC_SOFT_LIMIT=1024",
+            "MAX_ATTACHED=10",
+            "MAX_COLUMN=2000",
+            "MAX_COMPOUND_SELECT=500",
+            "MAX_DEFAULT_PAGE_SIZE=8192",
+            "MAX_EXPR_DEPTH=1000",
+            "MAX_FUNCTION_ARG=127",
+            "MAX_LENGTH=1000000000",
+            "MAX_LIKE_PATTERN_LENGTH=50000",
+            "MAX_MMAP_SIZE=0x7fff0000",
+            "MAX_PAGE_COUNT=0xfffffffe",
+            "MAX_PAGE_SIZE=65536",
+            "MAX_SQL_LENGTH=1000000000",
+            "MAX_TRIGGER_DEPTH=1000",
+            "MAX_VARIABLE_NUMBER=32766",
+            "MAX_VDBE_OP=250000000",
+            "MAX_WORKER_THREADS=8",
+            "MUTEX_PTHREADS",
+            "SOUNDEX",
+            "SYSTEM_MALLOC",
+            "TEMP_STORE=1",
+            "THREADSAFE=1",
+            "USE_URI"
+          ]
+        },
+        "footprints": {
+          "relational_baseline": {
+            "database_bytes": 926257152,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 226137,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 926257152,
+            "live_page_bytes": 926257152,
+            "index_bytes": 335720448
+          },
+          "chunked_before_reclamation": {
+            "database_bytes": 926273536,
+            "wal_bytes": 0,
+            "shm_bytes": 32768,
+            "page_size": 4096,
+            "page_count": 226141,
+            "freelist_pages": 204819,
+            "allocated_page_bytes": 926273536,
+            "live_page_bytes": 87334912,
+            "index_bytes": 532480
+          },
+          "chunked_after_vacuum": {
+            "database_bytes": 87265280,
+            "wal_bytes": 0,
+            "shm_bytes": 196608,
+            "page_size": 4096,
+            "page_count": 21305,
+            "freelist_pages": 0,
+            "allocated_page_bytes": 87265280,
+            "live_page_bytes": 87265280,
+            "index_bytes": 466944
+          },
+          "before_reclamation_reduction_percent": -0.0017688392434767053,
+          "after_vacuum_reduction_percent": 90.57871997948146,
+          "vacuum_wall_ms": 316.21137500000003
+        },
+        "timings_ms": {
+          "fixture_seed_batch": {
+            "samples": 4107,
+            "p50_ms": 13.419,
+            "p95_ms": 17.317,
+            "p99_ms": 18.095,
+            "max_ms": 28.766
+          },
+          "production_shaped_minute_append": {
+            "samples": 7,
+            "p50_ms": 0.167,
+            "p95_ms": 1.332,
+            "p99_ms": 1.332,
+            "max_ms": 1.332
+          },
+          "source_scan": {
+            "samples": 17522,
+            "p50_ms": 0.648,
+            "p95_ms": 1.32,
+            "p99_ms": 1.467,
+            "max_ms": 8.058
+          },
+          "encode": {
+            "samples": 17520,
+            "p50_ms": 0.221,
+            "p95_ms": 0.442,
+            "p99_ms": 0.452,
+            "max_ms": 1.217
+          },
+          "decode": {
+            "samples": 127020,
+            "p50_ms": 0.028,
+            "p95_ms": 0.17,
+            "p99_ms": 0.175,
+            "max_ms": 0.82
+          },
+          "chunk_insert_and_tail_delete": {
+            "samples": 17520,
+            "p50_ms": 0.882,
+            "p95_ms": 1.085,
+            "p99_ms": 4.295,
+            "max_ms": 12.114
+          },
+          "finalize_total": {
+            "samples": 17520,
+            "p50_ms": 2.452,
+            "p95_ms": 2.966,
+            "p99_ms": 5.905,
+            "max_ms": 12.291
+          },
+          "process_query_baseline": {
+            "samples": 7,
+            "p50_ms": 2108.398,
+            "p95_ms": 2468.62,
+            "p99_ms": 2468.62,
+            "max_ms": 2468.62
+          },
+          "process_query_chunked": {
+            "samples": 7,
+            "p50_ms": 2965.901,
+            "p95_ms": 2999.155,
+            "p99_ms": 2999.155,
+            "max_ms": 2999.155
+          },
+          "ambient_raw_query_baseline": {
+            "samples": 7,
+            "p50_ms": 1514.669,
+            "p95_ms": 1572.645,
+            "p99_ms": 1572.645,
+            "max_ms": 1572.645
+          },
+          "ambient_raw_query_chunked": {
+            "samples": 7,
+            "p50_ms": 6552.12,
+            "p95_ms": 6595.218,
+            "p99_ms": 6595.218,
+            "max_ms": 6595.218
+          }
+        },
+        "correctness": {
+          "exact_decoder_check": true,
+          "persisted_reopen_exact_records": true,
+          "process_query_equivalent": true,
+          "ambient_raw_range_equivalent": true,
+          "process_float_tolerance": "abs(actual-reference) <= max(1e-9, 1e-12*abs(reference))",
+          "precommit_changed_selection_rollback": true,
+          "postcommit_retry_exact_multiplicity": true,
+          "concurrent_snapshot_before_or_after": true,
+          "process_groups": 46,
+          "ambient_range_rows": 477818
+        },
+        "limitations": [
+          "Synthetic data is not real-world workload evidence.",
+          "Footprints cover two raw families, not the full application database or its 30 percent gate.",
+          "This experiment does not implement migration, pagination, retention, recovery selection, or the 30-minute background CPU gate.",
+          "Ambient is a representative raw epoch-millisecond inclusive range; production Cooling also has half-open pairing contracts.",
+          "Candidate query times include catalog reads, decoding, filtering, and aggregation.",
+          "Peak RSS and temporary SQLite bytes are not instrumented in this initial harness."
+        ]
+      }
+    }
+  ]
+}

--- a/docs/development/hardware-archive-g1-benchmark.md
+++ b/docs/development/hardware-archive-g1-benchmark.md
@@ -1,0 +1,209 @@
+# Hardware Archive G1 Initial Benchmark
+
+Status: experimental evidence for [#2052](https://github.com/shm11C3/HardwareVisualizer/issues/2052).
+The [G1 acceptance gate](hardware-archive-implementation-plan.md#g1--prove-process-stats-and-sensor-format-candidates)
+remains open. These measurements establish a reproducible two-family path;
+they do not select a production format or authorize G2.
+
+## Recommendation
+
+Continue evaluating one-hour columnar chunks with Deflate as a **size
+candidate**. Keep Process Stats mandatory. The first experiment demonstrates
+exact preservation and substantial reclaimed-file savings, but the measured
+query paths do not meet the proposed latency comparison. Optimize and remeasure
+the query strategy before accepting a format; do not relax the data-preservation
+contract to obtain a passing result.
+
+The next experiment should resolve bounded reads and aggregation for Process
+Stats, and an efficient Ambient query that preserves SQLite's timestamp
+membership semantics. Complete high-cardinality process workloads and the
+remaining families before deciding per-family storage. There is no evidence
+here to freeze a ten-year paging budget or a migration throughput floor.
+
+## Reproduce
+
+The measured executable is from commit
+`f4afeb9acc5b4c6a3206375db2b87b2b834fec2e`, based on develop
+`838d08da16d60ead84df3ddb1501ca19a57f24fc`. The
+[G1 inventory](hardware-archive-g1-inventory.md) pins all schema-v23 objects and
+query consumers, including the Cooling covariate summaries introduced by
+#2070. The executable copies only the current Process Stats and Ambient raw
+schemas and their timestamp indexes into a synthetic database.
+
+```bash
+cargo build -p hardviz-core --release --example archive_format_benchmark
+/usr/bin/time -l target/release/examples/archive_format_benchmark \
+  --output /tmp/hardviz-g1-24h-columnar-deflate \
+  --days 1 --seed 2052 --repetitions 7 \
+  --layout columnar --compression deflate
+```
+
+The output directory must not exist. The command creates its own relational
+oracle, candidate, and isolated transaction probes there, then writes
+`report.json`. It never locates or opens an application database. Run each case
+serially after building; use distinct directories. `/usr/bin/time -l` is the
+macOS wrapper for the external CPU/RSS observations below. Use an equivalent
+wrapper on other systems. See the committed
+[measurement artifact](benchmarks/hardware-archive-g1-2026-09-05.json) for every
+case's arguments, complete report, and external resource observations.
+
+Default limits are 60 represented minutes, 4,096 rows, and 4 MiB of decoded
+value bytes per chunk. The retained relational tail spans the newest half
+chunk duration. The time-limit comparisons therefore change tail length too;
+they are whole-configuration comparisons, not an isolated time-cap experiment.
+The 15-minute comparison also uses a 256-row cap. All cases use 15 ordinary
+process observations per minute, seed 2052, and duty cycle 1. No elapsed time
+is skipped to simulate longer histories.
+
+## Environment and method
+
+Measured on 2026-09-05 using Apple M4 (10 logical CPUs), 24 GiB RAM,
+macOS 26.6.2 (25G83), and APFS. The Rust binary reports SQLite 3.46.0, WAL mode,
+`synchronous=NORMAL`, 4,096-byte pages, and Rust 1.98.0
+(`88d9e12ae`, 2026-08-18). Full SQLite compile options are in the artifact.
+APFS was checked independently; the portable harness reports filesystem as
+unavailable on macOS. The inventory's system SQLite version is not substituted
+for the benchmark's bundled SQLite version.
+
+Synthetic identities rotate through 45 PID/name groups, with an additional
+sparse sentinel group. Ordinary rows use the producer's numeric ranges and
+bounded process lifetimes. Separate sentinels exercise exact i64 and binary64
+storage. Two Ambient source labels include gaps and nullable humidity.
+Unicode/NUL text is deliberate fixture data. This is not a realistic process
+ranking distribution or a high-churn workload. Duplicate instants, offset and
+submillisecond timestamp spellings, noncontiguous IDs, backward clock steps,
+and incomplete/corrupt chunks receive separate contract tests.
+
+Each case is one complete executable run with seven repetitions of each query.
+The source and candidate have already been populated and validated; the
+candidate has also been closed and reopened. Queries alternate baseline then
+candidate on the same host without cache purging. These are cache-primed measurements, including the first query, not
+controlled cold-cache results. With seven observations, the reported p95 and
+p99 both equal the maximum; use the raw p50 as additional context and do not
+interpret these as stable tail-latency estimates.
+
+Both queries cover the latter half of the represented history. Process Stats
+compares grouped averages/counts/maxima against SQLite, with exact group keys,
+counts, and timestamps and the design's separate float tolerance. Results are
+canonicalized by PID/name for comparison; the experiment does not implement
+production CPU-order pagination. Ambient compares an inclusive raw range using
+the current SQLite epoch-millisecond expression. The candidate decodes all
+Ambient chunks into a temporary SQLite timestamp/digest relation to preserve
+that predicate and original-ID ordering exactly. Its timing includes this
+work. This representative query does not prove every production Ambient bucket
+or half-open Cooling pairing query.
+
+## Measured results
+
+### Size and query comparison
+
+Sizes are MiB (`bytes / 1,048,576`). Query values are p95 milliseconds.
+
+| Configuration | Relational DB | DB after VACUUM | Reduction | Process row / chunk | Ambient row / chunk |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 24h-row-none | 2.367 | 2.004 | 15.35% | 3.345 / 11.655 | 2.708 / 19.360 |
+| 24h-row-deflate | 2.367 | 0.477 | 79.87% | 3.334 / 9.322 | 2.736 / 18.902 |
+| 24h-columnar-none | 2.367 | 0.812 | 65.68% | 3.153 / 8.615 | 2.677 / 18.851 |
+| 24h-columnar-deflate | 2.367 | 0.301 | 87.29% | 3.283 / 8.210 | 2.730 / 18.841 |
+| 24h-columnar-deflate-15m | 2.367 | 0.465 | 80.36% | 3.171 / 8.286 | 2.734 / 19.359 |
+| 24h-columnar-deflate-240m | 2.367 | 0.426 | 82.01% | 3.253 / 8.384 | 2.685 / 18.098 |
+| 30d-columnar-deflate | 72.027 | 6.906 | 90.41% | 134.360 / 244.489 | 85.041 / 536.850 |
+| 1y-columnar-deflate | 883.348 | 83.223 | 90.58% | 2468.620 / 2999.155 | 1572.645 / 6595.218 |
+
+These are logical file lengths for two raw families, including their indexes.
+They are not full-application savings or filesystem physical-block measurements.
+All measured WAL lengths were zero after explicit checkpointing; SHM sizes and
+index/live/free-page bytes are recorded separately in the artifact.
+
+### Longer-history comparison
+
+The proposed comparison is `candidate p95 <= max(1.2 * baseline p95,
+baseline p95 + 20 ms)`. The following uses the cache-primed measurements above
+as an initial comparison; it does not ratify a statistically stable warm budget.
+
+| Duration / query | Baseline p95 | Candidate p95 | Proposed ceiling | Result |
+| --- | ---: | ---: | ---: | --- |
+| 30d / Process Stats | 134.360 ms | 244.489 ms | 161.232 ms | Fail |
+| 30d / Ambient raw | 85.041 ms | 536.850 ms | 105.041 ms | Fail |
+| 1y / Process Stats | 2468.620 ms | 2999.155 ms | 2962.344 ms | Fail |
+| 1y / Ambient raw | 1572.645 ms | 6595.218 ms | 1887.174 ms | Fail |
+
+### Reclamation and resources
+
+| Default columnar/Deflate case | Process / Ambient rows | DB before VACUUM (MiB) | VACUUM (ms) | Append p99 (ms) | Total wall / CPU (s) | External peak RSS (MiB) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 24h | 21,615 / 2,618 | 2.383 | 1.234 | 0.113 | 0.560 / 0.586 | 29.00 |
+| 30d | 648,446 / 78,546 | 72.043 | 25.234 | 0.139 | 15.006 / 15.778 | 29.03 |
+| 1y | 7,889,419 / 955,636 | 883.363 | 316.211 | 1.332 | 200.460 / 197.950 | unavailable |
+
+Finalization frees pages for reuse but does not itself shorten the database
+file: the candidate before reclamation is slightly larger than the source.
+VACUUM is explicit here and is not a recommendation to run blocking reclamation
+in the application. The source copy is retained. Source-plus-candidate and
+SQLite temporary-file peak space were not instrumented.
+
+Total CPU is user plus system CPU across fixture generation, copying,
+validation, repeated queries, and reclamation. It is not steady-state maintenance
+CPU. Shorter runs use Python `os.wait4` resource usage for the benchmark child;
+macOS reports `ru_maxrss` in bytes. The one-year `/usr/bin/time -l` wrapper
+printed wall/user/system time, then failed with
+`sysctl kern.clockrate: Operation not permitted`. Its exit status was 1; the
+benchmark had already emitted matching complete file/stdout reports with every
+correctness flag true. Peak RSS for that case is therefore unavailable, not
+zero. The report's end-of-run RSS is a separate observation, not peak RSS.
+
+## What the results establish
+
+All recorded runs produced complete reports only after the seven required
+correctness flags passed: exact codec decoding, exact records after
+closing/reopening the persisted candidate, Process Stats aggregate equivalence, Ambient raw range
+equivalence, rollback when a selected row disappears before commit, unchanged
+multiplicity on post-commit retry, and a consistent read snapshot while another
+connection finalizes the tail. Exact validation checks the actual persisted IDs
+and values against the source and uses a temporary primary-key manifest to
+reject duplicates and missing coverage. These probes establish the implemented
+experimental boundaries, not the full online migration/recovery state machine.
+
+The lossless frame preserves SQLite value classes and exact integer, float-bit,
+text-byte, blob-byte, and null values. It has a version, integrity digest, and
+bounded decoding. Columnar encoding adds checked integer deltas, float XORs, and
+local text dictionaries. Row layout and uncompressed variants are controls.
+Deflate uses an already locked workspace dependency, added only as a Core
+development dependency; it is not a production codec commitment. Truncated
+compressed streams must reach neither a successful decode nor a correctness
+report, even when the outer hash has been recomputed.
+
+The catalog index is `(family, id)` because the measured readers consume one
+chunk at a time with `id > cursor ORDER BY id LIMIT 1`. An earlier timestamp
+index caused a repeated temporary sort for this access path. The corrected
+index is covered by an `EXPLAIN QUERY PLAN` regression test. It does not solve
+all interval-index selection or per-series partitioning questions.
+
+## Open acceptance gates
+
+| Gate | Evidence and remaining work |
+| --- | --- |
+| Exact preservation | Passes the two representative paths and focused corruption/boundary tests. Add the other raw families and preserved relational tables to full-database validation. |
+| Disk benefit | Strong two-family savings after explicit reclamation. Per-family Process Stats index accounting and a complete representative database are still needed for the 50%/30% gates. |
+| Query latency | The candidate misses the proposed comparison for longer ranges. Optimize the real query boundary and repeat these measurements before format acceptance. |
+| Ten-year history | Not measured in this initial report. Existing-range query failures must be addressed; continuous ten-year data and paged/aggregate budgets remain required by G1. |
+| Process workload | The generator has 46 aggregate groups at the default density. High PID/name churn, realistic ranking, bounded paging, spills, and partial errors remain unproven. |
+| Other families/layouts | System, GPU, fan, mixed metadata, per-series partitioning, byte-cap boundary configurations, and alternative compression candidates still need comparison. |
+| Append/visibility | Standalone minute-append transactions are measured, including commit. They do not establish append latency under concurrent maintenance or absence of missed intervals. |
+| CPU/memory | External total CPU/RSS are recorded for the entire synthetic run. They do not prove additional steady-state maintenance cost over 30 minutes or history-independent query/migration overhead. |
+| Migration/reclamation | Per-chunk finalization and explicit VACUUM are measured. Source growth, online capture, catch-up, full validation cost, temporary-space peak, recovery-copy protection, and cutover pauses need the later migration experiment. |
+| Platform and repeatability | Local measurements use one macOS host and one run per configuration. Native Linux/Windows measurements and repeated/cold-cache trials remain open. |
+| Human decision | No production format, numerical migration floor, or ten-year budget is ratified by this report. Maintainer acceptance remains required before G2. |
+
+## Validation commands
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p hardviz-core --all-targets -- -D warnings
+cargo test -p hardviz-core -- --test-threads=1
+npm run check:agent-guidance
+```
+
+The benchmark example has `test = true`, so the ordinary Core test command also
+runs its codec and SQLite contract tests. Production collection, migration
+selection, retention, and application queries are not wired to this executable.

--- a/docs/development/hardware-archive-g1-benchmark.md
+++ b/docs/development/hardware-archive-g1-benchmark.md
@@ -15,15 +15,14 @@ the query strategy before accepting a format; do not relax the data-preservation
 contract to obtain a passing result.
 
 The next experiment should resolve bounded reads and aggregation for Process
-Stats, and an efficient Ambient query that preserves SQLite's timestamp
-membership semantics. Complete high-cardinality process workloads and the
-remaining families before deciding per-family storage. There is no evidence
+Stats, while retaining SQLite's timestamp membership semantics in the Ambient
+query. Complete high-cardinality process workloads and the remaining families before deciding per-family storage. There is no evidence
 here to freeze a ten-year paging budget or a migration throughput floor.
 
 ## Reproduce
 
 The measured executable is from commit
-`f4afeb9acc5b4c6a3206375db2b87b2b834fec2e`, based on develop
+`f1de181f89054e52c42734ea69f276879e5cd389`, based on develop
 `838d08da16d60ead84df3ddb1501ca19a57f24fc`. The
 [G1 inventory](hardware-archive-g1-inventory.md) pins all schema-v23 objects and
 query consumers, including the Cooling covariate summaries introduced by
@@ -42,8 +41,9 @@ The output directory must not exist. The command creates its own relational
 oracle, candidate, and isolated transaction probes there, then writes
 `report.json`. It never locates or opens an application database. Run each case
 serially after building; use distinct directories. `/usr/bin/time -l` is the
-macOS wrapper for the external CPU/RSS observations below. Use an equivalent
-wrapper on other systems. See the committed
+macOS wrapper for collecting equivalent CPU/RSS observations. The recorded
+series uses Python `os.wait4`, detailed below. Use an equivalent wrapper on
+other systems. See the committed
 [measurement artifact](benchmarks/hardware-archive-g1-2026-09-05.json) for every
 case's arguments, complete report, and external resource observations.
 
@@ -51,9 +51,11 @@ Default limits are 60 represented minutes, 4,096 rows, and 4 MiB of decoded
 value bytes per chunk. The retained relational tail spans the newest half
 chunk duration. The time-limit comparisons therefore change tail length too;
 they are whole-configuration comparisons, not an isolated time-cap experiment.
-The 15-minute comparison also uses a 256-row cap. All cases use 15 ordinary
-process observations per minute, seed 2052, and duty cycle 1. No elapsed time
-is skipped to simulate longer histories.
+The 15-minute comparison also uses a 256-row cap. The report separately counts
+finalized and retained-tail decoded value bytes using the codec's size rule;
+workload decoded bytes include both and remain constant across configurations
+for the same source rows. All cases use 15 ordinary process observations per
+minute, seed 2052, and duty cycle 1. No elapsed time is skipped to simulate longer histories.
 
 ## Environment and method
 
@@ -77,9 +79,9 @@ and incomplete/corrupt chunks receive separate contract tests.
 Each case is one complete executable run with seven repetitions of each query.
 The source and candidate have already been populated and validated; the
 candidate has also been closed and reopened. Queries alternate baseline then
-candidate on the same host without cache purging. These are cache-primed measurements, including the first query, not
-controlled cold-cache results. With seven observations, the reported p95 and
-p99 both equal the maximum; use the raw p50 as additional context and do not
+candidate on the same host without cache purging. These are cache-primed
+measurements, including the first query, not controlled cold-cache results. With
+seven observations, the reported p95 and p99 both equal the maximum; use the raw p50 as additional context and do not
 interpret these as stable tail-latency estimates.
 
 Both queries cover the latter half of the represented history. Process Stats
@@ -88,10 +90,11 @@ counts, and timestamps and the design's separate float tolerance. Results are
 canonicalized by PID/name for comparison; the experiment does not implement
 production CPU-order pagination. Ambient compares an inclusive raw range using
 the current SQLite epoch-millisecond expression. The candidate decodes all
-Ambient chunks into a temporary SQLite timestamp/digest relation to preserve
-that predicate and original-ID ordering exactly. Its timing includes this
-work. This representative query does not prove every production Ambient bucket
-or half-open Cooling pairing query.
+Ambient chunks into a temporary SQLite timestamp/digest relation in bounded
+multi-row inserts to preserve that predicate and original-ID ordering exactly.
+Its timing includes materialization and filtering as well as decoding. This
+representative query does not prove every production Ambient bucket or
+half-open Cooling pairing query.
 
 ## Measured results
 
@@ -101,14 +104,14 @@ Sizes are MiB (`bytes / 1,048,576`). Query values are p95 milliseconds.
 
 | Configuration | Relational DB | DB after VACUUM | Reduction | Process row / chunk | Ambient row / chunk |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 24h-row-none | 2.367 | 2.004 | 15.35% | 3.345 / 11.655 | 2.708 / 19.360 |
-| 24h-row-deflate | 2.367 | 0.477 | 79.87% | 3.334 / 9.322 | 2.736 / 18.902 |
-| 24h-columnar-none | 2.367 | 0.812 | 65.68% | 3.153 / 8.615 | 2.677 / 18.851 |
-| 24h-columnar-deflate | 2.367 | 0.301 | 87.29% | 3.283 / 8.210 | 2.730 / 18.841 |
-| 24h-columnar-deflate-15m | 2.367 | 0.465 | 80.36% | 3.171 / 8.286 | 2.734 / 19.359 |
-| 24h-columnar-deflate-240m | 2.367 | 0.426 | 82.01% | 3.253 / 8.384 | 2.685 / 18.098 |
-| 30d-columnar-deflate | 72.027 | 6.906 | 90.41% | 134.360 / 244.489 | 85.041 / 536.850 |
-| 1y-columnar-deflate | 883.348 | 83.223 | 90.58% | 2468.620 / 2999.155 | 1572.645 / 6595.218 |
+| 24h-row-none | 2.367 | 2.004 | 15.35% | 3.062 / 11.221 | 2.723 / 5.983 |
+| 24h-row-deflate | 2.367 | 0.477 | 79.87% | 3.105 / 9.400 | 2.907 / 5.917 |
+| 24h-columnar-none | 2.367 | 0.812 | 65.68% | 3.090 / 8.510 | 2.731 / 5.815 |
+| 24h-columnar-deflate | 2.367 | 0.301 | 87.29% | 3.002 / 7.991 | 2.851 / 5.795 |
+| 24h-columnar-deflate-15m | 2.367 | 0.465 | 80.36% | 3.047 / 8.153 | 2.786 / 6.733 |
+| 24h-columnar-deflate-240m | 2.367 | 0.426 | 82.01% | 3.130 / 8.405 | 2.781 / 5.521 |
+| 30d-columnar-deflate | 72.027 | 6.906 | 90.41% | 136.601 / 244.865 | 85.561 / 165.447 |
+| 1y-columnar-deflate | 883.348 | 83.223 | 90.58% | 2447.772 / 2994.709 | 1340.537 / 2169.853 |
 
 These are logical file lengths for two raw families, including their indexes.
 They are not full-application savings or filesystem physical-block measurements.
@@ -123,18 +126,18 @@ as an initial comparison; it does not ratify a statistically stable warm budget.
 
 | Duration / query | Baseline p95 | Candidate p95 | Proposed ceiling | Result |
 | --- | ---: | ---: | ---: | --- |
-| 30d / Process Stats | 134.360 ms | 244.489 ms | 161.232 ms | Fail |
-| 30d / Ambient raw | 85.041 ms | 536.850 ms | 105.041 ms | Fail |
-| 1y / Process Stats | 2468.620 ms | 2999.155 ms | 2962.344 ms | Fail |
-| 1y / Ambient raw | 1572.645 ms | 6595.218 ms | 1887.174 ms | Fail |
+| 30d / Process Stats | 136.601 ms | 244.865 ms | 163.921 ms | Fail |
+| 30d / Ambient raw | 85.561 ms | 165.447 ms | 105.561 ms | Fail |
+| 1y / Process Stats | 2447.772 ms | 2994.709 ms | 2937.326 ms | Fail |
+| 1y / Ambient raw | 1340.537 ms | 2169.853 ms | 1608.644 ms | Fail |
 
 ### Reclamation and resources
 
 | Default columnar/Deflate case | Process / Ambient rows | DB before VACUUM (MiB) | VACUUM (ms) | Append p99 (ms) | Total wall / CPU (s) | External peak RSS (MiB) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 24h | 21,615 / 2,618 | 2.383 | 1.234 | 0.113 | 0.560 / 0.586 | 29.00 |
-| 30d | 648,446 / 78,546 | 72.043 | 25.234 | 0.139 | 15.006 / 15.778 | 29.03 |
-| 1y | 7,889,419 / 955,636 | 883.363 | 316.211 | 1.332 | 200.460 / 197.950 | unavailable |
+| 24h | 21,615 / 2,618 | 2.383 | 1.337 | 0.138 | 0.469 / 0.493 | 29.00 |
+| 30d | 648,446 / 78,546 | 72.043 | 25.368 | 0.134 | 12.528 / 13.161 | 29.02 |
+| 1y | 7,889,419 / 955,636 | 883.363 | 404.285 | 0.138 | 169.140 / 167.127 | 32.36 |
 
 Finalization frees pages for reuse but does not itself shorten the database
 file: the candidate before reclamation is slightly larger than the source.
@@ -144,13 +147,27 @@ SQLite temporary-file peak space were not instrumented.
 
 Total CPU is user plus system CPU across fixture generation, copying,
 validation, repeated queries, and reclamation. It is not steady-state maintenance
-CPU. Shorter runs use Python `os.wait4` resource usage for the benchmark child;
-macOS reports `ru_maxrss` in bytes. The one-year `/usr/bin/time -l` wrapper
-printed wall/user/system time, then failed with
-`sysctl kern.clockrate: Operation not permitted`. Its exit status was 1; the
-benchmark had already emitted matching complete file/stdout reports with every
-correctness flag true. Peak RSS for that case is therefore unavailable, not
-zero. The report's end-of-run RSS is a separate observation, not peak RSS.
+CPU. External measurements use Python `os.wait4` for the benchmark child;
+macOS reports `ru_maxrss` in bytes. The report's end-of-run RSS is a separate
+observation, not peak RSS. The measurement artifact records the method, child
+exit status, wall/user/system time, peak RSS, and swaps for every case.
+
+### Decoded value accounting
+
+The codec counts one type-tag byte per value, plus eight bytes for INTEGER/REAL
+or the byte length for TEXT/BLOB. This excludes frame and dictionary bookkeeping.
+The following separates finalized records and the retained relational tail;
+all six 24-hour cases have the same full-workload denominator. Storage savings
+above use complete database/WAL file lengths, not this logical byte count.
+
+| 24-hour configuration | Finalized decoded bytes | Tail decoded bytes | Full workload decoded bytes |
+| --- | ---: | ---: | ---: |
+| 24h-row-none | 1,924,216 | 42,067 | 1,966,283 |
+| 24h-row-deflate | 1,924,216 | 42,067 | 1,966,283 |
+| 24h-columnar-none | 1,924,216 | 42,067 | 1,966,283 |
+| 24h-columnar-deflate | 1,924,216 | 42,067 | 1,966,283 |
+| 24h-columnar-deflate-15m | 1,955,480 | 10,803 | 1,966,283 |
+| 24h-columnar-deflate-240m | 1,800,915 | 165,368 | 1,966,283 |
 
 ## What the results establish
 
@@ -166,7 +183,11 @@ experimental boundaries, not the full online migration/recovery state machine.
 
 The lossless frame preserves SQLite value classes and exact integer, float-bit,
 text-byte, blob-byte, and null values. It has a version, integrity digest, and
-bounded decoding. Columnar encoding adds checked integer deltas, float XORs, and
+bounded decoding. The SQLite adapter chooses each Value variant from the
+runtime storage class, including BLOBs retained in TEXT-affinity columns and
+fractional REALs retained in INTEGER-affinity columns. Separate adapter tests
+assert these variants directly; they do not pass both sides through a shared
+coercion. Columnar encoding adds checked integer deltas, float XORs, and
 local text dictionaries. Row layout and uncompressed variants are controls.
 Deflate uses an already locked workspace dependency, added only as a Core
 development dependency; it is not a production codec commitment. Truncated

--- a/docs/development/hardware-archive-g1-inventory.md
+++ b/docs/development/hardware-archive-g1-inventory.md
@@ -1,0 +1,324 @@
+# Hardware Archive G1 Inventory
+
+Status: G1 experimental-development inventory for
+[#2052](https://github.com/shm11C3/HardwareVisualizer/issues/2052).
+
+This pins the row-based oracle that G1 must benchmark before choosing a format.
+It does not enable migration, approve a codec/layout, establish benchmark
+results, or satisfy the G1 human-review gate.
+
+## Pinned scope and status
+
+- Revision: `838d08da16d60ead84df3ddb1501ca19a57f24fc` (merged #2070).
+- App migration ceiling: version 23.
+- [ADR 0019](../adr/0019-lossless-chunked-hardware-archive.md) is accepted.
+  [ADR 0021](../adr/0021-hardware-archive-migration-lifecycle.md) and the
+  [storage design](hardware-archive-storage-design.md) are proposed design
+  inputs. G1 implementation is authorized; format selection and numerical
+  budgets still await measurement and maintainer acceptance.
+- The #1666 checkpoint includes merged #2070 at this revision, including both
+  version-23 covariate tables and consumers. Starting G1 is authorized. This
+  makes no claim that the #1666 epic is closed.
+- G1 is isolated experimental development. Production recording and queries
+  remain relational until later delivery gates change that state.
+
+Design-review outcome: **Aligned with guardrail**. The experiment serves DP-02,
+DP-04, DP-05, DP-07, DP-09, and ADR 0019 only while it preserves the stored rows
+and query semantics below, keeps Core as persistence owner, and leaves format
+selection and budgets pending measurement and maintainer review.
+
+## SQLite baseline
+
+Core opens the App-selected database with WAL, a five-second busy timeout, and
+`synchronous=NORMAL`. App supplies append-only SQLx migrations; Core applies
+them before persistence workers start. Existing migration SQL/checksums must
+not be rewritten.
+
+Version 23 defines 15 product tables and four explicit indexes:
+`idx_process_stats_timestamp`, `idx_ambient_archive_timestamp`,
+`idx_fan_archive_timestamp`, and `idx_data_archive_timestamp`. It defines no
+application trigger or view. Applying the 23 SQL bodies alone with SQLite
+3.50.4 produces 16 tables including `sqlite_sequence`, 12 indexes including
+eight SQLite autoindexes, zero views, and zero triggers. SQLx separately creates
+`_sqlx_migrations`. The benchmark must record its own SQLite version; this
+inventory run is not benchmark evidence.
+
+Preflight must inspect actual `sqlite_schema`. An unknown table, column, index,
+trigger, view, storage class, or fingerprint refuses optimization while leaving
+the source usable.
+
+Sources: [App migration set](../../src-tauri/src/infrastructure/database/migration.rs),
+[Core migrator](../../core/src/infrastructure/database/migrate.rs), and
+[connection policy](../../core/src/infrastructure/database/db.rs).
+
+### Raw archive tables
+
+These are the five format-candidate families. Preserve row ID, SQLite storage
+class and value (including binary64 REAL bits and TEXT bytes), nullness,
+multiplicity, and exact timestamp representation. Narrower Rust producer types
+do not define the migration domain.
+
+```sql
+CREATE TABLE PROCESS_STATS (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pid INTEGER NOT NULL, process_name TEXT NOT NULL,
+  cpu_usage REAL NOT NULL, memory_usage INTEGER NOT NULL,
+  execution_sec INTEGER NOT NULL, timestamp DATETIME NOT NULL
+);
+CREATE INDEX idx_process_stats_timestamp ON PROCESS_STATS(timestamp);
+
+CREATE TABLE DATA_ARCHIVE (
+  id INTEGER PRIMARY KEY,
+  cpu_avg INTEGER, cpu_max INTEGER, cpu_min INTEGER,
+  ram_avg INTEGER, ram_max INTEGER, ram_min INTEGER,
+  timestamp DATETIME,
+  cpu_temperature_avg REAL, cpu_temperature_max REAL, cpu_temperature_min REAL,
+  cpu_power_avg REAL, cpu_power_max REAL, cpu_power_min REAL,
+  gpu_power_avg REAL, gpu_power_max REAL, gpu_power_min REAL,
+  ane_power_avg REAL, ane_power_max REAL, ane_power_min REAL,
+  package_power_avg REAL, package_power_max REAL, package_power_min REAL
+);
+CREATE INDEX idx_data_archive_timestamp ON DATA_ARCHIVE(timestamp);
+
+CREATE TABLE GPU_DATA_ARCHIVE (
+  id INTEGER PRIMARY KEY, gpu_name TEXT,
+  usage_avg INTEGER, usage_max INTEGER, usage_min INTEGER,
+  temperature_avg INTEGER, temperature_max INTEGER, temperature_min INTEGER,
+  timestamp DATETIME,
+  dedicated_memory_avg INTEGER, dedicated_memory_max INTEGER,
+  dedicated_memory_min INTEGER, gpu_id TEXT
+);
+
+CREATE TABLE AMBIENT_ARCHIVE (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL,
+  temperature REAL NOT NULL, humidity REAL, timestamp DATETIME NOT NULL
+);
+CREATE INDEX idx_ambient_archive_timestamp ON AMBIENT_ARCHIVE(timestamp);
+
+CREATE TABLE FAN_ARCHIVE (
+  id INTEGER PRIMARY KEY, source TEXT NOT NULL, rpm INTEGER NOT NULL,
+  timestamp DATETIME NOT NULL
+);
+CREATE INDEX idx_fan_archive_timestamp ON FAN_ARCHIVE(timestamp);
+```
+
+`DATA_ARCHIVE` and `GPU_DATA_ARCHIVE` retain old `INTEGER` affinity even
+though current writers bind floats to several columns. Compare actual values
+and storage classes, not affinity or current `f32` models.
+
+| Family | G1 decision and required preservation |
+| --- | --- |
+| `PROCESS_STATS` | Required conversion, format unselected. Preserve original `id`, `(pid, process_name)`, values, timestamp, multiplicity. |
+| `DATA_ARCHIVE` | Preferred candidate; measurement chooses conversion or relational preservation. Preserve every nullable metric/statistic independently. |
+| `GPU_DATA_ARCHIVE` | Preferred candidate; measurement chooses. Preserve name, opaque nullable ID, existing same-name combination, all statistics. |
+| `AMBIENT_ARCHIVE` | Preferred candidate; measurement chooses. Preserve source, temperature, nullable humidity, absent minutes, identity/timestamp. |
+| `FAN_ARCHIVE` | Preferred candidate; measurement chooses. Preserve fan source, real zero RPM, absent minutes, identity/timestamp. |
+
+Process Stats is mandatory for completed #2052 delivery. G1 must report a
+measured conversion or preservation recommendation for every other family.
+
+### Directly preserved relational tables
+
+Copy every row and constraint even when the raw input has expired.
+
+| Table and key | Version-23 shape and reason |
+| --- | --- |
+| `cooling_daily_summary`, PK `date` | Four bands with nullable temperature avg/max/min and counts; coverage; nullable CPU-power avg/max/min and count. Mutable, independently retained rollup. |
+| `cooling_hourly_summary`, PK `hour_start` | Nullable CPU-usage/temperature averages and count. Explorer projection. |
+| `cooling_fan_daily_summary`, PK `(date, source)` | Non-null RPM avg/max/min and count. Per-fan identity. |
+| `cooling_thermal_delta_daily_summary`, PK `(date, source)` | Coverage plus four bands of nullable Delta avg/max/min and paired counts. Source-separated and baseline protected. |
+| `cooling_covariate_daily_summary`, PK `(date, source, band)` | #2070 count/share, ambient median, nullable Delta/power medians and counts, additive power-fit `n`, sums x/y/xy/xx/yy. |
+| `cooling_fan_covariate_daily_summary`, PK `(date, source, fan_source, band)` | #2070 RPM count/median and additive fan-fit `n`, sums x/y/xy/xx/yy. |
+| `cooling_baseline`, fixed PK `id = 1` | Write-once window dates, idle-temperature average, count, establishment timestamp. |
+| `cooling_delta_baseline`, fixed PK `id = 1` | Write-once source, window dates, Delta average, count, establishment timestamp. |
+| `storage_devices`, PK `id` | Mutable device identity/display fields, nullable serial/protocol/capacity, seen times, active flag. |
+| `storage_health_daily_records`, autoincrement PK `id`, unique `(device_id, date)`, FK | Mutable same-day status/warning and nullable readings/counters, independently retained. |
+
+Exact preserved column sets:
+
+- `cooling_daily_summary`: `date TEXT`; for each of `idle/low/mid/high`,
+  nullable `*_cpu_temperature_{avg,max,min} REAL` and non-null
+  `*_sample_minutes INTEGER DEFAULT 0`; non-null `coverage_minutes`;
+  nullable `cpu_power_{avg,max,min} REAL`; non-null/default-zero power count.
+- `cooling_hourly_summary`: `hour_start TEXT`, nullable
+  `cpu_usage_avg REAL`, nullable `cpu_temperature_avg REAL`, non-null count.
+- `cooling_fan_daily_summary`: non-null `date TEXT`, `source TEXT`,
+  `rpm_avg REAL`, `rpm_max/min INTEGER`, and count.
+- `cooling_thermal_delta_daily_summary`: non-null date, source, coverage;
+  each band has nullable `*_delta_temperature_{avg,max,min} REAL` and a
+  non-null/default-zero paired count.
+- `cooling_covariate_daily_summary`: non-null date, source, band, sample
+  count/share, ambient median; nullable Delta/power medians with non-null counts;
+  non-null/default-zero power-fit `n` and sums x/y/xy/xx/yy.
+- `cooling_fan_covariate_daily_summary`: non-null date, ambient source, fan
+  source, band, RPM count/median; non-null/default-zero fit `n` and sums.
+- `cooling_baseline`: fixed integer ID; non-null window dates, idle average,
+  sample count, and establishment timestamp.
+- `cooling_delta_baseline`: fixed integer ID; non-null source, window dates,
+  Delta average, sample count, and establishment timestamp.
+- `storage_devices`: non-null text ID/display/first-seen/last-seen and integer
+  active flag; nullable model, serial hash, protocol, and integer capacity.
+- `storage_health_daily_records`: integer ID; non-null device/date/status,
+  warning level and collection timestamp; nullable warning JSON, temperature,
+  hours, wear/spare, sector/media/error-log, and unsafe-shutdown fields.
+
+Preserve every `_sqlx_migrations` row, including checksum/execution state;
+append real migrations rather than fabricate success. Preserve
+`sqlite_sequence` high-water marks for `PROCESS_STATS`, `AMBIENT_ARCHIVE`,
+and `storage_health_daily_records`. Converted tails for tables without
+`AUTOINCREMENT` also need monotonic non-reused record sequences. Recreate all
+known indexes and constraints; unknown objects require classification or refusal.
+
+Source for all product table and index definitions:
+[App migration set](../../src-tauri/src/infrastructure/database/migration.rs).
+
+## Producer and identity contracts
+
+`ArchiveTracker` retains up to 60 per-second EventBus samples. It writes every
+60 seconds and flushes a dirty partial interval on normal shutdown. One
+`Utc::now()` is shared across system, GPU, fan, process, and ambient writes.
+Instants are still irregular: delayed ticks, shutdown, restarts, clock changes,
+and legacy writes remain representable. Never reconstruct
+`start + interval * index` or deduplicate an instant.
+
+### Process Stats
+
+Sysinfo produces `ProcessSample { pid: u32, name: String, cpu_usage: f32,
+memory_kb: f32, run_time_secs: u64 }`. The tracker keys by PID, clears its
+rings on a name change, and retains a vanished PID for up to 60 ingest ticks.
+Same-name PID reuse is intentionally indistinguishable.
+
+At each write it requires CPU and memory samples, omits only a both-zero row,
+normalizes CPU by logical-core count, rounds memory to `i32`, casts run time
+to `i32`, and admits execution values through 30 days. It takes five from each
+CPU/memory/execution descending ranking and deduplicates by PID, for at most 15
+rows, committed in one transaction.
+
+Persisted identity is observation `id` plus subject `(pid, process_name)`.
+Neither identifies a process lifetime. Queries retain both fields; dictionaries
+are only chunk-local compression keys.
+
+### Representative sensor: ambient
+
+`EnvironmentalSensorRegistry::fresh_readings(tick)` supplies producer Source
+Labels, `f32` Celsius temperature, optional `f32` humidity, and no stored
+observation time. Rows use the shared tick. Stale/unavailable/invalid/missing
+readings create no row. Multiple labels at one tick are distinct identities.
+
+Fixtures need distinct labels, nullable humidity, multiple sources at one
+instant, missing intervals, duplicate instants, irregular timestamp forms, and
+SQLite REAL values that do not round-trip through `f32`.
+
+### Other families
+
+- System has seven nullable `f32` avg/max/min triples: CPU, memory, CPU
+  temperature, CPU/GPU/ANE/package power. Preserve all 21 fields.
+- GPU histories use live IDs. The writer groups by reported name, combines raw
+  samples with sample weighting, emits one row per name, and stores an ID only
+  for one contributing live ID. Queries select by name. IDs stay opaque; live
+  and inventory namespaces are disjoint, so migration performs no identity join.
+  Live forms include Windows `nvapi:<id>`,
+  `pci:<bus>:<device>:<function>`, `pdh:instance:<device_instance_id>` and
+  fallback `pdh:<luid_high>:<luid_low>`; Linux `pci:<BDF>` and fallback
+  `drm:card<n>`; and macOS `iokit:<name>`. Legacy strings and null remain
+  exactly as recorded.
+- Fan history keys on `MotherboardFanSpeed.name`, stored as `source`; the
+  provider's separate `source` is not stored. Zero is real; invalid/missing is
+  absent. The minute RPM uses integer division of a `u64` sum by present count.
+- Storage Health uses an HMAC-based device ID shared by daily and Live Storage
+  Health. Preserve IDs, FK/unique constraints, upserts, active changes,
+  deletions, and key changes outside raw archive conversion.
+
+Sources: [archive producer](../../core/src/persistence/archive.rs),
+[stored row types](../../core/src/persistence/archive_data.rs), and
+[system/process sampling](../../core/src/collector/sampling.rs).
+
+## Query and arithmetic oracle
+
+Semantics are intentionally non-uniform. Differential tests must preserve them.
+
+### Hardware, GPU, and Process
+
+System/GPU series use inclusive TEXT `BETWEEN` after App RFC-3339 parsing and
+millisecond `Z` normalization; GPU filters by name. SQL casts values to REAL
+and re-applies the requested statistic per bucket: avg uses `AVG`, max
+`MAX`, min `MIN`. Start placement floors and end placement ceils epoch
+milliseconds. Results are gap-filled and capped at 10,000 points. GPU names are
+sorted distinct non-null names excluding literal `Unknown`. Consumers are
+Hardware Insight, Insight Snapshot CPU/RAM, and Cooling timelines up to 30 days.
+
+Process queries use inclusive TEXT `BETWEEN`, group by `(pid, process_name)`,
+and return CPU/memory averages, max execution seconds, and max timestamp.
+`get_process_stats_in_period` orders CPU descending. `get_process_stats`
+does not order and subtracts 60 seconds from its supplied end before deriving
+the period. The current unbounded result includes every group and serves Process
+Insight and Insight Snapshot; G2 plans bounded paging without a new top-N rule.
+
+### Fan, ambient, and Cooling
+
+Fan series uses inclusive epoch-millisecond membership, groups by source/bucket,
+averages RPM, orders, and fills gaps per source.
+
+Ambient series reads buckets and sources in one transaction. It first averages
+ambient rows per minute and CPU temperatures per minute, then left-joins CPU.
+Buckets average ambient-minute means and paired per-minute `cpu - ambient`.
+Ambient-only minutes affect ambient but not Delta. Sources are distinct/sorted;
+downstream code must not subtract independent bucket averages.
+
+Cooling raw reads use half-open `[start, end)` epoch-millisecond membership; a
+one-day widened TEXT bound is only an index prefilter. Daily system input reads
+CPU usage, temperature triple, and power triple. Temperature bands require
+usage plus a complete temperature triple; power folds independently with a
+complete triple. Thermal Delta joins each hardware record to ambient averaged
+per `(minute, source)`. Fan rollup rows are ordered by timestamp then ID.
+
+Catch-up probes depend on earliest hardware timestamp, summary max dates,
+latest complete powered row, latest fan row, latest pairable ambient row, and
+latest classifiable pairable ambient row. Route every probe through mixed
+storage before emptying raw tables. One day's daily, hourly, fan, Delta, and
+both covariate projections upsert in one transaction.
+
+| App command | Core sources |
+| --- | --- |
+| `get_cooling_trend` | all daily system summaries |
+| `get_cooling_fan_trend` | all fan summaries plus `EXISTS(FAN_ARCHIVE)` |
+| `get_cooling_band_comparison` | daily system and source-specific Delta summaries |
+| `get_cooling_baseline_delta` | daily system/Delta summaries and pinned baselines |
+| `get_cooling_load_temperature_explorer` | daily idle and bounded hourly rows |
+| `get_cooling_covariate_comparison` | Delta and both v23 covariate tables, read sequentially through one Core pool; current code does not wrap these reads in one transaction |
+
+The complete direct raw-table read map is: `DATA_ARCHIVE` series, daily input,
+Thermal Delta/ambient pairing, earliest/powered catch-up, and retention;
+`GPU_DATA_ARCHIVE` series, name enumeration, and retention; `PROCESS_STATS`
+grouped results and retention; `AMBIENT_ARCHIVE` timeline, pairing/catch-up,
+and retention; `FAN_ARCHIVE` timeline, daily/covariate input,
+capability/catch-up probes, and retention.
+
+Sources: [archive series and Process Stats queries](../../core/src/infrastructure/database/archive_queries.rs),
+[daily raw reader](../../core/src/infrastructure/database/cooling_daily_summary.rs),
+[Thermal Delta raw reader](../../core/src/infrastructure/database/cooling_thermal_delta_daily_summary.rs),
+[fan raw reader](../../core/src/infrastructure/database/fan_archive.rs),
+[rollup coordinator](../../core/src/persistence/cooling_rollup.rs),
+[App archive service](../../src-tauri/src/services/archive_history_service.rs),
+[App archive commands](../../src-tauri/src/commands/hardware.rs),
+[App Cooling service](../../src-tauri/src/services/cooling_insight_service.rs),
+and [App Cooling commands](../../src-tauri/src/commands/cooling_insight.rs).
+
+Cooling dates/hours are local-calendar ISO TEXT. Daily Cooling retention is
+independently fixed at 400 days. Delta/covariate tables protect the pinned Delta
+baseline source/window. Both baselines may outlive all contributing input and
+cannot be regenerated as a copy shortcut.
+
+## G1 evidence still required
+
+This inventory unblocks candidate work; it does not pass G1. The report still
+needs reproducible 24-hour, 30-day, one-year, and ten-year synthetic datasets;
+exact Process Stats and sensor round trips; differential tests for every
+boundary; and layout/limit/codec/compression/index comparisons.
+
+Measure and ratify or revise disk targets, small-history overhead, p50/p95/p99
+query and append latency, CPU, peak RSS, migration throughput, temporary space,
+ten-year paging, and cutover. Record commit, seed, hardware, OS/filesystem,
+SQLite/Rust versions, repetitions, and cold/warm policy. No benchmark,
+compression, lifecycle acceptance, or #2052 completion claim exists until
+results and maintainer review are recorded.

--- a/docs/development/hardware-archive-implementation-plan.md
+++ b/docs/development/hardware-archive-implementation-plan.md
@@ -58,6 +58,12 @@ Partial implementation must not expose Optimize now to normal installations.
 
 **Type:** HITL. **Blocked by:** design acceptance and the #1666 scope checkpoint.
 
+Initial experiment: [schema/query inventory](hardware-archive-g1-inventory.md)
+and [measured benchmark report](hardware-archive-g1-benchmark.md). The report
+records exact two-family preservation and 24-hour/30-day/one-year results; the
+longer-range queries miss the proposed comparison. G1 remains open until the
+remaining evidence and maintainer decision below are complete.
+
 ### What to build
 
 Refresh the full database/query inventory, capture a reproducible row-based


### PR DESCRIPTION
## Summary

Adds the first executable G1 experiment for lossless Hardware Archive storage: synthetic Process Stats and Ambient rows pass through row/columnar encoding, optional Deflate, SQLite chunk persistence, atomic tail finalization, exact validation, and differential queries. The bounded decoder and SQLite contract tests run with the ordinary Core test suite.

Pins the schema-v23 inventory and records eight reproducible configurations covering 24 hours, 30 days, and one year. The default columnar/Deflate candidate reduces the two-family database after explicit VACUUM by 90.41% at 30 days and 90.58% at one year. Longer-range queries exceed the proposed latency comparison, so the report recommends further query experiments and leaves G1 format acceptance open.

The executable is isolated under `core/examples`; production recording, migration selection, retention, and application queries are unchanged. Ten-year workloads, complete database/per-family accounting, high process churn, online migration/resource budgets, and maintainer acceptance remain required before G2. All eight measurements use the corrected runtime-type adapter, bounded Ambient batch inserts, and shared decoded-value accounting; finalized chunks and retained tails are reported separately.

## Related Issues

Refs #2052. Follows the design in #2079; this PR does not close the parent issue or complete G1.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [ ] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [x] Other (`chore/` branch)

## Screenshots / Videos

Not applicable; this is a standalone benchmark and evidence report.

## Test Plan

- [x] Manual testing: eight release-mode synthetic runs; every completed report passes all seven correctness checks. Full parameters and observations are committed in the benchmark artifact.
- [x] Unit tests: `cargo test -p hardviz-core -- --test-threads=1` — 746 unit, 2 integration, and 23 example tests pass (771 total).
- [x] `cargo clippy -p hardviz-core --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `npm run check:agent-guidance`
- [x] Biome check of the measurement JSON, local documentation links, and `git diff --check`

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass for the changed Core/example and documentation artifacts
- [x] Relevant Core tests pass
- [x] No new compiler warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a synthetic archive-format benchmark comparing row and columnar storage, compression, integrity, query performance, and storage footprints.
  - Added archive encoding and decoding with validation, integrity checks, size limits, and corruption detection.
  - Added benchmark reporting for finalized and retained data sizes, correctness, resource usage, and performance measurements.

- **Documentation**
  - Added hardware archive schema, query, implementation, and benchmark documentation.
  - Documented timestamp-handling lessons and linked new archive resources from documentation indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->