### PR TITLE
feat(database): finalize DuckDB candidates and query them natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Check Tauri clippy
-        run: cargo clippy -p hardware_visualizer --all-targets -- -D warnings
+        run: cargo clippy -p hardware_visualizer --features duckdb-archive --all-targets -- -D warnings
 
   #
   # Tauri tests

--- a/core/src/infrastructure/database/mod.rs
+++ b/core/src/infrastructure/database/mod.rs
@@ -23,6 +23,8 @@ pub mod fan_archive;
 pub mod gpu_archive;
 pub mod hardware_archive;
 pub mod migrate;
+#[cfg(feature = "duckdb-archive")]
+pub mod native_database;
 pub mod process_stats;
 pub mod storage_health;
 #[cfg(test)]

--- a/core/src/infrastructure/database/native_database/cell.rs
+++ b/core/src/infrastructure/database/native_database/cell.rs
@@ -1,0 +1,223 @@
+//! Tagged cell values moved between the candidate and the finalized database.
+//!
+//! The tagged encoding deliberately matches the candidate builder's
+//! ([`crate::infrastructure::database::candidate_database`]) so a value that
+//! survived the SQLite -> candidate copy is still recognizable here: the tag
+//! byte distinguishes an integer from a real that happens to be integral, and
+//! both text and blob bytes are length-prefixed so `"ab"` and `"a"` + `"b"`
+//! cannot collide. It is duplicated rather than shared because the candidate's
+//! copy also carries snapshot-validation concerns this module has no use for.
+
+use sha2::{Digest, Sha256};
+
+/// Bounded copy limits for finalization. Buffer-safety limits, not
+/// whole-process memory caps - the same role they have in the candidate
+/// builder.
+pub(super) const COPY_BATCH_ROWS: u64 = 512;
+pub(super) const MAX_BATCH_BYTES: u64 = 8 * 1024 * 1024;
+
+/// The DuckDB storage types the candidate and the stable schema may use.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum NativeColumnKind {
+  BigInt,
+  /// Only the candidate's `__hv_source_ordinal` uses it; the stable schema
+  /// never declares an unsigned column.
+  UBigInt,
+  Double,
+  Varchar,
+  Blob,
+  /// `UNION(i BIGINT, r DOUBLE)`: a column holding both SQLite storage classes.
+  TaggedNumeric,
+}
+
+impl NativeColumnKind {
+  pub(super) fn parse(data_type: &str) -> Option<Self> {
+    match data_type.trim() {
+      "BIGINT" => Some(Self::BigInt),
+      "UBIGINT" => Some(Self::UBigInt),
+      "DOUBLE" => Some(Self::Double),
+      "VARCHAR" => Some(Self::Varchar),
+      "BLOB" => Some(Self::Blob),
+      "UNION(i BIGINT, r DOUBLE)" => Some(Self::TaggedNumeric),
+      _ => None,
+    }
+  }
+
+  pub(super) fn sql(self) -> &'static str {
+    match self {
+      Self::BigInt => "BIGINT",
+      Self::UBigInt => "UBIGINT",
+      Self::Double => "DOUBLE",
+      Self::Varchar => "VARCHAR",
+      Self::Blob => "BLOB",
+      Self::TaggedNumeric => "UNION(i BIGINT, r DOUBLE)",
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Cell {
+  Null,
+  Integer(i64),
+  /// binary64 bits, so a value round-trips without NaN or -0.0 comparison
+  /// surprises.
+  Real(u64),
+  Text(String),
+  Blob(Vec<u8>),
+}
+
+impl Cell {
+  pub(super) fn describe(&self) -> &'static str {
+    match self {
+      Self::Null => "NULL",
+      Self::Integer(_) => "an integer",
+      Self::Real(_) => "a real",
+      Self::Text(_) => "text",
+      Self::Blob(_) => "a blob",
+    }
+  }
+
+  pub(super) fn update_digest(&self, digest: &mut Sha256) {
+    match self {
+      Self::Null => digest.update([0]),
+      Self::Integer(value) => {
+        digest.update([1]);
+        digest.update(value.to_le_bytes());
+      }
+      Self::Real(bits) => {
+        digest.update([2]);
+        digest.update(bits.to_le_bytes());
+      }
+      Self::Text(value) => {
+        digest.update([3]);
+        update_bytes(digest, value.as_bytes());
+      }
+      Self::Blob(value) => {
+        digest.update([4]);
+        update_bytes(digest, value);
+      }
+    }
+  }
+}
+
+fn update_bytes(digest: &mut Sha256, bytes: &[u8]) {
+  digest.update((bytes.len() as u64).to_le_bytes());
+  digest.update(bytes);
+}
+
+/// A digest of a table's rows that does not depend on the order they are read
+/// back in.
+///
+/// The candidate keeps a `__hv_source_ordinal` column, so its digest can be
+/// ordered. The finalized schema deliberately does not carry that validation
+/// column, and DuckDB does not promise a scan order, so the comparison here is
+/// over the multiset of rows instead: each row's SHA-256 is added into a
+/// 256-bit accumulator. Addition (not XOR) keeps duplicate rows visible, and
+/// the row count is compared separately.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct RowMultisetDigest {
+  limbs: [u64; 4],
+  rows: u64,
+}
+
+impl RowMultisetDigest {
+  pub(super) fn add_row(&mut self, cells: &[Cell]) {
+    let mut digest = Sha256::new();
+    digest.update((cells.len() as u64).to_le_bytes());
+    for cell in cells {
+      cell.update_digest(&mut digest);
+    }
+    let row: [u8; 32] = digest.finalize().into();
+    let mut carry = 0_u64;
+    for (index, limb) in self.limbs.iter_mut().enumerate() {
+      let mut chunk = [0_u8; 8];
+      chunk.copy_from_slice(&row[index * 8..index * 8 + 8]);
+      let addend = u64::from_le_bytes(chunk);
+      let (sum, overflow_a) = limb.overflowing_add(addend);
+      let (sum, overflow_b) = sum.overflowing_add(carry);
+      *limb = sum;
+      carry = u64::from(overflow_a) + u64::from(overflow_b);
+    }
+    self.rows = self.rows.wrapping_add(1);
+  }
+
+  pub(super) fn rows(self) -> u64 {
+    self.rows
+  }
+
+  pub(super) fn encode(self) -> String {
+    use std::fmt::Write;
+
+    let mut encoded = String::with_capacity(64);
+    for limb in self.limbs.iter().rev() {
+      write!(&mut encoded, "{limb:016x}").expect("writing to String cannot fail");
+    }
+    encoded
+  }
+}
+
+pub(super) fn quote_identifier(identifier: &str) -> String {
+  format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_only_the_storage_types_the_candidate_can_produce() {
+    assert_eq!(
+      NativeColumnKind::parse("BIGINT"),
+      Some(NativeColumnKind::BigInt)
+    );
+    assert_eq!(
+      NativeColumnKind::parse("UNION(i BIGINT, r DOUBLE)"),
+      Some(NativeColumnKind::TaggedNumeric)
+    );
+    assert_eq!(
+      NativeColumnKind::parse("UBIGINT"),
+      Some(NativeColumnKind::UBigInt)
+    );
+    assert_eq!(NativeColumnKind::parse("DECIMAL(18,3)"), None);
+    assert_eq!(NativeColumnKind::parse("TIMESTAMP"), None);
+  }
+
+  #[test]
+  fn multiset_digest_ignores_row_order_but_not_multiplicity_or_tags() {
+    let a = vec![Cell::Integer(1), Cell::Text("x".to_owned())];
+    let b = vec![Cell::Real(2.0_f64.to_bits()), Cell::Null];
+
+    let mut forward = RowMultisetDigest::default();
+    forward.add_row(&a);
+    forward.add_row(&b);
+    let mut reverse = RowMultisetDigest::default();
+    reverse.add_row(&b);
+    reverse.add_row(&a);
+    assert_eq!(forward, reverse);
+    assert_eq!(forward.rows(), 2);
+    assert_eq!(forward.encode().len(), 64);
+
+    let mut duplicated = RowMultisetDigest::default();
+    duplicated.add_row(&a);
+    duplicated.add_row(&a);
+    assert_ne!(duplicated, forward);
+
+    let mut integral_real = RowMultisetDigest::default();
+    integral_real.add_row(&[Cell::Real(2.0_f64.to_bits())]);
+    let mut integer = RowMultisetDigest::default();
+    integer.add_row(&[Cell::Integer(2)]);
+    assert_ne!(integral_real, integer);
+  }
+
+  #[test]
+  fn multiset_digest_carries_across_limbs() {
+    let mut all_ones = RowMultisetDigest {
+      limbs: [u64::MAX; 4],
+      rows: 0,
+    };
+    all_ones.add_row(&[Cell::Integer(7)]);
+    let mut from_zero = RowMultisetDigest::default();
+    from_zero.add_row(&[Cell::Integer(7)]);
+    assert_ne!(all_ones, from_zero);
+  }
+}

--- a/core/src/infrastructure/database/native_database/epoch.rs
+++ b/core/src/infrastructure/database/native_database/epoch.rs
@@ -1,0 +1,174 @@
+//! Derived epoch-millisecond keys for stored timestamp text.
+//!
+//! The finalized schema keeps the original timestamp bytes and adds a
+//! `__hv_timestamp_epoch_ms` column so native range queries can compare
+//! instants instead of relying on every writer having produced the exact same
+//! string shape.
+//!
+//! The conversion is not reimplemented. It runs the production adapter
+//! ([`sqlite_epoch_milliseconds_of`]) inside a scratch in-memory SQLite
+//! database, so the derived key is by construction the value the current
+//! SQLite queries compute for the same text - including the cases where
+//! SQLite's `strftime` returns NULL, which stay NULL here rather than becoming
+//! a guessed instant. Reimplementing SQLite's date-string grammar in Rust would
+//! be a second, drifting definition of the same fact; the writers that will
+//! later insert new rows already hold the `DateTime<Utc>` and never need to
+//! parse text back.
+
+use sqlx::sqlite::SqliteConnection;
+use sqlx::{Connection, Row};
+
+use super::NativeDatabaseError;
+use crate::infrastructure::database::archive_queries::sqlite_epoch_milliseconds_of;
+
+/// Converts stored timestamp text in bounded batches through one scratch
+/// SQLite connection.
+pub(super) struct EpochMilliseconds {
+  runtime: tokio::runtime::Runtime,
+  connection: SqliteConnection,
+}
+
+impl EpochMilliseconds {
+  pub(super) fn open() -> Result<Self, NativeDatabaseError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .map_err(|error| NativeDatabaseError::Worker {
+        message: format!("failed to start the finalization runtime: {error}"),
+      })?;
+    let connection = runtime
+      .block_on(SqliteConnection::connect("sqlite::memory:"))
+      .map_err(|error| {
+        NativeDatabaseError::finalization(
+          "open the SQLite timestamp conversion oracle",
+          error,
+        )
+      })?;
+    Ok(Self {
+      runtime,
+      connection,
+    })
+  }
+
+  /// Convert one batch of stored texts. `None` inputs (a NULL timestamp cell)
+  /// and texts SQLite cannot read as an instant both yield `None`.
+  pub(super) fn convert(
+    &mut self,
+    texts: &[Option<String>],
+  ) -> Result<Vec<Option<i64>>, NativeDatabaseError> {
+    let mut converted = vec![None; texts.len()];
+    let present = texts
+      .iter()
+      .enumerate()
+      .filter_map(|(index, text)| text.as_ref().map(|text| (index, text)))
+      .collect::<Vec<_>>();
+    if present.is_empty() {
+      return Ok(converted);
+    }
+
+    let values = std::iter::repeat_n("(?,?)", present.len())
+      .collect::<Vec<_>>()
+      .join(",");
+    let sql = format!(
+      "WITH t(i, s) AS (VALUES {values}) SELECT i, {} FROM t",
+      sqlite_epoch_milliseconds_of("s")
+    );
+    let mut query = sqlx::query(&sql);
+    for (index, text) in &present {
+      query = query.bind(*index as i64).bind(*text);
+    }
+    let rows = self
+      .runtime
+      .block_on(query.fetch_all(&mut self.connection))
+      .map_err(|error| {
+        NativeDatabaseError::finalization("convert stored timestamp text", error)
+      })?;
+    if rows.len() != present.len() {
+      return Err(NativeDatabaseError::finalization(
+        "convert stored timestamp text",
+        format!(
+          "expected {} converted rows, got {}",
+          present.len(),
+          rows.len()
+        ),
+      ));
+    }
+    for row in rows {
+      let index: i64 = row.try_get(0).map_err(|error| {
+        NativeDatabaseError::finalization("convert stored timestamp text", error)
+      })?;
+      let milliseconds: Option<i64> = row.try_get(1).map_err(|error| {
+        NativeDatabaseError::finalization(
+          "convert stored timestamp text",
+          format!("SQLite returned a non-integer epoch value: {error}"),
+        )
+      })?;
+      let index = usize::try_from(index).map_err(|_| {
+        NativeDatabaseError::finalization(
+          "convert stored timestamp text",
+          "conversion batch index went negative",
+        )
+      })?;
+      *converted.get_mut(index).ok_or_else(|| {
+        NativeDatabaseError::finalization(
+          "convert stored timestamp text",
+          "conversion batch index is out of range",
+        )
+      })? = milliseconds;
+    }
+    Ok(converted)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn reproduces_sqlite_for_every_spelling_including_the_ones_it_refuses() {
+    let mut adapter = EpochMilliseconds::open().unwrap();
+    let texts = vec![
+      // The shape sqlx stores for a `DateTime<Utc>`.
+      Some("2026-09-01T00:00:00+00:00".to_owned()),
+      Some("2026-09-01T00:00:00.125+00:00".to_owned()),
+      // Fixture and legacy spellings SQLite also accepts.
+      Some("2026-09-01T00:00:00Z".to_owned()),
+      Some("2026-09-01 00:00:00".to_owned()),
+      Some("2026-09-01T09:00:00+09:00".to_owned()),
+      Some("1969-12-31T23:59:59.500Z".to_owned()),
+      // SQLite reads neither of these as an instant.
+      Some("not a timestamp".to_owned()),
+      Some(String::new()),
+      None,
+    ];
+
+    let converted = adapter.convert(&texts).unwrap();
+
+    assert_eq!(converted[0], Some(1_788_220_800_000));
+    assert_eq!(converted[1], Some(1_788_220_800_125));
+    assert_eq!(converted[2], converted[0]);
+    assert_eq!(converted[3], converted[0]);
+    assert_eq!(converted[4], converted[0]);
+    assert_eq!(converted[5], Some(-500));
+    assert_eq!(converted[6], None);
+    assert_eq!(converted[7], None);
+    assert_eq!(converted[8], None);
+  }
+
+  #[test]
+  fn keeps_batch_positions_when_only_some_inputs_convert() {
+    let mut adapter = EpochMilliseconds::open().unwrap();
+    let converted = adapter
+      .convert(&[
+        None,
+        Some("2026-09-01T00:00:00Z".to_owned()),
+        Some("still not a timestamp".to_owned()),
+        Some("2026-09-01T00:00:01Z".to_owned()),
+      ])
+      .unwrap();
+    assert_eq!(
+      converted,
+      vec![None, Some(1_788_220_800_000), None, Some(1_788_220_801_000)]
+    );
+  }
+}

--- a/core/src/infrastructure/database/native_database/error.rs
+++ b/core/src/infrastructure/database/native_database/error.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NativeDatabaseError {
+  #[error("native database file does not exist or is not a file: {path}")]
+  Unavailable { path: PathBuf },
+  #[error("candidate database does not exist or is not a file: {path}")]
+  CandidateUnavailable { path: PathBuf },
+  #[error("native database destination already exists: {path}")]
+  DestinationExists { path: PathBuf },
+  #[error("native database request capacity must be greater than zero")]
+  InvalidRequestCapacity,
+  #[error("native database is not finalized")]
+  Unfinalized,
+  #[error(
+    "native database schema version {actual} is incompatible with expected version {expected}"
+  )]
+  IncompatibleSchema { expected: u32, actual: u32 },
+  #[error("native database request cancellation may be attached to only one request")]
+  CancellationAlreadyUsed,
+  #[error("native database request was cancelled")]
+  Cancelled,
+  #[error("native database is closed")]
+  Closed,
+  #[error("native database worker failed: {message}")]
+  Worker { message: String },
+  #[error("native database operation failed during {context}: {source}")]
+  DuckDb {
+    context: &'static str,
+    #[source]
+    source: duckdb::Error,
+  },
+  #[error("candidate snapshot cannot be finalized: {message}")]
+  CandidateSnapshot { message: String },
+  #[error("candidate table {table} does not match the supplied native schema: {detail}")]
+  SchemaMismatch { table: String, detail: String },
+  #[error(
+    "candidate cell at {table}.{column}, source row ordinal {row_ordinal}, is {candidate} and the native column is {destination}"
+  )]
+  UnrepresentableCell {
+    table: String,
+    column: String,
+    row_ordinal: u64,
+    candidate: &'static str,
+    destination: String,
+  },
+  #[error(
+    "NULL in required native column {table}.{column} at source row ordinal {row_ordinal}"
+  )]
+  NullInRequiredColumn {
+    table: String,
+    column: String,
+    row_ordinal: u64,
+  },
+  #[error("finalized native database failed verification: {message}")]
+  Verification { message: String },
+  #[error("native database finalization failed during {context}: {message}")]
+  Finalization { context: String, message: String },
+}
+
+impl NativeDatabaseError {
+  pub(crate) fn duckdb(context: &'static str, source: duckdb::Error) -> Self {
+    Self::DuckDb { context, source }
+  }
+
+  pub(crate) fn finalization(
+    context: impl Into<String>,
+    message: impl std::fmt::Display,
+  ) -> Self {
+    Self::Finalization {
+      context: context.into(),
+      message: message.to_string(),
+    }
+  }
+}

--- a/core/src/infrastructure/database/native_database/error.rs
+++ b/core/src/infrastructure/database/native_database/error.rs
@@ -54,6 +54,14 @@ pub enum NativeDatabaseError {
   },
   #[error("finalized native database failed verification: {message}")]
   Verification { message: String },
+  #[error(
+    "the exact sum of {column} for Process ({pid}, {process_name:?}) exceeds a signed 64-bit integer, where SQLite's average is no longer exact"
+  )]
+  IntegerSumOverflow {
+    column: &'static str,
+    pid: i64,
+    process_name: String,
+  },
   #[error("native database finalization failed during {context}: {message}")]
   Finalization { context: String, message: String },
 }

--- a/core/src/infrastructure/database/native_database/finalize.rs
+++ b/core/src/infrastructure/database/native_database/finalize.rs
@@ -1,0 +1,1100 @@
+//! Turns one immutable #2088 candidate into a finalized native database.
+//!
+//! The candidate represents the SQLite source honestly but not usefully: its
+//! column types follow whatever storage classes the snapshot happened to
+//! contain, and it carries snapshot-validation metadata rather than domain
+//! constraints. Finalization copies it once into the App-supplied stable schema
+//! ([`NativeSchemaDefinition`]), fills the derived timestamp keys, and imports
+//! the identity high-water state.
+//!
+//! Nothing here publishes or selects the result. A finalized file is still
+//! unselected: SQLite stays authoritative until the lifecycle change that
+//! chooses a backend.
+
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use duckdb::types::Value;
+use duckdb::{AccessMode, Config, Connection, appender_params_from_iter};
+
+use super::NativeDatabaseError;
+use super::cell::{Cell, NativeColumnKind, RowMultisetDigest, quote_identifier};
+use super::epoch::EpochMilliseconds;
+use super::paging::{PagedReader, ReadColumn};
+use super::schema::{NativeIdentityMode, NativeSchemaDefinition};
+
+pub(super) const NATIVE_METADATA_TABLE: &str = "__hv_native_metadata";
+pub(super) const NATIVE_IDENTITY_TABLE: &str = "__hv_native_identities";
+pub(super) const FINALIZED_UNSELECTED: &str = "finalized_unselected";
+const SNAPSHOT_METADATA_TABLE: &str = "__hv_snapshot_metadata";
+const SOURCE_ORDINAL_COLUMN: &str = "__hv_source_ordinal";
+const SQLITE_SEQUENCE_TABLE: &str = "sqlite_sequence";
+const SQLX_MIGRATIONS_TABLE: &str = "_sqlx_migrations";
+const WORK_PREFIX: &str = ".hardwarevisualizer-duckdb-finalize-";
+
+/// Candidate tables that carry no domain rows, so the stable schema does not
+/// declare them: sqlx's migration ledger and SQLite's allocator state are
+/// carried forward as the recorded source schema digest and the imported
+/// identity high-water marks, and the snapshot metadata belongs to the
+/// candidate.
+const NON_DOMAIN_CANDIDATE_TABLES: &[&str] = &[
+  SNAPSHOT_METADATA_TABLE,
+  SQLITE_SEQUENCE_TABLE,
+  SQLX_MIGRATIONS_TABLE,
+];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativeTableReport {
+  pub name: String,
+  pub candidate_rows: u64,
+  pub copied_rows: u64,
+  pub reopened_rows: u64,
+  /// Order-independent digest of the rows written, in their finalized
+  /// representation.
+  pub copied_digest: String,
+  /// The same digest recomputed after the database was closed and reopened.
+  pub reopened_digest: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativeFinalizationReport {
+  pub source_candidate_path: PathBuf,
+  pub finalized_database_path: PathBuf,
+  pub state: String,
+  pub schema_version: u32,
+  /// The candidate's record of the SQLite schema it was copied from, carried
+  /// forward so a finalized file can still name its origin.
+  pub source_schema_sha256: String,
+  pub tables: Vec<NativeTableReport>,
+  pub total_rows: u64,
+  pub finalized_bytes: u64,
+}
+
+/// Build a finalized native file from an immutable candidate.
+///
+/// Neither the candidate nor the SQLite source it came from is modified, and a
+/// destination that already exists is refused rather than replaced. Everything
+/// is written inside a work directory next to `destination` and published by a
+/// hard link only after the closed file has been reopened and verified, so a
+/// failure leaves no partial destination behind.
+pub async fn finalize_candidate_database(
+  source_candidate: &Path,
+  destination: &Path,
+  schema: NativeSchemaDefinition,
+) -> Result<NativeFinalizationReport, NativeDatabaseError> {
+  validate_paths(source_candidate, destination)?;
+  let candidate = source_candidate.to_owned();
+  let destination = destination.to_owned();
+  tokio::task::spawn_blocking(move || finalize(&candidate, &destination, schema))
+    .await
+    .map_err(|error| NativeDatabaseError::Worker {
+      message: error.to_string(),
+    })?
+}
+
+fn validate_paths(
+  candidate: &Path,
+  destination: &Path,
+) -> Result<(), NativeDatabaseError> {
+  let metadata =
+    fs::metadata(candidate).map_err(|_| NativeDatabaseError::CandidateUnavailable {
+      path: candidate.to_owned(),
+    })?;
+  if !metadata.is_file() {
+    return Err(NativeDatabaseError::CandidateUnavailable {
+      path: candidate.to_owned(),
+    });
+  }
+  match fs::symlink_metadata(destination) {
+    Ok(_) => Err(NativeDatabaseError::DestinationExists {
+      path: destination.to_owned(),
+    }),
+    Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+    Err(error) => Err(NativeDatabaseError::finalization(
+      "inspect the finalization destination",
+      error,
+    )),
+  }
+}
+
+fn finalize(
+  candidate_path: &Path,
+  destination: &Path,
+  schema: NativeSchemaDefinition,
+) -> Result<NativeFinalizationReport, NativeDatabaseError> {
+  let parent = destination
+    .parent()
+    .filter(|path| !path.as_os_str().is_empty())
+    .ok_or_else(|| {
+      NativeDatabaseError::finalization(
+        "reserve the finalization work directory",
+        "destination must have a parent directory",
+      )
+    })?;
+  if !parent.is_dir() {
+    return Err(NativeDatabaseError::finalization(
+      "reserve the finalization work directory",
+      format!("destination parent does not exist: {}", parent.display()),
+    ));
+  }
+
+  // Declared before every connection so the connections drop first: Windows
+  // cannot remove an open database file.
+  let work = tempfile::Builder::new()
+    .prefix(WORK_PREFIX)
+    .tempdir_in(parent)
+    .map_err(|error| {
+      NativeDatabaseError::finalization("reserve the finalization work directory", error)
+    })?;
+  let database_path = work.path().join("finalized.duckdb");
+  // Independent DuckDB instances need independent spill directories.
+  let candidate_spill = work.path().join("spill-candidate");
+  let destination_spill = work.path().join("spill-destination");
+  for path in [&candidate_spill, &destination_spill] {
+    fs::create_dir(path).map_err(|error| {
+      NativeDatabaseError::finalization("create a finalization spill directory", error)
+    })?;
+  }
+
+  let mut epoch = EpochMilliseconds::open()?;
+  let copied;
+  let source_schema_sha256;
+  {
+    let candidate =
+      open_database(candidate_path, AccessMode::ReadOnly, &candidate_spill)?;
+    source_schema_sha256 = read_candidate_provenance(&candidate)?;
+    require_every_candidate_table_is_declared(&candidate, &schema)?;
+    let destination_database =
+      open_database(&database_path, AccessMode::ReadWrite, &destination_spill)?;
+    destination_database
+      .execute_batch(schema.sql)
+      .map_err(|error| NativeDatabaseError::duckdb("create the native schema", error))?;
+    destination_database
+      .execute_batch(&format!(
+        "CREATE TABLE {} (state VARCHAR NOT NULL, schema_version BIGINT NOT NULL, \
+         source_candidate_path VARCHAR NOT NULL, source_schema_sha256 VARCHAR NOT NULL, \
+         source_rows BIGINT NOT NULL); \
+         CREATE TABLE {} (table_name VARCHAR PRIMARY KEY, column_name VARCHAR NOT NULL, \
+         mode VARCHAR NOT NULL, high_water BIGINT NOT NULL)",
+        quote_identifier(NATIVE_METADATA_TABLE),
+        quote_identifier(NATIVE_IDENTITY_TABLE)
+      ))
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("create the native metadata tables", error)
+      })?;
+
+    let mut tables = Vec::with_capacity(schema.tables.len());
+    for table in schema.tables {
+      tables.push(copy_table(
+        &candidate,
+        &destination_database,
+        &mut epoch,
+        &schema,
+        table,
+      )?);
+    }
+    let total_rows = tables.iter().try_fold(0_u64, |total, table| {
+      total.checked_add(table.rows).ok_or_else(|| {
+        NativeDatabaseError::finalization(
+          "count the finalized rows",
+          "total row count overflowed u64",
+        )
+      })
+    })?;
+
+    write_identities(&candidate, &destination_database, &schema)?;
+    write_metadata(
+      &destination_database,
+      &schema,
+      candidate_path,
+      &source_schema_sha256,
+      total_rows,
+    )?;
+    destination_database
+      .execute_batch("CHECKPOINT")
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("checkpoint the finalized database", error)
+      })?;
+    copied = tables;
+  }
+  require_no_wal(&database_path)?;
+
+  let tables = verify_finalized(
+    &database_path,
+    &destination_spill,
+    &schema,
+    &source_schema_sha256,
+    &copied,
+  )?;
+  require_no_wal(&database_path)?;
+
+  let file = OpenOptions::new()
+    .read(true)
+    .write(true)
+    .open(&database_path)
+    .map_err(|error| {
+      NativeDatabaseError::finalization("open the finalized database for sync", error)
+    })?;
+  file.sync_all().map_err(|error| {
+    NativeDatabaseError::finalization("sync the finalized database", error)
+  })?;
+  let finalized_bytes = file
+    .metadata()
+    .map_err(|error| {
+      NativeDatabaseError::finalization("measure the finalized database", error)
+    })?
+    .len();
+  drop(file);
+  fs::hard_link(&database_path, destination).map_err(|error| {
+    NativeDatabaseError::finalization(
+      "publish the finalized database without replacement",
+      format!("{}: {error}", destination.display()),
+    )
+  })?;
+  drop(work);
+
+  let total_rows = tables.iter().map(|table| table.copied_rows).sum();
+  Ok(NativeFinalizationReport {
+    source_candidate_path: candidate_path.to_owned(),
+    finalized_database_path: destination.to_owned(),
+    state: FINALIZED_UNSELECTED.to_owned(),
+    schema_version: schema.version,
+    source_schema_sha256,
+    tables,
+    total_rows,
+    finalized_bytes,
+  })
+}
+
+/// Refuse a candidate that carries a domain table the stable schema never
+/// declared.
+///
+/// [`copy_table`] walks the App-declared table list, so a table the list forgot
+/// would simply not be copied - the table-level form of the missing-column
+/// failure [`plan_columns`] already refuses, and just as silent a loss of
+/// history. Checked before anything is written, so a schema definition that has
+/// fallen behind the migration set produces no partial file.
+fn require_every_candidate_table_is_declared(
+  candidate: &Connection,
+  schema: &NativeSchemaDefinition,
+) -> Result<(), NativeDatabaseError> {
+  let mut statement = candidate
+    .prepare(
+      "SELECT table_name FROM information_schema.tables \
+       WHERE table_schema = 'main' ORDER BY table_name",
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("prepare the candidate table read", error)
+    })?;
+  let names = statement
+    .query_map([], |row| row.get::<_, String>(0))
+    .map_err(|error| NativeDatabaseError::duckdb("read the candidate tables", error))?
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| NativeDatabaseError::duckdb("read the candidate tables", error))?;
+  for name in names {
+    if NON_DOMAIN_CANDIDATE_TABLES.contains(&name.as_str())
+      || schema.tables.contains(&name.as_str())
+    {
+      continue;
+    }
+    return Err(NativeDatabaseError::SchemaMismatch {
+      table: name,
+      detail: "the candidate carries this table but the native schema does not \
+               declare it, so finalizing would drop its rows"
+        .to_owned(),
+    });
+  }
+  Ok(())
+}
+
+struct CopiedTable {
+  name: String,
+  candidate_rows: u64,
+  rows: u64,
+  digest: RowMultisetDigest,
+}
+
+/// One finalized column and where its value comes from.
+struct ColumnPlan {
+  name: String,
+  kind: NativeColumnKind,
+  nullable: bool,
+  source: ColumnSource,
+}
+
+enum ColumnSource {
+  /// Copied verbatim from the candidate cell at this index.
+  Candidate(usize),
+  /// Derived from the stored timestamp text at this candidate index.
+  EpochMilliseconds(usize),
+}
+
+fn copy_table(
+  candidate: &Connection,
+  destination: &Connection,
+  epoch: &mut EpochMilliseconds,
+  schema: &NativeSchemaDefinition,
+  table: &str,
+) -> Result<CopiedTable, NativeDatabaseError> {
+  let candidate_columns = read_columns(candidate, table)?;
+  if candidate_columns.is_empty() {
+    return Err(NativeDatabaseError::SchemaMismatch {
+      table: table.to_owned(),
+      detail: "the candidate has no such table".to_owned(),
+    });
+  }
+  if !candidate_columns
+    .iter()
+    .any(|column| column.name == SOURCE_ORDINAL_COLUMN)
+  {
+    return Err(NativeDatabaseError::SchemaMismatch {
+      table: table.to_owned(),
+      detail: format!("the candidate table has no {SOURCE_ORDINAL_COLUMN} column"),
+    });
+  }
+  let source_columns = candidate_columns
+    .iter()
+    .filter(|column| column.name != SOURCE_ORDINAL_COLUMN)
+    .cloned()
+    .collect::<Vec<_>>();
+  let destination_columns = read_columns(destination, table)?;
+  let plan = plan_columns(schema, table, &source_columns, &destination_columns)?;
+
+  let candidate_rows = count_rows(candidate, table)?;
+  let staging = format!("__hv_finalize_stage_{table}");
+  destination
+    .execute_batch(&create_staging_sql(&staging, &plan))
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("create the finalization staging table", error)
+    })?;
+
+  // The ordinal is read last so a decoded row's source cells stay index-aligned
+  // with `source_columns`.
+  let projection = source_columns
+    .iter()
+    .chain(
+      candidate_columns
+        .iter()
+        .filter(|column| column.name == SOURCE_ORDINAL_COLUMN),
+    )
+    .map(|column| ReadColumn {
+      name: column.name.clone(),
+      kind: column.kind,
+    })
+    .collect::<Vec<_>>();
+  let mut reader = PagedReader::new(
+    candidate,
+    table,
+    projection,
+    vec![SOURCE_ORDINAL_COLUMN.to_owned()],
+  )?;
+
+  let mut digest = RowMultisetDigest::default();
+  let mut rows = 0_u64;
+  let mut ordinal_base = 0_u64;
+  destination
+    .execute_batch("BEGIN TRANSACTION")
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("begin the finalization transaction", error)
+    })?;
+  let result = (|| -> Result<(), NativeDatabaseError> {
+    while let Some(page) = reader.next_page()? {
+      let ordinals = page
+        .iter()
+        .map(|cells| match cells.last() {
+          Some(Cell::Integer(value)) => u64::try_from(*value).unwrap_or(u64::MAX),
+          _ => u64::MAX,
+        })
+        .collect::<Vec<_>>();
+      let derived = derive_epoch_milliseconds(epoch, table, &plan, &page, &ordinals)?;
+
+      let mut values = Vec::new();
+      for (row_index, cells) in page.iter().enumerate() {
+        let ordinal = ordinals[row_index];
+        let mut row_cells = Vec::with_capacity(plan.len());
+        for (column_index, column) in plan.iter().enumerate() {
+          let cell = match column.source {
+            ColumnSource::Candidate(index) => cells[index].clone(),
+            ColumnSource::EpochMilliseconds(_) => derived
+              .get(&(row_index, column_index))
+              .cloned()
+              .unwrap_or(Cell::Null),
+          };
+          stage_cell(table, column, ordinal, &cell, &mut values)?;
+          row_cells.push(cell);
+        }
+        values.push(Value::UBigInt(ordinal_base + row_index as u64));
+        digest.add_row(&row_cells);
+        rows = rows.checked_add(1).ok_or_else(|| {
+          NativeDatabaseError::finalization(
+            "copy a candidate table",
+            "row count overflowed u64",
+          )
+        })?;
+      }
+      append_staging(destination, &staging, &plan, page.len(), values)?;
+      destination
+        .execute_batch(&insert_from_staging_sql(table, &staging, &plan))
+        .map_err(|error| NativeDatabaseError::duckdb("insert a finalized page", error))?;
+      destination
+        .execute_batch(&format!(
+          "DELETE FROM temp.main.{}",
+          quote_identifier(&staging)
+        ))
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("clear the finalization staging table", error)
+        })?;
+      ordinal_base += page.len() as u64;
+    }
+    Ok(())
+  })();
+  if let Err(error) = result {
+    let _ = destination.execute_batch("ROLLBACK");
+    return Err(error);
+  }
+  destination.execute_batch("COMMIT").map_err(|error| {
+    NativeDatabaseError::duckdb("commit the finalization transaction", error)
+  })?;
+  destination
+    .execute_batch(&format!(
+      "DROP TABLE temp.main.{}",
+      quote_identifier(&staging)
+    ))
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("drop the finalization staging table", error)
+    })?;
+
+  if rows != candidate_rows {
+    return Err(NativeDatabaseError::Verification {
+      message: format!(
+        "{table} holds {candidate_rows} candidate rows but {rows} were copied"
+      ),
+    });
+  }
+  Ok(CopiedTable {
+    name: table.to_owned(),
+    candidate_rows,
+    rows,
+    digest,
+  })
+}
+
+/// Convert the page's stored timestamp texts in one batch per derived column.
+fn derive_epoch_milliseconds(
+  epoch: &mut EpochMilliseconds,
+  table: &str,
+  plan: &[ColumnPlan],
+  page: &[Vec<Cell>],
+  ordinals: &[u64],
+) -> Result<BTreeMap<(usize, usize), Cell>, NativeDatabaseError> {
+  let mut converted = BTreeMap::new();
+  for (column_index, column) in plan.iter().enumerate() {
+    let ColumnSource::EpochMilliseconds(source_index) = column.source else {
+      continue;
+    };
+    let mut texts = Vec::with_capacity(page.len());
+    for (row_index, cells) in page.iter().enumerate() {
+      match &cells[source_index] {
+        Cell::Text(text) => texts.push(Some(text.clone())),
+        Cell::Null => texts.push(None),
+        other => {
+          return Err(NativeDatabaseError::UnrepresentableCell {
+            table: table.to_owned(),
+            column: column.name.clone(),
+            row_ordinal: ordinals[row_index],
+            candidate: other.describe(),
+            destination: "a derived epoch-millisecond key, which needs stored \
+                          timestamp text"
+              .to_owned(),
+          });
+        }
+      }
+    }
+    for (row_index, milliseconds) in epoch.convert(&texts)?.into_iter().enumerate() {
+      converted.insert(
+        (row_index, column_index),
+        milliseconds.map_or(Cell::Null, Cell::Integer),
+      );
+    }
+  }
+  Ok(converted)
+}
+
+fn plan_columns(
+  schema: &NativeSchemaDefinition,
+  table: &str,
+  source_columns: &[TableColumn],
+  destination_columns: &[TableColumn],
+) -> Result<Vec<ColumnPlan>, NativeDatabaseError> {
+  let mut plan = Vec::with_capacity(destination_columns.len());
+  for column in destination_columns {
+    let source = if let Some(derived) = schema.derived_column_for(table, &column.name) {
+      let index = source_columns
+        .iter()
+        .position(|source| source.name == derived.source_column)
+        .ok_or_else(|| NativeDatabaseError::SchemaMismatch {
+          table: table.to_owned(),
+          detail: format!(
+            "derived column {} needs candidate column {}, which is absent",
+            column.name, derived.source_column
+          ),
+        })?;
+      ColumnSource::EpochMilliseconds(index)
+    } else {
+      let index = source_columns
+        .iter()
+        .position(|source| source.name == column.name)
+        .ok_or_else(|| NativeDatabaseError::SchemaMismatch {
+          table: table.to_owned(),
+          detail: format!("the candidate has no column {}", column.name),
+        })?;
+      ColumnSource::Candidate(index)
+    };
+    plan.push(ColumnPlan {
+      name: column.name.clone(),
+      kind: column.kind,
+      nullable: column.nullable,
+      source,
+    });
+  }
+
+  // Every candidate column must land somewhere: a column the stable schema
+  // forgot would silently drop history.
+  for source in source_columns {
+    if !destination_columns
+      .iter()
+      .any(|column| column.name == source.name)
+    {
+      return Err(NativeDatabaseError::SchemaMismatch {
+        table: table.to_owned(),
+        detail: format!(
+          "candidate column {} has no column in the native schema",
+          source.name
+        ),
+      });
+    }
+  }
+  Ok(plan)
+}
+
+/// Refuse, rather than coerce, any candidate cell the stable column cannot
+/// hold. Widening an integer to a double would round beyond 2^53 and narrowing
+/// a double to an integer would drop the fraction; both would make a stored
+/// reading say something the source never said.
+fn stage_cell(
+  table: &str,
+  column: &ColumnPlan,
+  row_ordinal: u64,
+  cell: &Cell,
+  values: &mut Vec<Value>,
+) -> Result<(), NativeDatabaseError> {
+  let unrepresentable = || NativeDatabaseError::UnrepresentableCell {
+    table: table.to_owned(),
+    column: column.name.clone(),
+    row_ordinal,
+    candidate: cell.describe(),
+    destination: column.kind.sql().to_owned(),
+  };
+  match (cell, column.kind) {
+    (Cell::Null, _) => {
+      if !column.nullable {
+        return Err(NativeDatabaseError::NullInRequiredColumn {
+          table: table.to_owned(),
+          column: column.name.clone(),
+          row_ordinal,
+        });
+      }
+      if column.kind == NativeColumnKind::TaggedNumeric {
+        values.extend([Value::UTinyInt(0), Value::Null, Value::Null]);
+      } else {
+        values.push(Value::Null);
+      }
+    }
+    (Cell::Integer(value), NativeColumnKind::BigInt) => {
+      values.push(Value::BigInt(*value));
+    }
+    (Cell::Integer(value), NativeColumnKind::TaggedNumeric) => {
+      values.extend([Value::UTinyInt(1), Value::BigInt(*value), Value::Null]);
+    }
+    (Cell::Real(bits), NativeColumnKind::Double) => {
+      values.push(Value::Double(f64::from_bits(*bits)));
+    }
+    (Cell::Real(bits), NativeColumnKind::TaggedNumeric) => {
+      values.extend([
+        Value::UTinyInt(2),
+        Value::Null,
+        Value::Double(f64::from_bits(*bits)),
+      ]);
+    }
+    (Cell::Text(value), NativeColumnKind::Varchar) => {
+      values.push(Value::Text(value.clone()));
+    }
+    (Cell::Blob(value), NativeColumnKind::Blob) => {
+      values.push(Value::Blob(value.clone()));
+    }
+    _ => return Err(unrepresentable()),
+  }
+  Ok(())
+}
+
+fn create_staging_sql(staging: &str, plan: &[ColumnPlan]) -> String {
+  let mut columns = Vec::new();
+  for (index, column) in plan.iter().enumerate() {
+    if column.kind == NativeColumnKind::TaggedNumeric {
+      columns.push(format!("\"c{index:04}_tag\" UTINYINT NOT NULL"));
+      columns.push(format!("\"c{index:04}_i\" BIGINT"));
+      columns.push(format!("\"c{index:04}_r\" DOUBLE"));
+    } else {
+      columns.push(format!("\"c{index:04}\" {}", column.kind.sql()));
+    }
+  }
+  columns.push("\"__hv_stage_ordinal\" UBIGINT NOT NULL".to_owned());
+  format!(
+    "CREATE TEMP TABLE {} ({})",
+    quote_identifier(staging),
+    columns.join(", ")
+  )
+}
+
+fn append_staging(
+  destination: &Connection,
+  staging: &str,
+  plan: &[ColumnPlan],
+  rows: usize,
+  values: Vec<Value>,
+) -> Result<(), NativeDatabaseError> {
+  let width = plan
+    .iter()
+    .map(|column| {
+      if column.kind == NativeColumnKind::TaggedNumeric {
+        3
+      } else {
+        1
+      }
+    })
+    .sum::<usize>()
+    + 1;
+  if values.len() != rows * width {
+    return Err(NativeDatabaseError::finalization(
+      "stage a finalized page",
+      format!("staged {} values for {rows} rows of {width}", values.len()),
+    ));
+  }
+  let mut appender = destination
+    .appender_to_catalog_and_db(staging, "temp", "main")
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("open the finalization staging appender", error)
+    })?;
+  for row in values.chunks(width) {
+    appender
+      .append_row(appender_params_from_iter(row.to_vec()))
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("append a finalized staging row", error)
+      })?;
+  }
+  appender.flush().map_err(|error| {
+    NativeDatabaseError::duckdb("flush the finalization staging appender", error)
+  })
+}
+
+fn insert_from_staging_sql(table: &str, staging: &str, plan: &[ColumnPlan]) -> String {
+  let mut names = Vec::with_capacity(plan.len());
+  let mut projections = Vec::with_capacity(plan.len());
+  for (index, column) in plan.iter().enumerate() {
+    names.push(quote_identifier(&column.name));
+    if column.kind == NativeColumnKind::TaggedNumeric {
+      projections.push(format!(
+        "CASE \"c{index:04}_tag\" \
+         WHEN 1 THEN union_value(i := \"c{index:04}_i\")::UNION(i BIGINT, r DOUBLE) \
+         WHEN 2 THEN union_value(r := \"c{index:04}_r\")::UNION(i BIGINT, r DOUBLE) \
+         ELSE NULL END"
+      ));
+    } else {
+      projections.push(format!("\"c{index:04}\""));
+    }
+  }
+  format!(
+    "INSERT INTO {} ({}) SELECT {} FROM temp.main.{} ORDER BY \"__hv_stage_ordinal\"",
+    quote_identifier(table),
+    names.join(", "),
+    projections.join(", "),
+    quote_identifier(staging)
+  )
+}
+
+/// Import the SQLite identity state the allocator has to keep reproducing.
+///
+/// AUTOINCREMENT tables take their high-water mark from the candidate's copied
+/// `sqlite_sequence` row, raised to the largest surviving id when the two
+/// disagree: a sequence that lags its own rows must never hand out a colliding
+/// id. Rowid tables record no high-water mark because SQLite derives their next
+/// id from the current maximum.
+fn write_identities(
+  candidate: &Connection,
+  destination: &Connection,
+  schema: &NativeSchemaDefinition,
+) -> Result<(), NativeDatabaseError> {
+  let sequences = read_sqlite_sequences(candidate)?;
+  for identity in schema.identities {
+    let (mode, high_water) = match identity.mode {
+      NativeIdentityMode::RowId => ("rowid", 0_i64),
+      NativeIdentityMode::AutoIncrement {
+        sqlite_sequence_name,
+      } => {
+        let sequence = sequences.get(sqlite_sequence_name).copied().unwrap_or(0);
+        let maximum: i64 = destination
+          .query_row(
+            &format!(
+              "SELECT COALESCE(MAX({}), 0) FROM {}",
+              quote_identifier(identity.column),
+              quote_identifier(identity.table)
+            ),
+            [],
+            |row| row.get(0),
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("read the finalized identity maximum", error)
+          })?;
+        ("autoincrement", sequence.max(maximum))
+      }
+    };
+    destination
+      .execute(
+        &format!(
+          "INSERT INTO {} VALUES (?, ?, ?, ?)",
+          quote_identifier(NATIVE_IDENTITY_TABLE)
+        ),
+        duckdb::params![identity.table, identity.column, mode, high_water],
+      )
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("write the native identity metadata", error)
+      })?;
+  }
+  Ok(())
+}
+
+fn read_sqlite_sequences(
+  candidate: &Connection,
+) -> Result<BTreeMap<String, i64>, NativeDatabaseError> {
+  let present: i64 = candidate
+    .query_row(
+      "SELECT count(*) FROM information_schema.tables WHERE table_name = ?",
+      [SQLITE_SEQUENCE_TABLE],
+      |row| row.get(0),
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("look for the copied sqlite_sequence table", error)
+    })?;
+  if present == 0 {
+    return Ok(BTreeMap::new());
+  }
+  let mut statement = candidate
+    .prepare(&format!(
+      "SELECT name, seq FROM {}",
+      quote_identifier(SQLITE_SEQUENCE_TABLE)
+    ))
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("prepare the sqlite_sequence read", error)
+    })?;
+  let rows = statement
+    .query_map([], |row| {
+      Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("read the copied sqlite_sequence rows", error)
+    })?
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("read the copied sqlite_sequence rows", error)
+    })?;
+  Ok(rows.into_iter().collect())
+}
+
+fn write_metadata(
+  destination: &Connection,
+  schema: &NativeSchemaDefinition,
+  candidate_path: &Path,
+  source_schema_sha256: &str,
+  total_rows: u64,
+) -> Result<(), NativeDatabaseError> {
+  let rows = i64::try_from(total_rows).map_err(|_| {
+    NativeDatabaseError::finalization(
+      "write the native metadata",
+      "total row count does not fit a signed 64-bit value",
+    )
+  })?;
+  destination
+    .execute(
+      &format!(
+        "INSERT INTO {} VALUES (?, ?, ?, ?, ?)",
+        quote_identifier(NATIVE_METADATA_TABLE)
+      ),
+      duckdb::params![
+        FINALIZED_UNSELECTED,
+        i64::from(schema.version),
+        candidate_path.to_string_lossy().as_ref(),
+        source_schema_sha256,
+        rows
+      ],
+    )
+    .map(|_| ())
+    .map_err(|error| NativeDatabaseError::duckdb("write the native metadata", error))
+}
+
+/// Reopen the closed file and recompute what was written.
+fn verify_finalized(
+  database_path: &Path,
+  spill: &Path,
+  schema: &NativeSchemaDefinition,
+  source_schema_sha256: &str,
+  copied: &[CopiedTable],
+) -> Result<Vec<NativeTableReport>, NativeDatabaseError> {
+  let connection = open_database(database_path, AccessMode::ReadOnly, spill)?;
+  let (state, version, digest): (String, i64, String) = connection
+    .query_row(
+      &format!(
+        "SELECT state, schema_version, source_schema_sha256 FROM {}",
+        quote_identifier(NATIVE_METADATA_TABLE)
+      ),
+      [],
+      |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("read the reopened native metadata", error)
+    })?;
+  if state != FINALIZED_UNSELECTED
+    || version != i64::from(schema.version)
+    || digest != source_schema_sha256
+  {
+    return Err(NativeDatabaseError::Verification {
+      message: "the reopened native metadata does not match what was written".to_owned(),
+    });
+  }
+  let identities: i64 = connection
+    .query_row(
+      &format!(
+        "SELECT count(*) FROM {}",
+        quote_identifier(NATIVE_IDENTITY_TABLE)
+      ),
+      [],
+      |row| row.get(0),
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("read the reopened identity metadata", error)
+    })?;
+  if identities != schema.identities.len() as i64 {
+    return Err(NativeDatabaseError::Verification {
+      message: format!(
+        "the reopened database records {identities} identities for {} declared tables",
+        schema.identities.len()
+      ),
+    });
+  }
+
+  let mut reports = Vec::with_capacity(copied.len());
+  for table in copied {
+    let columns = read_columns(&connection, &table.name)?;
+    let key_columns = read_primary_key(&connection, &table.name)?;
+    let mut reader = PagedReader::new(
+      &connection,
+      &table.name,
+      columns
+        .iter()
+        .map(|column| ReadColumn {
+          name: column.name.clone(),
+          kind: column.kind,
+        })
+        .collect(),
+      key_columns,
+    )?;
+    let mut digest = RowMultisetDigest::default();
+    while let Some(page) = reader.next_page()? {
+      for row in page {
+        digest.add_row(&row);
+      }
+    }
+    let reopened_rows = count_rows(&connection, &table.name)?;
+    if reopened_rows != table.rows
+      || digest.rows() != table.rows
+      || digest != table.digest
+    {
+      return Err(NativeDatabaseError::Verification {
+        message: format!(
+          "{} read back {reopened_rows} rows with digest {} after reopen, but {} rows with digest {} were written",
+          table.name,
+          digest.encode(),
+          table.rows,
+          table.digest.encode()
+        ),
+      });
+    }
+    reports.push(NativeTableReport {
+      name: table.name.clone(),
+      candidate_rows: table.candidate_rows,
+      copied_rows: table.rows,
+      reopened_rows,
+      copied_digest: table.digest.encode(),
+      reopened_digest: digest.encode(),
+    });
+  }
+  Ok(reports)
+}
+
+#[derive(Clone, Debug)]
+struct TableColumn {
+  name: String,
+  kind: NativeColumnKind,
+  nullable: bool,
+}
+
+fn read_columns(
+  connection: &Connection,
+  table: &str,
+) -> Result<Vec<TableColumn>, NativeDatabaseError> {
+  let mut statement = connection
+    .prepare(
+      "SELECT column_name, data_type, CAST(is_nullable AS VARCHAR) \
+       FROM information_schema.columns WHERE table_name = ? ORDER BY ordinal_position",
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("prepare the table column read", error)
+    })?;
+  let rows = statement
+    .query_map([table], |row| {
+      Ok((
+        row.get::<_, String>(0)?,
+        row.get::<_, String>(1)?,
+        row.get::<_, String>(2)?,
+      ))
+    })
+    .map_err(|error| NativeDatabaseError::duckdb("read the table columns", error))?
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| NativeDatabaseError::duckdb("read the table columns", error))?;
+  rows
+    .into_iter()
+    .map(|(name, data_type, nullable)| {
+      let kind = NativeColumnKind::parse(&data_type).ok_or_else(|| {
+        NativeDatabaseError::SchemaMismatch {
+          table: table.to_owned(),
+          detail: format!("column {name} has unsupported storage type {data_type}"),
+        }
+      })?;
+      Ok(TableColumn {
+        name,
+        kind,
+        nullable: nullable.eq_ignore_ascii_case("yes")
+          || nullable.eq_ignore_ascii_case("true"),
+      })
+    })
+    .collect()
+}
+
+fn read_primary_key(
+  connection: &Connection,
+  table: &str,
+) -> Result<Vec<String>, NativeDatabaseError> {
+  let mut statement = connection
+    .prepare(
+      "SELECT unnest(constraint_column_names) FROM duckdb_constraints() \
+       WHERE table_name = ? AND constraint_type = 'PRIMARY KEY'",
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("prepare the primary key read", error)
+    })?;
+  let columns = statement
+    .query_map([table], |row| row.get::<_, String>(0))
+    .map_err(|error| NativeDatabaseError::duckdb("read the primary key", error))?
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| NativeDatabaseError::duckdb("read the primary key", error))?;
+  if columns.is_empty() {
+    return Err(NativeDatabaseError::SchemaMismatch {
+      table: table.to_owned(),
+      detail: "the native schema declares no primary key, so the finalized table \
+               cannot be verified in bounded pages"
+        .to_owned(),
+    });
+  }
+  Ok(columns)
+}
+
+fn count_rows(connection: &Connection, table: &str) -> Result<u64, NativeDatabaseError> {
+  let count: i64 = connection
+    .query_row(
+      &format!("SELECT COUNT(*) FROM {}", quote_identifier(table)),
+      [],
+      |row| row.get(0),
+    )
+    .map_err(|error| NativeDatabaseError::duckdb("count a table", error))?;
+  u64::try_from(count).map_err(|_| NativeDatabaseError::Verification {
+    message: format!("DuckDB returned a negative row count for {table}"),
+  })
+}
+
+fn read_candidate_provenance(
+  candidate: &Connection,
+) -> Result<String, NativeDatabaseError> {
+  let (kind, digest): (String, Vec<u8>) = candidate
+    .query_row(
+      &format!(
+        "SELECT snapshot_kind, source_schema_digest FROM {}",
+        quote_identifier(SNAPSHOT_METADATA_TABLE)
+      ),
+      [],
+      |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .map_err(|error| NativeDatabaseError::CandidateSnapshot {
+      message: format!("failed to read {SNAPSHOT_METADATA_TABLE}: {error}"),
+    })?;
+  if kind != "immutable_source_snapshot" {
+    return Err(NativeDatabaseError::CandidateSnapshot {
+      message: format!("unexpected snapshot kind {kind}"),
+    });
+  }
+  Ok(encode_hex(&digest))
+}
+
+fn open_database(
+  path: &Path,
+  access_mode: AccessMode,
+  spill: &Path,
+) -> Result<Connection, NativeDatabaseError> {
+  let config = Config::default()
+    .access_mode(access_mode)
+    .and_then(|config| config.threads(2))
+    .and_then(|config| config.max_memory("128MB"))
+    .and_then(|config| config.enable_autoload_extension(false))
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("configure a finalization database", error)
+    })?;
+  let connection = Connection::open_with_flags(path, config).map_err(|error| {
+    NativeDatabaseError::duckdb("open a finalization database", error)
+  })?;
+  super::configure_spill(&connection, spill)?;
+  Ok(connection)
+}
+
+fn require_no_wal(database: &Path) -> Result<(), NativeDatabaseError> {
+  let mut wal = database.as_os_str().to_os_string();
+  wal.push(".wal");
+  if PathBuf::from(&wal).exists() {
+    return Err(NativeDatabaseError::Verification {
+      message: format!(
+        "a write-ahead log remains beside the finalized database: {}",
+        PathBuf::from(wal).display()
+      ),
+    });
+  }
+  Ok(())
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+  use std::fmt::Write;
+
+  let mut encoded = String::with_capacity(bytes.len() * 2);
+  for byte in bytes {
+    write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+  }
+  encoded
+}

--- a/core/src/infrastructure/database/native_database/mod.rs
+++ b/core/src/infrastructure/database/native_database/mod.rs
@@ -1,0 +1,52 @@
+//! Explicit native DuckDB access for a finalized, unselected database.
+//!
+//! SQLite remains authoritative. Nothing here is reached by the running
+//! application: finalization builds a separate file, the owner opens it only
+//! when a caller asks, and the per-family functions run beside - never instead
+//! of - their SQLite counterparts until App lifecycle selection is implemented.
+
+mod cell;
+mod epoch;
+mod error;
+mod finalize;
+mod paging;
+pub mod process_stats;
+mod runtime;
+mod schema;
+
+use std::path::Path;
+
+use duckdb::Connection;
+
+pub use error::NativeDatabaseError;
+pub use finalize::{
+  NativeFinalizationReport, NativeTableReport, finalize_candidate_database,
+};
+pub use runtime::{
+  NativeCancellation, NativeConnectionContext, NativeDatabase, NativeDatabaseOptions,
+  NativeTransactionContext,
+};
+pub use schema::{
+  NativeIdentity, NativeIdentityMode, NativeSchemaDefinition, NativeTimestampColumn,
+};
+
+/// Point one DuckDB instance at its own spill directory and close it to the
+/// filesystem afterwards.
+///
+/// DuckDB rejects `temp_directory` changes once external access is disabled, so
+/// the owned spill path has to be set first. Independent instances must not
+/// share a spill directory.
+fn configure_spill(
+  connection: &Connection,
+  spill: &Path,
+) -> Result<(), NativeDatabaseError> {
+  let spill = spill.to_str().ok_or_else(|| NativeDatabaseError::Worker {
+    message: format!("spill path is not valid UTF-8: {}", spill.display()),
+  })?;
+  connection
+    .execute_batch(&format!(
+      "SET temp_directory = '{}'; SET enable_external_access = false",
+      spill.replace('\'', "''")
+    ))
+    .map_err(|error| NativeDatabaseError::duckdb("configure the spill directory", error))
+}

--- a/core/src/infrastructure/database/native_database/paging.rs
+++ b/core/src/infrastructure/database/native_database/paging.rs
@@ -1,0 +1,350 @@
+//! Bounded, deterministic table reads used by finalization and its
+//! post-reopen verification.
+//!
+//! duckdb-rs materializes a query result before handing rows back, so reading
+//! a whole archive table in one statement would size peak memory by the user's
+//! history rather than by a fixed budget. Both sides of the copy therefore read
+//! through a key window: the candidate by its `__hv_source_ordinal`, the
+//! finalized table by its primary key. A byte preflight bounds the payload page
+//! the same way the candidate builder bounds its own copy, because a row's size
+//! is data-dependent while its row count is not.
+
+use duckdb::Connection;
+use duckdb::types::Value;
+
+use super::NativeDatabaseError;
+use super::cell::{
+  COPY_BATCH_ROWS, Cell, MAX_BATCH_BYTES, NativeColumnKind, quote_identifier,
+};
+
+/// One column read back from a DuckDB table.
+#[derive(Clone, Debug)]
+pub(super) struct ReadColumn {
+  pub(super) name: String,
+  pub(super) kind: NativeColumnKind,
+}
+
+/// Reads a table in bounded pages ordered by `key_columns`, which must be a
+/// unique, NOT NULL key so the window can never skip or repeat a row.
+pub(super) struct PagedReader<'a> {
+  connection: &'a Connection,
+  table: String,
+  key_columns: Vec<String>,
+  columns: Vec<ReadColumn>,
+  key_indices: Vec<usize>,
+  cursor: Option<Vec<Cell>>,
+  finished: bool,
+}
+
+impl<'a> PagedReader<'a> {
+  pub(super) fn new(
+    connection: &'a Connection,
+    table: &str,
+    columns: Vec<ReadColumn>,
+    key_columns: Vec<String>,
+  ) -> Result<Self, NativeDatabaseError> {
+    let key_indices = key_columns
+      .iter()
+      .map(|key| {
+        columns
+          .iter()
+          .position(|column| &column.name == key)
+          .ok_or_else(|| NativeDatabaseError::SchemaMismatch {
+            table: table.to_owned(),
+            detail: format!("paging key {key} is not part of the read projection"),
+          })
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+    if key_indices.is_empty() {
+      return Err(NativeDatabaseError::SchemaMismatch {
+        table: table.to_owned(),
+        detail: "table has no unique key to read it back in bounded pages".to_owned(),
+      });
+    }
+    Ok(Self {
+      connection,
+      table: table.to_owned(),
+      key_columns,
+      columns,
+      key_indices,
+      cursor: None,
+      finished: false,
+    })
+  }
+
+  /// The next page of decoded rows, or `None` once the table is exhausted.
+  pub(super) fn next_page(
+    &mut self,
+  ) -> Result<Option<Vec<Vec<Cell>>>, NativeDatabaseError> {
+    if self.finished {
+      return Ok(None);
+    }
+    let Some(page_end) = self.preflight()? else {
+      self.finished = true;
+      return Ok(None);
+    };
+
+    let mut sql = format!(
+      "SELECT {} FROM {}",
+      self
+        .columns
+        .iter()
+        .map(projection)
+        .collect::<Vec<_>>()
+        .join(", "),
+      quote_identifier(&self.table)
+    );
+    let mut parameters = Vec::new();
+    let mut conditions = Vec::new();
+    if let Some(cursor) = self.cursor.clone() {
+      conditions.push(format!(
+        "({})",
+        self.after_predicate(&mut parameters, &cursor)
+      ));
+    }
+    conditions.push(format!(
+      "NOT ({})",
+      self.after_predicate(&mut parameters, &page_end)
+    ));
+    sql.push_str(" WHERE ");
+    sql.push_str(&conditions.join(" AND "));
+    sql.push_str(&format!(" ORDER BY {}", self.order_by()));
+
+    let mut statement = self.connection.prepare(&sql).map_err(|error| {
+      NativeDatabaseError::duckdb("prepare bounded table read", error)
+    })?;
+    let mut rows = statement
+      .query(duckdb::params_from_iter(parameters))
+      .map_err(|error| NativeDatabaseError::duckdb("read bounded table page", error))?;
+    let mut page = Vec::new();
+    while let Some(row) = rows
+      .next()
+      .map_err(|error| NativeDatabaseError::duckdb("read bounded table page", error))?
+    {
+      page.push(decode_row(row, &self.columns)?);
+    }
+    if page.is_empty() {
+      return Err(NativeDatabaseError::Verification {
+        message: format!(
+          "{} changed between the preflight and the payload of one bounded page",
+          self.table
+        ),
+      });
+    }
+    self.cursor = Some(page_end);
+    Ok(Some(page))
+  }
+
+  /// The last key of the next page: at most [`COPY_BATCH_ROWS`] rows, and no
+  /// more than [`MAX_BATCH_BYTES`] of payload after the first row.
+  fn preflight(&self) -> Result<Option<Vec<Cell>>, NativeDatabaseError> {
+    let keys = self
+      .key_indices
+      .iter()
+      .map(|index| projection(&self.columns[*index]))
+      .collect::<Vec<_>>()
+      .join(", ");
+    let mut sql = format!(
+      "SELECT {keys}, {} FROM {}",
+      self.row_bytes_expression(),
+      quote_identifier(&self.table)
+    );
+    let mut parameters = Vec::new();
+    if let Some(cursor) = self.cursor.clone() {
+      sql.push_str(" WHERE ");
+      sql.push_str(&self.after_predicate(&mut parameters, &cursor));
+    }
+    sql.push_str(&format!(
+      " ORDER BY {} LIMIT {COPY_BATCH_ROWS}",
+      self.order_by()
+    ));
+
+    let key_columns = self
+      .key_indices
+      .iter()
+      .map(|index| self.columns[*index].clone())
+      .collect::<Vec<_>>();
+    let mut statement = self.connection.prepare(&sql).map_err(|error| {
+      NativeDatabaseError::duckdb("prepare bounded page preflight", error)
+    })?;
+    let mut rows = statement
+      .query(duckdb::params_from_iter(parameters))
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("read bounded page preflight", error)
+      })?;
+    let mut accepted: Option<Vec<Cell>> = None;
+    let mut bytes = 0_u64;
+    while let Some(row) = rows.next().map_err(|error| {
+      NativeDatabaseError::duckdb("read bounded page preflight", error)
+    })? {
+      let key = decode_row(row, &key_columns)?;
+      let row_bytes: i64 = row.get(key_columns.len()).map_err(|error| {
+        NativeDatabaseError::duckdb("decode bounded page row size", error)
+      })?;
+      let row_bytes = u64::try_from(row_bytes).unwrap_or(u64::MAX);
+      if accepted.is_some() && bytes.saturating_add(row_bytes) > MAX_BATCH_BYTES {
+        break;
+      }
+      bytes = bytes.saturating_add(row_bytes);
+      accepted = Some(key);
+    }
+    Ok(accepted)
+  }
+
+  fn order_by(&self) -> String {
+    self
+      .key_columns
+      .iter()
+      .map(|key| quote_identifier(key))
+      .collect::<Vec<_>>()
+      .join(", ")
+  }
+
+  /// `key > cursor` written out lexicographically, because DuckDB row
+  /// comparison syntax is not portable across the identifier quoting used here.
+  fn after_predicate(&self, parameters: &mut Vec<Value>, cursor: &[Cell]) -> String {
+    fn build(
+      keys: &[String],
+      cursor: &[Cell],
+      parameters: &mut Vec<Value>,
+      index: usize,
+    ) -> String {
+      let column = quote_identifier(&keys[index]);
+      let value = key_value(&cursor[index]);
+      if index + 1 == keys.len() {
+        parameters.push(value);
+        return format!("{column} > ?");
+      }
+      parameters.push(value.clone());
+      parameters.push(value);
+      let rest = build(keys, cursor, parameters, index + 1);
+      format!("{column} > ? OR ({column} = ? AND ({rest}))")
+    }
+
+    build(&self.key_columns, cursor, parameters, 0)
+  }
+
+  fn row_bytes_expression(&self) -> String {
+    self
+      .columns
+      .iter()
+      .map(|column| {
+        let name = quote_identifier(&column.name);
+        match column.kind {
+          NativeColumnKind::BigInt
+          | NativeColumnKind::UBigInt
+          | NativeColumnKind::Double => {
+            format!("CASE WHEN {name} IS NULL THEN 0 ELSE 8 END")
+          }
+          NativeColumnKind::TaggedNumeric => {
+            format!("CASE WHEN {name} IS NULL THEN 0 ELSE 9 END")
+          }
+          NativeColumnKind::Varchar => {
+            format!(
+              "CASE WHEN {name} IS NULL THEN 0 ELSE octet_length(encode({name})) END"
+            )
+          }
+          NativeColumnKind::Blob => {
+            format!("CASE WHEN {name} IS NULL THEN 0 ELSE octet_length({name}) END")
+          }
+        }
+      })
+      .collect::<Vec<_>>()
+      .join(" + ")
+  }
+}
+
+fn key_value(cell: &Cell) -> Value {
+  match cell {
+    Cell::Integer(value) => Value::BigInt(*value),
+    Cell::Real(bits) => Value::Double(f64::from_bits(*bits)),
+    Cell::Text(value) => Value::Text(value.clone()),
+    Cell::Blob(value) => Value::Blob(value.clone()),
+    // Unreachable for a NOT NULL key; binding NULL makes the window empty
+    // rather than silently wrapping around.
+    Cell::Null => Value::Null,
+  }
+}
+
+/// A column's projection, expanding a tagged union into its tag and members so
+/// the integer/real distinction survives decoding.
+pub(super) fn projection(column: &ReadColumn) -> String {
+  let name = quote_identifier(&column.name);
+  match column.kind {
+    NativeColumnKind::TaggedNumeric => format!(
+      "CAST(union_tag({name}) AS VARCHAR), union_extract({name}, 'i'), union_extract({name}, 'r')"
+    ),
+    _ => name,
+  }
+}
+
+pub(super) fn decode_row(
+  row: &duckdb::Row<'_>,
+  columns: &[ReadColumn],
+) -> Result<Vec<Cell>, NativeDatabaseError> {
+  let mut cells = Vec::with_capacity(columns.len());
+  let mut index = 0_usize;
+  for column in columns {
+    match column.kind {
+      NativeColumnKind::TaggedNumeric => {
+        let tag: Option<String> = row.get(index).map_err(decode_error)?;
+        let integer: Option<i64> = row.get(index + 1).map_err(decode_error)?;
+        let real: Option<f64> = row.get(index + 2).map_err(decode_error)?;
+        cells.push(match (tag.as_deref(), integer, real) {
+          (None, None, None) => Cell::Null,
+          (Some("i"), Some(value), None) => Cell::Integer(value),
+          (Some("r"), None, Some(value)) => Cell::Real(value.to_bits()),
+          _ => {
+            return Err(NativeDatabaseError::Verification {
+              message: format!(
+                "tagged numeric column {} has inconsistent tag and member payloads",
+                column.name
+              ),
+            });
+          }
+        });
+        index += 3;
+      }
+      NativeColumnKind::BigInt => {
+        let value: Option<i64> = row.get(index).map_err(decode_error)?;
+        cells.push(value.map_or(Cell::Null, Cell::Integer));
+        index += 1;
+      }
+      NativeColumnKind::UBigInt => {
+        let value: Option<u64> = row.get(index).map_err(decode_error)?;
+        let value = value
+          .map(|value| {
+            i64::try_from(value).map_err(|_| NativeDatabaseError::Verification {
+              message: format!(
+                "unsigned column {} holds {value}, which does not fit a signed 64-bit value",
+                column.name
+              ),
+            })
+          })
+          .transpose()?;
+        cells.push(value.map_or(Cell::Null, Cell::Integer));
+        index += 1;
+      }
+      NativeColumnKind::Double => {
+        let value: Option<f64> = row.get(index).map_err(decode_error)?;
+        cells.push(value.map_or(Cell::Null, |value| Cell::Real(value.to_bits())));
+        index += 1;
+      }
+      NativeColumnKind::Varchar => {
+        let value: Option<String> = row.get(index).map_err(decode_error)?;
+        cells.push(value.map_or(Cell::Null, Cell::Text));
+        index += 1;
+      }
+      NativeColumnKind::Blob => {
+        let value: Option<Vec<u8>> = row.get(index).map_err(decode_error)?;
+        cells.push(value.map_or(Cell::Null, Cell::Blob));
+        index += 1;
+      }
+    }
+  }
+  Ok(cells)
+}
+
+fn decode_error(error: duckdb::Error) -> NativeDatabaseError {
+  NativeDatabaseError::duckdb("decode a native table cell", error)
+}

--- a/core/src/infrastructure/database/native_database/process_stats.rs
+++ b/core/src/infrastructure/database/native_database/process_stats.rs
@@ -112,6 +112,18 @@ pub async fn delete_old_data(
     .await
 }
 
+/// SQLite's `avg()` over an INTEGER column that never overflowed: the exact
+/// `i64` sum converted to binary64, divided by the count converted to binary64.
+///
+/// DuckDB's own `AVG(BIGINT)` is not used for `memory_usage` because it divides
+/// the exact sum as a `long double`, whose width depends on the platform
+/// (80-bit on x86_64 Linux, 64-bit on aarch64 macOS and MSVC), so its last bit
+/// differs between operating systems. Reproducing SQLite's two conversions and
+/// one IEEE division here gives the same bits everywhere.
+pub fn sqlite_integer_average(sum: i64, count: i64) -> f64 {
+  sum as f64 / count as f64
+}
+
 /// The native form of
 /// [`crate::infrastructure::database::archive_queries::select_process_stats`].
 ///
@@ -120,6 +132,17 @@ pub async fn delete_old_data(
 /// stored spellings it would have selected in SQLite. Grouping stays on the
 /// recorded `(pid, process_name)` tuple - the Process identity ADR 0019 defines
 /// - rather than on the row id.
+///
+/// `avg_cpu_usage` comes from DuckDB's `AVG(DOUBLE)`, which is the binary64
+/// sum divided by the count, the same arithmetic as SQLite's `avg()` over REAL
+/// short of its compensation term (see `duckdb_avg_compatibility.rs` for the
+/// measured boundary). `avg_memory_usage` is rebuilt from DuckDB's exact
+/// 128-bit `SUM` and the count by [`sqlite_integer_average`]. A sum beyond
+/// `i64` is refused with [`NativeDatabaseError::IntegerSumOverflow`] instead
+/// of becoming a silently different number: that is where SQLite itself
+/// abandons exact integer summation for an order-dependent approximation, and
+/// `memory_usage` is written from an `i32`, so no archive within a Retention
+/// Period reaches it.
 pub async fn select_process_stats(
   database: &NativeDatabase,
   cancellation: NativeCancellation,
@@ -137,7 +160,8 @@ pub async fn select_process_stats(
        pid,
        process_name,
        AVG(cpu_usage) AS avg_cpu_usage,
-       AVG(memory_usage) AS avg_memory_usage,
+       SUM(memory_usage) AS memory_usage_sum,
+       COUNT(memory_usage) AS memory_usage_count,
        MAX(execution_sec) AS total_execution_sec,
        MAX(timestamp) AS latest_timestamp
      FROM PROCESS_STATS
@@ -152,14 +176,15 @@ pub async fn select_process_stats(
       })?;
       let rows = statement
         .query_map(params![start.as_str(), end.as_str()], |row| {
-          Ok(ProcessStatRecord {
-            pid: row.get(0)?,
-            process_name: row.get(1)?,
-            avg_cpu_usage: row.get(2)?,
-            avg_memory_usage: row.get(3)?,
-            total_execution_sec: row.get(4)?,
-            latest_timestamp: row.get(5)?,
-          })
+          Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, f64>(2)?,
+            row.get::<_, i128>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, String>(6)?,
+          ))
         })
         .map_err(|error| {
           NativeDatabaseError::duckdb("run the process stats query", error)
@@ -168,7 +193,36 @@ pub async fn select_process_stats(
         .map_err(|error| {
           NativeDatabaseError::duckdb("decode a process stats row", error)
         })?;
-      Ok(rows)
+      rows
+        .into_iter()
+        .map(
+          |(
+            pid,
+            process_name,
+            avg_cpu_usage,
+            memory_sum,
+            memory_count,
+            total_execution_sec,
+            latest_timestamp,
+          )| {
+            let memory_sum = i64::try_from(memory_sum).map_err(|_| {
+              NativeDatabaseError::IntegerSumOverflow {
+                column: "memory_usage",
+                pid,
+                process_name: process_name.clone(),
+              }
+            })?;
+            Ok(ProcessStatRecord {
+              pid,
+              process_name,
+              avg_cpu_usage,
+              avg_memory_usage: sqlite_integer_average(memory_sum, memory_count),
+              total_execution_sec,
+              latest_timestamp,
+            })
+          },
+        )
+        .collect()
     })
     .await
 }

--- a/core/src/infrastructure/database/native_database/process_stats.rs
+++ b/core/src/infrastructure/database/native_database/process_stats.rs
@@ -178,8 +178,8 @@ mod tests {
   use super::*;
 
   /// The exact bytes sqlx stores are pinned by
-  /// `native_process_stats_writes_the_same_timestamp_text_as_sqlite` in
-  /// `core/tests/duckdb_avg_compatibility.rs`, which round-trips them through a
+  /// `the_native_process_stats_family_reproduces_the_sqlite_family` in
+  /// `core/tests/duckdb_avg_compatibility.rs`, which reads them back from a
   /// real SQLite database. This only pins the shapes the renderer must produce.
   #[test]
   fn renders_the_sqlx_datetime_shapes() {

--- a/core/src/infrastructure/database/native_database/process_stats.rs
+++ b/core/src/infrastructure/database/native_database/process_stats.rs
@@ -1,0 +1,201 @@
+//! The Process Stats family against a finalized native database.
+//!
+//! These run *beside* [`crate::infrastructure::database::process_stats`] and
+//! [`crate::infrastructure::database::archive_queries::select_process_stats`],
+//! not instead of them. SQLite stays authoritative and keeps serving the
+//! application; choosing between the two backends is a separate change. Keeping
+//! both callable is what lets a test put the same fixture through each path and
+//! compare the results bit for bit.
+
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use crate::infrastructure::database::archive_queries::ProcessStatRecord;
+use crate::persistence::archive_data::ProcessStatData;
+
+const TABLE: &str = "PROCESS_STATS";
+
+/// Render an instant the way the SQLite writers store it.
+///
+/// The writers bind a `chrono::DateTime<Utc>`, and sqlx's SQLite encoder writes
+/// `to_rfc3339_opts(SecondsFormat::AutoSi, false)` - so `+00:00` rather than
+/// `Z`, and sub-second digits only when the instant has them. Every timestamp
+/// comparison in this family is a byte-wise string comparison, so the native
+/// writer has to produce the same bytes rather than an equivalent instant.
+pub fn sqlite_timestamp_text(timestamp: &DateTime<Utc>) -> String {
+  timestamp.to_rfc3339_opts(SecondsFormat::AutoSi, false)
+}
+
+/// Insert one write cycle's process rows, all stamped with the cycle's own
+/// `timestamp`, in a single transaction - the same boundary and the same shared
+/// instant as the SQLite writer.
+pub async fn insert(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  processes: Vec<ProcessStatData>,
+  timestamp: DateTime<Utc>,
+) -> Result<(), NativeDatabaseError> {
+  if processes.is_empty() {
+    return Ok(());
+  }
+  let stamp = sqlite_timestamp_text(&timestamp);
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let connection = transaction.connection();
+        let mut statement = connection
+          .prepare(
+            "INSERT INTO PROCESS_STATS \
+             (id, pid, process_name, cpu_usage, memory_usage, execution_sec, timestamp) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("prepare the process stats insert", error)
+          })?;
+        for process in &processes {
+          transaction.check_cancelled()?;
+          let id = transaction.next_id(TABLE)?;
+          statement
+            .execute(params![
+              id,
+              i64::from(process.pid),
+              process.process_name.as_str(),
+              f64::from(process.cpu_usage),
+              i64::from(process.memory_usage),
+              i64::from(process.execution_sec),
+              stamp.as_str()
+            ])
+            .map_err(|error| {
+              NativeDatabaseError::duckdb("insert a process stats row", error)
+            })?;
+        }
+        Ok(())
+      })
+    })
+    .await
+}
+
+/// Delete rows older than the Retention Period, returning how many went.
+///
+/// SQLite evaluates `timestamp < $1` between a `DATETIME` column - which has
+/// NUMERIC affinity - and a bound parameter, which has none, so it applies
+/// NUMERIC affinity to the parameter. The rendered ISO-8601 text is not a
+/// well-formed number, so it stays TEXT and the comparison runs under the
+/// BINARY collation: byte-wise, not chronological. DuckDB compares VARCHAR by
+/// the same byte order, and the candidate admits only valid UTF-8, so binding
+/// the identically rendered text reproduces the rule exactly instead of
+/// approximating it with an instant comparison.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+) -> Result<u64, NativeDatabaseError> {
+  let bound =
+    sqlite_timestamp_text(&(Utc::now() - Duration::days(i64::from(retention_days))));
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let deleted = transaction
+          .connection()
+          .execute(
+            "DELETE FROM PROCESS_STATS WHERE timestamp < ?",
+            params![bound.as_str()],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired process stats rows", error)
+          })?;
+        Ok(deleted as u64)
+      })
+    })
+    .await
+}
+
+/// The native form of
+/// [`crate::infrastructure::database::archive_queries::select_process_stats`].
+///
+/// `BETWEEN` keeps the SQLite endpoint semantics: both bounds are inclusive and
+/// compared as text, so a caller's rendering of an instant selects exactly the
+/// stored spellings it would have selected in SQLite. Grouping stays on the
+/// recorded `(pid, process_name)` tuple - the Process identity ADR 0019 defines
+/// - rather than on the row id.
+pub async fn select_process_stats(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: String,
+  end: String,
+  order_by_cpu_desc: bool,
+) -> Result<Vec<ProcessStatRecord>, NativeDatabaseError> {
+  let order_by = if order_by_cpu_desc {
+    " ORDER BY avg_cpu_usage DESC"
+  } else {
+    ""
+  };
+  let sql = format!(
+    "SELECT
+       pid,
+       process_name,
+       AVG(cpu_usage) AS avg_cpu_usage,
+       AVG(memory_usage) AS avg_memory_usage,
+       MAX(execution_sec) AS total_execution_sec,
+       MAX(timestamp) AS latest_timestamp
+     FROM PROCESS_STATS
+     WHERE timestamp BETWEEN ? AND ?
+     GROUP BY pid, process_name{order_by}"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the process stats query", error)
+      })?;
+      let rows = statement
+        .query_map(params![start.as_str(), end.as_str()], |row| {
+          Ok(ProcessStatRecord {
+            pid: row.get(0)?,
+            process_name: row.get(1)?,
+            avg_cpu_usage: row.get(2)?,
+            avg_memory_usage: row.get(3)?,
+            total_execution_sec: row.get(4)?,
+            latest_timestamp: row.get(5)?,
+          })
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the process stats query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a process stats row", error)
+        })?;
+      Ok(rows)
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// The exact bytes sqlx stores are pinned by
+  /// `native_process_stats_writes_the_same_timestamp_text_as_sqlite` in
+  /// `core/tests/duckdb_avg_compatibility.rs`, which round-trips them through a
+  /// real SQLite database. This only pins the shapes the renderer must produce.
+  #[test]
+  fn renders_the_sqlx_datetime_shapes() {
+    let whole = "2026-09-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+    assert_eq!(sqlite_timestamp_text(&whole), "2026-09-01T00:00:00+00:00");
+    let millis = "2026-09-01T00:00:00.125Z".parse::<DateTime<Utc>>().unwrap();
+    assert_eq!(
+      sqlite_timestamp_text(&millis),
+      "2026-09-01T00:00:00.125+00:00"
+    );
+    let micros = "2026-09-01T00:00:00.000125Z"
+      .parse::<DateTime<Utc>>()
+      .unwrap();
+    assert_eq!(
+      sqlite_timestamp_text(&micros),
+      "2026-09-01T00:00:00.000125+00:00"
+    );
+  }
+}

--- a/core/src/infrastructure/database/native_database/runtime.rs
+++ b/core/src/infrastructure/database/native_database/runtime.rs
@@ -1,0 +1,589 @@
+//! The dedicated blocking owner of one finalized native database.
+//!
+//! duckdb-rs is synchronous, so connections are never handed out. Two owned
+//! threads - one read lane, one write lane over `try_clone`d connections to the
+//! same instance - execute closures sent through bounded channels, so a slow
+//! reader can neither block a commit nor let callers queue unbounded work.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use duckdb::{AccessMode, Config, Connection, OptionalExt, Transaction, params};
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, RwLock, mpsc, oneshot};
+
+use super::NativeDatabaseError;
+use super::cell::quote_identifier;
+use super::finalize::{
+  FINALIZED_UNSELECTED, NATIVE_IDENTITY_TABLE, NATIVE_METADATA_TABLE,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct NativeDatabaseOptions {
+  pub expected_schema_version: u32,
+  /// How many requests may wait per lane before a caller is made to wait.
+  pub request_capacity: usize,
+}
+
+impl NativeDatabaseOptions {
+  pub fn new(expected_schema_version: u32) -> Self {
+    Self {
+      expected_schema_version,
+      request_capacity: 32,
+    }
+  }
+}
+
+/// A one-shot cancellation token for exactly one request.
+///
+/// Claimed when it is attached to a request so two requests can never share an
+/// interrupt handle, which would let one caller's cancellation abort another's
+/// statement.
+#[derive(Clone, Debug)]
+pub struct NativeCancellation {
+  inner: Arc<CancellationState>,
+}
+
+struct CancellationState {
+  claimed: AtomicBool,
+  cancelled: AtomicBool,
+  interrupt: Mutex<Option<Arc<duckdb::InterruptHandle>>>,
+}
+
+impl std::fmt::Debug for CancellationState {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter
+      .debug_struct("CancellationState")
+      .field("claimed", &self.claimed)
+      .field("cancelled", &self.cancelled)
+      .finish_non_exhaustive()
+  }
+}
+
+impl NativeCancellation {
+  pub fn new() -> Self {
+    Self {
+      inner: Arc::new(CancellationState {
+        claimed: AtomicBool::new(false),
+        cancelled: AtomicBool::new(false),
+        interrupt: Mutex::new(None),
+      }),
+    }
+  }
+
+  pub fn cancel(&self) {
+    self.inner.cancelled.store(true, Ordering::Release);
+    let interrupt = self
+      .inner
+      .interrupt
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(interrupt) = interrupt.as_ref() {
+      interrupt.interrupt();
+    }
+  }
+
+  pub fn is_cancelled(&self) -> bool {
+    self.inner.cancelled.load(Ordering::Acquire)
+  }
+
+  fn claim(&self) -> Result<(), NativeDatabaseError> {
+    self
+      .inner
+      .claimed
+      .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+      .map(|_| ())
+      .map_err(|_| NativeDatabaseError::CancellationAlreadyUsed)
+  }
+}
+
+impl Default for NativeCancellation {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+pub struct NativeConnectionContext<'a> {
+  connection: &'a mut Connection,
+  cancellation: NativeCancellation,
+  healthy: bool,
+}
+
+impl NativeConnectionContext<'_> {
+  pub fn connection(&mut self) -> &mut Connection {
+    self.connection
+  }
+
+  pub fn check_cancelled(&self) -> Result<(), NativeDatabaseError> {
+    if self.cancellation.is_cancelled() {
+      Err(NativeDatabaseError::Cancelled)
+    } else {
+      Ok(())
+    }
+  }
+
+  /// Run `operation` inside one DuckDB transaction, committing only if it
+  /// succeeded and was not cancelled.
+  ///
+  /// A rollback that itself fails marks the lane unhealthy and stops it: a
+  /// connection whose transaction state is unknown must not serve the next
+  /// request.
+  pub fn with_transaction<T, F>(&mut self, operation: F) -> Result<T, NativeDatabaseError>
+  where
+    F: FnOnce(&NativeTransactionContext<'_, '_>) -> Result<T, NativeDatabaseError>,
+  {
+    self.check_cancelled()?;
+    let transaction = self
+      .connection
+      .transaction()
+      .map_err(|error| NativeDatabaseError::duckdb("begin transaction", error))?;
+    let context = NativeTransactionContext {
+      transaction: &transaction,
+      cancellation: &self.cancellation,
+    };
+    let result = operation(&context);
+    let cancelled = self.cancellation.is_cancelled();
+    match result {
+      Ok(value) if !cancelled => transaction
+        .commit()
+        .map(|_| value)
+        .map_err(|error| NativeDatabaseError::duckdb("commit transaction", error)),
+      result => {
+        if let Err(rollback_error) = transaction.rollback() {
+          self.healthy = false;
+          return Err(NativeDatabaseError::Worker {
+            message: format!("failed to roll back native transaction: {rollback_error}"),
+          });
+        }
+        if cancelled {
+          Err(NativeDatabaseError::Cancelled)
+        } else {
+          result
+        }
+      }
+    }
+  }
+}
+
+pub struct NativeTransactionContext<'transaction, 'connection> {
+  transaction: &'transaction Transaction<'connection>,
+  cancellation: &'transaction NativeCancellation,
+}
+
+impl NativeTransactionContext<'_, '_> {
+  pub fn connection(&self) -> &Connection {
+    self.transaction
+  }
+
+  pub fn check_cancelled(&self) -> Result<(), NativeDatabaseError> {
+    if self.cancellation.is_cancelled() {
+      Err(NativeDatabaseError::Cancelled)
+    } else {
+      Ok(())
+    }
+  }
+
+  /// Allocate the next `id` for `table`.
+  ///
+  /// **Identity contract.** These ids are record identities, not domain
+  /// identities: a Process row is identified by its recorded `(pid,
+  /// process_name)` tuple, a Storage Health record by its producer-supplied
+  /// `storage:hmac-sha256:v1:...` device key, and an archived GPU row by its
+  /// opaque `gpu_id`. Nothing joins on the values produced here, so the only
+  /// contract they owe is the one SQLite gave them, which finalization recorded
+  /// per table in `__hv_native_identities`:
+  ///
+  /// - `autoincrement` reproduces `INTEGER PRIMARY KEY AUTOINCREMENT`. The next
+  ///   id is the stored high-water mark plus one, and the mark advances in the
+  ///   same transaction as the insert. Deleting the highest row therefore does
+  ///   **not** release its id, and a rolled-back insert releases it exactly as
+  ///   SQLite's `sqlite_sequence` update would.
+  /// - `rowid` reproduces plain `INTEGER PRIMARY KEY`. The next id is the
+  ///   current maximum plus one, so deleting the highest row does release its
+  ///   id - SQLite's behavior, deliberately preserved rather than "fixed",
+  ///   because an archive migrated to a stricter rule would start handing out
+  ///   ids the source would not have.
+  ///
+  /// Both modes read and write inside the caller's transaction, so two
+  /// concurrent writers cannot be handed the same id: the write lane is the
+  /// only lane that commits.
+  pub fn next_id(&self, table: &str) -> Result<i64, NativeDatabaseError> {
+    self.check_cancelled()?;
+    let metadata: Option<(String, String, i64)> = self
+      .transaction
+      .query_row(
+        &format!(
+          "SELECT column_name, mode, high_water FROM {NATIVE_IDENTITY_TABLE} WHERE table_name = ?"
+        ),
+        [table],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+      )
+      .optional()
+      .map_err(|error| {
+        NativeDatabaseError::duckdb("read native identity metadata", error)
+      })?;
+    let Some((column, mode, high_water)) = metadata else {
+      return Err(NativeDatabaseError::finalization(
+        "allocate a native id",
+        format!("table {table} has no native identity definition"),
+      ));
+    };
+    let next = match mode.as_str() {
+      "rowid" => {
+        let sql = format!(
+          "SELECT COALESCE(MAX({}), 0) FROM {}",
+          quote_identifier(&column),
+          quote_identifier(table)
+        );
+        let maximum: i64 = self
+          .transaction
+          .query_row(&sql, [], |row| row.get(0))
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("read native rowid maximum", error)
+          })?;
+        maximum.checked_add(1)
+      }
+      "autoincrement" => high_water.checked_add(1),
+      other => {
+        return Err(NativeDatabaseError::finalization(
+          "allocate a native id",
+          format!("table {table} has unsupported identity mode {other}"),
+        ));
+      }
+    }
+    .ok_or_else(|| {
+      NativeDatabaseError::finalization(
+        "allocate a native id",
+        format!("native identity for {table} exhausted signed 64-bit ids"),
+      )
+    })?;
+    if mode == "autoincrement" {
+      self
+        .transaction
+        .execute(
+          &format!(
+            "UPDATE {NATIVE_IDENTITY_TABLE} SET high_water = ? WHERE table_name = ?"
+          ),
+          params![next, table],
+        )
+        .map_err(|error| NativeDatabaseError::duckdb("advance native identity", error))?;
+    }
+    Ok(next)
+  }
+}
+
+type Operation = Box<dyn FnOnce(&mut NativeConnectionContext<'_>) + Send + 'static>;
+
+enum LaneMessage {
+  Run {
+    cancellation: NativeCancellation,
+    operation: Operation,
+  },
+  Shutdown,
+}
+
+struct NativeDatabaseInner {
+  read_sender: mpsc::Sender<LaneMessage>,
+  write_sender: mpsc::Sender<LaneMessage>,
+  lifecycle: RwLock<()>,
+  close_lock: AsyncMutex<()>,
+  closed: AtomicBool,
+  joins: AsyncMutex<Option<(JoinHandle<()>, JoinHandle<()>)>>,
+}
+
+#[derive(Clone)]
+pub struct NativeDatabase {
+  inner: Arc<NativeDatabaseInner>,
+}
+
+impl std::fmt::Debug for NativeDatabase {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter
+      .debug_struct("NativeDatabase")
+      .field("closed", &self.inner.closed.load(Ordering::Acquire))
+      .finish_non_exhaustive()
+  }
+}
+
+impl NativeDatabase {
+  /// Open a finalized, unselected native database.
+  ///
+  /// Refuses a file that finalization never produced, and one whose recorded
+  /// schema version is not the version the caller was built against.
+  pub async fn open(
+    path: impl AsRef<Path>,
+    options: NativeDatabaseOptions,
+  ) -> Result<Self, NativeDatabaseError> {
+    if options.request_capacity == 0 {
+      return Err(NativeDatabaseError::InvalidRequestCapacity);
+    }
+    let path = path.as_ref().to_owned();
+    let metadata = std::fs::metadata(&path)
+      .map_err(|_| NativeDatabaseError::Unavailable { path: path.clone() })?;
+    if !metadata.is_file() {
+      return Err(NativeDatabaseError::Unavailable { path });
+    }
+    let expected_version = options.expected_schema_version;
+    let (writer, reader, spill) =
+      tokio::task::spawn_blocking(move || open_connections(&path, expected_version))
+        .await
+        .map_err(|error| NativeDatabaseError::Worker {
+          message: error.to_string(),
+        })??;
+    let spill = Arc::new(spill);
+    let (read_sender, read_receiver) = mpsc::channel(options.request_capacity);
+    let (write_sender, write_receiver) = mpsc::channel(options.request_capacity);
+    let read_spill = Arc::clone(&spill);
+    let read_join = std::thread::Builder::new()
+      .name("hardviz-duckdb-read".to_owned())
+      .spawn(move || run_lane(read_spill, reader, read_receiver))
+      .map_err(|error| NativeDatabaseError::Worker {
+        message: format!("failed to start native read owner: {error}"),
+      })?;
+    let write_join = std::thread::Builder::new()
+      .name("hardviz-duckdb-write".to_owned())
+      .spawn(move || run_lane(spill, writer, write_receiver))
+      .map_err(|error| NativeDatabaseError::Worker {
+        message: format!("failed to start native write owner: {error}"),
+      })?;
+    Ok(Self {
+      inner: Arc::new(NativeDatabaseInner {
+        read_sender,
+        write_sender,
+        lifecycle: RwLock::new(()),
+        close_lock: AsyncMutex::new(()),
+        closed: AtomicBool::new(false),
+        joins: AsyncMutex::new(Some((read_join, write_join))),
+      }),
+    })
+  }
+
+  /// Stop both lanes and wait for them. Idempotent; every later request fails
+  /// with [`NativeDatabaseError::Closed`].
+  pub async fn close(&self) -> Result<(), NativeDatabaseError> {
+    let _close = self.inner.close_lock.lock().await;
+    let mut joins = self.inner.joins.lock().await;
+    let Some((read_join, write_join)) = joins.take() else {
+      return Ok(());
+    };
+    {
+      let _lifecycle = self.inner.lifecycle.write().await;
+      self.inner.closed.store(true, Ordering::Release);
+      let _ = self.inner.read_sender.send(LaneMessage::Shutdown).await;
+      let _ = self.inner.write_sender.send(LaneMessage::Shutdown).await;
+    }
+    tokio::task::spawn_blocking(move || {
+      read_join.join().map_err(|_| NativeDatabaseError::Worker {
+        message: "native read owner panicked".to_owned(),
+      })?;
+      write_join.join().map_err(|_| NativeDatabaseError::Worker {
+        message: "native write owner panicked".to_owned(),
+      })?;
+      Ok(())
+    })
+    .await
+    .map_err(|error| NativeDatabaseError::Worker {
+      message: error.to_string(),
+    })?
+  }
+
+  pub async fn request_read<T, F>(
+    &self,
+    cancellation: NativeCancellation,
+    operation: F,
+  ) -> Result<T, NativeDatabaseError>
+  where
+    T: Send + 'static,
+    F: FnOnce(&mut NativeConnectionContext<'_>) -> Result<T, NativeDatabaseError>
+      + Send
+      + 'static,
+  {
+    self
+      .request_on_lane(&self.inner.read_sender, cancellation, operation)
+      .await
+  }
+
+  pub async fn request_write<T, F>(
+    &self,
+    cancellation: NativeCancellation,
+    operation: F,
+  ) -> Result<T, NativeDatabaseError>
+  where
+    T: Send + 'static,
+    F: FnOnce(&mut NativeConnectionContext<'_>) -> Result<T, NativeDatabaseError>
+      + Send
+      + 'static,
+  {
+    self
+      .request_on_lane(&self.inner.write_sender, cancellation, operation)
+      .await
+  }
+
+  async fn request_on_lane<T, F>(
+    &self,
+    sender: &mpsc::Sender<LaneMessage>,
+    cancellation: NativeCancellation,
+    operation: F,
+  ) -> Result<T, NativeDatabaseError>
+  where
+    T: Send + 'static,
+    F: FnOnce(&mut NativeConnectionContext<'_>) -> Result<T, NativeDatabaseError>
+      + Send
+      + 'static,
+  {
+    cancellation.claim()?;
+    let (result_sender, result_receiver) = oneshot::channel();
+    let request_cancellation = cancellation.clone();
+    let operation = Box::new(move |context: &mut NativeConnectionContext<'_>| {
+      let result = context.check_cancelled().and_then(|_| operation(context));
+      // A DuckDB interrupt surfaces as an ordinary statement error; the token
+      // is what says the error was asked for.
+      let result = if request_cancellation.is_cancelled() && result.is_err() {
+        Err(NativeDatabaseError::Cancelled)
+      } else {
+        result
+      };
+      let _ = result_sender.send(result);
+    });
+    {
+      let _lifecycle = self.inner.lifecycle.read().await;
+      if self.inner.closed.load(Ordering::Acquire) {
+        return Err(NativeDatabaseError::Closed);
+      }
+      sender
+        .send(LaneMessage::Run {
+          cancellation,
+          operation,
+        })
+        .await
+        .map_err(|_| NativeDatabaseError::Closed)?;
+    }
+    result_receiver
+      .await
+      .map_err(|_| NativeDatabaseError::Worker {
+        message: "native database owner ended before returning a request".to_owned(),
+      })?
+  }
+}
+
+fn open_connections(
+  path: &Path,
+  expected_version: u32,
+) -> Result<(Connection, Connection, TempDir), NativeDatabaseError> {
+  let parent = path
+    .parent()
+    .filter(|parent| !parent.as_os_str().is_empty())
+    .ok_or_else(|| NativeDatabaseError::Unavailable {
+      path: path.to_owned(),
+    })?;
+  let spill = tempfile::Builder::new()
+    .prefix(".hardwarevisualizer-duckdb-runtime-")
+    .tempdir_in(parent)
+    .map_err(|error| NativeDatabaseError::Worker {
+      message: format!("failed to create native spill directory: {error}"),
+    })?;
+  let config = native_config()?;
+  let writer = Connection::open_with_flags(path, config)
+    .map_err(|error| NativeDatabaseError::duckdb("open native database", error))?;
+  super::configure_spill(&writer, spill.path())?;
+  validate_native_metadata(&writer, expected_version)?;
+  let reader = writer
+    .try_clone()
+    .map_err(|error| NativeDatabaseError::duckdb("open native read connection", error))?;
+  Ok((writer, reader, spill))
+}
+
+fn run_lane(
+  _spill: Arc<TempDir>,
+  mut connection: Connection,
+  mut receiver: mpsc::Receiver<LaneMessage>,
+) {
+  let interrupt = connection.interrupt_handle();
+  while let Some(message) = receiver.blocking_recv() {
+    let LaneMessage::Run {
+      cancellation,
+      operation,
+    } = message
+    else {
+      break;
+    };
+    {
+      let mut active = cancellation
+        .inner
+        .interrupt
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+      if !cancellation.is_cancelled() {
+        *active = Some(Arc::clone(&interrupt));
+      }
+    }
+    let mut context = NativeConnectionContext {
+      connection: &mut connection,
+      cancellation: cancellation.clone(),
+      healthy: true,
+    };
+    operation(&mut context);
+    let healthy = context.healthy;
+    *cancellation
+      .inner
+      .interrupt
+      .lock()
+      .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+    if !healthy {
+      break;
+    }
+  }
+}
+
+fn native_config() -> Result<Config, NativeDatabaseError> {
+  Config::default()
+    .access_mode(AccessMode::ReadWrite)
+    .and_then(|config| config.threads(2))
+    .and_then(|config| config.max_memory("128MB"))
+    .and_then(|config| config.enable_autoload_extension(false))
+    .map_err(|error| NativeDatabaseError::duckdb("configure native database", error))
+}
+
+fn validate_native_metadata(
+  connection: &Connection,
+  expected_version: u32,
+) -> Result<(), NativeDatabaseError> {
+  let present: i64 = connection
+    .query_row(
+      "SELECT count(*) FROM information_schema.tables WHERE table_name = ?",
+      [NATIVE_METADATA_TABLE],
+      |row| row.get(0),
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("look for the native schema metadata", error)
+    })?;
+  if present == 0 {
+    return Err(NativeDatabaseError::Unfinalized);
+  }
+  let row: Option<(String, i64)> = connection
+    .query_row(
+      &format!("SELECT state, schema_version FROM {NATIVE_METADATA_TABLE}"),
+      [],
+      |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("read the native schema metadata", error)
+    })?;
+  let Some((state, actual)) = row else {
+    return Err(NativeDatabaseError::Unfinalized);
+  };
+  if state != FINALIZED_UNSELECTED {
+    return Err(NativeDatabaseError::Unfinalized);
+  }
+  let actual = u32::try_from(actual).map_err(|_| NativeDatabaseError::Unfinalized)?;
+  if actual != expected_version {
+    return Err(NativeDatabaseError::IncompatibleSchema {
+      expected: expected_version,
+      actual,
+    });
+  }
+  Ok(())
+}

--- a/core/src/infrastructure/database/native_database/schema.rs
+++ b/core/src/infrastructure/database/native_database/schema.rs
@@ -1,0 +1,60 @@
+//! The App-supplied description of the stable native schema.
+//!
+//! Core owns how a candidate is finalized, how ids are allocated and how the
+//! tables are queried. App owns *which* tables exist, in which order they may
+//! be created, which columns are derived query keys, and which SQLite identity
+//! rule each `id` column carries - the same ownership split as the ordered
+//! SQLite migration set.
+
+/// One derived epoch-millisecond column and the stored timestamp text it is
+/// computed from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NativeTimestampColumn {
+  pub table: &'static str,
+  pub source_column: &'static str,
+  pub epoch_milliseconds_column: &'static str,
+}
+
+/// How SQLite allocated the table's `id`, so the native allocator can keep
+/// producing the same ids. See `NativeTransactionContext::next_id` for the
+/// contract each mode has to reproduce.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NativeIdentityMode {
+  /// `INTEGER PRIMARY KEY` without AUTOINCREMENT.
+  RowId,
+  /// `INTEGER PRIMARY KEY AUTOINCREMENT`, whose high-water mark lives in the
+  /// named `sqlite_sequence` row.
+  AutoIncrement { sqlite_sequence_name: &'static str },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NativeIdentity {
+  pub table: &'static str,
+  pub column: &'static str,
+  pub mode: NativeIdentityMode,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct NativeSchemaDefinition {
+  pub version: u32,
+  /// DDL creating every domain table, executed once against the empty
+  /// destination.
+  pub sql: &'static str,
+  /// The domain tables, ordered so a table is created and filled after the
+  /// tables its foreign keys reference.
+  pub tables: &'static [&'static str],
+  pub timestamp_columns: &'static [NativeTimestampColumn],
+  pub identities: &'static [NativeIdentity],
+}
+
+impl NativeSchemaDefinition {
+  pub(super) fn derived_column_for(
+    &self,
+    table: &str,
+    column: &str,
+  ) -> Option<&NativeTimestampColumn> {
+    self.timestamp_columns.iter().find(|timestamp| {
+      timestamp.table == table && timestamp.epoch_milliseconds_column == column
+    })
+  }
+}

--- a/core/tests/duckdb_avg_compatibility.rs
+++ b/core/tests/duckdb_avg_compatibility.rs
@@ -2,11 +2,12 @@
 //! Whether the native Process Stats family answers what the SQLite family
 //! answers.
 //!
-//! Two levels. The engine-level tests compare SQLite's and DuckDB's own
-//! aggregates on the same rows, which is what says where the two are
-//! interchangeable at all. The family-level test then puts one fixture through
-//! the real SQLite writer and query and through candidate -> finalize -> native,
-//! and compares the answers bit for bit.
+//! Two levels. The engine-level tests compare SQLite's own `avg()` with the
+//! arithmetic the native query uses on the same rows - DuckDB's `AVG` for the
+//! binary64 column, the exact sum and count for the integer column - which is
+//! what says where the two are interchangeable at all. The family-level test
+//! then puts one fixture through the real SQLite writer and query and through
+//! candidate -> finalize -> native, and compares the answers bit for bit.
 
 mod native_support;
 
@@ -41,9 +42,15 @@ struct AggregateBits {
 }
 
 /// The engine-level claim the native Process query rests on: for the values the
-/// production writers can produce, DuckDB's `AVG` returns SQLite's exact
-/// binary64 result, independently of row order and of how many threads DuckDB
-/// aggregates with.
+/// production writers can produce, DuckDB's `AVG(DOUBLE)` returns SQLite's
+/// exact binary64 result, independently of row order and of how many threads
+/// DuckDB aggregates with, and the integer average rebuilt from DuckDB's exact
+/// `SUM`/`COUNT` matches SQLite's integer `avg()` bit for bit.
+///
+/// The integer column deliberately does not go through DuckDB's `AVG(BIGINT)`:
+/// that divides the exact sum as a `long double`, so its last bit depends on
+/// the platform's `long double` width (this fixture's `i64-memory` group came
+/// back one ulp apart on x86_64 Linux and aarch64 macOS).
 #[tokio::test]
 async fn duckdb_avg_matches_sqlite_for_archive_magnitude_process_values() {
   let mut mismatches = Vec::new();
@@ -429,8 +436,16 @@ fn process_input(order: Order) -> Vec<ProcessInput> {
       pid: 2,
       name: "i64-memory",
       cpu: [100.0, 0.0, 0.5][triplet],
-      // Memory beyond i32, so the integer average has to stay exact.
-      memory: [i64::MAX, i64::MAX - 3, i64::MIN + 2_052][triplet],
+      // Memory far beyond i32 with a group sum beyond 2^53, so converting
+      // the exact sum to binary64 has to round the same way on both sides.
+      // The sum still fits i64: past that SQLite switches to approximate
+      // summation and the native query refuses, so that region is outside
+      // the claim (and outside what an `i32` writer can reach).
+      memory: [
+        i64::MAX / 10_000,
+        i64::MAX / 10_000 - 3,
+        i64::MIN / 10_000 + 2_052,
+      ][triplet],
       ordinal: (rows.len() + 1) as i64,
       timestamp: timestamp.clone(),
     });
@@ -557,9 +572,12 @@ fn duckdb_aggregates(input: &[ProcessInput], threads: i64) -> AggregateBits {
     appender.flush().unwrap();
   }
 
+  // The same shape as the production native query: DuckDB's `AVG` for the
+  // binary64 column, the exact sum and count for the integer column.
   let mut statement = connection
     .prepare(
-      "SELECT pid, process_name, AVG(cpu_usage), AVG(memory_usage)
+      "SELECT pid, process_name, AVG(cpu_usage),
+              SUM(memory_usage), COUNT(memory_usage)
        FROM PROCESS_STATS
        WHERE timestamp BETWEEN '2026-01-01T00:00:00.000Z' AND '2026-01-01T00:59:59.999Z'
        GROUP BY pid, process_name
@@ -572,7 +590,10 @@ fn duckdb_aggregates(input: &[ProcessInput], threads: i64) -> AggregateBits {
         row.get::<_, i64>(0)?,
         row.get::<_, String>(1)?,
         row.get::<_, f64>(2)?,
-        row.get::<_, f64>(3)?,
+        native_process_stats::sqlite_integer_average(
+          i64::try_from(row.get::<_, i128>(3)?).expect("fixture sums fit i64"),
+          row.get::<_, i64>(4)?,
+        ),
       ))
     })
     .unwrap()

--- a/core/tests/duckdb_avg_compatibility.rs
+++ b/core/tests/duckdb_avg_compatibility.rs
@@ -1,0 +1,633 @@
+#![cfg(feature = "duckdb-archive")]
+//! Whether the native Process Stats family answers what the SQLite family
+//! answers.
+//!
+//! Two levels. The engine-level tests compare SQLite's and DuckDB's own
+//! aggregates on the same rows, which is what says where the two are
+//! interchangeable at all. The family-level test then puts one fixture through
+//! the real SQLite writer and query and through candidate -> finalize -> native,
+//! and compares the answers bit for bit.
+
+mod native_support;
+
+use std::collections::BTreeMap;
+
+use duckdb::{Config, Connection, params};
+use hardviz_core::infrastructure::database::native_database::NativeCancellation;
+use hardviz_core::infrastructure::database::native_database::process_stats as native_process_stats;
+use hardviz_core::infrastructure::database::{
+  archive_queries, db, migrate, process_stats,
+};
+use hardviz_core::persistence::archive_data::ProcessStatData;
+use native_support::{NativeFixture, app_migrations};
+use sqlx::{Executor, QueryBuilder, Row, Sqlite, SqlitePool};
+
+const VECTOR_CROSSING_ROWS: usize = 8_193;
+
+#[derive(Clone)]
+struct ProcessInput {
+  pid: i64,
+  name: &'static str,
+  cpu: f32,
+  memory: i64,
+  ordinal: i64,
+  timestamp: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct AggregateBits {
+  by_identity: BTreeMap<(i64, String), (u64, u64)>,
+  cpu_rank_bands: Vec<(u64, Vec<(i64, String)>)>,
+}
+
+/// The engine-level claim the native Process query rests on: for the values the
+/// production writers can produce, DuckDB's `AVG` returns SQLite's exact
+/// binary64 result, independently of row order and of how many threads DuckDB
+/// aggregates with.
+#[tokio::test]
+async fn duckdb_avg_matches_sqlite_for_archive_magnitude_process_values() {
+  let mut mismatches = Vec::new();
+  for order in [Order::Forward, Order::Reverse, Order::Interleaved] {
+    let input = process_input(order);
+    let sqlite = sqlite_aggregates(&input).await;
+
+    for threads in [1, 2, 4] {
+      let duckdb = duckdb_aggregates(&input, threads);
+      if duckdb != sqlite {
+        mismatches.push(format!(
+          "{order:?}/threads={threads}: {}",
+          describe_mismatches(&sqlite, &duckdb)
+        ));
+      }
+    }
+  }
+  assert!(
+    mismatches.is_empty(),
+    "DuckDB AVG diverged from SQLite:\n{}",
+    mismatches.join("\n")
+  );
+}
+
+/// Where that stops being true, measured rather than assumed.
+///
+/// SQLite's `avg()` over REAL has used Kahan-Babuska-Neumaier compensated
+/// summation since 3.43, so it recovers a sum that plain binary64 accumulation
+/// loses. DuckDB has no aggregate that reproduces it: `avg`, `fsum`/`favg`
+/// (classic Kahan) and `sum` all collapse `[x, 1.0, -x]` to 0 once `x` exceeds
+/// about 2^53 - while SQLite returns 1/3.
+///
+/// This test pins that boundary instead of hiding it. It is inside binary64,
+/// not inside the archive: `cpu_usage` is a CPU-usage percentage written from
+/// `f32`, so a group can only reach this if something other than the collector
+/// wrote it. See the finalization report and #2089 for the open decision on
+/// whether that residue needs an exact Rust-side aggregation.
+#[tokio::test]
+async fn duckdb_avg_diverges_from_sqlite_only_beyond_binary64_cancellation() {
+  let scales: [f32; 4] = [1e6, 1e15, 1e16, 1e17];
+  let mut input = Vec::new();
+  for index in 0..VECTOR_CROSSING_ROWS {
+    let triplet = index % 3;
+    for (group, scale) in scales.iter().enumerate() {
+      input.push(ProcessInput {
+        pid: group as i64 + 1,
+        name: "cancellation",
+        cpu: [*scale, 1.0, -*scale][triplet],
+        memory: 1,
+        ordinal: (input.len() + 1) as i64,
+        timestamp: "2026-01-01T00:00:00.000Z".to_owned(),
+      });
+    }
+  }
+  let sqlite = sqlite_aggregates(&input).await;
+  let duckdb = duckdb_aggregates(&input, 1);
+
+  for (group, scale) in scales.iter().enumerate() {
+    let identity = (group as i64 + 1, "cancellation".to_owned());
+    let expected = sqlite.by_identity[&identity];
+    let actual = duckdb.by_identity[&identity];
+    if *scale <= 1e15 {
+      assert_eq!(actual, expected, "scale {scale:e} must still agree");
+    } else {
+      assert_ne!(
+        actual, expected,
+        "scale {scale:e} is the measured divergence; update this test if an \
+         engine changes"
+      );
+      assert_eq!(actual.0, 0.0_f64.to_bits(), "scale {scale:e}");
+    }
+  }
+}
+
+/// The whole family, end to end: the production SQLite writer and query against
+/// candidate -> finalize -> native.
+#[tokio::test]
+async fn the_native_process_stats_family_reproduces_the_sqlite_family() {
+  let fixture = NativeFixture::new();
+  // The only test in this binary that initializes Core's process-wide database
+  // path, so the SQLite side runs through the real writer and the real query.
+  assert!(db::init(fixture.source.clone()));
+  migrate::run(app_migrations::get_migrations())
+    .await
+    .unwrap();
+
+  // 1. Written by the production writer, so the stored timestamp text is
+  //    whatever sqlx actually produces rather than whatever a test spells.
+  let whole = "2026-09-01T00:00:00Z".parse().unwrap();
+  let fractional = "2026-09-01T00:01:00.125Z".parse().unwrap();
+  process_stats::insert(
+    vec![
+      stat(4000, "renderer", 12.5, 4_096, 60),
+      stat(4001, "helper", 0.0, 0, 0),
+      stat(4002, "idle", 100.0, 8_192, 1),
+    ],
+    whole,
+  )
+  .await
+  .unwrap();
+  process_stats::insert(
+    vec![
+      // The same identity tuple again: Process identity is (pid,
+      // process_name), so these must merge into one group.
+      stat(4000, "renderer", 37.5, 4_096, 120),
+      // A tie with `renderer`'s average, to pin the rank bands.
+      stat(4003, "tied", 25.0, 4_096, 5),
+    ],
+    fractional,
+  )
+  .await
+  .unwrap();
+
+  let pool = native_support::open_pool(&fixture.source, false).await;
+  let stored: Vec<(String, i64)> = sqlx::query(
+    "SELECT CAST(timestamp AS TEXT), COUNT(*) FROM PROCESS_STATS GROUP BY 1 ORDER BY 1",
+  )
+  .fetch_all(&pool)
+  .await
+  .unwrap()
+  .into_iter()
+  .map(|row| (row.get(0), row.get(1)))
+  .collect();
+  assert_eq!(
+    stored,
+    vec![
+      (native_process_stats::sqlite_timestamp_text(&whole), 3),
+      (native_process_stats::sqlite_timestamp_text(&fractional), 2),
+    ],
+    "the native writer must render the bytes sqlx stores"
+  );
+
+  // 2. Rows an older build or a wider integer could have left behind: other
+  //    accepted timestamp spellings, an i64 memory value no `i32` writer can
+  //    produce, and an embedded NUL in a process name.
+  pool
+    .execute(
+      r#"
+      INSERT INTO PROCESS_STATS(pid,process_name,cpu_usage,memory_usage,execution_sec,timestamp)
+      VALUES
+        (4004,'legacy-z',7.25,9223372036854775807,10,'2026-09-01T00:02:00Z'),
+        (4005,'legacy-offset',3.5,4096,11,'2026-09-01T09:03:00+09:00'),
+        (4006,'nul'||char(0)||'name',1.25,4096,12,'2026-09-01T00:04:00+00:00');
+      "#,
+    )
+    .await
+    .unwrap();
+
+  // Rows placed relative to the clock, so the Retention Period actually
+  // bisects them below.
+  let now = chrono::Utc::now();
+  for (days, name) in [(10_i64, "expired"), (5, "kept-old"), (1, "kept-recent")] {
+    process_stats::insert(
+      vec![stat(5000 + days as i32, name, 2.0, 1_024, 30)],
+      now - chrono::Duration::days(days),
+    )
+    .await
+    .unwrap();
+  }
+  pool.close().await;
+
+  fixture.finalize().await;
+  let database = fixture.open().await;
+
+  // 3. The same ranges through both query paths.
+  let ranges: [(&str, &str, bool); 8] = [
+    ("", "zzzz", false),
+    ("", "zzzz", true),
+    // Inclusive endpoints, exactly on stored spellings.
+    (
+      "2026-09-01T00:00:00+00:00",
+      "2026-09-01T00:01:00.125+00:00",
+      false,
+    ),
+    (
+      "2026-09-01T00:00:00+00:00",
+      "2026-09-01T00:01:00.125+00:00",
+      true,
+    ),
+    // One stamp only.
+    (
+      "2026-09-01T00:00:00+00:00",
+      "2026-09-01T00:00:00+00:00",
+      false,
+    ),
+    // Just inside the fractional stamp, which text comparison excludes.
+    (
+      "2026-09-01T00:00:00+00:00",
+      "2026-09-01T00:01:00.124+00:00",
+      false,
+    ),
+    // Spellings that sort outside the ISO-8601 UTC block.
+    ("2026-09-01T00:02:00Z", "2026-09-01T09:03:00+09:00", false),
+    // Empty.
+    (
+      "2027-01-01T00:00:00+00:00",
+      "2027-01-02T00:00:00+00:00",
+      false,
+    ),
+  ];
+  for (start, end, order_by_cpu_desc) in ranges {
+    let expected = archive_queries::select_process_stats(start, end, order_by_cpu_desc)
+      .await
+      .unwrap();
+    let actual = native_process_stats::select_process_stats(
+      &database,
+      NativeCancellation::new(),
+      start.to_owned(),
+      end.to_owned(),
+      order_by_cpu_desc,
+    )
+    .await
+    .unwrap();
+    assert_records_match(&expected, &actual, start, end, order_by_cpu_desc);
+  }
+  assert!(
+    archive_queries::select_process_stats("", "zzzz", false)
+      .await
+      .unwrap()
+      .iter()
+      .any(|record| record.avg_memory_usage > 4.0e18),
+    "the large-memory row must be inside the compared range"
+  );
+
+  // 4. The same Retention Period through both delete paths.
+  let survivors_before = surviving_identities(&database).await;
+  assert!(survivors_before.iter().any(|(_, name)| name == "expired"));
+  process_stats::delete_old_data(7).await.unwrap();
+  let deleted =
+    native_process_stats::delete_old_data(&database, NativeCancellation::new(), 7)
+      .await
+      .unwrap();
+  assert_eq!(deleted, 1);
+
+  let pool = native_support::open_pool(&fixture.source, false).await;
+  let mut expected: Vec<(i64, String)> =
+    sqlx::query("SELECT pid, process_name FROM PROCESS_STATS")
+      .fetch_all(&pool)
+      .await
+      .unwrap()
+      .into_iter()
+      .map(|row| (row.get(0), row.get(1)))
+      .collect();
+  pool.close().await;
+  expected.sort();
+  let mut actual = surviving_identities(&database).await;
+  actual.sort();
+  assert_eq!(actual, expected);
+  assert!(!actual.iter().any(|(_, name)| name == "expired"));
+  assert!(actual.iter().any(|(_, name)| name == "kept-old"));
+  database.close().await.unwrap();
+}
+
+fn stat(
+  pid: i32,
+  name: &str,
+  cpu_usage: f32,
+  memory_usage: i32,
+  execution_sec: i32,
+) -> ProcessStatData {
+  ProcessStatData {
+    pid,
+    process_name: name.to_owned(),
+    cpu_usage,
+    memory_usage,
+    execution_sec,
+  }
+}
+
+async fn surviving_identities(
+  database: &hardviz_core::infrastructure::database::native_database::NativeDatabase,
+) -> Vec<(i64, String)> {
+  database
+    .request_read(NativeCancellation::new(), |context| {
+      let mut statement = context
+        .connection()
+        .prepare("SELECT pid, process_name FROM PROCESS_STATS")
+        .unwrap();
+      let rows = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+      Ok(rows)
+    })
+    .await
+    .unwrap()
+}
+
+/// Compare every field exactly, floats by their binary64 bits, and - when the
+/// query was asked to rank - the sequence of equal-average bands, so a tie can
+/// keep its members in either engine's order without hiding a real difference.
+fn assert_records_match(
+  expected: &[archive_queries::ProcessStatRecord],
+  actual: &[archive_queries::ProcessStatRecord],
+  start: &str,
+  end: &str,
+  order_by_cpu_desc: bool,
+) {
+  let context = format!("range {start}..{end} ordered={order_by_cpu_desc}");
+  let key = |record: &archive_queries::ProcessStatRecord| {
+    (record.pid, record.process_name.clone())
+  };
+  let fields = |record: &archive_queries::ProcessStatRecord| {
+    (
+      record.avg_cpu_usage.to_bits(),
+      record.avg_memory_usage.to_bits(),
+      record.total_execution_sec,
+      record.latest_timestamp.clone(),
+    )
+  };
+  let expected_by_identity: BTreeMap<_, _> = expected
+    .iter()
+    .map(|record| (key(record), fields(record)))
+    .collect();
+  let actual_by_identity: BTreeMap<_, _> = actual
+    .iter()
+    .map(|record| (key(record), fields(record)))
+    .collect();
+  assert_eq!(expected.len(), expected_by_identity.len(), "{context}");
+  assert_eq!(actual.len(), actual_by_identity.len(), "{context}");
+  assert_eq!(actual_by_identity, expected_by_identity, "{context}");
+
+  if order_by_cpu_desc {
+    assert_eq!(rank_bands(expected), rank_bands(actual), "{context}");
+  }
+}
+
+fn rank_bands(
+  records: &[archive_queries::ProcessStatRecord],
+) -> Vec<(u64, Vec<(i64, String)>)> {
+  let mut bands: Vec<(u64, Vec<(i64, String)>)> = Vec::new();
+  for record in records {
+    let bits = record.avg_cpu_usage.to_bits();
+    if bands.last().is_none_or(|band| band.0 != bits) {
+      bands.push((bits, Vec::new()));
+    }
+    bands
+      .last_mut()
+      .expect("a band was just pushed")
+      .1
+      .push((record.pid, record.process_name.clone()));
+  }
+  for (_, identities) in &mut bands {
+    identities.sort();
+  }
+  bands
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Order {
+  Forward,
+  Reverse,
+  Interleaved,
+}
+
+fn process_input(order: Order) -> Vec<ProcessInput> {
+  let mut rows = Vec::with_capacity(VECTOR_CROSSING_ROWS * 4);
+  for index in 0..VECTOR_CROSSING_ROWS {
+    let triplet = index % 3;
+    let varied = ((index.wrapping_mul(2_654_435_761) % 1_000_003) as f32) / 10_000.03_f32;
+    let timestamp = format!(
+      "2026-01-01T00:{:02}:{:02}.{:03}Z",
+      (index / 60) % 60,
+      index % 60,
+      index % 1_000
+    );
+    rows.push(ProcessInput {
+      pid: 1,
+      name: "ordinary-telemetry",
+      cpu: match index % 257 {
+        // A denormal and the smallest positive normal: still archive-plausible
+        // magnitudes, unlike the cancellation fixture above.
+        0 => f32::from_bits(1),
+        1 => f32::MIN_POSITIVE,
+        _ => varied,
+      },
+      memory: ((index % 2_001) * 4_096) as i64,
+      ordinal: (rows.len() + 1) as i64,
+      timestamp: timestamp.clone(),
+    });
+    rows.push(ProcessInput {
+      pid: 2,
+      name: "i64-memory",
+      cpu: [100.0, 0.0, 0.5][triplet],
+      // Memory beyond i32, so the integer average has to stay exact.
+      memory: [i64::MAX, i64::MAX - 3, i64::MIN + 2_052][triplet],
+      ordinal: (rows.len() + 1) as i64,
+      timestamp: timestamp.clone(),
+    });
+    rows.push(ProcessInput {
+      pid: 3,
+      name: "alternating",
+      cpu: [1.0, -1.0, 0.5][triplet],
+      memory: [1, -1, 0][triplet],
+      ordinal: (rows.len() + 1) as i64,
+      timestamp: timestamp.clone(),
+    });
+    rows.push(ProcessInput {
+      pid: 4,
+      name: "positive-rank-neighbor",
+      cpu: 50.0,
+      memory: 4_096,
+      ordinal: (rows.len() + 1) as i64,
+      timestamp,
+    });
+  }
+
+  match order {
+    Order::Forward => {}
+    Order::Reverse => rows.reverse(),
+    Order::Interleaved => rows.sort_by_key(|row| (row.ordinal % 257, row.ordinal)),
+  }
+  for (index, row) in rows.iter_mut().enumerate() {
+    row.ordinal = (index + 1) as i64;
+  }
+  rows
+}
+
+async fn sqlite_aggregates(input: &[ProcessInput]) -> AggregateBits {
+  let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+  sqlx::query(
+    "CREATE TABLE PROCESS_STATS (
+       id INTEGER PRIMARY KEY,
+       pid INTEGER NOT NULL,
+       process_name TEXT NOT NULL,
+       cpu_usage REAL NOT NULL,
+       memory_usage INTEGER NOT NULL
+       ,timestamp TEXT NOT NULL
+     )",
+  )
+  .execute(&pool)
+  .await
+  .unwrap();
+  sqlx::query("CREATE INDEX idx_process_stats_timestamp ON PROCESS_STATS(timestamp)")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+  for chunk in input.chunks(1_000) {
+    let mut query = QueryBuilder::<Sqlite>::new(
+      "INSERT INTO PROCESS_STATS (id, pid, process_name, cpu_usage, memory_usage, timestamp) ",
+    );
+    query.push_values(chunk, |mut values, row| {
+      values
+        .push_bind(row.ordinal)
+        .push_bind(row.pid)
+        .push_bind(row.name)
+        .push_bind(row.cpu)
+        .push_bind(row.memory)
+        .push_bind(&row.timestamp);
+    });
+    query.build().execute(&pool).await.unwrap();
+  }
+
+  let rows = sqlx::query(
+    "SELECT pid, process_name, AVG(cpu_usage), AVG(memory_usage)
+     FROM PROCESS_STATS INDEXED BY idx_process_stats_timestamp
+     WHERE timestamp BETWEEN '2026-01-01T00:00:00.000Z' AND '2026-01-01T00:59:59.999Z'
+     GROUP BY pid, process_name
+     ORDER BY AVG(cpu_usage) DESC",
+  )
+  .fetch_all(&pool)
+  .await
+  .unwrap()
+  .into_iter()
+  .map(|row| {
+    (
+      row.get::<i64, _>(0),
+      row.get::<String, _>(1),
+      row.get::<f64, _>(2),
+      row.get::<f64, _>(3),
+    )
+  })
+  .collect::<Vec<_>>();
+  aggregate_bits(rows)
+}
+
+fn duckdb_aggregates(input: &[ProcessInput], threads: i64) -> AggregateBits {
+  let config = Config::default().threads(threads).unwrap();
+  let connection = Connection::open_in_memory_with_flags(config).unwrap();
+  connection
+    .execute_batch(
+      "CREATE TABLE PROCESS_STATS (
+         id BIGINT PRIMARY KEY,
+         pid BIGINT NOT NULL,
+         process_name VARCHAR NOT NULL,
+         cpu_usage DOUBLE NOT NULL,
+         memory_usage BIGINT NOT NULL,
+         timestamp VARCHAR NOT NULL
+       )",
+    )
+    .unwrap();
+  connection
+    .execute_batch("CREATE INDEX idx_process_stats_timestamp ON PROCESS_STATS(timestamp)")
+    .unwrap();
+  {
+    let mut appender = connection.appender("PROCESS_STATS").unwrap();
+    for row in input {
+      appender
+        .append_row(params![
+          row.ordinal,
+          row.pid,
+          row.name,
+          f64::from(row.cpu),
+          row.memory,
+          &row.timestamp
+        ])
+        .unwrap();
+    }
+    appender.flush().unwrap();
+  }
+
+  let mut statement = connection
+    .prepare(
+      "SELECT pid, process_name, AVG(cpu_usage), AVG(memory_usage)
+       FROM PROCESS_STATS
+       WHERE timestamp BETWEEN '2026-01-01T00:00:00.000Z' AND '2026-01-01T00:59:59.999Z'
+       GROUP BY pid, process_name
+       ORDER BY AVG(cpu_usage) DESC",
+    )
+    .unwrap();
+  let rows = statement
+    .query_map([], |row| {
+      Ok((
+        row.get::<_, i64>(0)?,
+        row.get::<_, String>(1)?,
+        row.get::<_, f64>(2)?,
+        row.get::<_, f64>(3)?,
+      ))
+    })
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap();
+  aggregate_bits(rows)
+}
+
+fn aggregate_bits(rows: Vec<(i64, String, f64, f64)>) -> AggregateBits {
+  let by_identity = rows
+    .iter()
+    .map(|(pid, name, cpu, memory)| {
+      ((*pid, name.clone()), (cpu.to_bits(), memory.to_bits()))
+    })
+    .collect();
+  let mut cpu_rank_bands: Vec<(u64, Vec<(i64, String)>)> = Vec::new();
+  for (pid, name, cpu, _) in rows {
+    let bits = cpu.to_bits();
+    if cpu_rank_bands.last().is_none_or(|band| band.0 != bits) {
+      cpu_rank_bands.push((bits, Vec::new()));
+    }
+    cpu_rank_bands
+      .last_mut()
+      .expect("a band was just pushed")
+      .1
+      .push((pid, name));
+  }
+  for (_, identities) in &mut cpu_rank_bands {
+    identities.sort();
+  }
+  AggregateBits {
+    by_identity,
+    cpu_rank_bands,
+  }
+}
+
+fn describe_mismatches(expected: &AggregateBits, actual: &AggregateBits) -> String {
+  let mut differences = expected
+    .by_identity
+    .iter()
+    .filter_map(|(identity, expected_bits)| {
+      let actual_bits = actual.by_identity.get(identity);
+      (actual_bits != Some(expected_bits)).then(|| {
+        format!(
+          "{identity:?}: SQLite(cpu={:016x},memory={:016x}) DuckDB={actual_bits:?}",
+          expected_bits.0, expected_bits.1
+        )
+      })
+    })
+    .collect::<Vec<_>>();
+  if expected.cpu_rank_bands != actual.cpu_rank_bands {
+    differences.push(format!(
+      "rank bands: SQLite={:?} DuckDB={:?}",
+      expected.cpu_rank_bands, actual.cpu_rank_bands
+    ));
+  }
+  differences.join("; ")
+}

--- a/core/tests/duckdb_native.rs
+++ b/core/tests/duckdb_native.rs
@@ -90,7 +90,9 @@ async fn finalizes_every_domain_table_preserving_classes_ids_and_multiplicity() 
     .unwrap();
   assert_eq!(gpu_name.as_bytes(), b"Discrete GPU\0Secondary");
 
-  // Extreme integers and duplicated identity tuples survive unrounded.
+  // Extreme integers and duplicated identity tuples survive unrounded. The
+  // `i64::MAX` row keeps its own identity so a whole-range Process query still
+  // has an exact integer sum for every group.
   let memory: i64 = connection
     .query_row(
       "SELECT memory_usage FROM PROCESS_STATS WHERE id = 2",
@@ -902,10 +904,10 @@ async fn seed_domain_tables(pool: &SqlitePool) {
       INSERT INTO PROCESS_STATS(pid,process_name,cpu_usage,memory_usage,execution_sec,timestamp)
       VALUES
         (4000,'renderer',12.5,4096,60,'2026-09-01T00:00:00+00:00'),
-        (4000,'renderer',37.5,9223372036854775807,120,'2026-09-01T00:01:00+00:00'),
+        (4003,'legacy-wide',37.5,9223372036854775807,120,'2026-09-01T00:01:00+00:00'),
         (4000,'renderer',12.5,4096,180,'2026-09-01T00:02:00+00:00'),
         (4001,'helper'||char(0)||'worker',0.0,0,0,'2026-09-01T00:00:00+00:00'),
-        (4002,'idle',100.0,8192,1,'2026-09-01T00:03:00+00:00'),
+        (4000,'renderer',37.5,4096,120,'2026-09-01T00:03:00+00:00'),
         (4002,'idle',0.5,8192,2,'2026-09-01T00:04:00.500+00:00');
       INSERT INTO storage_devices
         (id,display_name,model,serial_hash,protocol,capacity_bytes,first_seen_at,last_seen_at,is_active)

--- a/core/tests/duckdb_native.rs
+++ b/core/tests/duckdb_native.rs
@@ -1,0 +1,968 @@
+#![cfg(feature = "duckdb-archive")]
+//! Finalization of a #2088 candidate into the stable native schema, and the
+//! behavior of the blocking owner that serves the result.
+
+mod native_support;
+
+use std::time::Duration;
+
+use duckdb::Connection;
+use hardviz_core::infrastructure::database::native_database::{
+  NativeCancellation, NativeDatabaseError, NativeDatabaseOptions, process_stats,
+};
+use hardviz_core::persistence::archive_data::ProcessStatData;
+use native_support::{
+  NativeFixture, app_native_schema, file_hash, read_only, sqlite_epoch_milliseconds_of,
+};
+use sqlx::{Executor, Row, SqlitePool};
+
+const STORAGE_ID: &str = "storage:hmac-sha256:v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+#[tokio::test]
+async fn finalizes_every_domain_table_preserving_classes_ids_and_multiplicity() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  let source_hash = file_hash(&fixture.source);
+
+  fixture.build_candidate().await.unwrap();
+  let candidate_hash = file_hash(&fixture.candidate);
+  let report = fixture.try_finalize().await.unwrap();
+
+  assert_eq!(report.state, "finalized_unselected");
+  assert_eq!(
+    report.schema_version,
+    app_native_schema::NATIVE_SCHEMA_VERSION
+  );
+  assert_eq!(report.source_schema_sha256.len(), 64);
+  assert_eq!(report.tables.len(), 15);
+  assert!(report.finalized_bytes > 0);
+  for table in &report.tables {
+    assert_eq!(table.candidate_rows, table.copied_rows, "{}", table.name);
+    assert_eq!(table.copied_rows, table.reopened_rows, "{}", table.name);
+    assert_eq!(table.copied_digest, table.reopened_digest, "{}", table.name);
+    assert_eq!(table.copied_digest.len(), 64, "{}", table.name);
+  }
+  assert_eq!(
+    report.tables.iter().map(|t| t.copied_rows).sum::<u64>(),
+    report.total_rows
+  );
+  // The `_sqlx_migrations` and `sqlite_sequence` rows the candidate carries are
+  // provenance and allocator state, not domain rows, so they are not copied.
+  let process = report
+    .tables
+    .iter()
+    .find(|table| table.name == "PROCESS_STATS")
+    .unwrap();
+  assert_eq!(process.copied_rows, 6);
+
+  // Neither input was touched, and no work directory survived.
+  assert_eq!(file_hash(&fixture.source), source_hash);
+  assert_eq!(file_hash(&fixture.candidate), candidate_hash);
+  assert!(fixture.work_directories().is_empty());
+
+  let connection = read_only(&fixture.finalized);
+  // Tagged unions keep the integer/real distinction and the exact binary64 bits.
+  assert_eq!(
+    cpu_avg_union(&connection, i64::MIN),
+    (Some("i".to_owned()), Some(i64::MIN), None)
+  );
+  assert_eq!(
+    cpu_avg_union(&connection, i64::MAX),
+    (Some("i".to_owned()), Some(i64::MAX), None)
+  );
+  let real = cpu_avg_union(&connection, 0);
+  assert_eq!(real.0.as_deref(), Some("r"));
+  assert_eq!(
+    real.2.map(f64::to_bits),
+    Some(f64::from(25.25_f32).to_bits())
+  );
+  assert_eq!(cpu_avg_union(&connection, -1), (None, None, None));
+
+  // Text bytes survive, including an embedded NUL.
+  let gpu_name: String = connection
+    .query_row(
+      "SELECT gpu_name FROM GPU_DATA_ARCHIVE WHERE id = 2",
+      [],
+      |row| row.get(0),
+    )
+    .unwrap();
+  assert_eq!(gpu_name.as_bytes(), b"Discrete GPU\0Secondary");
+
+  // Extreme integers and duplicated identity tuples survive unrounded.
+  let memory: i64 = connection
+    .query_row(
+      "SELECT memory_usage FROM PROCESS_STATS WHERE id = 2",
+      [],
+      |row| row.get(0),
+    )
+    .unwrap();
+  assert_eq!(memory, i64::MAX);
+  let duplicates: i64 = connection
+    .query_row(
+      "SELECT COUNT(*) FROM PROCESS_STATS WHERE pid = 4000 AND process_name = 'renderer'",
+      [],
+      |row| row.get(0),
+    )
+    .unwrap();
+  assert_eq!(duplicates, 3);
+
+  // A REAL-declared column stays DOUBLE rather than becoming a union.
+  let declared: Vec<(String, String)> = connection
+    .prepare(
+      "SELECT column_name, data_type FROM information_schema.columns \
+       WHERE table_name = 'DATA_ARCHIVE' AND column_name IN ('cpu_avg','cpu_temperature_avg') \
+       ORDER BY column_name",
+    )
+    .unwrap()
+    .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap();
+  assert_eq!(
+    declared,
+    vec![
+      ("cpu_avg".to_owned(), "UNION(i BIGINT, r DOUBLE)".to_owned()),
+      ("cpu_temperature_avg".to_owned(), "DOUBLE".to_owned()),
+    ]
+  );
+}
+
+#[tokio::test]
+async fn derived_epoch_keys_equal_the_sqlite_expression_including_the_stamps_it_refuses()
+{
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  // Every spelling a writer or an older build could have stored, plus one
+  // SQLite cannot read as an instant at all.
+  pool
+    .execute(
+      r#"
+      INSERT INTO AMBIENT_ARCHIVE(source,temperature,humidity,timestamp) VALUES
+        ('spelling:z',20.0,NULL,'2026-09-01T00:00:00Z'),
+        ('spelling:offset',20.0,NULL,'2026-09-01T09:00:00+09:00'),
+        ('spelling:millis',20.0,NULL,'2026-09-01T00:00:00.125+00:00'),
+        ('spelling:micros',20.0,NULL,'2026-09-01T00:00:00.000125+00:00'),
+        ('spelling:space',20.0,NULL,'2026-09-01 00:00:00'),
+        ('spelling:unreadable',20.0,NULL,'not a timestamp');
+      INSERT INTO FAN_ARCHIVE(id,source,rpm,timestamp) VALUES
+        (10,'CPU Fan',1200,'2026-09-01T00:00:00.500Z'),
+        (11,'CPU Fan',1200,'');
+      "#,
+    )
+    .await
+    .unwrap();
+
+  // The oracle: the production epoch adapter run against the SQLite source.
+  let expected: Vec<(i64, Option<i64>)> = sqlx::query(&format!(
+    "SELECT id, {} FROM AMBIENT_ARCHIVE ORDER BY id",
+    sqlite_epoch_milliseconds_of("timestamp")
+  ))
+  .fetch_all(&pool)
+  .await
+  .unwrap()
+  .into_iter()
+  .map(|row| (row.get(0), row.get(1)))
+  .collect();
+  let expected_fan: Vec<(i64, Option<i64>)> = sqlx::query(&format!(
+    "SELECT id, {} FROM FAN_ARCHIVE ORDER BY id",
+    sqlite_epoch_milliseconds_of("timestamp")
+  ))
+  .fetch_all(&pool)
+  .await
+  .unwrap()
+  .into_iter()
+  .map(|row| (row.get(0), row.get(1)))
+  .collect();
+  pool.close().await;
+  assert!(expected.iter().any(|(_, value)| value.is_none()));
+  assert!(expected_fan.iter().any(|(_, value)| value.is_none()));
+
+  fixture.finalize().await;
+  let connection = read_only(&fixture.finalized);
+  for (table, expected) in [("AMBIENT_ARCHIVE", expected), ("FAN_ARCHIVE", expected_fan)]
+  {
+    let actual = connection
+      .prepare(&format!(
+        "SELECT id, __hv_timestamp_epoch_ms FROM {table} ORDER BY id"
+      ))
+      .unwrap()
+      .query_map([], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, Option<i64>>(1)?))
+      })
+      .unwrap()
+      .collect::<Result<Vec<_>, _>>()
+      .unwrap();
+    assert_eq!(actual, expected, "{table}");
+  }
+}
+
+#[tokio::test]
+async fn imports_autoincrement_high_water_and_records_rowid_tables() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  // A deleted highest row leaves its AUTOINCREMENT high-water mark behind.
+  pool
+    .execute(
+      r#"
+      INSERT INTO PROCESS_STATS VALUES
+        (900,9999,'deleted',0.0,0,0,'2026-09-02T00:00:00+00:00');
+      DELETE FROM PROCESS_STATS WHERE id = 900;
+      "#,
+    )
+    .await
+    .unwrap();
+  let sequence: i64 =
+    sqlx::query_scalar("SELECT seq FROM sqlite_sequence WHERE name = 'PROCESS_STATS'")
+      .fetch_one(&pool)
+      .await
+      .unwrap();
+  assert_eq!(sequence, 900);
+  pool.close().await;
+
+  fixture.finalize().await;
+  let connection = read_only(&fixture.finalized);
+  let identities = connection
+    .prepare("SELECT table_name, column_name, mode, high_water FROM __hv_native_identities ORDER BY table_name")
+    .unwrap()
+    .query_map([], |row| {
+      Ok((
+        row.get::<_, String>(0)?,
+        row.get::<_, String>(1)?,
+        row.get::<_, String>(2)?,
+        row.get::<_, i64>(3)?,
+      ))
+    })
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap();
+  assert_eq!(
+    identities,
+    vec![
+      (
+        "AMBIENT_ARCHIVE".into(),
+        "id".into(),
+        "autoincrement".into(),
+        2
+      ),
+      ("DATA_ARCHIVE".into(), "id".into(), "rowid".into(), 0),
+      ("FAN_ARCHIVE".into(), "id".into(), "rowid".into(), 0),
+      ("GPU_DATA_ARCHIVE".into(), "id".into(), "rowid".into(), 0),
+      (
+        "PROCESS_STATS".into(),
+        "id".into(),
+        "autoincrement".into(),
+        900
+      ),
+      (
+        "storage_health_daily_records".into(),
+        "id".into(),
+        "autoincrement".into(),
+        1
+      ),
+    ]
+  );
+}
+
+#[tokio::test]
+async fn identity_allocation_survives_deletion_and_reopen() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  fixture.finalize().await;
+
+  let database = fixture.open().await;
+  let stamp = "2026-09-03T00:00:00Z".parse().unwrap();
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("first", 1.0)],
+    stamp,
+  )
+  .await
+  .unwrap();
+  let first = highest_process_id(&database).await;
+  assert_eq!(first, 7);
+
+  // Deleting the highest AUTOINCREMENT row must not release its id, and the
+  // rowid table beside it must behave the way SQLite's rowid tables do.
+  database
+    .request_write(NativeCancellation::new(), |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute("DELETE FROM PROCESS_STATS WHERE id >= 6", [])
+          .unwrap();
+        transaction
+          .connection()
+          .execute(
+            "DELETE FROM DATA_ARCHIVE WHERE id = 9223372036854775807",
+            [],
+          )
+          .unwrap();
+        Ok(())
+      })
+    })
+    .await
+    .unwrap();
+
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("second", 2.0)],
+    stamp,
+  )
+  .await
+  .unwrap();
+  assert_eq!(highest_process_id(&database).await, 8);
+  database.close().await.unwrap();
+
+  let database = fixture.open().await;
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("third", 3.0)],
+    stamp,
+  )
+  .await
+  .unwrap();
+  assert_eq!(highest_process_id(&database).await, 9);
+
+  // The rowid table reuses the id of the deleted highest row, exactly as
+  // SQLite's `INTEGER PRIMARY KEY` allocation does.
+  let reused = database
+    .request_write(NativeCancellation::new(), |context| {
+      context.with_transaction(|transaction| transaction.next_id("DATA_ARCHIVE"))
+    })
+    .await
+    .unwrap();
+  assert_eq!(reused, 2);
+  database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn refuses_an_existing_destination_without_touching_it() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  fixture.build_candidate().await.unwrap();
+
+  let sentinel = b"an existing native database must survive";
+  std::fs::write(&fixture.finalized, sentinel).unwrap();
+  let error = fixture.try_finalize().await.unwrap_err();
+
+  assert!(
+    matches!(error, NativeDatabaseError::DestinationExists { .. }),
+    "{error:?}"
+  );
+  assert_eq!(std::fs::read(&fixture.finalized).unwrap(), sentinel);
+  assert!(fixture.work_directories().is_empty());
+}
+
+#[tokio::test]
+async fn refuses_a_cell_the_stable_column_cannot_hold() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  // `temperature_max` is written from `Option<i32>`, so the stable schema
+  // declares it BIGINT. A REAL cell there is a legacy representation the
+  // finalized column cannot hold without dropping the fraction.
+  sqlx::query("UPDATE GPU_DATA_ARCHIVE SET temperature_max = ? WHERE id = 2")
+    .bind(Some(55.5_f32))
+    .execute(&pool)
+    .await
+    .unwrap();
+  let classes: Vec<String> = sqlx::query_scalar(
+    "SELECT typeof(temperature_max) FROM GPU_DATA_ARCHIVE ORDER BY id",
+  )
+  .fetch_all(&pool)
+  .await
+  .unwrap();
+  assert_eq!(classes, ["integer", "real"]);
+  pool.close().await;
+  fixture.build_candidate().await.unwrap();
+
+  let error = fixture.try_finalize().await.unwrap_err();
+
+  match error {
+    NativeDatabaseError::UnrepresentableCell {
+      ref table,
+      ref column,
+      row_ordinal,
+      candidate,
+      ref destination,
+    } => {
+      assert_eq!(table, "GPU_DATA_ARCHIVE");
+      assert_eq!(column, "temperature_max");
+      assert_eq!(row_ordinal, 1);
+      assert_eq!(candidate, "a real");
+      assert_eq!(destination, "BIGINT");
+    }
+    other => panic!("unexpected error: {other:?}"),
+  }
+  assert!(!fixture.finalized.exists());
+  assert!(fixture.work_directories().is_empty());
+}
+
+/// The stable schema is App-owned and the migration set can move without it.
+/// A table the definition forgot would otherwise be dropped silently, which is
+/// the loss the missing-column refusal above already rules out.
+#[tokio::test]
+async fn refuses_a_candidate_table_the_stable_schema_never_declared() {
+  // The App list minus one table. Its DDL still runs, so the only difference
+  // is that nothing would copy its rows.
+  const WITHOUT_HOURLY_SUMMARY: &[&str] = &[
+    "DATA_ARCHIVE",
+    "GPU_DATA_ARCHIVE",
+    "PROCESS_STATS",
+    "storage_devices",
+    "storage_health_daily_records",
+    "cooling_daily_summary",
+    "cooling_baseline",
+    "AMBIENT_ARCHIVE",
+    "FAN_ARCHIVE",
+    "cooling_fan_daily_summary",
+    "cooling_delta_baseline",
+    "cooling_thermal_delta_daily_summary",
+    "cooling_covariate_daily_summary",
+    "cooling_fan_covariate_daily_summary",
+  ];
+
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  fixture.build_candidate().await.unwrap();
+
+  let mut schema = app_native_schema::get_native_schema();
+  schema.tables = WITHOUT_HOURLY_SUMMARY;
+  let error =
+    hardviz_core::infrastructure::database::native_database::finalize_candidate_database(
+      &fixture.candidate,
+      &fixture.finalized,
+      schema,
+    )
+    .await
+    .unwrap_err();
+
+  match error {
+    NativeDatabaseError::SchemaMismatch { ref table, .. } => {
+      assert_eq!(table, "cooling_hourly_summary");
+    }
+    other => panic!("unexpected error: {other:?}"),
+  }
+  assert!(!fixture.finalized.exists());
+  assert!(fixture.work_directories().is_empty());
+}
+
+#[tokio::test]
+async fn refuses_an_unfinalized_or_incompatible_database() {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  fixture.finalize().await;
+
+  // The candidate is a valid DuckDB file, but it was never finalized.
+  let unfinalized = fixture.directory.path().join("unfinalized.duckdb");
+  std::fs::copy(&fixture.candidate, &unfinalized).unwrap();
+  let error =
+    hardviz_core::infrastructure::database::native_database::NativeDatabase::open(
+      &unfinalized,
+      NativeDatabaseOptions::new(app_native_schema::NATIVE_SCHEMA_VERSION),
+    )
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::Unfinalized),
+    "{error:?}"
+  );
+
+  let error = fixture
+    .try_open(app_native_schema::NATIVE_SCHEMA_VERSION + 1)
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(
+      error,
+      NativeDatabaseError::IncompatibleSchema { actual: 1, .. }
+    ),
+    "{error:?}"
+  );
+
+  let missing = fixture.directory.path().join("absent.duckdb");
+  let error =
+    hardviz_core::infrastructure::database::native_database::NativeDatabase::open(
+      &missing,
+      NativeDatabaseOptions::new(app_native_schema::NATIVE_SCHEMA_VERSION),
+    )
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::Unavailable { .. }),
+    "{error:?}"
+  );
+}
+
+#[tokio::test]
+async fn requests_after_close_report_closed() {
+  let fixture = seeded_native().await;
+  let database = fixture.open().await;
+  database.close().await.unwrap();
+  // Closing twice is a no-op rather than an error.
+  database.close().await.unwrap();
+
+  let error = process_stats::select_process_stats(
+    &database,
+    NativeCancellation::new(),
+    String::new(),
+    "z".to_owned(),
+    false,
+  )
+  .await
+  .unwrap_err();
+  assert!(matches!(error, NativeDatabaseError::Closed), "{error:?}");
+
+  let error = process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("after-close", 1.0)],
+    "2026-09-03T00:00:00Z".parse().unwrap(),
+  )
+  .await
+  .unwrap_err();
+  assert!(matches!(error, NativeDatabaseError::Closed), "{error:?}");
+}
+
+#[tokio::test]
+async fn a_cancellation_may_be_attached_to_only_one_request() {
+  let fixture = seeded_native().await;
+  let database = fixture.open().await;
+  let cancellation = NativeCancellation::new();
+  process_stats::select_process_stats(
+    &database,
+    cancellation.clone(),
+    String::new(),
+    "z".to_owned(),
+    false,
+  )
+  .await
+  .unwrap();
+
+  let error = process_stats::select_process_stats(
+    &database,
+    cancellation,
+    String::new(),
+    "z".to_owned(),
+    false,
+  )
+  .await
+  .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::CancellationAlreadyUsed),
+    "{error:?}"
+  );
+  database.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancellation_interrupts_a_read_and_the_owner_keeps_serving() {
+  let fixture = seeded_native().await;
+  let database = fixture.open().await;
+  let cancellation = NativeCancellation::new();
+  let (started, mut started_rx) = tokio::sync::mpsc::channel::<()>(1);
+  let running = database.clone();
+  let token = cancellation.clone();
+  let long_read = tokio::spawn(async move {
+    running
+      .request_read(token, move |context| {
+        started.blocking_send(()).unwrap();
+        context
+          .connection()
+          .query_row(
+            "SELECT max(hash(range)) FROM range(0, 5000000000)",
+            [],
+            |row| row.get::<_, u64>(0),
+          )
+          .map_err(|error| NativeDatabaseError::Worker {
+            message: error.to_string(),
+          })
+      })
+      .await
+  });
+
+  started_rx.recv().await.unwrap();
+  tokio::time::sleep(Duration::from_millis(400)).await;
+  cancellation.cancel();
+  let error = tokio::time::timeout(Duration::from_secs(60), long_read)
+    .await
+    .expect("the interrupted read must finish")
+    .unwrap()
+    .unwrap_err();
+  assert!(matches!(error, NativeDatabaseError::Cancelled), "{error:?}");
+
+  // The same owner keeps serving both lanes afterwards.
+  let before = process_stats::select_process_stats(
+    &database,
+    NativeCancellation::new(),
+    String::new(),
+    "z".to_owned(),
+    false,
+  )
+  .await
+  .unwrap();
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("after-cancellation", 9.5)],
+    "2026-09-03T00:00:00Z".parse().unwrap(),
+  )
+  .await
+  .unwrap();
+  let after = process_stats::select_process_stats(
+    &database,
+    NativeCancellation::new(),
+    String::new(),
+    "z".to_owned(),
+    false,
+  )
+  .await
+  .unwrap();
+  assert_eq!(after.len(), before.len() + 1);
+  database.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_reader_snapshot_stays_pinned_while_a_write_commits() {
+  let fixture = seeded_native().await;
+  let database = fixture.open().await;
+  let (started, mut started_rx) = tokio::sync::mpsc::channel::<i64>(1);
+  let (release, mut release_rx) = tokio::sync::mpsc::channel::<()>(1);
+  let reader = database.clone();
+  let pinned = tokio::spawn(async move {
+    reader
+      .request_read(NativeCancellation::new(), move |context| {
+        context.with_transaction(|transaction| {
+          let first = count_processes(transaction.connection());
+          started.blocking_send(first).unwrap();
+          release_rx.blocking_recv().unwrap();
+          Ok((first, count_processes(transaction.connection())))
+        })
+      })
+      .await
+  });
+
+  let before = started_rx.recv().await.unwrap();
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("committed-during-read", 4.5)],
+    "2026-09-03T00:00:00Z".parse().unwrap(),
+  )
+  .await
+  .unwrap();
+  release.send(()).await.unwrap();
+
+  let (first, second) = pinned.await.unwrap().unwrap();
+  assert_eq!(first, before);
+  assert_eq!(
+    second, before,
+    "the pinned snapshot must not see the commit"
+  );
+
+  let after = database
+    .request_read(NativeCancellation::new(), |context| {
+      Ok(count_processes(context.connection()))
+    })
+    .await
+    .unwrap();
+  assert_eq!(after, before + 1);
+  database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn a_failed_write_rolls_back_and_the_owner_stays_healthy() {
+  let fixture = seeded_native().await;
+  let database = fixture.open().await;
+  let before = database
+    .request_read(NativeCancellation::new(), |context| {
+      Ok(count_processes(context.connection()))
+    })
+    .await
+    .unwrap();
+
+  let error = database
+    .request_write(NativeCancellation::new(), |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(
+            "INSERT INTO PROCESS_STATS VALUES (5000, 1, 'rolled-back', 1.0, 1, 1, '2026-09-03T00:00:00+00:00')",
+            [],
+          )
+          .unwrap();
+        Err::<(), _>(NativeDatabaseError::Worker {
+          message: "deliberate failure after a write".to_owned(),
+        })
+      })
+    })
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::Worker { .. }),
+    "{error:?}"
+  );
+
+  process_stats::insert(
+    &database,
+    NativeCancellation::new(),
+    vec![process("after-rollback", 1.5)],
+    "2026-09-03T00:00:00Z".parse().unwrap(),
+  )
+  .await
+  .unwrap();
+  let after = database
+    .request_read(NativeCancellation::new(), |context| {
+      Ok(count_processes(context.connection()))
+    })
+    .await
+    .unwrap();
+  assert_eq!(after, before + 1, "only the successful write survived");
+  database.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bounded_request_capacity_makes_a_caller_wait() {
+  let fixture = seeded_native().await;
+  let database =
+    hardviz_core::infrastructure::database::native_database::NativeDatabase::open(
+      &fixture.finalized,
+      NativeDatabaseOptions {
+        expected_schema_version: app_native_schema::NATIVE_SCHEMA_VERSION,
+        request_capacity: 1,
+      },
+    )
+    .await
+    .unwrap();
+
+  let (started, mut started_rx) = tokio::sync::mpsc::channel::<()>(1);
+  let (release, mut release_rx) = tokio::sync::mpsc::channel::<()>(1);
+  let blocking = database.clone();
+  let occupied = tokio::spawn(async move {
+    blocking
+      .request_read(NativeCancellation::new(), move |_| {
+        started.blocking_send(()).unwrap();
+        release_rx.blocking_recv().unwrap();
+        Ok(())
+      })
+      .await
+  });
+  started_rx.recv().await.unwrap();
+
+  // One request fits the bounded channel; the next caller has to wait for room
+  // rather than queueing without limit.
+  let queued = database.clone();
+  let waiting = tokio::spawn(async move {
+    queued
+      .request_read(NativeCancellation::new(), |context| {
+        Ok(count_processes(context.connection()))
+      })
+      .await
+  });
+  tokio::time::sleep(Duration::from_millis(200)).await;
+  let refused = tokio::time::timeout(
+    Duration::from_millis(300),
+    database.request_read(NativeCancellation::new(), |context| {
+      Ok(count_processes(context.connection()))
+    }),
+  )
+  .await;
+  assert!(refused.is_err(), "a third request must not be accepted yet");
+
+  release.send(()).await.unwrap();
+  occupied.await.unwrap().unwrap();
+  waiting.await.unwrap().unwrap();
+  database
+    .request_read(NativeCancellation::new(), |context| {
+      Ok(count_processes(context.connection()))
+    })
+    .await
+    .unwrap();
+  database.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn refuses_a_request_capacity_of_zero() {
+  let fixture = seeded_native().await;
+  let error =
+    hardviz_core::infrastructure::database::native_database::NativeDatabase::open(
+      &fixture.finalized,
+      NativeDatabaseOptions {
+        expected_schema_version: app_native_schema::NATIVE_SCHEMA_VERSION,
+        request_capacity: 0,
+      },
+    )
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::InvalidRequestCapacity),
+    "{error:?}"
+  );
+}
+
+async fn seeded_native() -> NativeFixture {
+  let fixture = NativeFixture::new();
+  let pool = fixture.migrated_pool().await;
+  seed_domain_tables(&pool).await;
+  pool.close().await;
+  fixture.finalize().await;
+  fixture
+}
+
+fn process(name: &str, cpu: f32) -> ProcessStatData {
+  ProcessStatData {
+    pid: 4242,
+    process_name: name.to_owned(),
+    cpu_usage: cpu,
+    memory_usage: 4096,
+    execution_sec: 60,
+  }
+}
+
+fn count_processes(connection: &Connection) -> i64 {
+  connection
+    .query_row("SELECT COUNT(*) FROM PROCESS_STATS", [], |row| row.get(0))
+    .unwrap()
+}
+
+async fn highest_process_id(
+  database: &hardviz_core::infrastructure::database::native_database::NativeDatabase,
+) -> i64 {
+  database
+    .request_read(NativeCancellation::new(), |context| {
+      Ok(
+        context
+          .connection()
+          .query_row(
+            "SELECT COALESCE(MAX(id), 0) FROM PROCESS_STATS",
+            [],
+            |row| row.get(0),
+          )
+          .unwrap(),
+      )
+    })
+    .await
+    .unwrap()
+}
+
+fn cpu_avg_union(
+  connection: &Connection,
+  id: i64,
+) -> (Option<String>, Option<i64>, Option<f64>) {
+  connection
+    .query_row(
+      "SELECT CAST(union_tag(cpu_avg) AS VARCHAR), union_extract(cpu_avg,'i'), \
+       union_extract(cpu_avg,'r') FROM DATA_ARCHIVE WHERE id = ?",
+      [id],
+      |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .unwrap()
+}
+
+/// One row in every domain table, chosen so the copy has to preserve both
+/// numeric tags, i64 extremes, embedded NUL text, NULLs, duplicated Process
+/// identity tuples and every foreign key.
+async fn seed_domain_tables(pool: &SqlitePool) {
+  pool
+    .execute(
+      r#"
+      INSERT INTO DATA_ARCHIVE
+        (id,cpu_avg,cpu_max,cpu_min,ram_avg,ram_max,ram_min,timestamp,
+         cpu_temperature_avg,cpu_temperature_max,cpu_power_avg,package_power_avg)
+      VALUES
+        (-9223372036854775808,-9223372036854775808,0,9223372036854775807,
+         NULL,42,NULL,'2026-09-01T00:00:00+00:00',40.25,NULL,10.125,30.25),
+        (-1,NULL,2,0,NULL,4,NULL,'2026-09-01T00:01:00+00:00',NULL,NULL,NULL,NULL),
+        (0,NULL,40,10,NULL,60,NULL,'2026-09-01T00:02:00+00:00',
+         45.12500000000001,50.0,-0.0,16.0),
+        (1,0,0,0,NULL,0,NULL,'2026-09-01T00:03:00+00:00',NULL,NULL,NULL,NULL),
+        (9223372036854775807,9223372036854775807,NULL,NULL,NULL,NULL,NULL,NULL,
+         NULL,NULL,NULL,NULL);
+      INSERT INTO GPU_DATA_ARCHIVE
+        (id,gpu_name,usage_avg,usage_max,temperature_avg,temperature_max,
+         timestamp,dedicated_memory_avg,gpu_id)
+      VALUES
+        (1,'Apple M4 Max',NULL,50,42,55,'2026-09-01T00:00:00+00:00',1024,'gpu-persisted-name'),
+        (2,'Discrete GPU'||char(0)||'Secondary',NULL,NULL,NULL,60,NULL,NULL,NULL);
+      INSERT INTO PROCESS_STATS(pid,process_name,cpu_usage,memory_usage,execution_sec,timestamp)
+      VALUES
+        (4000,'renderer',12.5,4096,60,'2026-09-01T00:00:00+00:00'),
+        (4000,'renderer',37.5,9223372036854775807,120,'2026-09-01T00:01:00+00:00'),
+        (4000,'renderer',12.5,4096,180,'2026-09-01T00:02:00+00:00'),
+        (4001,'helper'||char(0)||'worker',0.0,0,0,'2026-09-01T00:00:00+00:00'),
+        (4002,'idle',100.0,8192,1,'2026-09-01T00:03:00+00:00'),
+        (4002,'idle',0.5,8192,2,'2026-09-01T00:04:00.500+00:00');
+      INSERT INTO storage_devices
+        (id,display_name,model,serial_hash,protocol,capacity_bytes,first_seen_at,last_seen_at,is_active)
+      VALUES
+        ('storage:hmac-sha256:v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+         'System SSD','NVMe Model','serial-hash','NVMe',9223372036854775807,'2026-01-01','2026-09-01',1);
+      INSERT INTO storage_health_daily_records
+        (device_id,date,health_status,temperature_celsius,power_on_hours,percentage_used,collected_at)
+      VALUES
+        ('storage:hmac-sha256:v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+         '2026-09-01','healthy',38.125,12345,2.5,'2026-09-01T23:59:00+00:00');
+      INSERT INTO cooling_daily_summary
+        (date,idle_cpu_temperature_avg,idle_sample_minutes,coverage_minutes,cpu_power_avg,power_sample_minutes)
+      VALUES ('2026-09-01',35.25,240,720,22.25,600);
+      INSERT INTO cooling_baseline VALUES
+        (1,'2026-08-01','2026-08-30',36.25,7200,'2026-09-01T00:00:00+00:00');
+      INSERT INTO cooling_hourly_summary VALUES
+        ('2026-09-01T00:00:00+00:00',12.25,41.5,60);
+      INSERT INTO AMBIENT_ARCHIVE(source,temperature,humidity,timestamp) VALUES
+        ('SwitchBot Meter (a1b2)',24.125,45.5,'2026-09-01T00:00:00+00:00'),
+        ('SwitchBot Meter (c3d4)',23.75,NULL,'2026-09-01T00:01:00+00:00');
+      INSERT INTO FAN_ARCHIVE VALUES
+        (0,'CPU Fan',0,'2026-09-01T00:00:00+00:00'),
+        (-1,'System Fan',1400,'2026-09-01T00:01:00+00:00');
+      INSERT INTO cooling_fan_daily_summary VALUES
+        ('2026-09-01','CPU Fan',1250.25,2200,0,720);
+      INSERT INTO cooling_delta_baseline VALUES
+        (1,'SwitchBot Meter (a1b2)','2026-08-01','2026-08-30',12.125,7200,
+         '2026-09-01T00:00:00+00:00');
+      INSERT INTO cooling_thermal_delta_daily_summary
+        (date,source,coverage_minutes,idle_delta_temperature_avg,idle_delta_sample_minutes)
+      VALUES ('2026-09-01','SwitchBot Meter (a1b2)',700,10.0,200);
+      INSERT INTO cooling_covariate_daily_summary
+        (date,source,band,sample_minutes,band_share,ambient_temperature_median,
+         delta_minutes,delta_temperature_median,power_minutes,cpu_power_median,
+         power_fit_n,power_fit_sum_x,power_fit_sum_y,power_fit_sum_xy,power_fit_sum_xx,power_fit_sum_yy)
+      VALUES ('2026-09-01','SwitchBot Meter (a1b2)','low',300,0.25,24.125,
+         300,20.5,280,22.25,280,6230.0,5740.0,127755.0,140000.0,120000.0);
+      INSERT INTO cooling_fan_covariate_daily_summary VALUES
+        ('2026-09-01','SwitchBot Meter (a1b2)','CPU Fan','low',280,1250.25,
+         280,350000.0,5740.0,7175000.0,438000000.0,120000.0);
+      "#,
+    )
+    .await
+    .unwrap();
+
+  // The same `Option<f32>` binding the production Hardware and GPU writers use:
+  // an INTEGER-affinity column stores a fractional reading as a REAL cell.
+  sqlx::query("UPDATE DATA_ARCHIVE SET cpu_avg = ? WHERE id = 0")
+    .bind(Some(25.25_f32))
+    .execute(pool)
+    .await
+    .unwrap();
+  let stored_device: String =
+    sqlx::query_scalar("SELECT device_id FROM storage_health_daily_records")
+      .fetch_one(pool)
+      .await
+      .unwrap();
+  assert_eq!(stored_device, STORAGE_ID);
+}

--- a/core/tests/native_support/mod.rs
+++ b/core/tests/native_support/mod.rs
@@ -1,0 +1,149 @@
+//! Shared fixture for the native DuckDB backend tests.
+//!
+//! Everything goes through the real path: App's ordered SQLite migrations,
+//! Core's migrator, the #2088 candidate builder, and finalization against App's
+//! own stable schema definition. Nothing here hand-writes a native file, so a
+//! test can only pass if the production conversion produced it.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use hardviz_core::infrastructure::database::candidate_database::{
+  CandidateError, CandidateReport, build_candidate_database,
+};
+use hardviz_core::infrastructure::database::migrate;
+use hardviz_core::infrastructure::database::native_database::{
+  NativeDatabase, NativeDatabaseError, NativeDatabaseOptions, NativeFinalizationReport,
+  finalize_candidate_database,
+};
+use sha2::{Digest, Sha256};
+use sqlx::ConnectOptions;
+use sqlx::sqlite::{
+  SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions,
+};
+use tempfile::TempDir;
+
+#[path = "../../../src-tauri/src/infrastructure/database/migration.rs"]
+pub mod app_migrations;
+
+#[path = "../../../src-tauri/src/infrastructure/database/native_schema.rs"]
+pub mod app_native_schema;
+
+/// A SQLite source, the candidate copied from it, and the finalized native
+/// database, all inside one temporary directory.
+pub struct NativeFixture {
+  pub directory: TempDir,
+  pub source: PathBuf,
+  pub candidate: PathBuf,
+  pub finalized: PathBuf,
+}
+
+impl NativeFixture {
+  pub fn new() -> Self {
+    let directory = tempfile::tempdir().unwrap();
+    Self {
+      source: directory.path().join("source.sqlite3"),
+      candidate: directory.path().join("candidate.duckdb"),
+      finalized: directory.path().join("finalized.duckdb"),
+      directory,
+    }
+  }
+
+  pub async fn migrated_pool(&self) -> SqlitePool {
+    let pool = open_pool(&self.source, true).await;
+    migrate::run_on_pool(&pool, app_migrations::get_migrations())
+      .await
+      .unwrap();
+    pool
+  }
+
+  pub async fn build_candidate(&self) -> Result<CandidateReport, CandidateError> {
+    build_candidate_database(
+      &self.source,
+      &self.candidate,
+      app_migrations::get_migrations(),
+    )
+    .await
+  }
+
+  pub async fn try_finalize(
+    &self,
+  ) -> Result<NativeFinalizationReport, NativeDatabaseError> {
+    finalize_candidate_database(
+      &self.candidate,
+      &self.finalized,
+      app_native_schema::get_native_schema(),
+    )
+    .await
+  }
+
+  /// Copy the source into a candidate and finalize it into the stable schema.
+  pub async fn finalize(&self) -> NativeFinalizationReport {
+    self.build_candidate().await.unwrap();
+    self.try_finalize().await.unwrap()
+  }
+
+  pub async fn try_open(
+    &self,
+    expected_version: u32,
+  ) -> Result<NativeDatabase, NativeDatabaseError> {
+    NativeDatabase::open(
+      &self.finalized,
+      NativeDatabaseOptions::new(expected_version),
+    )
+    .await
+  }
+
+  pub async fn open(&self) -> NativeDatabase {
+    self
+      .try_open(app_native_schema::NATIVE_SCHEMA_VERSION)
+      .await
+      .unwrap()
+  }
+
+  pub fn work_directories(&self) -> Vec<String> {
+    std::fs::read_dir(self.directory.path())
+      .unwrap()
+      .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+      .filter(|name| name.starts_with(".hardwarevisualizer-duckdb-"))
+      .collect()
+  }
+}
+
+pub async fn open_pool(path: &Path, create: bool) -> SqlitePool {
+  let options = SqliteConnectOptions::new()
+    .filename(path)
+    .create_if_missing(create)
+    .foreign_keys(true)
+    .journal_mode(SqliteJournalMode::Wal)
+    .disable_statement_logging();
+  SqlitePoolOptions::new()
+    .max_connections(1)
+    .connect_with(options)
+    .await
+    .unwrap()
+}
+
+pub fn file_hash(path: &Path) -> String {
+  format!("{:x}", Sha256::digest(std::fs::read(path).unwrap()))
+}
+
+pub fn read_only(path: &Path) -> duckdb::Connection {
+  let config = duckdb::Config::default()
+    .access_mode(duckdb::AccessMode::ReadOnly)
+    .unwrap();
+  duckdb::Connection::open_with_flags(path, config).unwrap()
+}
+
+/// The production epoch-millisecond adapter,
+/// `archive_queries::sqlite_epoch_milliseconds_of`, restated so a test can run
+/// it against SQLite independently of the finalizer. It is `pub(crate)` in Core,
+/// so this copy is the pinned specification: a change there must be mirrored
+/// here deliberately.
+pub fn sqlite_epoch_milliseconds_of(column: &str) -> String {
+  format!(
+    "(CAST(strftime('%s', {column}) AS INTEGER) * 1000 + \
+     CAST(substr(strftime('%f', {column}), 4, 3) AS INTEGER))"
+  )
+}

--- a/docs/design/hardware-archive-duckdb.md
+++ b/docs/design/hardware-archive-duckdb.md
@@ -227,6 +227,15 @@ is an `f32` percentage, so the collector cannot produce that span. Whether the
 residue justifies an exact Rust-side aggregation, at the cost of DuckDB's
 vectorized grouping, is unresolved.
 
+Integer averages do not use DuckDB's `AVG(BIGINT)` at all. It divides the exact
+sum as a `long double`, whose width is 80 bits on x86_64 Linux and 64 bits on
+aarch64 macOS and MSVC, so the same rows produced results one ulp apart across
+CI platforms. The native query reads the exact `SUM` and `COUNT` and performs
+SQLite's own arithmetic - two binary64 conversions and one division - in Rust,
+which is bit-identical everywhere. A sum beyond `i64` becomes a query error
+rather than a different number; SQLite abandons exact summation there too, and
+an `i32` `memory_usage` writer cannot reach it within a Retention Period.
+
 ## Remaining design questions
 
 - [#2089](https://github.com/shm11C3/HardwareVisualizer/issues/2089): native

--- a/docs/design/hardware-archive-duckdb.md
+++ b/docs/design/hardware-archive-duckdb.md
@@ -197,6 +197,36 @@ pinned reader snapshot, reopened expected rows, and exercised committed and
 in-flight termination cases. It supports the direction but does not replace
 application-level concurrency, cancellation, migration, and power-loss tests.
 
+### Finalization and the measured compatibility boundary
+
+Finalization ([#2089](https://github.com/shm11C3/HardwareVisualizer/issues/2089))
+adds one more step after the candidate: a separate copy into the App-owned
+stable schema, refusing rather than coercing any cell the declared column cannot
+hold. Two questions this document left open are now measured rather than
+assumed.
+
+**Timestamps.** The derived `__hv_timestamp_epoch_ms` key is not a Rust
+reimplementation of SQLite's date-string grammar. Finalization runs the
+production adapter (`archive_queries::sqlite_epoch_milliseconds_of`) against a
+scratch in-memory SQLite database for each stored text, so the key is by
+construction the value the current queries compute. The column stays nullable
+even where its source `timestamp` is `NOT NULL`, because SQLite returns NULL for
+text it cannot read as an instant and a missing conversion must stay missing
+rather than become a guessed zero. Writers that insert new rows already hold the
+`DateTime<Utc>` and never parse stored text back.
+
+**Aggregates.** SQLite's `avg()` over REAL has used Kahan-Babuska-Neumaier
+compensated summation since 3.43, and DuckDB has no aggregate that reproduces
+it: `avg`, `sum`, and the Kahan `fsum`/`favg` all lose the compensation.
+Measured on 8,193-row Process fixtures across three row orders and 1/2/4 DuckDB
+threads, DuckDB's `AVG` returns SQLite's exact binary64 bits for
+archive-magnitude values - including denormal `f32` CPU readings and `i64`
+memory extremes - and diverges only once one group's values span more than about
+2^53, where `[x, 1.0, -x]` collapses to `0` against SQLite's `1/3`. `cpu_usage`
+is an `f32` percentage, so the collector cannot produce that span. Whether the
+residue justifies an exact Rust-side aggregation, at the cost of DuckDB's
+vectorized grouping, is unresolved.
+
 ## Remaining design questions
 
 - [#2089](https://github.com/shm11C3/HardwareVisualizer/issues/2089): native

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,7 @@ features = [
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
 bindings-export = []
+duckdb-archive = ["hardviz-core/duckdb-archive"]
 
 [[bin]]
 name = "export_bindings"

--- a/src-tauri/src/infrastructure/database/mod.rs
+++ b/src-tauri/src/infrastructure/database/mod.rs
@@ -9,3 +9,5 @@
 //! [`hardviz_core::persistence`] in #1407.
 
 pub mod migration;
+#[cfg(feature = "duckdb-archive")]
+pub mod native_schema;

--- a/src-tauri/src/infrastructure/database/native_schema.rs
+++ b/src-tauri/src/infrastructure/database/native_schema.rs
@@ -1,0 +1,448 @@
+//! Stable native DuckDB schema supplied by the App database boundary.
+//!
+//! This is the authoritative runtime shape, not a translation of SQLite
+//! syntax. Candidate finalization
+//! ([`hardviz_core::infrastructure::database::native_database::finalize_candidate_database`])
+//! copies the validated snapshot into these constrained tables before the
+//! result can be exercised as a native backend. App owns the ordered schema
+//! definition for the same reason it owns the SQLite migration set; Core owns
+//! how the copy, the identity allocator and the queries behave.
+//!
+//! Original timestamp text stays stored verbatim. The `__hv_timestamp_epoch_ms`
+//! columns are derived query keys the finalizer fills from the stored text.
+
+// No App caller reads this definition yet: the finalizer that consumes it is
+// Core's, exercised from Core's tests, and App lifecycle only chooses a backend
+// in the dependent cutover change. Moving the definition into Core would settle
+// the lint and put schema ownership on the wrong side of the boundary that also
+// keeps the ordered SQLite migration set here, so the lint is suppressed
+// instead.
+#![allow(dead_code)]
+
+use hardviz_core::infrastructure::database::native_database::{
+  NativeIdentity, NativeIdentityMode, NativeSchemaDefinition, NativeTimestampColumn,
+};
+
+pub const NATIVE_SCHEMA_VERSION: u32 = 1;
+
+/// Every current domain table, ordered so a table is created and filled after
+/// the tables its foreign keys reference (`storage_health_daily_records`
+/// references `storage_devices`).
+const TABLES: &[&str] = &[
+  "DATA_ARCHIVE",
+  "GPU_DATA_ARCHIVE",
+  "PROCESS_STATS",
+  "storage_devices",
+  "storage_health_daily_records",
+  "cooling_daily_summary",
+  "cooling_baseline",
+  "cooling_hourly_summary",
+  "AMBIENT_ARCHIVE",
+  "FAN_ARCHIVE",
+  "cooling_fan_daily_summary",
+  "cooling_delta_baseline",
+  "cooling_thermal_delta_daily_summary",
+  "cooling_covariate_daily_summary",
+  "cooling_fan_covariate_daily_summary",
+];
+
+/// The three archive tables whose rows are read back by time range. Cooling
+/// summaries and Storage Health are keyed by a `date`/`hour_start` string
+/// rather than an instant, so they need no derived epoch key.
+const TIMESTAMPS: &[NativeTimestampColumn] = &[
+  NativeTimestampColumn {
+    table: "DATA_ARCHIVE",
+    source_column: "timestamp",
+    epoch_milliseconds_column: "__hv_timestamp_epoch_ms",
+  },
+  NativeTimestampColumn {
+    table: "AMBIENT_ARCHIVE",
+    source_column: "timestamp",
+    epoch_milliseconds_column: "__hv_timestamp_epoch_ms",
+  },
+  NativeTimestampColumn {
+    table: "FAN_ARCHIVE",
+    source_column: "timestamp",
+    epoch_milliseconds_column: "__hv_timestamp_epoch_ms",
+  },
+];
+
+/// Which SQLite identity rule each `id` column carries, so the native
+/// allocator can reproduce it. `AutoIncrement` names the `sqlite_sequence` row
+/// whose high-water mark the finalizer imports; the remaining tables use plain
+/// `INTEGER PRIMARY KEY` rowid allocation.
+const IDENTITIES: &[NativeIdentity] = &[
+  NativeIdentity {
+    table: "DATA_ARCHIVE",
+    column: "id",
+    mode: NativeIdentityMode::RowId,
+  },
+  NativeIdentity {
+    table: "GPU_DATA_ARCHIVE",
+    column: "id",
+    mode: NativeIdentityMode::RowId,
+  },
+  NativeIdentity {
+    table: "PROCESS_STATS",
+    column: "id",
+    mode: NativeIdentityMode::AutoIncrement {
+      sqlite_sequence_name: "PROCESS_STATS",
+    },
+  },
+  NativeIdentity {
+    table: "AMBIENT_ARCHIVE",
+    column: "id",
+    mode: NativeIdentityMode::AutoIncrement {
+      sqlite_sequence_name: "AMBIENT_ARCHIVE",
+    },
+  },
+  NativeIdentity {
+    table: "FAN_ARCHIVE",
+    column: "id",
+    mode: NativeIdentityMode::RowId,
+  },
+  NativeIdentity {
+    table: "storage_health_daily_records",
+    column: "id",
+    mode: NativeIdentityMode::AutoIncrement {
+      sqlite_sequence_name: "storage_health_daily_records",
+    },
+  },
+];
+
+pub fn get_native_schema() -> NativeSchemaDefinition {
+  NativeSchemaDefinition {
+    version: NATIVE_SCHEMA_VERSION,
+    sql: NATIVE_SCHEMA_SQL,
+    tables: TABLES,
+    timestamp_columns: TIMESTAMPS,
+    identities: IDENTITIES,
+  }
+}
+
+/// The fifteen current application data tables. Finalizer-owned metadata and
+/// allocator state live outside these domain tables.
+///
+/// `UNION(i BIGINT, r DOUBLE)` marks the ten measurement columns whose SQLite
+/// declaration is INTEGER but whose production writers bind `Option<f32>`, so
+/// existing databases hold both storage classes in the same column (see the
+/// Design Doc, "Preserving meaning through conversion"). Converting them to
+/// DOUBLE would round large integers; converting them to BIGINT would drop the
+/// fractional readings. Every other column is single-class in the source, and
+/// finalization refuses - naming the table, column and row - any cell the
+/// declared type cannot hold rather than coercing it.
+///
+/// `__hv_timestamp_epoch_ms` is nullable even where its source `timestamp` is
+/// NOT NULL: it must be NULL exactly when SQLite's `strftime` returns NULL for
+/// the stored text, and an absent conversion is not a guessable zero (DP-02).
+pub const NATIVE_SCHEMA_SQL: &str = r#"
+CREATE TABLE DATA_ARCHIVE (
+  id BIGINT PRIMARY KEY,
+  cpu_avg UNION(i BIGINT, r DOUBLE),
+  cpu_max UNION(i BIGINT, r DOUBLE),
+  cpu_min UNION(i BIGINT, r DOUBLE),
+  ram_avg UNION(i BIGINT, r DOUBLE),
+  ram_max UNION(i BIGINT, r DOUBLE),
+  ram_min UNION(i BIGINT, r DOUBLE),
+  timestamp VARCHAR,
+  cpu_temperature_avg DOUBLE,
+  cpu_temperature_max DOUBLE,
+  cpu_temperature_min DOUBLE,
+  cpu_power_avg DOUBLE,
+  cpu_power_max DOUBLE,
+  cpu_power_min DOUBLE,
+  gpu_power_avg DOUBLE,
+  gpu_power_max DOUBLE,
+  gpu_power_min DOUBLE,
+  ane_power_avg DOUBLE,
+  ane_power_max DOUBLE,
+  ane_power_min DOUBLE,
+  package_power_avg DOUBLE,
+  package_power_max DOUBLE,
+  package_power_min DOUBLE,
+  __hv_timestamp_epoch_ms BIGINT
+);
+
+CREATE TABLE GPU_DATA_ARCHIVE (
+  id BIGINT PRIMARY KEY,
+  gpu_name VARCHAR,
+  usage_avg UNION(i BIGINT, r DOUBLE),
+  usage_max UNION(i BIGINT, r DOUBLE),
+  usage_min UNION(i BIGINT, r DOUBLE),
+  temperature_avg UNION(i BIGINT, r DOUBLE),
+  temperature_max BIGINT,
+  temperature_min BIGINT,
+  timestamp VARCHAR,
+  dedicated_memory_avg BIGINT,
+  dedicated_memory_max BIGINT,
+  dedicated_memory_min BIGINT,
+  gpu_id VARCHAR
+);
+
+CREATE TABLE PROCESS_STATS (
+  id BIGINT PRIMARY KEY,
+  pid BIGINT NOT NULL,
+  process_name VARCHAR NOT NULL,
+  cpu_usage DOUBLE NOT NULL,
+  memory_usage BIGINT NOT NULL,
+  execution_sec BIGINT NOT NULL,
+  timestamp VARCHAR NOT NULL
+);
+
+CREATE TABLE storage_devices (
+  id VARCHAR PRIMARY KEY,
+  display_name VARCHAR NOT NULL,
+  model VARCHAR,
+  serial_hash VARCHAR,
+  protocol VARCHAR,
+  capacity_bytes BIGINT,
+  first_seen_at VARCHAR NOT NULL,
+  last_seen_at VARCHAR NOT NULL,
+  is_active BIGINT NOT NULL DEFAULT 1
+);
+
+CREATE TABLE storage_health_daily_records (
+  id BIGINT PRIMARY KEY,
+  device_id VARCHAR NOT NULL,
+  date VARCHAR NOT NULL,
+  health_status VARCHAR NOT NULL,
+  warning_level VARCHAR NOT NULL DEFAULT 'none',
+  warning_reasons VARCHAR,
+  temperature_celsius DOUBLE,
+  power_on_hours BIGINT,
+  percentage_used DOUBLE,
+  available_spare_percent DOUBLE,
+  reallocated_sector_count BIGINT,
+  current_pending_sector_count BIGINT,
+  offline_uncorrectable_count BIGINT,
+  media_errors BIGINT,
+  error_log_entries BIGINT,
+  unsafe_shutdown_count BIGINT,
+  collected_at VARCHAR NOT NULL,
+  UNIQUE(device_id, date),
+  FOREIGN KEY(device_id) REFERENCES storage_devices(id)
+);
+
+CREATE TABLE cooling_daily_summary (
+  date VARCHAR PRIMARY KEY,
+  idle_cpu_temperature_avg DOUBLE,
+  idle_cpu_temperature_max DOUBLE,
+  idle_cpu_temperature_min DOUBLE,
+  idle_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  low_cpu_temperature_avg DOUBLE,
+  low_cpu_temperature_max DOUBLE,
+  low_cpu_temperature_min DOUBLE,
+  low_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  mid_cpu_temperature_avg DOUBLE,
+  mid_cpu_temperature_max DOUBLE,
+  mid_cpu_temperature_min DOUBLE,
+  mid_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  high_cpu_temperature_avg DOUBLE,
+  high_cpu_temperature_max DOUBLE,
+  high_cpu_temperature_min DOUBLE,
+  high_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  coverage_minutes BIGINT NOT NULL,
+  cpu_power_avg DOUBLE,
+  cpu_power_max DOUBLE,
+  cpu_power_min DOUBLE,
+  power_sample_minutes BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE cooling_baseline (
+  id BIGINT PRIMARY KEY CHECK (id = 1),
+  window_start_date VARCHAR NOT NULL,
+  window_end_date VARCHAR NOT NULL,
+  idle_temperature_avg DOUBLE NOT NULL,
+  sample_minutes BIGINT NOT NULL,
+  established_at VARCHAR NOT NULL
+);
+
+CREATE TABLE cooling_hourly_summary (
+  hour_start VARCHAR PRIMARY KEY,
+  cpu_usage_avg DOUBLE,
+  cpu_temperature_avg DOUBLE,
+  sample_minutes BIGINT NOT NULL
+);
+
+CREATE TABLE AMBIENT_ARCHIVE (
+  id BIGINT PRIMARY KEY,
+  source VARCHAR NOT NULL,
+  temperature DOUBLE NOT NULL,
+  humidity DOUBLE,
+  timestamp VARCHAR NOT NULL,
+  __hv_timestamp_epoch_ms BIGINT
+);
+
+CREATE TABLE FAN_ARCHIVE (
+  id BIGINT PRIMARY KEY,
+  source VARCHAR NOT NULL,
+  rpm BIGINT NOT NULL,
+  timestamp VARCHAR NOT NULL,
+  __hv_timestamp_epoch_ms BIGINT
+);
+
+CREATE TABLE cooling_fan_daily_summary (
+  date VARCHAR NOT NULL,
+  source VARCHAR NOT NULL,
+  rpm_avg DOUBLE NOT NULL,
+  rpm_max BIGINT NOT NULL,
+  rpm_min BIGINT NOT NULL,
+  sample_minutes BIGINT NOT NULL,
+  PRIMARY KEY (date, source)
+);
+
+CREATE TABLE cooling_delta_baseline (
+  id BIGINT PRIMARY KEY CHECK (id = 1),
+  source VARCHAR NOT NULL,
+  window_start_date VARCHAR NOT NULL,
+  window_end_date VARCHAR NOT NULL,
+  delta_temperature_avg DOUBLE NOT NULL,
+  sample_minutes BIGINT NOT NULL,
+  established_at VARCHAR NOT NULL
+);
+
+CREATE TABLE cooling_thermal_delta_daily_summary (
+  date VARCHAR NOT NULL,
+  source VARCHAR NOT NULL,
+  coverage_minutes BIGINT NOT NULL,
+  idle_delta_temperature_avg DOUBLE,
+  idle_delta_temperature_max DOUBLE,
+  idle_delta_temperature_min DOUBLE,
+  idle_delta_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  low_delta_temperature_avg DOUBLE,
+  low_delta_temperature_max DOUBLE,
+  low_delta_temperature_min DOUBLE,
+  low_delta_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  mid_delta_temperature_avg DOUBLE,
+  mid_delta_temperature_max DOUBLE,
+  mid_delta_temperature_min DOUBLE,
+  mid_delta_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  high_delta_temperature_avg DOUBLE,
+  high_delta_temperature_max DOUBLE,
+  high_delta_temperature_min DOUBLE,
+  high_delta_sample_minutes BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (date, source)
+);
+
+CREATE TABLE cooling_covariate_daily_summary (
+  date VARCHAR NOT NULL,
+  source VARCHAR NOT NULL,
+  band VARCHAR NOT NULL,
+  sample_minutes BIGINT NOT NULL,
+  band_share DOUBLE NOT NULL,
+  ambient_temperature_median DOUBLE NOT NULL,
+  delta_minutes BIGINT NOT NULL DEFAULT 0,
+  delta_temperature_median DOUBLE,
+  power_minutes BIGINT NOT NULL DEFAULT 0,
+  cpu_power_median DOUBLE,
+  power_fit_n BIGINT NOT NULL DEFAULT 0,
+  power_fit_sum_x DOUBLE NOT NULL DEFAULT 0,
+  power_fit_sum_y DOUBLE NOT NULL DEFAULT 0,
+  power_fit_sum_xy DOUBLE NOT NULL DEFAULT 0,
+  power_fit_sum_xx DOUBLE NOT NULL DEFAULT 0,
+  power_fit_sum_yy DOUBLE NOT NULL DEFAULT 0,
+  PRIMARY KEY (date, source, band)
+);
+
+CREATE TABLE cooling_fan_covariate_daily_summary (
+  date VARCHAR NOT NULL,
+  source VARCHAR NOT NULL,
+  fan_source VARCHAR NOT NULL,
+  band VARCHAR NOT NULL,
+  rpm_minutes BIGINT NOT NULL,
+  rpm_median DOUBLE NOT NULL,
+  fit_n BIGINT NOT NULL DEFAULT 0,
+  fit_sum_x DOUBLE NOT NULL DEFAULT 0,
+  fit_sum_y DOUBLE NOT NULL DEFAULT 0,
+  fit_sum_xy DOUBLE NOT NULL DEFAULT 0,
+  fit_sum_xx DOUBLE NOT NULL DEFAULT 0,
+  fit_sum_yy DOUBLE NOT NULL DEFAULT 0,
+  PRIMARY KEY (date, source, fan_source, band)
+);
+"#;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn stable_schema_names_every_current_domain_table_once() {
+    assert_eq!(TABLES.len(), 15);
+    for table in TABLES {
+      assert_eq!(
+        NATIVE_SCHEMA_SQL
+          .matches(&format!("CREATE TABLE {table} "))
+          .count(),
+        1,
+        "{table}"
+      );
+    }
+    assert_eq!(
+      NATIVE_SCHEMA_SQL.matches("CREATE TABLE ").count(),
+      TABLES.len()
+    );
+  }
+
+  #[test]
+  fn storage_devices_is_created_before_the_table_referencing_it() {
+    let parent = TABLES.iter().position(|t| *t == "storage_devices").unwrap();
+    let child = TABLES
+      .iter()
+      .position(|t| *t == "storage_health_daily_records")
+      .unwrap();
+    assert!(parent < child);
+  }
+
+  #[test]
+  fn only_writer_proven_mixed_measurements_use_tagged_unions() {
+    assert_eq!(
+      NATIVE_SCHEMA_SQL
+        .matches("UNION(i BIGINT, r DOUBLE)")
+        .count(),
+      10
+    );
+  }
+
+  #[test]
+  fn derived_epoch_columns_stay_nullable_so_an_unconvertible_stamp_reads_absent() {
+    assert_eq!(TIMESTAMPS.len(), 3);
+    assert_eq!(
+      NATIVE_SCHEMA_SQL
+        .matches("__hv_timestamp_epoch_ms BIGINT\n")
+        .count(),
+      3
+    );
+    assert!(!NATIVE_SCHEMA_SQL.contains("__hv_timestamp_epoch_ms BIGINT NOT NULL"));
+  }
+
+  #[test]
+  fn mutable_domain_keys_have_native_constraints() {
+    for constraint in [
+      "UNIQUE(device_id, date)",
+      "PRIMARY KEY (date, source)",
+      "PRIMARY KEY (date, source, band)",
+      "PRIMARY KEY (date, source, fan_source, band)",
+      "CHECK (id = 1)",
+    ] {
+      assert!(
+        NATIVE_SCHEMA_SQL.contains(constraint),
+        "missing {constraint}"
+      );
+    }
+  }
+
+  #[test]
+  fn every_identity_names_a_declared_table() {
+    assert_eq!(IDENTITIES.len(), 6);
+    for identity in IDENTITIES {
+      assert!(TABLES.contains(&identity.table), "{}", identity.table);
+    }
+    let autoincrement = IDENTITIES
+      .iter()
+      .filter(|identity| {
+        matches!(identity.mode, NativeIdentityMode::AutoIncrement { .. })
+      })
+      .count();
+    assert_eq!(autoincrement, 3);
+  }
+}


### PR DESCRIPTION
## Summary

First implementation slice of #2089, building on the #2088 candidate builder (#2091). Core can now turn an immutable candidate into a finalized native DuckDB file in the App-owned stable schema, open it through a bounded blocking owner, and run the Process Stats family against it. Nothing selects the result: SQLite stays authoritative and every native function runs beside, never instead of, its SQLite counterpart.

- **Finalization** (`core/src/infrastructure/database/native_database/finalize.rs`): copies every candidate table into the stable schema in bounded pages, refuses rather than coerces any cell the declared column cannot hold, refuses a candidate table the schema does not declare (so a schema definition that falls behind the migration set cannot silently drop history), imports AUTOINCREMENT high-water marks from the copied `sqlite_sequence`, records rowid-mode tables, writes `finalized_unselected` metadata, and publishes by hard link only after the closed file was reopened and its per-table row multiset digests matched. The candidate and the SQLite source are never modified.
- **Derived epoch keys** (`epoch.rs`): `__hv_timestamp_epoch_ms` is computed by running the production adapter `archive_queries::sqlite_epoch_milliseconds_of` in a scratch in-memory SQLite database, so the key is by construction what the current SQLite queries compute. Text SQLite cannot read stays NULL rather than becoming a guessed instant, which is why the derived columns are nullable even where the source `timestamp` is `NOT NULL`.
- **Native owner** (`runtime.rs`): two blocking lanes (read/write) over one DuckDB connection and its clone, bounded per-lane request capacity, one-shot cancellation backed by DuckDB's interrupt handle, pinned reader snapshots, lanes that stay healthy after a rolled-back write, `Closed` after close, and an identity allocator that reproduces SQLite's AUTOINCREMENT (never reuses a deleted highest id) and rowid (max+1) rules per table. The id contract is recorded on `next_id`.
- **Process Stats family** (`native_database/process_stats.rs`): `insert`, `delete_old_data`, `select_process_stats` reproduce the SQLite versions, including the byte-wise TEXT comparison SQLite applies to `timestamp BETWEEN`/`<` under NUMERIC affinity and the exact `to_rfc3339_opts(AutoSi, false)` bytes sqlx stores. `avg_memory_usage` is rebuilt in Rust from DuckDB's exact 128-bit `SUM` and `COUNT` rather than `AVG(BIGINT)`: DuckDB divides the integer sum as a `long double`, whose width differs between x86_64 Linux (80-bit) and aarch64 macOS / MSVC (64-bit), and the first CI run showed exactly that one-ulp split. SQLite's own integer `avg()` arithmetic (two binary64 conversions, one division) is bit-identical on every platform. A sum beyond `i64` is refused with a typed `IntegerSumOverflow` error naming the Process instead of returning a different number (SQLite's own result there is an order-dependent approximation).
- **App schema** (`src-tauri/src/infrastructure/database/native_schema.rs`): the 15 domain tables in stable DuckDB types, `UNION(i BIGINT, r DOUBLE)` for the 10 writer-proven mixed-storage-class measurement columns, derived epoch columns on `DATA_ARCHIVE`/`AMBIENT_ARCHIVE`/`FAN_ARCHIVE`, and the per-table identity modes. App owns this definition for the same reason it owns the ordered SQLite migration set; no App caller reads it until the cutover slice, so the file carries a documented `#![allow(dead_code)]`.
- **Design Doc**: records the measured boundaries this slice settled (timestamp adapter reuse; where DuckDB `AVG(DOUBLE)` stops matching SQLite's Kahan-Babuska-Neumaier `avg()`, beyond about 2^53 of cancellation, which the collector's `f32` `cpu_usage` cannot reach; and the platform-dependent `AVG(BIGINT)` that made the integer average move to Rust). Whether the binary64 residue needs an exact Rust-side aggregation is left open.

Not in this slice, by design: startup cutover, backend dispatch, reconciliation of live writes, selection/recovery (#2090), and the other query families (raw archives, Ambient, Fan, Cooling, Storage Health), which follow in later #2089 slices. Runtime behavior of the shipped application is unchanged.

This branch started from an uncommitted draft on `feat/duckdb-native-backend`; that draft was reviewed and completed here rather than merged.

## Related Issues

Part of #2089. Follows #2088 / #2091 and the direction selected in #2052 (ADR 0022). Startup selection and recovery remain #2090.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [x] Manual testing (real-database check below)
- [x] Unit tests

All native tests go through the real path: App's ordered SQLite migrations via Core's migrator, the #2088 candidate builder, finalization against App's own `get_native_schema()`, then the owner. Nothing hand-writes a native file.

- `core/tests/duckdb_native.rs` (15 tests): every domain table finalized with storage classes, ids and multiplicity preserved; derived epoch keys equal the SQLite expression including the stamps it refuses; AUTOINCREMENT high-water import and rowid recording; allocation after deleting the highest rows and reopening; existing destination, unrepresentable cell and undeclared candidate table refused without side effects; unfinalized/incompatible files refused; `Closed` after close; single-use cancellation; a long read interrupted while the same owner then serves another read and a write; a pinned reader snapshot across a committing write; a failed write rolling back with the owner healthy; bounded request capacity; zero capacity refused.
- `core/tests/duckdb_avg_compatibility.rs` (3 tests): the native query's arithmetic (DuckDB `AVG(DOUBLE)` for `cpu_usage`, exact `SUM`/`COUNT` for `memory_usage`) equals SQLite's `avg()` bit-for-bit for archive-magnitude Process values across three row orders and 1/2/4 threads on 8,193-row (vector-crossing) fixtures, including an integer group whose sum passes 2^53; the measured divergence boundary beyond about 2^53 of cancellation; and the Process Stats family end to end, where the same fixture goes through the production SQLite writer/query and the native path and results are compared bit-for-bit across eight ranges (inclusive endpoints, one-stamp range, just-inside-fractional exclusion, offset/`Z` spellings, empty range, cpu-desc ordering), an `i64::MAX` memory value, an embedded NUL in a process name, and a Retention Period delete that bisects clock-relative rows on both sides.
- `epoch.rs` and `native_schema.rs` unit tests pin the adapter spellings and the schema's table/UNION/constraint inventory.

Local validation on macOS arm64 with the pinned toolchain and locked bundled DuckDB 1.5.5:

- `cargo fmt --all -- --check` and `git diff --check`: pass.
- `cargo clippy -p hardviz-core --features duckdb-archive --all-targets --locked --offline -- -D warnings`: pass.
- `cargo clippy -p hardviz-core --all-targets --locked --offline -- -D warnings` (feature off): pass.
- `cargo clippy -p hardware_visualizer --features duckdb-archive --all-targets --locked --offline -- -D warnings`: pass.
- `cargo test -p hardviz-core --features duckdb-archive --locked --offline -- --test-threads=1`: 882 passed, 0 failed (755 lib, 50 `duckdb_native`, 38 `duckdb_avg_compatibility`, 37 `duckdb_candidate`, 2 `persistence_decoupling`).
- `cargo test -p hardware_visualizer --lib --features duckdb-archive --locked --offline -- --test-threads=1`: 304 passed, 0 failed.

The first CI run failed `duckdb_avg_matches_sqlite_for_archive_magnitude_process_values` on Ubuntu only (`i64-memory` group one ulp apart from SQLite) while macOS passed; that is the `long double` divergence above, fixed by the Rust-side integer average. The fixture also no longer overflows `i64`, which SQLite handles by switching to approximate summation and is outside the claim.

### Real-database check (2026-09-12, macOS arm64, release profile)

A `sqlite3 .backup` copy of the maintainer's production `hv-database.db` (22.2 MiB, migration v9 from the installed v1.9.x build, 170,802 `PROCESS_STATS` rows in 6,083 `(pid, process_name)` groups spanning 2026-08-07 to 2026-09-12) was run through a temporary, uncommitted probe: App migrations 10-23 applied exactly as startup does, then #2088 candidate, finalization against `get_native_schema()`, the native owner, and both query paths. Every comparison below is bit-for-bit (`f64::to_bits`) on `avg_cpu_usage` / `avg_memory_usage`, plus `total_execution_sec`, `latest_timestamp`, identity sets and the cpu-desc rank sequence.

- Finalization copied and reopen-verified all 5 populated tables (194,310 rows); `DATA_ARCHIVE.cpu_avg` holds the real mixed storage classes (218 integer / 11,533 real cells) as UNION members; 0 unconvertible timestamps; AUTOINCREMENT high-water imported as 353,979 for `PROCESS_STATS` (deleted history above the surviving 170,802 rows) and 25 for `storage_health_daily_records`; no work directory left behind.
- Process Stats queries matched on all 12 runs: whole range (6,083 groups), last 60 min, last 24 h, last 7 d, a range bounded by two stored microsecond spellings, and an empty range, each unordered and cpu-desc. Bounds were rendered the way the App commands render them (`SecondsFormat::Millis`, `Z`).
- A 14-day retention delete removed the same 61,813 rows on both sides (108,989 remaining) and the whole range still matched (3,311 groups). A native `insert` of one cycle read back identically through both paths with the microsecond `+00:00` stamp.
- Timings (release): candidate 4.5 s, finalization 3.4 s; whole-range query SQLite 131 ms vs native 7.8 ms, 7-day 45 ms vs 3.0 ms, while sub-day ranges are 0.2-1.4 ms on SQLite vs 1.5-2.4 ms native (per-query overhead). Files: SQLite 22.7 MiB, candidate 8.0 MiB, finalized 13.5 MiB (primary-key indexes, derived epoch columns and UNION storage on top of the candidate). Single run, not a benchmark.

CI: the Tauri clippy job now enables `duckdb-archive` so the App schema file is checked under `-D warnings`; the Tauri test jobs keep the default features because the schema's unit tests already run inside the Core test binary through the `#[path]` include.

## Review notes

- `duckdb_avg_diverges_from_sqlite_only_beyond_binary64_cancellation` deliberately asserts the measured divergence (`assert_ne!`) beyond 1e15, so it will fail if a DuckDB upgrade starts matching SQLite's compensated `avg()`. That is intended as a tripwire that forces the open aggregation question to be revisited; say if you would rather it only asserted the in-range equality.
- A legacy `DATETIME` cell stored as a number (NUMERIC affinity allows it) is refused by finalization because the stable column is `VARCHAR`. That is the refuse-don't-coerce policy; a repair path, if one is ever needed, belongs to the cutover slice.
- `sqlite_epoch_milliseconds_of` is restated in `core/tests/native_support/mod.rs` because the Core function is `pub(crate)`; the copy is commented as the pinned specification.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors
