### PR TITLE
feat(database): query the ambient, fan and cooling families natively

### DIFF
--- a/core/src/infrastructure/database/archive_queries.rs
+++ b/core/src/infrastructure/database/archive_queries.rs
@@ -206,10 +206,10 @@ pub struct ArchiveRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
-struct AggregatedArchiveBucket {
-  timestamp: i64,
-  value: Option<f64>,
-  value_count: i64,
+pub(crate) struct AggregatedArchiveBucket {
+  pub(crate) timestamp: i64,
+  pub(crate) value: Option<f64>,
+  pub(crate) value_count: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
@@ -430,11 +430,11 @@ pub struct AmbientArchiveSeries {
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
-struct AggregatedAmbientBucket {
-  timestamp: i64,
-  ambient_avg: Option<f64>,
-  delta_avg: Option<f64>,
-  minute_count: i64,
+pub(crate) struct AggregatedAmbientBucket {
+  pub(crate) timestamp: i64,
+  pub(crate) ambient_avg: Option<f64>,
+  pub(crate) delta_avg: Option<f64>,
+  pub(crate) minute_count: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
@@ -610,7 +610,7 @@ async fn select_gpu_archive_series_from_pool(
 }
 
 #[derive(Debug, Clone, Copy)]
-struct ArchiveSeriesBounds {
+pub(crate) struct ArchiveSeriesBounds {
   first: i64,
   last: i64,
   end: i64,
@@ -620,7 +620,7 @@ struct ArchiveSeriesBounds {
 }
 
 impl ArchiveSeriesBounds {
-  fn new(
+  pub(crate) fn new(
     start: &DateTime<Utc>,
     end: &DateTime<Utc>,
     width: i64,
@@ -782,7 +782,7 @@ fn gpu_archive_series_sql(
   )
 }
 
-fn fill_archive_series(
+pub(crate) fn fill_archive_series(
   rows: Vec<AggregatedArchiveBucket>,
   bounds: ArchiveSeriesBounds,
 ) -> Vec<ArchiveSeriesPoint> {
@@ -830,7 +830,7 @@ fn fill_archive_series(
 /// convention is deliberately identical: a bucket nobody recorded comes
 /// back absent on both readings, so the lane breaks where the other lanes
 /// break instead of drawing a line through air nobody measured.
-fn fill_ambient_archive_series(
+pub(crate) fn fill_ambient_archive_series(
   rows: Vec<AggregatedAmbientBucket>,
   bounds: ArchiveSeriesBounds,
 ) -> Vec<AmbientArchiveBucket> {

--- a/core/src/infrastructure/database/native_database/ambient_archive.rs
+++ b/core/src/infrastructure/database/native_database/ambient_archive.rs
@@ -1,0 +1,216 @@
+//! The `AMBIENT_ARCHIVE` family against a finalized native database.
+//!
+//! Runs beside [`crate::infrastructure::database::ambient_archive`] and the
+//! ambient lane of
+//! [`crate::infrastructure::database::archive_queries`], never instead of them:
+//! SQLite stays authoritative, and keeping both callable is what lets a test
+//! put one fixture through each path and compare the answers bit for bit.
+
+use chrono::{DateTime, Duration, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{AMBIENT_EPOCH_MS, DATA_EPOCH_MS, bucket_of_epoch, minute_key};
+use super::binding::{required_real, sqlite_real_binding};
+use super::process_stats::sqlite_timestamp_text;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use super::write_stamp::write_stamp;
+use crate::infrastructure::database::archive_queries::{
+  AggregatedAmbientBucket, AmbientArchiveSeries, ArchiveBucketTimestamp,
+  ArchiveSeriesBounds, fill_ambient_archive_series,
+};
+use crate::persistence::archive_data::AmbientData;
+
+const TABLE: &str = "AMBIENT_ARCHIVE";
+
+/// One archive minute's ambient rows, all stamped with the cycle's own
+/// `timestamp`, in a single transaction - the same boundary and the same shared
+/// instant as the SQLite writer.
+///
+/// A minute with no usable reading writes no row: nothing here fills a gap, and
+/// a NULL humidity stays NULL rather than becoming a measured 0%.
+pub async fn insert(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  rows: Vec<AmbientData>,
+  timestamp: DateTime<Utc>,
+) -> Result<(), NativeDatabaseError> {
+  if rows.is_empty() {
+    return Ok(());
+  }
+  let (timestamp_text, timestamp_epoch_ms) = write_stamp(timestamp).await?;
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let connection = transaction.connection();
+        let mut statement = connection
+          .prepare(
+            "INSERT INTO AMBIENT_ARCHIVE \
+             (id, source, temperature, humidity, timestamp, __hv_timestamp_epoch_ms) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("prepare the ambient archive insert", error)
+          })?;
+        for row in &rows {
+          transaction.check_cancelled()?;
+          let id = transaction.next_id(TABLE)?;
+          statement
+            .execute(params![
+              id,
+              row.source.as_str(),
+              required_real(TABLE, "temperature", f64::from(row.temperature))?,
+              row
+                .humidity
+                .and_then(|humidity| { sqlite_real_binding(f64::from(humidity)) }),
+              timestamp_text.as_str(),
+              timestamp_epoch_ms
+            ])
+            .map_err(|error| {
+              NativeDatabaseError::duckdb("insert an ambient archive row", error)
+            })?;
+        }
+        Ok(())
+      })
+    })
+    .await
+}
+
+/// Delete rows older than the Retention Period, returning how many went.
+///
+/// The same byte-wise rule as every other raw archive retention: SQLite
+/// compares the rendered bound against the stored text under the BINARY
+/// collation, and DuckDB's VARCHAR comparison is the same byte order.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+) -> Result<u64, NativeDatabaseError> {
+  let bound =
+    sqlite_timestamp_text(&(Utc::now() - Duration::days(i64::from(retention_days))));
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let deleted = transaction
+          .connection()
+          .execute(
+            "DELETE FROM AMBIENT_ARCHIVE WHERE timestamp < ?",
+            params![bound.as_str()],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired ambient archive rows", error)
+          })?;
+        Ok(deleted as u64)
+      })
+    })
+    .await
+}
+
+/// The native form of
+/// [`crate::infrastructure::database::archive_queries::select_ambient_archive_series`].
+///
+/// The pairing rule is structural here exactly as it is in SQLite: each side
+/// collapses to one value per minute *before* the `LEFT JOIN`, so a bucket ΔT
+/// is the mean of per-minute differences and never the difference of two
+/// independently aggregated means. `AVG` skips NULLs, so an ambient minute with
+/// no CPU temperature beside it still counts towards `ambient_avg` while
+/// dropping out of `delta_avg`.
+///
+/// The readings and the labels are read in one transaction for the same reason
+/// the SQLite query uses one: the lane reads `sources` as evidence that a
+/// sensor contributed to this window, and two independent reads could straddle
+/// an archive commit and report a label whose rows the bucket query never saw.
+pub async fn select_ambient_archive_series(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+  bucket_width_ms: i64,
+  bucket_timestamp: ArchiveBucketTimestamp,
+) -> Result<AmbientArchiveSeries, NativeDatabaseError> {
+  let bounds = ArchiveSeriesBounds::new(start, end, bucket_width_ms, bucket_timestamp)
+    .map_err(|source| NativeDatabaseError::ArchiveSeries { source })?;
+  let (start_ms, end_ms) = (start.timestamp_millis(), end.timestamp_millis());
+  let ambient_minute_key = minute_key(AMBIENT_EPOCH_MS);
+  let data_minute_key = minute_key(DATA_EPOCH_MS);
+  let bucket =
+    bucket_of_epoch(bucket_timestamp, "ambient.minute_epoch_ms", bucket_width_ms);
+  let buckets_sql = format!(
+    "WITH ambient AS (
+       SELECT {ambient_minute_key} AS minute_key,
+              MIN({AMBIENT_EPOCH_MS}) AS minute_epoch_ms,
+              AVG(CAST(AMBIENT_ARCHIVE.temperature AS DOUBLE)) AS ambient_value
+       FROM AMBIENT_ARCHIVE
+       WHERE {AMBIENT_EPOCH_MS} BETWEEN {start_ms} AND {end_ms}
+       GROUP BY minute_key
+     ),
+     cpu AS (
+       SELECT {data_minute_key} AS minute_key,
+              AVG(CAST(DATA_ARCHIVE.cpu_temperature_avg AS DOUBLE)) AS cpu_value
+       FROM DATA_ARCHIVE
+       WHERE {DATA_EPOCH_MS} BETWEEN {start_ms} AND {end_ms}
+         AND DATA_ARCHIVE.cpu_temperature_avg IS NOT NULL
+       GROUP BY minute_key
+     )
+     SELECT {bucket} AS timestamp,
+            AVG(ambient.ambient_value) AS ambient_avg,
+            AVG(cpu.cpu_value - ambient.ambient_value) AS delta_avg,
+            COUNT(ambient.ambient_value) AS minute_count
+     FROM ambient
+     LEFT JOIN cpu ON cpu.minute_key = ambient.minute_key
+     GROUP BY 1
+     ORDER BY 1 ASC"
+  );
+  let sources_sql = format!(
+    "SELECT DISTINCT source
+     FROM AMBIENT_ARCHIVE
+     WHERE {AMBIENT_EPOCH_MS} BETWEEN {start_ms} AND {end_ms}
+     ORDER BY source ASC"
+  );
+
+  database
+    .request_read(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let connection = transaction.connection();
+        let mut statement = connection.prepare(&buckets_sql).map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the ambient series query", error)
+        })?;
+        let rows = statement
+          .query_map([], |row| {
+            Ok(AggregatedAmbientBucket {
+              timestamp: row.get(0)?,
+              ambient_avg: row.get(1)?,
+              delta_avg: row.get(2)?,
+              minute_count: row.get(3)?,
+            })
+          })
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("run the ambient series query", error)
+          })?
+          .collect::<Result<Vec<_>, _>>()
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("decode an ambient series bucket", error)
+          })?;
+
+        transaction.check_cancelled()?;
+        let mut statement = connection.prepare(&sources_sql).map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the ambient source query", error)
+        })?;
+        let sources = statement
+          .query_map([], |row| row.get::<_, String>(0))
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("run the ambient source query", error)
+          })?
+          .collect::<Result<Vec<_>, _>>()
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("decode an ambient source label", error)
+          })?;
+
+        Ok(AmbientArchiveSeries {
+          sources,
+          buckets: fill_ambient_archive_series(rows, bounds),
+        })
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/archive_sql.rs
+++ b/core/src/infrastructure/database/native_database/archive_sql.rs
@@ -1,0 +1,172 @@
+//! SQL fragments that restate the SQLite archive rules against the finalized
+//! native schema.
+//!
+//! Three systematic differences, and nothing else:
+//!
+//! - **Epoch keys.** SQLite computes `strftime('%s', timestamp)` per row.
+//!   Finalization already ran that same adapter over every stored text and
+//!   stored the result in `__hv_timestamp_epoch_ms`, so the native queries read
+//!   the column instead of recomputing it. A text SQLite cannot read as an
+//!   instant left the column NULL, which drops the row from a range predicate
+//!   exactly as the NULL from `strftime` does.
+//! - **Integer division.** SQLite's `/` between integers truncates toward zero.
+//!   DuckDB's `/` returns a DOUBLE, and `//` is the truncating integer
+//!   division, so every minute key and bucket floor uses `//`.
+//! - **Tagged numeric columns.** `CAST(cpu_avg AS REAL)` reads a column that is
+//!   `UNION(i BIGINT, r DOUBLE)` natively, so the union member is extracted and
+//!   the integer member converted, which is what SQLite's CAST does.
+//!
+//! Bucket widths and epoch bounds are `i64` and are written into the statement
+//! text; only caller-supplied strings are bound as parameters.
+
+use chrono::NaiveDate;
+
+use crate::infrastructure::database::archive_queries::ArchiveBucketTimestamp;
+
+pub(super) const DATA_EPOCH_MS: &str = "DATA_ARCHIVE.__hv_timestamp_epoch_ms";
+pub(super) const AMBIENT_EPOCH_MS: &str = "AMBIENT_ARCHIVE.__hv_timestamp_epoch_ms";
+pub(super) const FAN_EPOCH_MS: &str = "FAN_ARCHIVE.__hv_timestamp_epoch_ms";
+
+/// `cooling_daily_summary::sqlite_minute_key` over a native epoch expression.
+pub(super) fn minute_key(epoch_milliseconds: &str) -> String {
+  format!("(({epoch_milliseconds}) // 60000)")
+}
+
+/// `archive_queries::bucket_of_epoch_sql` over a native epoch expression.
+pub(super) fn bucket_of_epoch(
+  bucket_timestamp: ArchiveBucketTimestamp,
+  epoch_milliseconds: &str,
+  width: i64,
+) -> String {
+  match bucket_timestamp {
+    ArchiveBucketTimestamp::Start => {
+      format!("(({epoch_milliseconds}) // {width}) * {width}")
+    }
+    ArchiveBucketTimestamp::End => {
+      format!("((({epoch_milliseconds}) + {width} - 1) // {width}) * {width}")
+    }
+  }
+}
+
+/// `CAST(<column> AS REAL)` against a `UNION(i BIGINT, r DOUBLE)` column.
+pub(super) fn union_real(column: &str) -> String {
+  format!(
+    "CASE union_tag({column}) \
+     WHEN 'i' THEN CAST(union_extract({column}, 'i') AS DOUBLE) \
+     ELSE union_extract({column}, 'r') END"
+  )
+}
+
+/// `strftime('%Y-%m-%dT%H:%M:%S', <text>, '<offset> minutes')` rebuilt from the
+/// derived epoch key.
+///
+/// The key already *is* what SQLite's date parser made of the stored text, so
+/// shifting it and formatting the result reproduces the modifier without
+/// parsing the text a second time. A NULL key formats to NULL, which is what
+/// `strftime` returns for a text it cannot read - so the bracket it guards
+/// excludes the row either way.
+pub(super) fn shifted_seconds_text(epoch_milliseconds: &str, offset_ms: i64) -> String {
+  format!(
+    "strftime(make_timestamp(CAST(({epoch_milliseconds}) + {offset_ms} AS BIGINT) * 1000), \
+     '%Y-%m-%dT%H:%M:%S')"
+  )
+}
+
+/// `cooling_daily_summary::preserving_delete_sql` with DuckDB's positional
+/// parameters. Pinned against the SQLite builder by
+/// `matches_the_sqlite_preserving_delete_rule`.
+pub(super) fn preserving_delete_sql(
+  table: &str,
+  column: &str,
+  window_count: usize,
+) -> String {
+  let mut sql = format!("DELETE FROM {table} WHERE {column} < ?");
+  for _ in 0..window_count {
+    sql.push_str(&format!(" AND NOT ({column} >= ? AND {column} <= ?)"));
+  }
+  sql
+}
+
+/// The local-date retention cutoff every cooling projection deletes against.
+pub(super) fn local_retention_cutoff(retention_days: u32) -> String {
+  (chrono::Local::now().date_naive() - chrono::Duration::days(i64::from(retention_days)))
+    .format("%Y-%m-%d")
+    .to_string()
+}
+
+/// The stored spelling of a calendar day, as every cooling writer formats it.
+pub(super) fn date_key(date: NaiveDate) -> String {
+  date.format("%Y-%m-%d").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::infrastructure::database::cooling_daily_summary;
+
+  /// The native builder differs from the SQLite one only in how a parameter is
+  /// spelled. Restating the clause shape would let the two drift apart
+  /// silently, so the shapes are compared instead.
+  #[test]
+  fn matches_the_sqlite_preserving_delete_rule() {
+    for windows in 0..3 {
+      let sqlite = cooling_daily_summary::preserving_delete_sql("t", "c", windows);
+      let mut expected = sqlite.clone();
+      for index in (1..=windows * 2 + 1).rev() {
+        expected = expected.replace(&format!("${index}"), "?");
+      }
+      assert_eq!(preserving_delete_sql("t", "c", windows), expected);
+    }
+  }
+
+  #[test]
+  fn integer_division_is_spelled_the_way_duckdb_truncates() {
+    assert_eq!(minute_key("e"), "((e) // 60000)");
+    assert_eq!(
+      bucket_of_epoch(ArchiveBucketTimestamp::Start, "e", 60000),
+      "((e) // 60000) * 60000"
+    );
+    assert_eq!(
+      bucket_of_epoch(ArchiveBucketTimestamp::End, "e", 60000),
+      "(((e) + 60000 - 1) // 60000) * 60000"
+    );
+  }
+
+  /// The reason every minute key and bucket floor is spelled `//`.
+  ///
+  /// SQLite's `/` between integers truncates toward zero; DuckDB's `/` is a
+  /// DOUBLE division and its `//` is the truncating one. The two agree on
+  /// every positive epoch, which is why the difference is invisible on a
+  /// fixture of present-day rows - so it is pinned here instead, over the
+  /// pre-epoch values where `//` and a floor division part company.
+  #[tokio::test]
+  async fn duckdb_integer_division_truncates_toward_zero_as_sqlite_does() {
+    use sqlx::{Connection, Row};
+
+    let cases: [i64; 6] = [-90_001, -60_000, -59_999, -1, 0, 90_001];
+    let duckdb = duckdb::Connection::open_in_memory().unwrap();
+    let mut sqlite = sqlx::sqlite::SqliteConnection::connect("sqlite::memory:")
+      .await
+      .unwrap();
+
+    for value in cases {
+      let native: i64 = duckdb
+        .query_row(
+          &format!("SELECT {}", minute_key(&value.to_string())),
+          [],
+          |row| row.get(0),
+        )
+        .unwrap();
+      let oracle: i64 = sqlx::query(&format!("SELECT ({value} / 60000)"))
+        .fetch_one(&mut sqlite)
+        .await
+        .unwrap()
+        .get(0);
+      assert_eq!(native, oracle, "minute key of {value}");
+    }
+    // And it is genuinely different from a floor division, so the choice is
+    // load-bearing rather than incidental.
+    assert_eq!((-59_999i64) / 60_000, 0);
+    assert_eq!((-59_999i64).div_euclid(60_000), -1);
+  }
+}

--- a/core/src/infrastructure/database/native_database/binding.rs
+++ b/core/src/infrastructure/database/native_database/binding.rs
@@ -1,0 +1,130 @@
+//! What a native writer may bind into a column SQLite would have written.
+//!
+//! SQLite has no NaN. `sqlite3VdbeMemSetDouble` stores a bound IEEE NaN as
+//! NULL, so every SQLite writer in this codebase silently turns a NaN reading
+//! into a gap - and the readers above them are built on that: `AVG` skips it,
+//! `MIN`/`MAX` ignore it, `COUNT(column)` does not count it, and a lane draws a
+//! break rather than a line. DuckDB has no such rule: a bound NaN is a
+//! perfectly good DOUBLE, and an archive written natively would start answering
+//! NaN where the same rows written through SQLite answer "no reading".
+//!
+//! That is a difference in *meaning*, not in formatting, so it is removed at
+//! the only place it can be: the bind. Measured, not assumed - SQLite's two
+//! behaviours are pinned by `binds_a_nan_the_way_sqlite_does` below, against
+//! sqlx itself:
+//!
+//! - into a nullable REAL column, a bound NaN reads back as `typeof() = 'null'`;
+//! - into a `NOT NULL` REAL column, the insert *fails* with
+//!   `SQLITE_CONSTRAINT_NOTNULL` rather than storing anything.
+//!
+//! Only NaN is special. `±Infinity` is stored as a real value by both engines
+//! and is deliberately left alone: it is an out-of-range reading, not an
+//! absent one, and turning it into a gap would be this module inventing a rule
+//! SQLite does not have.
+
+use super::NativeDatabaseError;
+
+/// The value a native writer binds where a SQLite writer would have bound
+/// `value` - `None` for NaN, because that is what SQLite stores.
+///
+/// Shared verbatim with the `DATA_ARCHIVE`/GPU lane so both families have one
+/// definition of "what SQLite does with a NaN".
+pub(super) fn sqlite_real_binding(value: f64) -> Option<f64> {
+  if value.is_nan() { None } else { Some(value) }
+}
+
+/// [`sqlite_real_binding`] for a column the stable schema declares `NOT NULL`.
+///
+/// SQLite refuses the row outright there, so a native writer must refuse it
+/// too - and must refuse it *before* the statement runs, so the caller is told
+/// which column carried the NaN instead of reading it out of a DuckDB
+/// constraint message. Storing the NaN instead would be the one outcome
+/// neither engine produces.
+pub(super) fn required_real(
+  table: &'static str,
+  column: &'static str,
+  value: f64,
+) -> Result<f64, NativeDatabaseError> {
+  sqlite_real_binding(value)
+    .ok_or(NativeDatabaseError::NotANumberInRequiredColumn { table, column })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use sqlx::{Connection, Row};
+
+  #[test]
+  fn only_nan_becomes_absent() {
+    assert_eq!(sqlite_real_binding(0.0), Some(0.0));
+    assert_eq!(sqlite_real_binding(-0.0), Some(-0.0));
+    assert_eq!(sqlite_real_binding(f64::INFINITY), Some(f64::INFINITY));
+    assert_eq!(
+      sqlite_real_binding(f64::NEG_INFINITY),
+      Some(f64::NEG_INFINITY)
+    );
+    assert_eq!(sqlite_real_binding(f64::NAN), None);
+    // A signalling NaN and a NaN that arrived by widening an `f32` are still
+    // NaN, and every reading in these families arrives as an `f32`.
+    assert_eq!(sqlite_real_binding(f64::from(f32::NAN)), None);
+    assert_eq!(sqlite_real_binding(-f64::NAN), None);
+
+    assert_eq!(required_real("T", "c", 1.5).unwrap(), 1.5);
+    assert!(matches!(
+      required_real("T", "c", f64::NAN),
+      Err(NativeDatabaseError::NotANumberInRequiredColumn {
+        table: "T",
+        column: "c"
+      })
+    ));
+  }
+
+  /// The two SQLite behaviours this module exists to reproduce, measured
+  /// against sqlx rather than taken from the documentation.
+  #[tokio::test]
+  async fn binds_a_nan_the_way_sqlite_does() {
+    let mut sqlite = sqlx::sqlite::SqliteConnection::connect("sqlite::memory:")
+      .await
+      .unwrap();
+    sqlx::query("CREATE TABLE t (optional REAL, required REAL NOT NULL)")
+      .execute(&mut sqlite)
+      .await
+      .unwrap();
+
+    // A NaN in a nullable REAL column is stored as NULL, not as a NaN.
+    sqlx::query("INSERT INTO t (optional, required) VALUES (?, 1.0)")
+      .bind(f64::NAN)
+      .execute(&mut sqlite)
+      .await
+      .unwrap();
+    let row = sqlx::query("SELECT typeof(optional), COUNT(optional) FROM t")
+      .fetch_one(&mut sqlite)
+      .await
+      .unwrap();
+    assert_eq!(row.get::<String, _>(0), "null");
+    assert_eq!(row.get::<i64, _>(1), 0, "AVG and friends skip it");
+
+    // A NaN in a NOT NULL REAL column fails the insert.
+    let refused = sqlx::query("INSERT INTO t (optional, required) VALUES (1.0, ?)")
+      .bind(f64::NAN)
+      .execute(&mut sqlite)
+      .await;
+    assert!(
+      matches!(&refused, Err(sqlx::Error::Database(error))
+        if error.message().contains("NOT NULL constraint failed")),
+      "{refused:?}"
+    );
+
+    // Infinity is a value in both engines, which is why it is left alone.
+    sqlx::query("INSERT INTO t (optional, required) VALUES (?, 1.0)")
+      .bind(f64::INFINITY)
+      .execute(&mut sqlite)
+      .await
+      .unwrap();
+    let row = sqlx::query("SELECT typeof(optional) FROM t ORDER BY rowid DESC LIMIT 1")
+      .fetch_one(&mut sqlite)
+      .await
+      .unwrap();
+    assert_eq!(row.get::<String, _>(0), "real");
+  }
+}

--- a/core/src/infrastructure/database/native_database/cooling_baseline.rs
+++ b/core/src/infrastructure/database/native_database/cooling_baseline.rs
@@ -1,0 +1,100 @@
+//! The `cooling_baseline` single pinned row against a finalized native
+//! database.
+//!
+//! Runs beside [`crate::infrastructure::database::cooling_baseline`].
+//!
+//! Establishment is write-once. SQLite spells that `INSERT OR IGNORE` against
+//! the fixed `id = 1`; DuckDB spells it `ON CONFLICT DO NOTHING` against the
+//! same primary key, and the finalized schema carries the `CHECK (id = 1)` that
+//! keeps the table one row wide. Replacing the pinned value is exactly the
+//! drift this table exists to prevent, so a second establishment must change
+//! nothing - not even `established_at`.
+
+use chrono::{DateTime, Utc};
+use duckdb::{OptionalExt, params};
+
+use super::NativeDatabaseError;
+use super::archive_sql::date_key;
+use super::binding::required_real;
+use super::process_stats::sqlite_timestamp_text;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use super::stored_text;
+use crate::persistence::cooling_baseline::EstablishedBaseline;
+
+const TABLE: &str = "cooling_baseline";
+
+pub async fn select_established_baseline(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<EstablishedBaseline>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let row: Option<(String, String, f64, i64)> = context
+        .connection()
+        .query_row(
+          "SELECT window_start_date, window_end_date, idle_temperature_avg, sample_minutes
+           FROM cooling_baseline
+           WHERE id = 1",
+          [],
+          |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the pinned cooling baseline", error)
+        })?;
+      row
+        .map(|(start, end, idle_temperature_avg, sample_minutes)| {
+          Ok(EstablishedBaseline {
+            idle_temperature_avg: idle_temperature_avg as f32,
+            window_start_date: stored_text::date(TABLE, "window_start_date", &start)?,
+            window_end_date: stored_text::date(TABLE, "window_end_date", &end)?,
+            sample_minutes: stored_text::count(sample_minutes),
+          })
+        })
+        .transpose()
+    })
+    .await
+}
+
+pub async fn insert_established_baseline(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  baseline: &EstablishedBaseline,
+  established_at: DateTime<Utc>,
+) -> Result<(), NativeDatabaseError> {
+  let window_start = date_key(baseline.window_start_date);
+  let window_end = date_key(baseline.window_end_date);
+  let idle_temperature_avg = required_real(
+    TABLE,
+    "idle_temperature_avg",
+    f64::from(baseline.idle_temperature_avg),
+  )?;
+  let sample_minutes = i64::from(baseline.sample_minutes);
+  let established_at = sqlite_timestamp_text(&established_at);
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(
+            "INSERT INTO cooling_baseline
+               (id, window_start_date, window_end_date, idle_temperature_avg, sample_minutes, established_at)
+             VALUES (1, ?, ?, ?, ?, ?)
+             ON CONFLICT DO NOTHING",
+            params![
+              window_start.as_str(),
+              window_end.as_str(),
+              idle_temperature_avg,
+              sample_minutes,
+              established_at.as_str()
+            ],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("pin the cooling baseline", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_covariate_daily_summary.rs
+++ b/core/src/infrastructure/database/native_database/cooling_covariate_daily_summary.rs
@@ -1,0 +1,396 @@
+//! The `cooling_covariate_daily_summary` and
+//! `cooling_fan_covariate_daily_summary` projections against a finalized
+//! native database.
+//!
+//! Runs beside
+//! [`crate::infrastructure::database::cooling_covariate_daily_summary`].
+//!
+//! One module for both tables, as in SQLite: they are two shapes of one
+//! projection, folded from one read and written in one transaction, and
+//! nothing reads one without the other. The ambient source is on every row
+//! because which sensor the Thermal Delta was measured against is part of the
+//! fit, so a sensor change can never blend two placements into one row.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{date_key, local_retention_cutoff, preserving_delete_sql};
+use super::binding::{required_real, sqlite_real_binding};
+use super::cooling_thermal_delta_daily_summary::pairable_ambient_cursor;
+use super::runtime::{NativeCancellation, NativeDatabase, NativeTransactionContext};
+use super::stored_text;
+use crate::persistence::cooling_covariate_rollup::{
+  CovariateDailySummary, FanCovariateDailySummary, PairedFitStatistics,
+};
+
+const TABLE: &str = "cooling_covariate_daily_summary";
+const FAN_TABLE: &str = "cooling_fan_covariate_daily_summary";
+
+/// The hardware-side clause that makes a paired minute classifiable.
+const CLASSIFIABLE_PREDICATE: &str = "AND DATA_ARCHIVE.cpu_avg IS NOT NULL";
+
+/// `MAX(date)` - the co-variate projection's own catch-up cursor.
+///
+/// The fan table has no cursor of its own: a fan row needs a paired
+/// classifiable minute to sit beside, so it never exists on a day the band
+/// table has no row for.
+pub async fn max_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(
+          "SELECT MAX(date) FROM cooling_covariate_daily_summary",
+          [],
+          |row| row.get(0),
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest summarized co-variate day", error)
+        })?;
+      latest
+        .map(|text| stored_text::date(TABLE, "date", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The most recent ambient archive timestamp strictly before `before` whose
+/// minute also has a `DATA_ARCHIVE` row carrying a CPU usage reading.
+///
+/// The ΔT cursor narrowed by one more predicate, because this rollup's row
+/// gate is one step stricter: a paired minute with no usage reading has no
+/// band to be filed under and yields no row here, so counting it as evidence
+/// of a missed day would send the catch-up chasing a day it can never fill.
+pub async fn max_classifiable_pairable_ambient_archive_timestamp_before(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  before: &DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  pairable_ambient_cursor(
+    database,
+    cancellation,
+    before,
+    CLASSIFIABLE_PREDICATE,
+    "read the latest classifiable pairable ambient stamp",
+  )
+  .await
+}
+
+/// Every summarized source-band-day, oldest first and grouped by source then
+/// band within a day.
+pub async fn select_all_covariate_daily_summaries(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<CovariateDailySummary>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context
+        .connection()
+        .prepare(
+          "SELECT date, source, band, sample_minutes, band_share, ambient_temperature_median,
+             delta_minutes, delta_temperature_median, power_minutes, cpu_power_median,
+             power_fit_n, power_fit_sum_x, power_fit_sum_y, power_fit_sum_xy, power_fit_sum_xx, power_fit_sum_yy
+           FROM cooling_covariate_daily_summary
+           ORDER BY date ASC, source ASC, band ASC",
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the co-variate daily summary query", error)
+        })?;
+      let rows = statement
+        .query_map([], |row| {
+          let mut fit = [0f64; 5];
+          for (slot, column) in fit.iter_mut().zip([11, 12, 13, 14, 15]) {
+            *slot = row.get::<_, f64>(column)?;
+          }
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            [
+              row.get::<_, i64>(3)?,
+              row.get::<_, i64>(6)?,
+              row.get::<_, i64>(8)?,
+              row.get::<_, i64>(10)?,
+            ],
+            row.get::<_, f64>(4)?,
+            row.get::<_, f64>(5)?,
+            row.get::<_, Option<f64>>(7)?,
+            row.get::<_, Option<f64>>(9)?,
+            fit,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the co-variate daily summary query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a co-variate daily summary row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(
+          |(
+            date,
+            source,
+            band,
+            counts,
+            band_share,
+            ambient_temperature_median,
+            delta_temperature_median,
+            cpu_power_median,
+            fit,
+          )| {
+            Ok(CovariateDailySummary {
+              date: stored_text::date(TABLE, "date", &date)?,
+              source,
+              band: stored_text::band(TABLE, &band)?,
+              sample_minutes: stored_text::count(counts[0]),
+              band_share: band_share as f32,
+              ambient_temperature_median: ambient_temperature_median as f32,
+              delta_minutes: stored_text::count(counts[1]),
+              delta_temperature_median: delta_temperature_median
+                .map(|value| value as f32),
+              power_minutes: stored_text::count(counts[2]),
+              cpu_power_median: cpu_power_median.map(|value| value as f32),
+              delta_per_watt: PairedFitStatistics {
+                n: stored_text::count(counts[3]),
+                sum_x: fit[0],
+                sum_y: fit[1],
+                sum_xy: fit[2],
+                sum_xx: fit[3],
+                sum_yy: fit[4],
+              },
+            })
+          },
+        )
+        .collect()
+    })
+    .await
+}
+
+/// Every summarized fan row, oldest first and grouped by source, fan and band
+/// within a day.
+pub async fn select_all_fan_covariate_daily_summaries(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<FanCovariateDailySummary>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context
+        .connection()
+        .prepare(
+          "SELECT date, source, fan_source, band, rpm_minutes, rpm_median,
+             fit_n, fit_sum_x, fit_sum_y, fit_sum_xy, fit_sum_xx, fit_sum_yy
+           FROM cooling_fan_covariate_daily_summary
+           ORDER BY date ASC, source ASC, fan_source ASC, band ASC",
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb(
+            "prepare the fan co-variate daily summary query",
+            error,
+          )
+        })?;
+      let rows = statement
+        .query_map([], |row| {
+          let mut fit = [0f64; 5];
+          for (slot, column) in fit.iter_mut().zip([7, 8, 9, 10, 11]) {
+            *slot = row.get::<_, f64>(column)?;
+          }
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, f64>(5)?,
+            row.get::<_, i64>(6)?,
+            fit,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the fan co-variate daily summary query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a fan co-variate daily summary row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(
+          |(date, source, fan_source, band, rpm_minutes, rpm_median, fit_n, fit)| {
+            Ok(FanCovariateDailySummary {
+              date: stored_text::date(FAN_TABLE, "date", &date)?,
+              source,
+              fan_source,
+              band: stored_text::band(FAN_TABLE, &band)?,
+              rpm_minutes: stored_text::count(rpm_minutes),
+              rpm_median: rpm_median as f32,
+              delta_per_rpm: PairedFitStatistics {
+                n: stored_text::count(fit_n),
+                sum_x: fit[0],
+                sum_y: fit[1],
+                sum_xy: fit[2],
+                sum_xx: fit[3],
+                sum_yy: fit[4],
+              },
+            })
+          },
+        )
+        .collect()
+    })
+    .await
+}
+
+/// Upsert one source-band-day inside a caller's transaction.
+pub(super) fn upsert_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &CovariateDailySummary,
+) -> Result<(), NativeDatabaseError> {
+  let fit = &summary.delta_per_watt;
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_covariate_daily_summary (
+         date, source, band, sample_minutes, band_share, ambient_temperature_median,
+         delta_minutes, delta_temperature_median, power_minutes, cpu_power_median,
+         power_fit_n, power_fit_sum_x, power_fit_sum_y, power_fit_sum_xy, power_fit_sum_xx, power_fit_sum_yy
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (date, source, band) DO UPDATE SET
+         sample_minutes = excluded.sample_minutes,
+         band_share = excluded.band_share,
+         ambient_temperature_median = excluded.ambient_temperature_median,
+         delta_minutes = excluded.delta_minutes,
+         delta_temperature_median = excluded.delta_temperature_median,
+         power_minutes = excluded.power_minutes,
+         cpu_power_median = excluded.cpu_power_median,
+         power_fit_n = excluded.power_fit_n,
+         power_fit_sum_x = excluded.power_fit_sum_x,
+         power_fit_sum_y = excluded.power_fit_sum_y,
+         power_fit_sum_xy = excluded.power_fit_sum_xy,
+         power_fit_sum_xx = excluded.power_fit_sum_xx,
+         power_fit_sum_yy = excluded.power_fit_sum_yy",
+      params![
+        date_key(summary.date),
+        summary.source.as_str(),
+        summary.band.column_key(),
+        i64::from(summary.sample_minutes),
+        required_real(TABLE, "band_share", f64::from(summary.band_share))?,
+        required_real(
+          TABLE,
+          "ambient_temperature_median",
+          f64::from(summary.ambient_temperature_median),
+        )?,
+        i64::from(summary.delta_minutes),
+        summary
+          .delta_temperature_median
+          .and_then(|reading| sqlite_real_binding(f64::from(reading))),
+        i64::from(summary.power_minutes),
+        summary
+          .cpu_power_median
+          .and_then(|reading| sqlite_real_binding(f64::from(reading))),
+        i64::from(fit.n),
+        required_real(TABLE, "power_fit_sum_x", fit.sum_x)?,
+        required_real(TABLE, "power_fit_sum_y", fit.sum_y)?,
+        required_real(TABLE, "power_fit_sum_xy", fit.sum_xy)?,
+        required_real(TABLE, "power_fit_sum_xx", fit.sum_xx)?,
+        required_real(TABLE, "power_fit_sum_yy", fit.sum_yy)?,
+      ],
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("upsert a co-variate daily summary", error)
+    })?;
+  Ok(())
+}
+
+/// Upsert one fan row inside a caller's transaction.
+pub(super) fn upsert_fan_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &FanCovariateDailySummary,
+) -> Result<(), NativeDatabaseError> {
+  let fit = &summary.delta_per_rpm;
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_fan_covariate_daily_summary (
+         date, source, fan_source, band, rpm_minutes, rpm_median,
+         fit_n, fit_sum_x, fit_sum_y, fit_sum_xy, fit_sum_xx, fit_sum_yy
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (date, source, fan_source, band) DO UPDATE SET
+         rpm_minutes = excluded.rpm_minutes,
+         rpm_median = excluded.rpm_median,
+         fit_n = excluded.fit_n,
+         fit_sum_x = excluded.fit_sum_x,
+         fit_sum_y = excluded.fit_sum_y,
+         fit_sum_xy = excluded.fit_sum_xy,
+         fit_sum_xx = excluded.fit_sum_xx,
+         fit_sum_yy = excluded.fit_sum_yy",
+      params![
+        date_key(summary.date),
+        summary.source.as_str(),
+        summary.fan_source.as_str(),
+        summary.band.column_key(),
+        i64::from(summary.rpm_minutes),
+        required_real(FAN_TABLE, "rpm_median", f64::from(summary.rpm_median))?,
+        i64::from(fit.n),
+        required_real(FAN_TABLE, "fit_sum_x", fit.sum_x)?,
+        required_real(FAN_TABLE, "fit_sum_y", fit.sum_y)?,
+        required_real(FAN_TABLE, "fit_sum_xy", fit.sum_xy)?,
+        required_real(FAN_TABLE, "fit_sum_xx", fit.sum_xx)?,
+        required_real(FAN_TABLE, "fit_sum_yy", fit.sum_yy)?,
+      ],
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("upsert a fan co-variate daily summary", error)
+    })?;
+  Ok(())
+}
+
+/// Delete rows of both tables older than `retention_days`, except those inside
+/// any of `preserved_windows` - the pinned ΔT baseline's calendar window, from
+/// which the co-variate comparison reads its baseline side.
+///
+/// Both tables go in one transaction: they are two shapes of one projection,
+/// and a cutoff applied to one but not the other would leave a band row whose
+/// fan rows had aged out from under it.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+  preserved_windows: &[(NaiveDate, NaiveDate)],
+) -> Result<(), NativeDatabaseError> {
+  let mut bounds = vec![local_retention_cutoff(retention_days)];
+  for (start, end) in preserved_windows {
+    bounds.push(date_key(*start));
+    bounds.push(date_key(*end));
+  }
+  let statements = [TABLE, FAN_TABLE]
+    .map(|table| preserving_delete_sql(table, "date", preserved_windows.len()));
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        for sql in &statements {
+          transaction.check_cancelled()?;
+          transaction
+            .connection()
+            .execute(sql, duckdb::params_from_iter(bounds.iter()))
+            .map_err(|error| {
+              NativeDatabaseError::duckdb(
+                "delete expired co-variate daily summaries",
+                error,
+              )
+            })?;
+        }
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_daily_summary.rs
+++ b/core/src/infrastructure/database/native_database/cooling_daily_summary.rs
@@ -1,0 +1,500 @@
+//! The `cooling_daily_summary` projection, and the `DATA_ARCHIVE` reads the
+//! cooling rollup folds it from, against a finalized native database.
+//!
+//! Runs beside [`crate::infrastructure::database::cooling_daily_summary`],
+//! never instead of it.
+//!
+//! Three differences from the SQLite module, all of them consequences of the
+//! finalized schema rather than choices:
+//!
+//! - **The raw-TEXT pre-filter is gone.** In SQLite the range reads carry a
+//!   widened `timestamp >= ?` bracket beside the exact predicate purely so the
+//!   timestamp index can be range-scanned; the computed `strftime` expression
+//!   cannot be. Natively the exact predicate *is* a stored column
+//!   (`__hv_timestamp_epoch_ms`), so there is nothing to hint around. Dropping
+//!   it cannot change which rows come back - the bracket was chosen to be
+//!   incapable of excluding a row the exact predicate keeps.
+//! - **`CAST(cpu_avg AS REAL)`** reads a `UNION(i BIGINT, r DOUBLE)` column
+//!   natively, so it goes through [`union_real`]. The temperature and power
+//!   columns are plain DOUBLE in the native schema and need no such handling.
+//! - **`date` is read back as text** and decoded with the same grammar the
+//!   sqlx reader uses ([`stored_text::date`]), because there is no sqlx codec
+//!   on this side to hand the cell to.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{
+  DATA_EPOCH_MS, date_key, local_retention_cutoff, preserving_delete_sql, union_real,
+};
+use super::binding::sqlite_real_binding;
+use super::runtime::{NativeCancellation, NativeDatabase, NativeTransactionContext};
+use super::stored_text;
+use crate::persistence::cooling_baseline::DailyIdleSample;
+use crate::persistence::cooling_rollup::{
+  ArchiveMinuteSample, BandSummary, DailyCoolingSummary, PowerSummary,
+};
+
+const TABLE: &str = "cooling_daily_summary";
+const ARCHIVE_TABLE: &str = "DATA_ARCHIVE";
+
+/// Every archived minute in `[start, end)`, oldest first, for the daily
+/// rollup's own pass.
+///
+/// The ambient side is deliberately not joined here, exactly as in SQLite: one
+/// per-minute ambient value averaged across sources would mix two sensor
+/// placements into a ΔT no sensor observed (#2062), so the Thermal Delta is
+/// folded per source from its own paired read.
+pub async fn select_archive_minutes_for_range(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+) -> Result<Vec<ArchiveMinuteSample>, NativeDatabaseError> {
+  let (start_ms, end_ms) = (start.timestamp_millis(), end.timestamp_millis());
+  let cpu_avg = union_real("DATA_ARCHIVE.cpu_avg");
+  let sql = format!(
+    "SELECT
+       DATA_ARCHIVE.timestamp,
+       {cpu_avg},
+       DATA_ARCHIVE.cpu_temperature_avg,
+       DATA_ARCHIVE.cpu_temperature_max,
+       DATA_ARCHIVE.cpu_temperature_min,
+       DATA_ARCHIVE.cpu_power_avg,
+       DATA_ARCHIVE.cpu_power_max,
+       DATA_ARCHIVE.cpu_power_min
+     FROM DATA_ARCHIVE
+     WHERE {DATA_EPOCH_MS} >= {start_ms} AND {DATA_EPOCH_MS} < {end_ms}
+     ORDER BY DATA_ARCHIVE.timestamp ASC"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the archive minute query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            [
+              row.get::<_, Option<f64>>(1)?,
+              row.get::<_, Option<f64>>(2)?,
+              row.get::<_, Option<f64>>(3)?,
+              row.get::<_, Option<f64>>(4)?,
+              row.get::<_, Option<f64>>(5)?,
+              row.get::<_, Option<f64>>(6)?,
+              row.get::<_, Option<f64>>(7)?,
+            ],
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the archive minute query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode an archive minute row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(|(timestamp, measurements)| {
+          let narrow = |index: usize| measurements[index].map(|value| value as f32);
+          Ok(ArchiveMinuteSample {
+            timestamp: stored_text::datetime(ARCHIVE_TABLE, "timestamp", &timestamp)?,
+            cpu_usage_avg: narrow(0),
+            cpu_temperature_avg: narrow(1),
+            cpu_temperature_max: narrow(2),
+            cpu_temperature_min: narrow(3),
+            cpu_power_avg: narrow(4),
+            cpu_power_max: narrow(5),
+            cpu_power_min: narrow(6),
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// The latest summarized day, or `None` when nothing has been summarized.
+pub async fn max_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  max_date_matching(
+    database,
+    cancellation,
+    "SELECT MAX(date) FROM cooling_daily_summary",
+    "read the latest summarized cooling day",
+  )
+  .await
+}
+
+/// The latest summarized day that recorded at least one minute carrying both
+/// a CPU usage and a CPU temperature reading - the equivalence the catch-up
+/// cursor rests on (see `cooling_rollup::rollup_catch_up_cursor`).
+pub async fn max_pairable_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  max_date_matching(
+    database,
+    cancellation,
+    "SELECT MAX(date) FROM cooling_daily_summary
+     WHERE idle_sample_minutes + low_sample_minutes
+         + mid_sample_minutes + high_sample_minutes > 0",
+    "read the latest pairable summarized cooling day",
+  )
+  .await
+}
+
+/// The latest summarized day that recorded any CPU package power (#2021).
+pub async fn max_powered_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  max_date_matching(
+    database,
+    cancellation,
+    "SELECT MAX(date) FROM cooling_daily_summary WHERE power_sample_minutes > 0",
+    "read the latest powered summarized cooling day",
+  )
+  .await
+}
+
+/// `MAX(date)` over `cooling_daily_summary`, decoded the way the SQLite reader
+/// decodes it. Shared by the three cursors above so one decoding rule covers
+/// all of them.
+async fn max_date_matching(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  sql: &'static str,
+  context_label: &'static str,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(sql, [], |row| row.get(0))
+        .map_err(|error| NativeDatabaseError::duckdb(context_label, error))?;
+      latest
+        .map(|text| stored_text::date(TABLE, "date", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The oldest archived instant, or `None` on an empty archive.
+///
+/// `MIN(timestamp)` over the stored text, a byte-wise minimum in both engines,
+/// then decoded - the same order the SQLite reader works in.
+pub async fn earliest_archived_timestamp(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let earliest: Option<String> = context
+        .connection()
+        .query_row("SELECT MIN(timestamp) FROM DATA_ARCHIVE", [], |row| {
+          row.get(0)
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the earliest archived timestamp", error)
+        })?;
+      earliest
+        .map(|text| stored_text::datetime(ARCHIVE_TABLE, "timestamp", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The most recent archived timestamp strictly before `before` whose row
+/// carries a full CPU package power triple (#2021).
+///
+/// All three columns are required, matching `summarize_day`'s own power gate:
+/// a partial triple contributes nothing there, so it must not count as power
+/// the rollup failed to pick up either.
+pub async fn max_powered_archive_timestamp_before(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  before: &DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  let before_ms = before.timestamp_millis();
+  let sql = format!(
+    "SELECT MAX(timestamp) FROM DATA_ARCHIVE
+     WHERE {DATA_EPOCH_MS} < {before_ms}
+       AND cpu_power_avg IS NOT NULL
+       AND cpu_power_max IS NOT NULL
+       AND cpu_power_min IS NOT NULL"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(&sql, [], |row| row.get(0))
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest powered archive stamp", error)
+        })?;
+      latest
+        .map(|text| stored_text::datetime(ARCHIVE_TABLE, "timestamp", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// Every summarized day's idle-band facts, oldest first, for the cooling
+/// baseline derivation. Reads the whole table for the same reason SQLite does:
+/// it holds at most one retention window of three narrow columns, and the
+/// baseline is defined over the *first* qualifying days.
+pub async fn select_daily_idle_samples(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<DailyIdleSample>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context
+        .connection()
+        .prepare(
+          "SELECT date, idle_cpu_temperature_avg, idle_sample_minutes
+           FROM cooling_daily_summary
+           ORDER BY date ASC",
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the daily idle sample query", error)
+        })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?,
+            row.get::<_, i64>(2)?,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the daily idle sample query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a daily idle sample row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(|(date, idle_temperature_avg, idle_sample_minutes)| {
+          Ok(DailyIdleSample {
+            date: stored_text::date(TABLE, "date", &date)?,
+            idle_temperature_avg: idle_temperature_avg.map(|value| value as f32),
+            idle_sample_minutes: stored_text::count(idle_sample_minutes),
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// The twenty-two columns of one summarized day, in the order both the read
+/// and the upsert use them.
+const COLUMNS: &str = "date,
+  idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+  low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+  mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+  high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+  coverage_minutes,
+  cpu_power_avg, cpu_power_max, cpu_power_min, power_sample_minutes";
+
+/// Every summarized day's full band breakdown, oldest first, for Cooling
+/// Insight's long-range trend and load-band comparison queries (#2017).
+pub async fn select_all_daily_cooling_summaries(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<DailyCoolingSummary>, NativeDatabaseError> {
+  let sql = format!("SELECT {COLUMNS} FROM cooling_daily_summary ORDER BY date ASC");
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the daily cooling summary query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          // The five measurement groups are `avg, max, min` triples at the
+          // column offsets below, each followed by its own count. Reading
+          // them by explicit index keeps the two arrays in the order the
+          // reconstruction below expects.
+          let mut readings = [None; 15];
+          for (slot, column) in readings
+            .iter_mut()
+            .zip([1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 18, 19, 20])
+          {
+            *slot = row.get::<_, Option<f64>>(column)?;
+          }
+          let mut counts = [0i64; 6];
+          for (slot, column) in counts.iter_mut().zip([4, 8, 12, 16, 17, 21]) {
+            *slot = row.get::<_, i64>(column)?;
+          }
+          Ok((row.get::<_, String>(0)?, readings, counts))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the daily cooling summary query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a daily cooling summary row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(|(date, readings, counts)| {
+          let narrow = |index: usize| readings[index].map(|value| value as f32);
+          let band = |first: usize, minutes: i64| BandSummary {
+            avg: narrow(first),
+            max: narrow(first + 1),
+            min: narrow(first + 2),
+            sample_minutes: stored_text::count(minutes),
+          };
+          Ok(DailyCoolingSummary {
+            date: stored_text::date(TABLE, "date", &date)?,
+            coverage_minutes: stored_text::count(counts[4]),
+            idle: band(0, counts[0]),
+            low: band(3, counts[1]),
+            mid: band(6, counts[2]),
+            high: band(9, counts[3]),
+            power: PowerSummary {
+              avg: narrow(12),
+              max: narrow(13),
+              min: narrow(14),
+              sample_minutes: stored_text::count(counts[5]),
+            },
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// Upsert one summarized day inside a caller's transaction, so a whole day's
+/// projections commit together (see [`super::cooling_rollup`]).
+pub(super) fn upsert_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &DailyCoolingSummary,
+) -> Result<(), NativeDatabaseError> {
+  let minutes = |band: &BandSummary| i64::from(band.sample_minutes);
+  // Every real column here is nullable, so a NaN reading becomes the gap
+  // SQLite would have stored rather than failing the day.
+  let value = |reading: Option<f32>| {
+    reading.and_then(|reading| sqlite_real_binding(f64::from(reading)))
+  };
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_daily_summary (
+         date,
+         idle_cpu_temperature_avg, idle_cpu_temperature_max, idle_cpu_temperature_min, idle_sample_minutes,
+         low_cpu_temperature_avg, low_cpu_temperature_max, low_cpu_temperature_min, low_sample_minutes,
+         mid_cpu_temperature_avg, mid_cpu_temperature_max, mid_cpu_temperature_min, mid_sample_minutes,
+         high_cpu_temperature_avg, high_cpu_temperature_max, high_cpu_temperature_min, high_sample_minutes,
+         coverage_minutes,
+         cpu_power_avg, cpu_power_max, cpu_power_min, power_sample_minutes
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (date) DO UPDATE SET
+         idle_cpu_temperature_avg = excluded.idle_cpu_temperature_avg,
+         idle_cpu_temperature_max = excluded.idle_cpu_temperature_max,
+         idle_cpu_temperature_min = excluded.idle_cpu_temperature_min,
+         idle_sample_minutes = excluded.idle_sample_minutes,
+         low_cpu_temperature_avg = excluded.low_cpu_temperature_avg,
+         low_cpu_temperature_max = excluded.low_cpu_temperature_max,
+         low_cpu_temperature_min = excluded.low_cpu_temperature_min,
+         low_sample_minutes = excluded.low_sample_minutes,
+         mid_cpu_temperature_avg = excluded.mid_cpu_temperature_avg,
+         mid_cpu_temperature_max = excluded.mid_cpu_temperature_max,
+         mid_cpu_temperature_min = excluded.mid_cpu_temperature_min,
+         mid_sample_minutes = excluded.mid_sample_minutes,
+         high_cpu_temperature_avg = excluded.high_cpu_temperature_avg,
+         high_cpu_temperature_max = excluded.high_cpu_temperature_max,
+         high_cpu_temperature_min = excluded.high_cpu_temperature_min,
+         high_sample_minutes = excluded.high_sample_minutes,
+         coverage_minutes = excluded.coverage_minutes,
+         cpu_power_avg = excluded.cpu_power_avg,
+         cpu_power_max = excluded.cpu_power_max,
+         cpu_power_min = excluded.cpu_power_min,
+         power_sample_minutes = excluded.power_sample_minutes",
+      params![
+        date_key(summary.date),
+        value(summary.idle.avg),
+        value(summary.idle.max),
+        value(summary.idle.min),
+        minutes(&summary.idle),
+        value(summary.low.avg),
+        value(summary.low.max),
+        value(summary.low.min),
+        minutes(&summary.low),
+        value(summary.mid.avg),
+        value(summary.mid.max),
+        value(summary.mid.min),
+        minutes(&summary.mid),
+        value(summary.high.avg),
+        value(summary.high.max),
+        value(summary.high.min),
+        minutes(&summary.high),
+        i64::from(summary.coverage_minutes),
+        value(summary.power.avg),
+        value(summary.power.max),
+        value(summary.power.min),
+        i64::from(summary.power.sample_minutes),
+      ],
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("upsert a daily cooling summary", error)
+    })?;
+  Ok(())
+}
+
+/// Upsert one summarized day on its own.
+pub async fn upsert(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  summary: DailyCoolingSummary,
+) -> Result<(), NativeDatabaseError> {
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| upsert_in(transaction, &summary))
+    })
+    .await
+}
+
+/// Delete rows older than `retention_days`, except those inside any of
+/// `preserved_windows` - the pinned absolute idle baseline's calendar window,
+/// exempt because deleting it would leave every baseline-side comparison
+/// permanently empty while the pinned baseline still names that period as the
+/// reference.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+  preserved_windows: &[(NaiveDate, NaiveDate)],
+) -> Result<(), NativeDatabaseError> {
+  let sql =
+    preserving_delete_sql("cooling_daily_summary", "date", preserved_windows.len());
+  let mut bounds = vec![local_retention_cutoff(retention_days)];
+  for (start, end) in preserved_windows {
+    bounds.push(date_key(*start));
+    bounds.push(date_key(*end));
+  }
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(&sql, duckdb::params_from_iter(bounds.iter()))
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired daily cooling summaries", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_delta_baseline.rs
+++ b/core/src/infrastructure/database/native_database/cooling_delta_baseline.rs
@@ -1,0 +1,101 @@
+//! The `cooling_delta_baseline` single pinned row against a finalized native
+//! database.
+//!
+//! Runs beside [`crate::infrastructure::database::cooling_delta_baseline`].
+//! Its own table rather than columns on `cooling_baseline`, because two
+//! baselines that establish at different times cannot share one write-once
+//! row - and the same write-once rule applies here.
+
+use chrono::{DateTime, Utc};
+use duckdb::{OptionalExt, params};
+
+use super::NativeDatabaseError;
+use super::archive_sql::date_key;
+use super::binding::required_real;
+use super::process_stats::sqlite_timestamp_text;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use super::stored_text;
+use crate::persistence::cooling_delta_baseline::EstablishedDeltaBaseline;
+
+const TABLE: &str = "cooling_delta_baseline";
+
+pub async fn select_established_delta_baseline(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<EstablishedDeltaBaseline>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let row: Option<(String, String, String, f64, i64)> = context
+        .connection()
+        .query_row(
+          "SELECT source, window_start_date, window_end_date, delta_temperature_avg, sample_minutes
+           FROM cooling_delta_baseline
+           WHERE id = 1",
+          [],
+          |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?))
+          },
+        )
+        .optional()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the pinned ΔT cooling baseline", error)
+        })?;
+      row
+        .map(|(source, start, end, delta_temperature_avg, sample_minutes)| {
+          Ok(EstablishedDeltaBaseline {
+            source,
+            delta_temperature_avg: delta_temperature_avg as f32,
+            window_start_date: stored_text::date(TABLE, "window_start_date", &start)?,
+            window_end_date: stored_text::date(TABLE, "window_end_date", &end)?,
+            sample_minutes: stored_text::count(sample_minutes),
+          })
+        })
+        .transpose()
+    })
+    .await
+}
+
+pub async fn insert_established_delta_baseline(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  baseline: &EstablishedDeltaBaseline,
+  established_at: DateTime<Utc>,
+) -> Result<(), NativeDatabaseError> {
+  let source = baseline.source.clone();
+  let window_start = date_key(baseline.window_start_date);
+  let window_end = date_key(baseline.window_end_date);
+  let delta_temperature_avg = required_real(
+    TABLE,
+    "delta_temperature_avg",
+    f64::from(baseline.delta_temperature_avg),
+  )?;
+  let sample_minutes = i64::from(baseline.sample_minutes);
+  let established_at = sqlite_timestamp_text(&established_at);
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(
+            "INSERT INTO cooling_delta_baseline
+               (id, source, window_start_date, window_end_date, delta_temperature_avg, sample_minutes, established_at)
+             VALUES (1, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT DO NOTHING",
+            params![
+              source.as_str(),
+              window_start.as_str(),
+              window_end.as_str(),
+              delta_temperature_avg,
+              sample_minutes,
+              established_at.as_str()
+            ],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("pin the ΔT cooling baseline", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_fan_daily_summary.rs
+++ b/core/src/infrastructure/database/native_database/cooling_fan_daily_summary.rs
@@ -1,0 +1,157 @@
+//! The `cooling_fan_daily_summary` projection against a finalized native
+//! database.
+//!
+//! Runs beside [`crate::infrastructure::database::cooling_fan_daily_summary`].
+//!
+//! Keyed by `(date, source)` rather than by `date` alone: how many fans a
+//! machine exposes is configuration-dependent, so each fan gets its own row and
+//! a fan with no reading that day is simply absent.
+
+use chrono::NaiveDate;
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{date_key, local_retention_cutoff};
+use super::binding::required_real;
+use super::runtime::{NativeCancellation, NativeDatabase, NativeTransactionContext};
+use super::stored_text;
+use crate::persistence::cooling_fan_rollup::FanDailySummary;
+
+const TABLE: &str = "cooling_fan_daily_summary";
+
+/// `MAX(date)` - the fan projection's own catch-up cursor.
+pub async fn max_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(
+          "SELECT MAX(date) FROM cooling_fan_daily_summary",
+          [],
+          |row| row.get(0),
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest summarized fan day", error)
+        })?;
+      latest
+        .map(|text| stored_text::date(TABLE, "date", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// Every summarized fan-day, oldest first and grouped by fan within a day.
+pub async fn select_all_fan_daily_summaries(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<FanDailySummary>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context
+        .connection()
+        .prepare(
+          "SELECT date, source, rpm_avg, rpm_max, rpm_min, sample_minutes
+           FROM cooling_fan_daily_summary
+           ORDER BY date ASC, source ASC",
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the fan daily summary query", error)
+        })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, f64>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the fan daily summary query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a fan daily summary row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(
+          |(date, source, rpm_avg, rpm_max, rpm_min, sample_minutes)| {
+            Ok(FanDailySummary {
+              date: stored_text::date(TABLE, "date", &date)?,
+              source,
+              rpm_avg: rpm_avg as f32,
+              rpm_max: stored_text::count(rpm_max),
+              rpm_min: stored_text::count(rpm_min),
+              sample_minutes: stored_text::count(sample_minutes),
+            })
+          },
+        )
+        .collect()
+    })
+    .await
+}
+
+/// Upsert one fan-day inside a caller's transaction.
+pub(super) fn upsert_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &FanDailySummary,
+) -> Result<(), NativeDatabaseError> {
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_fan_daily_summary
+         (date, source, rpm_avg, rpm_max, rpm_min, sample_minutes)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (date, source) DO UPDATE SET
+         rpm_avg = excluded.rpm_avg,
+         rpm_max = excluded.rpm_max,
+         rpm_min = excluded.rpm_min,
+         sample_minutes = excluded.sample_minutes",
+      params![
+        date_key(summary.date),
+        summary.source.as_str(),
+        required_real(TABLE, "rpm_avg", f64::from(summary.rpm_avg))?,
+        i64::from(summary.rpm_max),
+        i64::from(summary.rpm_min),
+        i64::from(summary.sample_minutes),
+      ],
+    )
+    .map_err(|error| NativeDatabaseError::duckdb("upsert a fan daily summary", error))?;
+  Ok(())
+}
+
+/// Delete rows older than `retention_days`.
+///
+/// No preserved window: no pinned baseline is derived from this table, so
+/// there is nothing here a comparison would keep reading past the cutoff.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+) -> Result<(), NativeDatabaseError> {
+  let cutoff = local_retention_cutoff(retention_days);
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(
+            "DELETE FROM cooling_fan_daily_summary WHERE date < ?",
+            params![cutoff.as_str()],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired fan daily summaries", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_hourly_summary.rs
+++ b/core/src/infrastructure/database/native_database/cooling_hourly_summary.rs
@@ -1,0 +1,200 @@
+//! The `cooling_hourly_summary` projection against a finalized native
+//! database.
+//!
+//! Runs beside [`crate::infrastructure::database::cooling_hourly_summary`].
+//!
+//! `hour_start` is the local wall-clock hour string `cooling_hourly_rollup`
+//! formats. Every comparison here is a byte-wise text comparison against it -
+//! the same rule in both engines - and a row whose `hour_start` is not in the
+//! stored format is dropped rather than failing the read, exactly as the
+//! sqlx reader's `filter_map` does: one hand-edited row must not take the
+//! Explorer's whole query with it.
+
+use chrono::NaiveDate;
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{date_key, local_retention_cutoff, preserving_delete_sql};
+use super::binding::sqlite_real_binding;
+use super::runtime::{NativeCancellation, NativeDatabase, NativeTransactionContext};
+use super::stored_text;
+use crate::persistence::cooling_hourly_rollup::{
+  HourlyCoolingSummary, format_hour_start, parse_hour_start,
+};
+
+/// Every hourly row whose local day falls in `[start_date, end_date]`
+/// (inclusive), oldest first.
+///
+/// Bounded rather than a whole-table read, as in SQLite: this table holds 24x
+/// the rows of the daily projection for the same retention window, and the
+/// Explorer only ever looks at two bounded windows.
+pub async fn select_hours_in_date_range(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start_date: NaiveDate,
+  end_date: NaiveDate,
+) -> Result<Vec<HourlyCoolingSummary>, NativeDatabaseError> {
+  // `>= "YYYY-MM-DD"` includes that day's 00:00 hour, and `<` the day after
+  // `end_date` includes its 23:00 hour - the half-open upper bound avoids a
+  // literal that would depend on the hour format's exact width.
+  let start = date_key(start_date);
+  let end = date_key(end_date + chrono::Duration::days(1));
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context
+        .connection()
+        .prepare(
+          "SELECT hour_start, cpu_usage_avg, cpu_temperature_avg, sample_minutes
+           FROM cooling_hourly_summary
+           WHERE hour_start >= ? AND hour_start < ?
+           ORDER BY hour_start ASC",
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("prepare the hourly cooling query", error)
+        })?;
+      let rows = statement
+        .query_map(params![start.as_str(), end.as_str()], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<f64>>(1)?,
+            row.get::<_, Option<f64>>(2)?,
+            row.get::<_, i64>(3)?,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the hourly cooling query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode an hourly cooling row", error)
+        })?;
+      Ok(
+        rows
+          .into_iter()
+          .filter_map(
+            |(hour_start, cpu_usage_avg, cpu_temperature_avg, minutes)| {
+              Some(HourlyCoolingSummary {
+                hour_start: parse_hour_start(&hour_start)?,
+                cpu_usage_avg: cpu_usage_avg.map(|value| value as f32),
+                cpu_temperature_avg: cpu_temperature_avg.map(|value| value as f32),
+                sample_minutes: stored_text::count(minutes),
+              })
+            },
+          )
+          .collect(),
+      )
+    })
+    .await
+}
+
+/// The local day of the most recent hourly row, or `None` when the table is
+/// empty - which is how the catch-up tells "hourly is behind" apart from
+/// "hourly has never run".
+pub async fn max_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(
+          "SELECT MAX(hour_start) FROM cooling_hourly_summary",
+          [],
+          |row| row.get(0),
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest summarized hour", error)
+        })?;
+      // An unparseable `MAX` reads as "no summarized day", the same answer
+      // the sqlx reader's `and_then` gives.
+      Ok(latest.and_then(|raw| parse_hour_start(&raw).map(|hour| hour.date())))
+    })
+    .await
+}
+
+/// Upsert one summarized hour inside a caller's transaction.
+pub(super) fn upsert_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &HourlyCoolingSummary,
+) -> Result<(), NativeDatabaseError> {
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_hourly_summary
+         (hour_start, cpu_usage_avg, cpu_temperature_avg, sample_minutes)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT (hour_start) DO UPDATE SET
+         cpu_usage_avg = excluded.cpu_usage_avg,
+         cpu_temperature_avg = excluded.cpu_temperature_avg,
+         sample_minutes = excluded.sample_minutes",
+      params![
+        format_hour_start(summary.hour_start),
+        summary
+          .cpu_usage_avg
+          .and_then(|reading| sqlite_real_binding(f64::from(reading))),
+        summary
+          .cpu_temperature_avg
+          .and_then(|reading| sqlite_real_binding(f64::from(reading))),
+        i64::from(summary.sample_minutes),
+      ],
+    )
+    .map_err(|error| {
+      NativeDatabaseError::duckdb("upsert an hourly cooling summary", error)
+    })?;
+  Ok(())
+}
+
+/// Upsert one summarized hour on its own.
+pub async fn upsert(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  summary: HourlyCoolingSummary,
+) -> Result<(), NativeDatabaseError> {
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| upsert_in(transaction, &summary))
+    })
+    .await
+}
+
+/// Delete rows older than `retention_days`, except those inside any of
+/// `preserved_windows`.
+///
+/// The same local-date cutoff the daily projection uses, so both tables age
+/// out on exactly the same boundary. Comparing an hour key against a bare date
+/// string is correct because every hour of a day sorts after that day's date
+/// string; the exemption's upper bound is suffixed past any hour a day can
+/// carry so `<= ?` still covers that day's 23:00 row.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+  preserved_windows: &[(NaiveDate, NaiveDate)],
+) -> Result<(), NativeDatabaseError> {
+  let sql = preserving_delete_sql(
+    "cooling_hourly_summary",
+    "hour_start",
+    preserved_windows.len(),
+  );
+  let mut bounds = vec![local_retention_cutoff(retention_days)];
+  for (start, end) in preserved_windows {
+    bounds.push(date_key(*start));
+    bounds.push(format!("{} 24", date_key(*end)));
+  }
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(&sql, duckdb::params_from_iter(bounds.iter()))
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired hourly cooling summaries", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_rollup.rs
+++ b/core/src/infrastructure/database/native_database/cooling_rollup.rs
@@ -1,0 +1,81 @@
+//! One rolled-up day's six cooling projections, written in a single native
+//! transaction.
+//!
+//! The native form of
+//! [`crate::persistence::cooling_rollup::persist_day_rollup_from_pool`], and
+//! atomic for exactly the same reason: a committed daily row with its hourly
+//! rows missing is a half-written state the catch-up cursor would have to
+//! repair, and it cannot tell that case apart from a day that legitimately had
+//! no pairs once the archive rows behind it age out. Failing the day as a whole
+//! leaves the cursor unmoved, so the next pass simply retries it.
+//!
+//! Six tables, one boundary: `cooling_daily_summary`,
+//! `cooling_hourly_summary`, `cooling_fan_daily_summary`,
+//! `cooling_thermal_delta_daily_summary`, `cooling_covariate_daily_summary`
+//! and `cooling_fan_covariate_daily_summary`. They are written in that order -
+//! the order the SQLite transaction uses - so a failure part-way leaves the
+//! same rollback either way and the two paths cannot diverge in what a
+//! partially applied day would have looked like.
+
+use super::NativeDatabaseError;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use super::{
+  cooling_covariate_daily_summary, cooling_daily_summary, cooling_fan_daily_summary,
+  cooling_hourly_summary, cooling_thermal_delta_daily_summary,
+};
+use crate::persistence::cooling_covariate_rollup::CovariateDaySummary;
+use crate::persistence::cooling_fan_rollup::FanDailySummary;
+use crate::persistence::cooling_hourly_rollup::HourlyCoolingSummary;
+use crate::persistence::cooling_rollup::DailyCoolingSummary;
+use crate::persistence::cooling_thermal_delta_rollup::ThermalDeltaDailySummary;
+
+/// Everything one rolled-up day writes, gathered so the six tables cross the
+/// transaction boundary together rather than as five loose argument lists.
+#[derive(Debug, Default)]
+pub struct DayRollup {
+  /// `None` for a day that produced no daily row at all - the other
+  /// projections may still have rows, and the day still commits.
+  pub summary: Option<DailyCoolingSummary>,
+  pub hours: Vec<HourlyCoolingSummary>,
+  pub fans: Vec<FanDailySummary>,
+  pub thermal_deltas: Vec<ThermalDeltaDailySummary>,
+  pub covariates: CovariateDaySummary,
+}
+
+/// Write one day's rollup projections in a single transaction.
+pub async fn persist_day_rollup(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  rollup: DayRollup,
+) -> Result<(), NativeDatabaseError> {
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        if let Some(summary) = &rollup.summary {
+          cooling_daily_summary::upsert_in(transaction, summary)?;
+        }
+        for hour in &rollup.hours {
+          transaction.check_cancelled()?;
+          cooling_hourly_summary::upsert_in(transaction, hour)?;
+        }
+        for fan in &rollup.fans {
+          transaction.check_cancelled()?;
+          cooling_fan_daily_summary::upsert_in(transaction, fan)?;
+        }
+        for thermal_delta in &rollup.thermal_deltas {
+          transaction.check_cancelled()?;
+          cooling_thermal_delta_daily_summary::upsert_in(transaction, thermal_delta)?;
+        }
+        for covariate in &rollup.covariates.bands {
+          transaction.check_cancelled()?;
+          cooling_covariate_daily_summary::upsert_in(transaction, covariate)?;
+        }
+        for covariate in &rollup.covariates.fans {
+          transaction.check_cancelled()?;
+          cooling_covariate_daily_summary::upsert_fan_in(transaction, covariate)?;
+        }
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/cooling_thermal_delta_daily_summary.rs
+++ b/core/src/infrastructure/database/native_database/cooling_thermal_delta_daily_summary.rs
@@ -1,0 +1,407 @@
+//! The `cooling_thermal_delta_daily_summary` projection, the paired-minute
+//! read the rollup folds it from, and the pairable-ambient cursor both it and
+//! the co-variate projection share - against a finalized native database.
+//!
+//! Runs beside
+//! [`crate::infrastructure::database::cooling_thermal_delta_daily_summary`].
+//!
+//! The pairing rule is structural here exactly as it is in SQLite: the ambient
+//! side is collapsed to one value per `(minute, source)` and then INNER JOINed
+//! on the minute, so every row is one archived minute beside one sensor's
+//! reading for that same minute. A minute with no ambient row for a source
+//! yields no row for that source, never an interpolated one - and nothing
+//! downstream can subtract two summaries built over different sample sets, or
+//! since #2062 over different sensors.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{
+  AMBIENT_EPOCH_MS, DATA_EPOCH_MS, date_key, local_retention_cutoff, minute_key,
+  preserving_delete_sql, shifted_seconds_text, union_real,
+};
+use super::binding::sqlite_real_binding;
+use super::runtime::{NativeCancellation, NativeDatabase, NativeTransactionContext};
+use super::stored_text;
+use crate::persistence::cooling_rollup::BandSummary;
+use crate::persistence::cooling_thermal_delta_rollup::{
+  ThermalDeltaDailySummary, ThermalDeltaMinuteSample,
+};
+
+const TABLE: &str = "cooling_thermal_delta_daily_summary";
+const ARCHIVE_TABLE: &str = "DATA_ARCHIVE";
+
+/// Every `(archived minute, ambient source)` pair inside `[start, end)`,
+/// oldest first and grouped by source within a minute.
+///
+/// The per-source `AVG` is a formality: the archive writer refuses a second
+/// row for a label it already wrote this minute, so the group is one row wide
+/// unless the database was edited by hand. What the `GROUP BY` must never do
+/// is average *across* sources, and it does not.
+pub async fn select_thermal_delta_minutes_for_range(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+) -> Result<Vec<ThermalDeltaMinuteSample>, NativeDatabaseError> {
+  let (start_ms, end_ms) = (start.timestamp_millis(), end.timestamp_millis());
+  let ambient_minute_key = minute_key(AMBIENT_EPOCH_MS);
+  let hardware_minute_key = minute_key(DATA_EPOCH_MS);
+  let cpu_avg = union_real("DATA_ARCHIVE.cpu_avg");
+  let sql = format!(
+    "SELECT
+       DATA_ARCHIVE.timestamp,
+       ambient.source,
+       ambient.ambient_temperature,
+       {cpu_avg},
+       DATA_ARCHIVE.cpu_temperature_avg,
+       DATA_ARCHIVE.cpu_temperature_max,
+       DATA_ARCHIVE.cpu_temperature_min,
+       DATA_ARCHIVE.cpu_power_avg
+     FROM DATA_ARCHIVE
+     JOIN (
+       SELECT {ambient_minute_key} AS ambient_minute_key,
+              AMBIENT_ARCHIVE.source AS source,
+              AVG(CAST(AMBIENT_ARCHIVE.temperature AS DOUBLE)) AS ambient_temperature
+       FROM AMBIENT_ARCHIVE
+       WHERE {AMBIENT_EPOCH_MS} >= {start_ms} AND {AMBIENT_EPOCH_MS} < {end_ms}
+       GROUP BY ambient_minute_key, AMBIENT_ARCHIVE.source
+     ) AS ambient ON ambient.ambient_minute_key = {hardware_minute_key}
+     WHERE {DATA_EPOCH_MS} >= {start_ms} AND {DATA_EPOCH_MS} < {end_ms}
+     ORDER BY DATA_ARCHIVE.timestamp ASC, ambient.source ASC"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the paired minute query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, f64>(2)?,
+            [
+              row.get::<_, Option<f64>>(3)?,
+              row.get::<_, Option<f64>>(4)?,
+              row.get::<_, Option<f64>>(5)?,
+              row.get::<_, Option<f64>>(6)?,
+              row.get::<_, Option<f64>>(7)?,
+            ],
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the paired minute query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a paired minute row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(|(timestamp, source, ambient_temperature, measurements)| {
+          let narrow = |index: usize| measurements[index].map(|value| value as f32);
+          Ok(ThermalDeltaMinuteSample {
+            timestamp: stored_text::datetime(ARCHIVE_TABLE, "timestamp", &timestamp)?,
+            source,
+            ambient_temperature: ambient_temperature as f32,
+            cpu_usage_avg: narrow(0),
+            cpu_temperature_avg: narrow(1),
+            cpu_temperature_max: narrow(2),
+            cpu_temperature_min: narrow(3),
+            cpu_power_avg: narrow(4),
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// `MAX(date)` - the Thermal Delta projection's own catch-up cursor. A row
+/// exists only for a `(day, source)` that paired at least one minute, so this
+/// is exactly the latest day that recorded any ambient coverage.
+pub async fn max_summarized_date(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Option<NaiveDate>, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(
+          "SELECT MAX(date) FROM cooling_thermal_delta_daily_summary",
+          [],
+          |row| row.get(0),
+        )
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest summarized ΔT day", error)
+        })?;
+      latest
+        .map(|text| stored_text::date(TABLE, "date", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The SQL behind [`max_pairable_ambient_archive_timestamp_before`]: the
+/// latest ambient archive timestamp before `before_ms` whose minute has a
+/// `DATA_ARCHIVE` row satisfying `hardware_predicate` - an extra `AND ...`
+/// clause on the hardware row, or empty. The co-variate rollup's cursor
+/// narrows the hardware side to classifiable minutes through it (#2068), so
+/// the two cursors share one pairing rule.
+///
+/// The two-minute text bracket inside the `EXISTS` is kept rather than
+/// dropped. In SQLite it exists to let the timestamp index be range-scanned,
+/// which a native stored key does not need - but it is also the only place
+/// where the SQLite answer is *approximate*, because it compares raw text
+/// across writers that may differ in offset suffix. Reproducing it keeps the
+/// native answer identical to the SQLite one on every database, including one
+/// edited by hand into mixed spellings, rather than merely on the ones a
+/// HardwareVisualizer writer produced. `strftime` over the derived key
+/// normalizes the ambient side to the same `%Y-%m-%dT%H:%M:%S` prefix SQLite's
+/// `strftime` does.
+pub(super) fn pairable_ambient_cursor_sql(
+  before_ms: i64,
+  hardware_predicate: &str,
+) -> String {
+  let ambient_minute_key = minute_key(AMBIENT_EPOCH_MS);
+  let hardware_minute_key = minute_key(DATA_EPOCH_MS);
+  let lower = shifted_seconds_text(AMBIENT_EPOCH_MS, -120_000);
+  let upper = shifted_seconds_text(AMBIENT_EPOCH_MS, 120_000);
+  format!(
+    "SELECT MAX(AMBIENT_ARCHIVE.timestamp) FROM AMBIENT_ARCHIVE
+     WHERE {AMBIENT_EPOCH_MS} < {before_ms}
+       AND EXISTS (
+         SELECT 1 FROM DATA_ARCHIVE
+         WHERE DATA_ARCHIVE.timestamp >= {lower}
+           AND DATA_ARCHIVE.timestamp <= {upper}
+           AND {hardware_minute_key} = {ambient_minute_key}
+           {hardware_predicate}
+       )"
+  )
+}
+
+/// Run one of the two pairable-ambient cursors and decode its answer.
+pub(super) async fn pairable_ambient_cursor(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  before: &DateTime<Utc>,
+  hardware_predicate: &'static str,
+  context_label: &'static str,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  let sql = pairable_ambient_cursor_sql(before.timestamp_millis(), hardware_predicate);
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(&sql, [], |row| row.get(0))
+        .map_err(|error| NativeDatabaseError::duckdb(context_label, error))?;
+      latest
+        .map(|text| stored_text::datetime("AMBIENT_ARCHIVE", "timestamp", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The most recent ambient archive timestamp strictly before `before` whose
+/// minute also has a `DATA_ARCHIVE` row (#2045).
+///
+/// `before` is the start of today in local time, so the answer only ever names
+/// a *completed* day: today's ambient rows are not evidence that a day was
+/// missed, and counting them would rewind the catch-up on every cycle forever.
+/// The `EXISTS` matches the rollup's own coverage gate - an ambient row whose
+/// minute has no hardware row can never become coverage however often the day
+/// is re-rolled.
+pub async fn max_pairable_ambient_archive_timestamp_before(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  before: &DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  pairable_ambient_cursor(
+    database,
+    cancellation,
+    before,
+    "",
+    "read the latest pairable ambient stamp",
+  )
+  .await
+}
+
+/// The nineteen columns of one summarized source-day.
+const COLUMNS: &str = "date, source, coverage_minutes,
+  idle_delta_temperature_avg, idle_delta_temperature_max, idle_delta_temperature_min, idle_delta_sample_minutes,
+  low_delta_temperature_avg, low_delta_temperature_max, low_delta_temperature_min, low_delta_sample_minutes,
+  mid_delta_temperature_avg, mid_delta_temperature_max, mid_delta_temperature_min, mid_delta_sample_minutes,
+  high_delta_temperature_avg, high_delta_temperature_max, high_delta_temperature_min, high_delta_sample_minutes";
+
+/// Every summarized source-day, oldest first and grouped by source within a
+/// day.
+pub async fn select_all_thermal_delta_daily_summaries(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<Vec<ThermalDeltaDailySummary>, NativeDatabaseError> {
+  let sql = format!(
+    "SELECT {COLUMNS} FROM cooling_thermal_delta_daily_summary
+     ORDER BY date ASC, source ASC"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the ΔT daily summary query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          // Four `avg, max, min` triples, each followed by its own count,
+          // starting at column 3.
+          let mut readings = [None; 12];
+          for (slot, column) in readings
+            .iter_mut()
+            .zip([3, 4, 5, 7, 8, 9, 11, 12, 13, 15, 16, 17])
+          {
+            *slot = row.get::<_, Option<f64>>(column)?;
+          }
+          let mut counts = [0i64; 4];
+          for (slot, column) in counts.iter_mut().zip([6, 10, 14, 18]) {
+            *slot = row.get::<_, i64>(column)?;
+          }
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            readings,
+            counts,
+          ))
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("run the ΔT daily summary query", error)
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a ΔT daily summary row", error)
+        })?;
+      rows
+        .into_iter()
+        .map(|(date, source, coverage_minutes, readings, counts)| {
+          let narrow = |index: usize| readings[index].map(|value| value as f32);
+          let band = |first: usize, minutes: i64| BandSummary {
+            avg: narrow(first),
+            max: narrow(first + 1),
+            min: narrow(first + 2),
+            sample_minutes: stored_text::count(minutes),
+          };
+          Ok(ThermalDeltaDailySummary {
+            date: stored_text::date(TABLE, "date", &date)?,
+            source,
+            coverage_minutes: stored_text::count(coverage_minutes),
+            idle: band(0, counts[0]),
+            low: band(3, counts[1]),
+            mid: band(6, counts[2]),
+            high: band(9, counts[3]),
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// Upsert one source-day inside a caller's transaction.
+pub(super) fn upsert_in(
+  transaction: &NativeTransactionContext<'_, '_>,
+  summary: &ThermalDeltaDailySummary,
+) -> Result<(), NativeDatabaseError> {
+  let minutes = |band: &BandSummary| i64::from(band.sample_minutes);
+  let value = |reading: Option<f32>| {
+    reading.and_then(|reading| sqlite_real_binding(f64::from(reading)))
+  };
+  transaction
+    .connection()
+    .execute(
+      "INSERT INTO cooling_thermal_delta_daily_summary (
+         date, source, coverage_minutes,
+         idle_delta_temperature_avg, idle_delta_temperature_max, idle_delta_temperature_min, idle_delta_sample_minutes,
+         low_delta_temperature_avg, low_delta_temperature_max, low_delta_temperature_min, low_delta_sample_minutes,
+         mid_delta_temperature_avg, mid_delta_temperature_max, mid_delta_temperature_min, mid_delta_sample_minutes,
+         high_delta_temperature_avg, high_delta_temperature_max, high_delta_temperature_min, high_delta_sample_minutes
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (date, source) DO UPDATE SET
+         coverage_minutes = excluded.coverage_minutes,
+         idle_delta_temperature_avg = excluded.idle_delta_temperature_avg,
+         idle_delta_temperature_max = excluded.idle_delta_temperature_max,
+         idle_delta_temperature_min = excluded.idle_delta_temperature_min,
+         idle_delta_sample_minutes = excluded.idle_delta_sample_minutes,
+         low_delta_temperature_avg = excluded.low_delta_temperature_avg,
+         low_delta_temperature_max = excluded.low_delta_temperature_max,
+         low_delta_temperature_min = excluded.low_delta_temperature_min,
+         low_delta_sample_minutes = excluded.low_delta_sample_minutes,
+         mid_delta_temperature_avg = excluded.mid_delta_temperature_avg,
+         mid_delta_temperature_max = excluded.mid_delta_temperature_max,
+         mid_delta_temperature_min = excluded.mid_delta_temperature_min,
+         mid_delta_sample_minutes = excluded.mid_delta_sample_minutes,
+         high_delta_temperature_avg = excluded.high_delta_temperature_avg,
+         high_delta_temperature_max = excluded.high_delta_temperature_max,
+         high_delta_temperature_min = excluded.high_delta_temperature_min,
+         high_delta_sample_minutes = excluded.high_delta_sample_minutes",
+      params![
+        date_key(summary.date),
+        summary.source.as_str(),
+        i64::from(summary.coverage_minutes),
+        value(summary.idle.avg),
+        value(summary.idle.max),
+        value(summary.idle.min),
+        minutes(&summary.idle),
+        value(summary.low.avg),
+        value(summary.low.max),
+        value(summary.low.min),
+        minutes(&summary.low),
+        value(summary.mid.avg),
+        value(summary.mid.max),
+        value(summary.mid.min),
+        minutes(&summary.mid),
+        value(summary.high.avg),
+        value(summary.high.max),
+        value(summary.high.min),
+        minutes(&summary.high),
+      ],
+    )
+    .map_err(|error| NativeDatabaseError::duckdb("upsert a ΔT daily summary", error))?;
+  Ok(())
+}
+
+/// Delete rows older than `retention_days`, except those inside any of
+/// `preserved_windows` - the pinned ΔT baseline's calendar window.
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+  preserved_windows: &[(NaiveDate, NaiveDate)],
+) -> Result<(), NativeDatabaseError> {
+  let sql = preserving_delete_sql(
+    "cooling_thermal_delta_daily_summary",
+    "date",
+    preserved_windows.len(),
+  );
+  let mut bounds = vec![local_retention_cutoff(retention_days)];
+  for (start, end) in preserved_windows {
+    bounds.push(date_key(*start));
+    bounds.push(date_key(*end));
+  }
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        transaction
+          .connection()
+          .execute(&sql, duckdb::params_from_iter(bounds.iter()))
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired ΔT daily summaries", error)
+          })?;
+        Ok(())
+      })
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/error.rs
+++ b/core/src/infrastructure/database/native_database/error.rs
@@ -45,6 +45,13 @@ pub enum NativeDatabaseError {
     destination: String,
   },
   #[error(
+    "{table}.{column} is NOT NULL and the reading is NaN, which SQLite refuses to store"
+  )]
+  NotANumberInRequiredColumn {
+    table: &'static str,
+    column: &'static str,
+  },
+  #[error(
     "NULL in required native column {table}.{column} at source row ordinal {row_ordinal}"
   )]
   NullInRequiredColumn {
@@ -61,6 +68,20 @@ pub enum NativeDatabaseError {
     column: &'static str,
     pid: i64,
     process_name: String,
+  },
+  #[error(
+    "stored {kind} in {table}.{column} is not a value the SQLite reader decodes: {value:?}"
+  )]
+  UndecodableStoredValue {
+    table: &'static str,
+    column: &'static str,
+    kind: &'static str,
+    value: String,
+  },
+  #[error("native archive series request is not answerable: {source}")]
+  ArchiveSeries {
+    #[source]
+    source: crate::infrastructure::database::archive_queries::ArchiveSeriesError,
   },
   #[error("native database finalization failed during {context}: {message}")]
   Finalization { context: String, message: String },

--- a/core/src/infrastructure/database/native_database/fan_archive.rs
+++ b/core/src/infrastructure/database/native_database/fan_archive.rs
@@ -1,0 +1,276 @@
+//! The `FAN_ARCHIVE` family against a finalized native database.
+//!
+//! Runs beside [`crate::infrastructure::database::fan_archive`] and the fan
+//! lane of [`crate::infrastructure::database::archive_queries`], never instead
+//! of them.
+//!
+//! Row-per-fan, exactly as in SQLite: only a fan that reported an archivable
+//! reading gets a row, and a real 0 RPM Inactive Fan Reading is stored as the
+//! observation it is rather than treated as a gap.
+
+use chrono::{DateTime, Duration, Utc};
+use duckdb::params;
+
+use super::NativeDatabaseError;
+use super::archive_sql::{FAN_EPOCH_MS, bucket_of_epoch};
+use super::process_stats::sqlite_timestamp_text;
+use super::runtime::{NativeCancellation, NativeDatabase};
+use super::stored_text;
+use super::write_stamp::write_stamp;
+use crate::infrastructure::database::archive_queries::{
+  AggregatedArchiveBucket, ArchiveBucketTimestamp, ArchiveSeriesBounds, FanArchiveSeries,
+  fill_archive_series,
+};
+use crate::persistence::archive_data::FanArchiveRow;
+use crate::persistence::cooling_fan_rollup::FanArchiveMinuteSample;
+
+const TABLE: &str = "FAN_ARCHIVE";
+
+/// Write one archive interval's fan rows, all stamped `timestamp`, in a single
+/// transaction: a partially written minute would show some fans dropping out of
+/// the lane for a single bucket, which reads as a sensor glitch that never
+/// happened.
+pub async fn insert(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  rows: Vec<FanArchiveRow>,
+  timestamp: DateTime<Utc>,
+) -> Result<(), NativeDatabaseError> {
+  let (timestamp_text, timestamp_epoch_ms) = write_stamp(timestamp).await?;
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let connection = transaction.connection();
+        let mut statement = connection
+          .prepare(
+            "INSERT INTO FAN_ARCHIVE \
+             (id, source, rpm, timestamp, __hv_timestamp_epoch_ms) \
+             VALUES (?, ?, ?, ?, ?)",
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("prepare the fan archive insert", error)
+          })?;
+        for row in &rows {
+          transaction.check_cancelled()?;
+          let id = transaction.next_id(TABLE)?;
+          statement
+            .execute(params![
+              id,
+              row.source.as_str(),
+              i64::from(row.rpm),
+              timestamp_text.as_str(),
+              timestamp_epoch_ms
+            ])
+            .map_err(|error| {
+              NativeDatabaseError::duckdb("insert a fan archive row", error)
+            })?;
+        }
+        Ok(())
+      })
+    })
+    .await
+}
+
+/// Delete rows older than the Retention Period, returning how many went. Same
+/// byte-wise bound as [`super::ambient_archive::delete_old_data`].
+pub async fn delete_old_data(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  retention_days: u32,
+) -> Result<u64, NativeDatabaseError> {
+  let bound =
+    sqlite_timestamp_text(&(Utc::now() - Duration::days(i64::from(retention_days))));
+  database
+    .request_write(cancellation, move |context| {
+      context.with_transaction(|transaction| {
+        let deleted = transaction
+          .connection()
+          .execute(
+            "DELETE FROM FAN_ARCHIVE WHERE timestamp < ?",
+            params![bound.as_str()],
+          )
+          .map_err(|error| {
+            NativeDatabaseError::duckdb("delete expired fan archive rows", error)
+          })?;
+        Ok(deleted as u64)
+      })
+    })
+    .await
+}
+
+/// Every archived fan reading in `[start, end)`, oldest first, for the daily
+/// rollup's own pass.
+pub async fn select_fan_minutes_for_range(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+) -> Result<Vec<FanArchiveMinuteSample>, NativeDatabaseError> {
+  let (start_ms, end_ms) = (start.timestamp_millis(), end.timestamp_millis());
+  let sql = format!(
+    "SELECT timestamp, source, CAST(rpm AS BIGINT) AS rpm
+     FROM FAN_ARCHIVE
+     WHERE {FAN_EPOCH_MS} >= {start_ms} AND {FAN_EPOCH_MS} < {end_ms}
+     ORDER BY timestamp ASC, id ASC"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the fan minute query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+          ))
+        })
+        .map_err(|error| NativeDatabaseError::duckdb("run the fan minute query", error))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| NativeDatabaseError::duckdb("decode a fan minute row", error))?;
+      rows
+        .into_iter()
+        .map(|(timestamp, source, rpm)| {
+          Ok(FanArchiveMinuteSample {
+            timestamp: stored_text::datetime(TABLE, "timestamp", &timestamp)?,
+            source,
+            // The column is only ever written from a `u32`; clamp rather than
+            // wrap if a hand-edited database ever carries a negative.
+            rpm: rpm.max(0) as u32,
+          })
+        })
+        .collect()
+    })
+    .await
+}
+
+/// Whether the one-minute fan archive currently holds any reading at all - the
+/// evidence that separates "this machine has no readable fan" from "the daily
+/// rollup has not summarized the fan yet". Deliberately unbounded in time, as
+/// in SQLite.
+pub async fn has_any_reading(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+) -> Result<bool, NativeDatabaseError> {
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      context
+        .connection()
+        .query_row("SELECT EXISTS(SELECT 1 FROM FAN_ARCHIVE)", [], |row| {
+          row.get::<_, bool>(0)
+        })
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("look for any archived fan reading", error)
+        })
+    })
+    .await
+}
+
+/// The most recent archived fan timestamp strictly before `before`.
+///
+/// Membership is decided by the derived epoch key, but the answer is
+/// `MAX(timestamp)` over the stored text - a byte-wise maximum in both engines,
+/// so a database mixing timestamp spellings picks the same row either way.
+pub async fn max_fan_archive_timestamp_before(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  before: &DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, NativeDatabaseError> {
+  let before_ms = before.timestamp_millis();
+  let sql =
+    format!("SELECT MAX(timestamp) FROM FAN_ARCHIVE WHERE {FAN_EPOCH_MS} < {before_ms}");
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let latest: Option<String> = context
+        .connection()
+        .query_row(&sql, [], |row| row.get(0))
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("read the latest archived fan timestamp", error)
+        })?;
+      latest
+        .map(|text| stored_text::datetime(TABLE, "timestamp", &text))
+        .transpose()
+    })
+    .await
+}
+
+/// The native form of
+/// [`crate::infrastructure::database::archive_queries::select_fan_archive_series`].
+///
+/// One round trip for every fan, grouped in Rust: the rows already arrive
+/// ordered by source, and each source's buckets then go through the same
+/// gap-filling every other archive series uses.
+pub async fn select_fan_archive_series(
+  database: &NativeDatabase,
+  cancellation: NativeCancellation,
+  start: &DateTime<Utc>,
+  end: &DateTime<Utc>,
+  bucket_width_ms: i64,
+  bucket_timestamp: ArchiveBucketTimestamp,
+) -> Result<Vec<FanArchiveSeries>, NativeDatabaseError> {
+  let bounds = ArchiveSeriesBounds::new(start, end, bucket_width_ms, bucket_timestamp)
+    .map_err(|source| NativeDatabaseError::ArchiveSeries { source })?;
+  let (start_ms, end_ms) = (start.timestamp_millis(), end.timestamp_millis());
+  let bucket = bucket_of_epoch(bucket_timestamp, FAN_EPOCH_MS, bucket_width_ms);
+  let sql = format!(
+    "SELECT source,
+            {bucket} AS timestamp,
+            AVG(CAST(rpm AS DOUBLE)) AS value,
+            COUNT(rpm) AS value_count
+     FROM FAN_ARCHIVE
+     WHERE {FAN_EPOCH_MS} BETWEEN {start_ms} AND {end_ms}
+     GROUP BY source, 2
+     ORDER BY source ASC, 2 ASC"
+  );
+  database
+    .request_read(cancellation, move |context| {
+      context.check_cancelled()?;
+      let mut statement = context.connection().prepare(&sql).map_err(|error| {
+        NativeDatabaseError::duckdb("prepare the fan series query", error)
+      })?;
+      let rows = statement
+        .query_map([], |row| {
+          Ok((
+            row.get::<_, String>(0)?,
+            AggregatedArchiveBucket {
+              timestamp: row.get(1)?,
+              value: row.get(2)?,
+              value_count: row.get(3)?,
+            },
+          ))
+        })
+        .map_err(|error| NativeDatabaseError::duckdb("run the fan series query", error))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+          NativeDatabaseError::duckdb("decode a fan series bucket", error)
+        })?;
+
+      let mut series: Vec<FanArchiveSeries> = Vec::new();
+      let mut current: Vec<AggregatedArchiveBucket> = Vec::new();
+      let mut current_source: Option<String> = None;
+      for (source, bucket) in rows {
+        if current_source.as_deref() != Some(source.as_str()) {
+          if let Some(previous) = current_source.take() {
+            series.push(FanArchiveSeries {
+              source: previous,
+              points: fill_archive_series(std::mem::take(&mut current), bounds),
+            });
+          }
+          current_source = Some(source);
+        }
+        current.push(bucket);
+      }
+      if let Some(source) = current_source {
+        series.push(FanArchiveSeries {
+          source,
+          points: fill_archive_series(current, bounds),
+        });
+      }
+      Ok(series)
+    })
+    .await
+}

--- a/core/src/infrastructure/database/native_database/mod.rs
+++ b/core/src/infrastructure/database/native_database/mod.rs
@@ -5,19 +5,34 @@
 //! when a caller asks, and the per-family functions run beside - never instead
 //! of - their SQLite counterparts until App lifecycle selection is implemented.
 
+pub mod ambient_archive;
+mod archive_sql;
+mod binding;
 mod cell;
+pub mod cooling_baseline;
+pub mod cooling_covariate_daily_summary;
+pub mod cooling_daily_summary;
+pub mod cooling_delta_baseline;
+pub mod cooling_fan_daily_summary;
+pub mod cooling_hourly_summary;
+pub mod cooling_rollup;
+pub mod cooling_thermal_delta_daily_summary;
 mod epoch;
 mod error;
+pub mod fan_archive;
 mod finalize;
 mod paging;
 pub mod process_stats;
 mod runtime;
 mod schema;
+mod stored_text;
+mod write_stamp;
 
 use std::path::Path;
 
 use duckdb::Connection;
 
+pub use cooling_rollup::DayRollup;
 pub use error::NativeDatabaseError;
 pub use finalize::{
   NativeFinalizationReport, NativeTableReport, finalize_candidate_database,

--- a/core/src/infrastructure/database/native_database/process_stats.rs
+++ b/core/src/infrastructure/database/native_database/process_stats.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use duckdb::params;
 
 use super::NativeDatabaseError;
+use super::binding::required_real;
 use super::runtime::{NativeCancellation, NativeDatabase};
 use crate::infrastructure::database::archive_queries::ProcessStatRecord;
 use crate::persistence::archive_data::ProcessStatData;
@@ -62,7 +63,7 @@ pub async fn insert(
               id,
               i64::from(process.pid),
               process.process_name.as_str(),
-              f64::from(process.cpu_usage),
+              required_real(TABLE, "cpu_usage", f64::from(process.cpu_usage))?,
               i64::from(process.memory_usage),
               i64::from(process.execution_sec),
               stamp.as_str()

--- a/core/src/infrastructure/database/native_database/stored_text.rs
+++ b/core/src/infrastructure/database/native_database/stored_text.rs
@@ -1,0 +1,186 @@
+//! Decoding stored text exactly as the SQLite readers decode it.
+//!
+//! The SQLite modules never parse these columns themselves: they hand the
+//! cell to sqlx, which owns one definition of "what text is a date". A native
+//! reader has no sqlx value to hand over, so the same grammar is restated
+//! here - deliberately as a transcription of
+//! `sqlx_sqlite::types::chrono::decode_datetime_from_text` and its `NaiveDate`
+//! sibling rather than as a "better" parser, because a reader that accepted
+//! one more spelling than SQLite would return a row the oracle does not.
+//!
+//! `core/tests/duckdb_ambient_fan.rs` pins the transcription against sqlx
+//! itself over every spelling the archives can carry.
+
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, Offset, TimeZone, Utc};
+
+use super::NativeDatabaseError;
+use crate::persistence::cooling_rollup::CpuLoadBand;
+
+/// The patterns sqlx tries after RFC 3339, in its order. Order matters: the
+/// first pattern that parses wins, and several of these overlap.
+const SQLITE_DATETIME_FORMATS: &[&str] = &[
+  "%F %T%.f",
+  "%F %R",
+  "%F %RZ",
+  "%F %R%:z",
+  "%F %T%.fZ",
+  "%F %T%.f%:z",
+  "%FT%R",
+  "%FT%RZ",
+  "%FT%R%:z",
+  "%FT%T%.f",
+  "%FT%T%.fZ",
+  "%FT%T%.f%:z",
+];
+
+fn parse_datetime(value: &str) -> Option<DateTime<FixedOffset>> {
+  if let Ok(datetime) = DateTime::parse_from_rfc3339(value) {
+    return Some(datetime);
+  }
+  for format in SQLITE_DATETIME_FORMATS {
+    if let Ok(datetime) = DateTime::parse_from_str(value, format) {
+      return Some(datetime);
+    }
+    if let Ok(naive) = NaiveDateTime::parse_from_str(value, format) {
+      return Some(Utc.fix().from_utc_datetime(&naive));
+    }
+  }
+  None
+}
+
+/// The instant the SQLite reader would have decoded from `value`.
+pub(super) fn datetime(
+  table: &'static str,
+  column: &'static str,
+  value: &str,
+) -> Result<DateTime<Utc>, NativeDatabaseError> {
+  parse_datetime(value)
+    .map(|datetime| Utc.from_utc_datetime(&datetime.naive_utc()))
+    .ok_or_else(|| NativeDatabaseError::UndecodableStoredValue {
+      table,
+      column,
+      kind: "an instant",
+      value: value.to_owned(),
+    })
+}
+
+/// The calendar day the SQLite reader would have decoded from `value`.
+pub(super) fn date(
+  table: &'static str,
+  column: &'static str,
+  value: &str,
+) -> Result<NaiveDate, NativeDatabaseError> {
+  NaiveDate::parse_from_str(value, "%F").map_err(|_| {
+    NativeDatabaseError::UndecodableStoredValue {
+      table,
+      column,
+      kind: "a calendar day",
+      value: value.to_owned(),
+    }
+  })
+}
+
+/// The CPU-load band a stored `band` key names, refusing an unknown key the
+/// way `cooling_covariate_daily_summary`'s `sqlx::Error::Decode` does.
+pub(super) fn band(
+  table: &'static str,
+  value: &str,
+) -> Result<CpuLoadBand, NativeDatabaseError> {
+  CpuLoadBand::from_column_key(value).ok_or_else(|| {
+    NativeDatabaseError::UndecodableStoredValue {
+      table,
+      column: "band",
+      kind: "a CPU-load band",
+      value: value.to_owned(),
+    }
+  })
+}
+
+/// The same defensive clamp every SQLite row decoder applies to a count
+/// column that is `NOT NULL` and only ever written from a `u32`.
+pub(super) fn count(value: i64) -> u32 {
+  value.max(0) as u32
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn reads_the_shapes_the_archives_carry_and_refuses_the_rest() {
+    let at = |text: &str| datetime("T", "timestamp", text).unwrap();
+    assert_eq!(
+      at("2026-09-01T00:00:00+00:00"),
+      "2026-09-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+    assert_eq!(at("2026-09-01T00:00:00Z"), at("2026-09-01 00:00:00"));
+    assert_eq!(at("2026-09-01T09:00:00+09:00"), at("2026-09-01T00:00:00Z"));
+    assert!(datetime("T", "timestamp", "not a timestamp").is_err());
+
+    assert_eq!(
+      date("T", "date", "2026-09-01").unwrap(),
+      NaiveDate::from_ymd_opt(2026, 9, 1).unwrap()
+    );
+    // `%F` is lenient about zero padding, and so is the sqlx reader this
+    // transcribes - the point is to accept exactly what SQLite's reader
+    // accepts, not to be stricter than it.
+    assert_eq!(
+      date("T", "date", "2026-9-1").unwrap(),
+      NaiveDate::from_ymd_opt(2026, 9, 1).unwrap()
+    );
+    assert!(date("T", "date", "2026-09").is_err());
+    assert!(date("T", "date", "not a day").is_err());
+    assert_eq!(band("T", "mid").unwrap(), CpuLoadBand::Mid);
+    assert!(band("T", "warm").is_err());
+    assert_eq!(count(-3), 0);
+  }
+
+  /// The transcription is only worth having if it agrees with the reader it
+  /// transcribes, so it is compared against sqlx itself rather than against a
+  /// second opinion about what SQLite accepts - including on the spellings
+  /// both refuse, where a native reader that accepted one more shape would
+  /// return a row the oracle does not.
+  #[tokio::test]
+  async fn agrees_with_sqlx_on_every_spelling_the_archives_can_carry() {
+    use sqlx::{Connection, Row};
+
+    let mut sqlite = sqlx::sqlite::SqliteConnection::connect("sqlite::memory:")
+      .await
+      .unwrap();
+
+    for text in [
+      "2026-09-01T00:00:00+00:00",
+      "2026-09-01T00:00:00Z",
+      "2026-09-01 00:00:00",
+      "2026-09-01 00:00",
+      "2026-09-01T00:00",
+      "2026-09-01T09:00:00+09:00",
+      "2026-09-01T00:00:00.000500+00:00",
+      "2026-09-01 00:00:00.123",
+      "not a timestamp",
+      "",
+    ] {
+      let oracle: Option<DateTime<Utc>> = sqlx::query("SELECT ?")
+        .bind(text)
+        .fetch_one(&mut sqlite)
+        .await
+        .unwrap()
+        .try_get(0)
+        .ok();
+      let ours = datetime("T", "timestamp", text).ok();
+      assert_eq!(ours, oracle, "instant from {text:?}");
+    }
+
+    for text in ["2026-09-01", "2026-9-1", "2026-09", "not a day", ""] {
+      let oracle: Option<NaiveDate> = sqlx::query("SELECT ?")
+        .bind(text)
+        .fetch_one(&mut sqlite)
+        .await
+        .unwrap()
+        .try_get(0)
+        .ok();
+      let ours = date("T", "date", text).ok();
+      assert_eq!(ours, oracle, "calendar day from {text:?}");
+    }
+  }
+}

--- a/core/src/infrastructure/database/native_database/write_stamp.rs
+++ b/core/src/infrastructure/database/native_database/write_stamp.rs
@@ -1,0 +1,101 @@
+//! What a native archive writer stores for one write cycle's instant.
+//!
+//! Two things have to be right, and neither may be guessed:
+//!
+//! - The **stored bytes** are whatever sqlx would have written for the same
+//!   `DateTime<Utc>`, because every timestamp comparison in these families is a
+//!   byte-wise text comparison ([`sqlite_timestamp_text`]).
+//! - The **derived key** is whatever finalization would have computed for those
+//!   bytes. It is not `timestamp_millis()`: SQLite's date parser rounds a
+//!   fractional second to the nearest millisecond (`(i64)(s*1000 + 0.5)`) while
+//!   `timestamp_millis` truncates, so the two disagree on a `.xxx500`
+//!   microsecond stamp. Rather than re-deriving the rounding rule in Rust -
+//!   where the tie lands on whichever side binary64 rounds `s*1000` to - the
+//!   writer runs the same oracle the finalizer runs
+//!   ([`super::epoch::EpochMilliseconds`]), so the key is by construction the
+//!   value finalization would have produced for the row.
+//!
+//! The oracle opens a scratch in-memory SQLite database, so [`write_stamp`]
+//! runs it on a blocking task once per write cycle - not once per row, and
+//! never on the DuckDB lane. [`stamp_for_write`] is the blocking core, shared
+//! verbatim with the `DATA_ARCHIVE`/GPU lane so both families derive the key
+//! the one way.
+//!
+//! The key is an `i64`, not an `Option<i64>`: the text being converted is this
+//! module's own rendering of a `DateTime<Utc>`, which SQLite's date parser
+//! always reads. A NULL back from the oracle would mean the two disagreed
+//! about our own output, which is a defect rather than a missing reading, so it
+//! is refused instead of silently stored as an unqueryable NULL.
+
+use chrono::{DateTime, Utc};
+
+use super::NativeDatabaseError;
+use super::epoch::EpochMilliseconds;
+use super::process_stats::sqlite_timestamp_text;
+
+/// One write cycle's timestamp as the stored text and the derived epoch key
+/// finalization would have computed from it.
+///
+/// Blocking: opens an in-memory SQLite database. Call it from
+/// [`write_stamp`] rather than directly from an async writer.
+pub(super) fn stamp_for_write(
+  timestamp: &DateTime<Utc>,
+) -> Result<(String, i64), NativeDatabaseError> {
+  let text = sqlite_timestamp_text(timestamp);
+  let mut oracle = EpochMilliseconds::open()?;
+  let epoch_milliseconds = oracle
+    .convert(std::slice::from_ref(&Some(text.clone())))?
+    .into_iter()
+    .next()
+    .flatten()
+    .ok_or_else(|| {
+      NativeDatabaseError::finalization(
+        "derive a native timestamp key",
+        format!("SQLite did not read the rendered stamp {text:?} as an instant"),
+      )
+    })?;
+  Ok((text, epoch_milliseconds))
+}
+
+/// [`stamp_for_write`] off the async runtime's worker threads.
+pub(super) async fn write_stamp(
+  timestamp: DateTime<Utc>,
+) -> Result<(String, i64), NativeDatabaseError> {
+  tokio::task::spawn_blocking(move || stamp_for_write(&timestamp))
+    .await
+    .map_err(|error| NativeDatabaseError::Worker {
+      message: error.to_string(),
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn rounds_a_half_millisecond_stamp_the_way_sqlite_does() {
+    // `timestamp_millis()` truncates both of these to ...000; SQLite rounds
+    // the second one up. The key must follow SQLite.
+    let below: DateTime<Utc> = "2026-09-01T00:00:00.000499Z".parse().unwrap();
+    let tie: DateTime<Utc> = "2026-09-01T00:00:00.000500Z".parse().unwrap();
+    assert_eq!(below.timestamp_millis(), tie.timestamp_millis());
+
+    let below = write_stamp(below).await.unwrap();
+    let tie = write_stamp(tie).await.unwrap();
+
+    assert_eq!(below.0, "2026-09-01T00:00:00.000499+00:00");
+    assert_eq!(tie.0, "2026-09-01T00:00:00.000500+00:00");
+    assert_eq!(below.1, 1_788_220_800_000);
+    assert_eq!(tie.1, 1_788_220_800_001);
+  }
+
+  #[tokio::test]
+  async fn keeps_a_pre_epoch_stamp_negative() {
+    let (text, epoch_milliseconds) =
+      write_stamp("1969-12-31T23:59:59.500Z".parse().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(text, "1969-12-31T23:59:59.500+00:00");
+    assert_eq!(epoch_milliseconds, -500);
+  }
+}

--- a/core/tests/duckdb_ambient_fan.rs
+++ b/core/tests/duckdb_ambient_fan.rs
@@ -1,0 +1,793 @@
+#![cfg(feature = "duckdb-archive")]
+//! The `AMBIENT_ARCHIVE` and `FAN_ARCHIVE` families, native beside SQLite.
+//!
+//! Every test here is a differential one: one fixture is seeded through the
+//! real SQLite writers, finalized through the real candidate and finalization
+//! path, and then the *same question* is put to both engines. A native module
+//! is correct here only if it answers what SQLite answers - not if it answers
+//! something a reviewer finds reasonable.
+//!
+//! The fixture is shared across the binary because finalization is the
+//! expensive step and none of the read tests mutate it. The one test that does
+//! write works on its own copy of the finalized file.
+
+mod native_support;
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use hardviz_core::infrastructure::database::archive_queries::{
+  self, ArchiveBucketTimestamp,
+};
+use hardviz_core::infrastructure::database::native_database::{
+  NativeCancellation, NativeDatabase, NativeDatabaseError, NativeDatabaseOptions,
+  ambient_archive as native_ambient, fan_archive as native_fan,
+};
+use hardviz_core::infrastructure::database::{
+  ambient_archive, db, fan_archive, hardware_archive,
+};
+use hardviz_core::persistence::archive_data::{
+  AmbientData, FanArchiveRow, HardwareArchiveRow, HardwareData,
+};
+use native_support::{NativeFixture, app_native_schema};
+use tokio::sync::OnceCell;
+
+/// The window every series test asks about: a couple of hours around the
+/// seeded minutes, wide enough that gap filling has gaps to fill.
+fn window() -> (DateTime<Utc>, DateTime<Utc>) {
+  (at("2026-09-01T00:00:00Z"), at("2026-09-01T00:20:00Z"))
+}
+
+fn at(text: &str) -> DateTime<Utc> {
+  text.parse().unwrap()
+}
+
+fn cancel() -> NativeCancellation {
+  NativeCancellation::new()
+}
+
+fn reading(avg: f32) -> HardwareData {
+  HardwareData {
+    avg: Some(avg),
+    max: Some(avg + 1.0),
+    min: Some(avg - 1.0),
+  }
+}
+
+fn absent() -> HardwareData {
+  HardwareData {
+    avg: None,
+    max: None,
+    min: None,
+  }
+}
+
+/// The seeded SQLite source and the finalized template copied from it.
+///
+/// Deliberately does *not* hold an open `NativeDatabase`: see [`Owned`].
+struct Shared {
+  fixture: NativeFixture,
+}
+
+static SHARED: OnceCell<Shared> = OnceCell::const_new();
+
+async fn shared() -> &'static Shared {
+  SHARED
+    .get_or_init(|| async {
+      let fixture = NativeFixture::new();
+      // One process-wide pool location for the whole binary, so the SQLite
+      // oracle reads the same file the fixture finalizes.
+      assert!(db::init(fixture.source.clone()));
+      let pool = fixture.migrated_pool().await;
+      seed().await;
+      pool.close().await;
+
+      fixture.finalize().await;
+      Shared { fixture }
+    })
+    .await
+}
+
+/// A private copy of the finalized fixture, plus the owner serving it.
+///
+/// Every test takes its own copy instead of sharing one open `NativeDatabase`.
+/// On Windows a DuckDB file cannot be read, hashed, or opened by a second
+/// instance while any owner still holds it, so a shared open handle makes
+/// `std::fs::copy` fail with a sharing violation and `read_only` fail with
+/// "File is already open". Finalization - the expensive step - stays shared;
+/// only the copy is per test.
+struct Owned {
+  /// Kept alive so [`Owned::path`] stays valid after the database is closed.
+  _directory: tempfile::TempDir,
+  path: std::path::PathBuf,
+  database: Option<NativeDatabase>,
+}
+
+impl Owned {
+  async fn open(name: &str) -> Self {
+    let shared = shared().await;
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join(name);
+    // Safe because nothing holds the finalized template: `shared` deliberately
+    // does not keep it open.
+    std::fs::copy(&shared.fixture.finalized, &path).unwrap();
+    let database = NativeDatabase::open(
+      &path,
+      NativeDatabaseOptions::new(app_native_schema::NATIVE_SCHEMA_VERSION),
+    )
+    .await
+    .unwrap();
+    Self {
+      _directory: directory,
+      path,
+      database: Some(database),
+    }
+  }
+
+  fn database(&self) -> &NativeDatabase {
+    self.database.as_ref().expect("database already closed")
+  }
+
+  /// Release the file so it can be read by a second instance. Call before any
+  /// `read_only` on [`Owned::path`].
+  async fn close(&mut self) {
+    if let Some(database) = self.database.take() {
+      database.close().await.unwrap();
+    }
+  }
+}
+
+/// Twenty archive minutes with deliberately awkward shape:
+///
+/// - two ambient sources, one of which stops reporting half way through, so
+///   `sources` and the per-minute averages have to disagree about coverage;
+/// - a minute with an ambient reading but no CPU temperature, which must count
+///   towards `ambient_avg` and drop out of `delta_avg`;
+/// - a fan that reports a real 0 RPM, which is an observation and not a gap;
+/// - a sub-millisecond pair straddling SQLite's rounding tie, so the derived
+///   epoch keys are exercised rather than assumed.
+async fn seed() {
+  let base = at("2026-09-01T00:01:00Z");
+  for minute in 0..10i64 {
+    let tick = base + Duration::minutes(minute);
+    let mut ambient = vec![AmbientData {
+      source: "Room".to_owned(),
+      temperature: 21.0 + minute as f32 * 0.25,
+      humidity: Some(48.0),
+    }];
+    if minute < 5 {
+      ambient.push(AmbientData {
+        source: "Cabinet".to_owned(),
+        // A NULL humidity stays NULL rather than becoming a measured 0%.
+        temperature: 24.5 + minute as f32 * 0.1,
+        humidity: None,
+      });
+    }
+    ambient_archive::insert(ambient, tick).await.unwrap();
+
+    fan_archive::insert(
+      vec![
+        FanArchiveRow {
+          source: "Exhaust".to_owned(),
+          rpm: 800 + minute as u32 * 25,
+        },
+        FanArchiveRow {
+          source: "Intake".to_owned(),
+          // A genuine Inactive Fan Reading, stored as the observation it is.
+          rpm: if minute == 3 { 0 } else { 1200 },
+        },
+      ],
+      tick,
+    )
+    .await
+    .unwrap();
+
+    hardware_archive::insert(
+      HardwareArchiveRow {
+        cpu: reading(30.0 + minute as f32),
+        memory: reading(40.0),
+        // Minute 7 has ambient but no CPU temperature: it counts towards
+        // `ambient_avg` and must drop out of `delta_avg`.
+        cpu_temperature: if minute == 7 {
+          absent()
+        } else {
+          reading(55.0 + minute as f32 * 0.5)
+        },
+        cpu_power: reading(12.0),
+        gpu_power: absent(),
+        ane_power: absent(),
+        package_power: absent(),
+      },
+      tick,
+    )
+    .await
+    .unwrap();
+  }
+
+  // The rounding tie, written through the real SQLite writer so finalization
+  // derives its key from the bytes sqlx actually stored.
+  for tick in TIE_STAMPS {
+    ambient_archive::insert(
+      vec![AmbientData {
+        source: "Room".to_owned(),
+        temperature: 30.0,
+        humidity: None,
+      }],
+      at(tick),
+    )
+    .await
+    .unwrap();
+    fan_archive::insert(
+      vec![FanArchiveRow {
+        source: "Exhaust".to_owned(),
+        rpm: 999,
+      }],
+      at(tick),
+    )
+    .await
+    .unwrap();
+  }
+}
+
+/// `timestamp_millis()` truncates both of these to the same millisecond;
+/// SQLite's date parser rounds the second one up.
+const TIE_STAMPS: [&str; 2] =
+  ["2026-09-01T00:15:00.000499Z", "2026-09-01T00:15:00.000500Z"];
+
+/// The bucket averages compared here go through DuckDB's `AVG(DOUBLE)` on one
+/// side and SQLite's compensated `avg()` on the other. They agree bit for bit
+/// on archive-magnitude readings, which is what this fixture holds and what a
+/// sensor can produce; they are known to diverge once one bucket's finite `f32`
+/// values span more than about 2^53 (`[f32::MAX, 1.0, -f32::MAX]`), which is
+/// the unresolved binary64 residue the Design Doc records rather than a defect
+/// this lane fixes. The fixture deliberately stays inside that boundary, so a
+/// failure here means a real disagreement and not the known residue.
+#[tokio::test]
+async fn ambient_series_answers_what_sqlite_answers() {
+  let mut owned = Owned::open("ambient-series.duckdb").await;
+  let (start, end) = window();
+
+  for bucket_timestamp in [ArchiveBucketTimestamp::Start, ArchiveBucketTimestamp::End] {
+    for width in [60_000i64, 300_000, 600_000] {
+      let expected = archive_queries::select_ambient_archive_series(
+        &start,
+        &end,
+        width,
+        bucket_timestamp,
+      )
+      .await
+      .unwrap();
+      let actual = native_ambient::select_ambient_archive_series(
+        owned.database(),
+        cancel(),
+        &start,
+        &end,
+        width,
+        bucket_timestamp,
+      )
+      .await
+      .unwrap();
+
+      assert_eq!(actual, expected, "width {width}, {bucket_timestamp:?}");
+    }
+  }
+
+  // The fixture is only evidence if it actually produced the awkward shapes
+  // the modules have to get right.
+  let series = archive_queries::select_ambient_archive_series(
+    &start,
+    &end,
+    60_000,
+    ArchiveBucketTimestamp::Start,
+  )
+  .await
+  .unwrap();
+  assert_eq!(
+    series.sources,
+    vec!["Cabinet".to_owned(), "Room".to_owned()]
+  );
+  assert!(
+    series
+      .buckets
+      .iter()
+      .any(|bucket| bucket.ambient_avg.is_some() && bucket.delta_avg.is_none()),
+    "the unpaired minute must count towards ambient_avg and not towards delta_avg"
+  );
+  assert!(
+    series
+      .buckets
+      .iter()
+      .any(|bucket| bucket.ambient_avg.is_none()),
+    "the window must contain a gap for the filler to leave empty"
+  );
+  owned.close().await;
+}
+
+#[tokio::test]
+async fn fan_series_answers_what_sqlite_answers() {
+  let mut owned = Owned::open("fan-series.duckdb").await;
+  let (start, end) = window();
+
+  for bucket_timestamp in [ArchiveBucketTimestamp::Start, ArchiveBucketTimestamp::End] {
+    for width in [60_000i64, 300_000] {
+      let expected =
+        archive_queries::select_fan_archive_series(&start, &end, width, bucket_timestamp)
+          .await
+          .unwrap();
+      let actual = native_fan::select_fan_archive_series(
+        owned.database(),
+        cancel(),
+        &start,
+        &end,
+        width,
+        bucket_timestamp,
+      )
+      .await
+      .unwrap();
+
+      assert_eq!(actual, expected, "width {width}, {bucket_timestamp:?}");
+    }
+  }
+
+  let series = archive_queries::select_fan_archive_series(
+    &start,
+    &end,
+    60_000,
+    ArchiveBucketTimestamp::Start,
+  )
+  .await
+  .unwrap();
+  assert_eq!(series.len(), 2, "both fans must be present");
+  assert!(
+    series
+      .iter()
+      .any(|fan| fan.points.iter().any(|point| point.value == Some(0.0))),
+    "a real 0 RPM reading must survive as an observation, not become a gap"
+  );
+  owned.close().await;
+}
+
+#[tokio::test]
+async fn fan_rollup_reads_answer_what_sqlite_answers() {
+  let mut owned = Owned::open("fan-rollup.duckdb").await;
+  let (start, end) = window();
+
+  assert_eq!(
+    native_fan::select_fan_minutes_for_range(owned.database(), cancel(), &start, &end)
+      .await
+      .unwrap(),
+    fan_archive::select_fan_minutes_for_range(&start, &end)
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_fan::has_any_reading(owned.database(), cancel())
+      .await
+      .unwrap(),
+    fan_archive::has_any_reading().await.unwrap()
+  );
+  for before in [
+    at("2026-09-01T00:05:00Z"),
+    at("2026-09-01T00:15:00.000500Z"),
+    at("2026-09-01T12:00:00Z"),
+    // Before everything: both sides must answer `None` rather than an
+    // epoch-zero instant.
+    at("2020-01-01T00:00:00Z"),
+  ] {
+    assert_eq!(
+      native_fan::max_fan_archive_timestamp_before(owned.database(), cancel(), &before)
+        .await
+        .unwrap(),
+      fan_archive::max_fan_archive_timestamp_before(&before)
+        .await
+        .unwrap(),
+      "before {before}"
+    );
+  }
+  owned.close().await;
+}
+
+/// The derived key is what finalization computed from the stored bytes, and
+/// finalization runs SQLite's own date parser. The two stamps below differ by
+/// one microsecond and land on opposite sides of SQLite's millisecond rounding
+/// tie, while `timestamp_millis()` truncates both to the same value - so this
+/// is the case a hand-written `timestamp_millis` key would get wrong.
+#[tokio::test]
+async fn the_derived_key_follows_sqlites_rounding_not_rusts_truncation() {
+  // Its own copy, released before a second DuckDB instance reads it: on
+  // Windows the file cannot be opened twice while an owner holds it.
+  let mut owned = Owned::open("derived-key.duckdb").await;
+  owned.close().await;
+  let connection = native_support::read_only(&owned.path);
+  let mut statement = connection
+    .prepare(
+      "SELECT timestamp, __hv_timestamp_epoch_ms
+       FROM AMBIENT_ARCHIVE
+       WHERE timestamp LIKE '2026-09-01T00:15:00.0005%'
+          OR timestamp LIKE '2026-09-01T00:15:00.0004%'
+       ORDER BY timestamp ASC",
+    )
+    .unwrap();
+  let rows: Vec<(String, Option<i64>)> = statement
+    .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+    .unwrap()
+    .collect::<Result<_, _>>()
+    .unwrap();
+
+  assert_eq!(
+    rows,
+    vec![
+      (
+        "2026-09-01T00:15:00.000499+00:00".to_owned(),
+        Some(1_788_221_700_000)
+      ),
+      (
+        "2026-09-01T00:15:00.000500+00:00".to_owned(),
+        Some(1_788_221_700_001)
+      ),
+    ],
+    "SQLite rounds the .000500 stamp up; Rust's timestamp_millis truncates both"
+  );
+  // The truncating key both stamps would have received.
+  assert_eq!(
+    at(TIE_STAMPS[0]).timestamp_millis(),
+    at(TIE_STAMPS[1]).timestamp_millis()
+  );
+  assert_eq!(at(TIE_STAMPS[0]).timestamp_millis(), 1_788_221_700_000);
+}
+
+/// A native write has to produce the same two things the SQLite writer
+/// produces: the same stored bytes, and the key finalization would have
+/// derived from them. Written into a copy of the finalized file so the read
+/// tests keep seeing the fixture they were seeded with.
+#[tokio::test]
+async fn a_native_write_stores_the_bytes_and_key_sqlite_would() {
+  let mut owned = Owned::open("writable.duckdb").await;
+
+  // The same two tie stamps, now written by the native writer rather than
+  // recovered from a finalized SQLite row.
+  for tick in TIE_STAMPS {
+    native_ambient::insert(
+      owned.database(),
+      cancel(),
+      vec![AmbientData {
+        source: "Native".to_owned(),
+        temperature: 30.0,
+        humidity: None,
+      }],
+      at(tick),
+    )
+    .await
+    .unwrap();
+    native_fan::insert(
+      owned.database(),
+      cancel(),
+      vec![FanArchiveRow {
+        source: "Native".to_owned(),
+        rpm: 999,
+      }],
+      at(tick),
+    )
+    .await
+    .unwrap();
+  }
+  owned.close().await;
+
+  let connection = native_support::read_only(&owned.path);
+  for (table, label) in [("AMBIENT_ARCHIVE", "Native"), ("FAN_ARCHIVE", "Native")] {
+    let mut statement = connection
+      .prepare(&format!(
+        "SELECT timestamp, __hv_timestamp_epoch_ms FROM {table}
+         WHERE source = '{label}' ORDER BY timestamp ASC"
+      ))
+      .unwrap();
+    let written: Vec<(String, Option<i64>)> = statement
+      .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+      .unwrap()
+      .collect::<Result<_, _>>()
+      .unwrap();
+    assert_eq!(
+      written,
+      vec![
+        (
+          "2026-09-01T00:15:00.000499+00:00".to_owned(),
+          Some(1_788_221_700_000)
+        ),
+        (
+          "2026-09-01T00:15:00.000500+00:00".to_owned(),
+          Some(1_788_221_700_001)
+        ),
+      ],
+      "{table}"
+    );
+  }
+
+  // And the bytes match what SQLite's own writer stored for the same instants
+  // (the rows seeded through `ambient_archive::insert`).
+  let seeded: Vec<String> = {
+    let mut statement = connection
+      .prepare(
+        "SELECT DISTINCT timestamp FROM AMBIENT_ARCHIVE
+         WHERE source = 'Room' AND timestamp LIKE '2026-09-01T00:15:%'
+         ORDER BY timestamp ASC",
+      )
+      .unwrap();
+    statement
+      .query_map([], |row| row.get(0))
+      .unwrap()
+      .collect::<Result<_, _>>()
+      .unwrap()
+  };
+  assert_eq!(
+    seeded,
+    vec![
+      "2026-09-01T00:15:00.000499+00:00".to_owned(),
+      "2026-09-01T00:15:00.000500+00:00".to_owned(),
+    ]
+  );
+}
+
+/// Retention is a byte-wise text comparison in both engines, so the same
+/// cutoff has to take the same rows.
+#[tokio::test]
+async fn native_retention_takes_the_same_rows_as_sqlite() {
+  let mut owned = Owned::open("retained.duckdb").await;
+  let native = owned.database();
+
+  // Every seeded row is far in the past relative to `Utc::now()`, so a
+  // zero-day retention must take all of them and report the count.
+  let ambient_before = count(native, "AMBIENT_ARCHIVE").await;
+  let fan_before = count(native, "FAN_ARCHIVE").await;
+  assert!(ambient_before > 0 && fan_before > 0);
+
+  assert_eq!(
+    native_ambient::delete_old_data(native, cancel(), 0)
+      .await
+      .unwrap(),
+    ambient_before
+  );
+  assert_eq!(
+    native_fan::delete_old_data(native, cancel(), 0)
+      .await
+      .unwrap(),
+    fan_before
+  );
+  assert_eq!(count(native, "AMBIENT_ARCHIVE").await, 0);
+  assert_eq!(count(native, "FAN_ARCHIVE").await, 0);
+
+  // A second pass deletes nothing rather than failing.
+  assert_eq!(
+    native_ambient::delete_old_data(native, cancel(), 0)
+      .await
+      .unwrap(),
+    0
+  );
+  owned.close().await;
+}
+
+async fn count(native: &NativeDatabase, table: &'static str) -> u64 {
+  let sql = format!("SELECT COUNT(*) FROM {table}");
+  native
+    .request_read(cancel(), move |context| {
+      Ok(
+        context
+          .connection()
+          .query_row(&sql, [], |row| row.get::<_, i64>(0))
+          .unwrap() as u64,
+      )
+    })
+    .await
+    .unwrap()
+}
+
+/// The stored-text decoder is a transcription of sqlx's own grammar, so a
+/// stamp written by sqlx must read back through the native path as the same
+/// instant sqlx decodes it to. Exercised through the public native reader
+/// rather than against the private module, so it pins the behaviour callers
+/// actually get.
+#[tokio::test]
+async fn native_decoding_agrees_with_sqlx_on_every_spelling_the_archive_carries() {
+  let mut owned = Owned::open("decoding.duckdb").await;
+  let (start, end) = window();
+
+  let native =
+    native_fan::select_fan_minutes_for_range(owned.database(), cancel(), &start, &end)
+      .await
+      .unwrap();
+  let sqlite = fan_archive::select_fan_minutes_for_range(&start, &end)
+    .await
+    .unwrap();
+  assert_eq!(native, sqlite);
+  assert!(
+    !native.is_empty(),
+    "the comparison is only evidence if rows came back"
+  );
+  // Including the sub-millisecond stamps, whose fractional part is exactly
+  // where a looser parser would disagree with sqlx.
+  assert!(
+    native.iter().any(
+      |sample| sample.timestamp == Utc.timestamp_micros(1_788_221_700_000_500).unwrap()
+    ),
+    "the .000500 stamp must decode to the microsecond, not to the rounded key"
+  );
+  owned.close().await;
+}
+
+/// The one place both engines can be asked the NaN question directly: the
+/// ambient writer is public on both sides, and `humidity` is nullable while
+/// `temperature` is `NOT NULL`, so one table covers both of SQLite's NaN
+/// behaviours.
+///
+/// The probes are stamped far outside every window the other tests read, so
+/// the SQLite side can be written after the fixture was finalized without
+/// disturbing a single comparison above.
+const NAN_PROBE_STAMP: &str = "2030-01-01T00:00:00Z";
+
+#[tokio::test]
+async fn a_nan_reading_is_the_same_absence_in_both_engines() {
+  let shared = shared().await;
+
+  // SQLite, through the production writer: a NaN humidity is stored as NULL,
+  // and a finite one beside it is stored as a real.
+  ambient_archive::insert(
+    vec![
+      AmbientData {
+        source: "NaN probe".to_owned(),
+        temperature: 21.0,
+        humidity: Some(f32::NAN),
+      },
+      AmbientData {
+        source: "Finite probe".to_owned(),
+        temperature: 21.0,
+        humidity: Some(48.0),
+      },
+    ],
+    at(NAN_PROBE_STAMP),
+  )
+  .await
+  .unwrap();
+
+  let pool = native_support::open_pool(&shared.fixture.source, false).await;
+  let stored: Vec<(String, String)> = sqlx::query_as(
+    "SELECT source, typeof(humidity) FROM AMBIENT_ARCHIVE
+     WHERE source IN ('NaN probe', 'Finite probe') ORDER BY source ASC",
+  )
+  .fetch_all(&pool)
+  .await
+  .unwrap();
+  pool.close().await;
+  assert_eq!(
+    stored,
+    vec![
+      ("Finite probe".to_owned(), "real".to_owned()),
+      ("NaN probe".to_owned(), "null".to_owned()),
+    ],
+    "SQLite stores a bound NaN as NULL and leaves a finite reading alone"
+  );
+
+  // The native writer, given the same two rows, has to reach the same state.
+  let mut owned = Owned::open("nan.duckdb").await;
+  native_ambient::insert(
+    owned.database(),
+    cancel(),
+    vec![
+      AmbientData {
+        source: "NaN probe".to_owned(),
+        temperature: 21.0,
+        humidity: Some(f32::NAN),
+      },
+      AmbientData {
+        source: "Finite probe".to_owned(),
+        temperature: 21.0,
+        humidity: Some(48.0),
+      },
+    ],
+    at(NAN_PROBE_STAMP),
+  )
+  .await
+  .unwrap();
+  owned.close().await;
+
+  let connection = native_support::read_only(&owned.path);
+  let mut statement = connection
+    .prepare(
+      "SELECT source, CASE WHEN humidity IS NULL THEN 'null'
+                           WHEN isnan(humidity) THEN 'nan'
+                           ELSE 'real' END
+       FROM AMBIENT_ARCHIVE
+       WHERE source IN ('NaN probe', 'Finite probe') ORDER BY source ASC",
+    )
+    .unwrap();
+  let written: Vec<(String, String)> = statement
+    .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+    .unwrap()
+    .collect::<Result<_, _>>()
+    .unwrap();
+  assert_eq!(written, stored, "native nullness must match SQLite's");
+}
+
+/// `AMBIENT_ARCHIVE.temperature` and `PROCESS_STATS.cpu_usage` are `NOT NULL`,
+/// so SQLite does not absorb the NaN into a gap - it refuses the row. Both
+/// writers must refuse it, and both must leave nothing behind.
+#[tokio::test]
+async fn a_nan_in_a_required_column_is_refused_by_both_engines() {
+  let shared = shared().await;
+  let refused = at("2030-06-01T00:00:00Z");
+
+  let sqlite_error = ambient_archive::insert(
+    vec![AmbientData {
+      source: "Refused probe".to_owned(),
+      temperature: f32::NAN,
+      humidity: None,
+    }],
+    refused,
+  )
+  .await
+  .unwrap_err();
+  assert!(
+    matches!(&sqlite_error, sqlx::Error::Database(error)
+      if error.message().contains("NOT NULL constraint failed")),
+    "{sqlite_error:?}"
+  );
+
+  let pool = native_support::open_pool(&shared.fixture.source, false).await;
+  let surviving: i64 = sqlx::query_scalar(
+    "SELECT COUNT(*) FROM AMBIENT_ARCHIVE WHERE source = 'Refused probe'",
+  )
+  .fetch_one(&pool)
+  .await
+  .unwrap();
+  pool.close().await;
+  assert_eq!(surviving, 0, "SQLite wrote nothing");
+
+  let mut owned = Owned::open("refused.duckdb").await;
+  let native_error = native_ambient::insert(
+    owned.database(),
+    cancel(),
+    vec![AmbientData {
+      source: "Refused probe".to_owned(),
+      temperature: f32::NAN,
+      humidity: None,
+    }],
+    refused,
+  )
+  .await
+  .unwrap_err();
+  assert!(
+    matches!(
+      native_error,
+      NativeDatabaseError::NotANumberInRequiredColumn {
+        table: "AMBIENT_ARCHIVE",
+        column: "temperature"
+      }
+    ),
+    "{native_error:?}"
+  );
+  assert_eq!(
+    count_where(
+      owned.database(),
+      "AMBIENT_ARCHIVE",
+      "source = 'Refused probe'"
+    )
+    .await,
+    0
+  );
+  owned.close().await;
+}
+
+async fn count_where(
+  native: &NativeDatabase,
+  table: &'static str,
+  predicate: &'static str,
+) -> u64 {
+  let sql = format!("SELECT COUNT(*) FROM {table} WHERE {predicate}");
+  native
+    .request_read(cancel(), move |context| {
+      Ok(
+        context
+          .connection()
+          .query_row(&sql, [], |row| row.get::<_, i64>(0))
+          .unwrap() as u64,
+      )
+    })
+    .await
+    .unwrap()
+}

--- a/core/tests/duckdb_cooling.rs
+++ b/core/tests/duckdb_cooling.rs
@@ -1,0 +1,1319 @@
+#![cfg(feature = "duckdb-archive")]
+//! The Cooling Insight projections, native beside SQLite.
+//!
+//! Same differential discipline as `duckdb_ambient_fan`: one fixture seeded
+//! through the real SQLite path, finalized through the real finalizer, and
+//! then the same question put to both engines. The rollup's own six-table
+//! transaction is tested on writable copies, because proving a boundary needs
+//! a write that fails.
+
+mod native_support;
+
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, Utc};
+use hardviz_core::infrastructure::database::native_database::{
+  DayRollup, NativeCancellation, NativeDatabase, NativeDatabaseError,
+  NativeDatabaseOptions, cooling_baseline as native_baseline,
+  cooling_covariate_daily_summary as native_covariate,
+  cooling_daily_summary as native_daily, cooling_delta_baseline as native_delta_baseline,
+  cooling_fan_daily_summary as native_fan_daily, cooling_hourly_summary as native_hourly,
+  cooling_rollup as native_rollup,
+  cooling_thermal_delta_daily_summary as native_thermal_delta,
+};
+use hardviz_core::infrastructure::database::{
+  ambient_archive, cooling_baseline, cooling_covariate_daily_summary,
+  cooling_daily_summary, cooling_delta_baseline, cooling_fan_daily_summary,
+  cooling_hourly_summary, cooling_thermal_delta_daily_summary, db, hardware_archive,
+};
+use hardviz_core::persistence::archive_data::{
+  AmbientData, HardwareArchiveRow, HardwareData,
+};
+use hardviz_core::persistence::cooling_baseline::EstablishedBaseline;
+use hardviz_core::persistence::cooling_covariate_rollup::{
+  CovariateDailySummary, CovariateDaySummary, FanCovariateDailySummary,
+  PairedFitStatistics,
+};
+use hardviz_core::persistence::cooling_fan_rollup::FanDailySummary;
+use hardviz_core::persistence::cooling_hourly_rollup::HourlyCoolingSummary;
+use hardviz_core::persistence::cooling_rollup::{
+  BandSummary, CpuLoadBand, DailyCoolingSummary, PowerSummary,
+};
+use hardviz_core::persistence::cooling_thermal_delta_rollup::ThermalDeltaDailySummary;
+use native_support::{NativeFixture, app_native_schema};
+use sqlx::SqlitePool;
+use tokio::sync::OnceCell;
+
+fn at(text: &str) -> DateTime<Utc> {
+  text.parse().unwrap()
+}
+
+fn day(text: &str) -> NaiveDate {
+  text.parse().unwrap()
+}
+
+fn hour(text: &str) -> NaiveDateTime {
+  NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S").unwrap()
+}
+
+fn cancel() -> NativeCancellation {
+  NativeCancellation::new()
+}
+
+fn reading(avg: f32) -> HardwareData {
+  HardwareData {
+    avg: Some(avg),
+    max: Some(avg + 1.0),
+    min: Some(avg - 1.0),
+  }
+}
+
+fn absent() -> HardwareData {
+  HardwareData {
+    avg: None,
+    max: None,
+    min: None,
+  }
+}
+
+fn band(avg: f32, minutes: u32) -> BandSummary {
+  BandSummary {
+    avg: Some(avg),
+    max: Some(avg + 2.0),
+    min: Some(avg - 2.0),
+    sample_minutes: minutes,
+  }
+}
+
+/// A band whose every reading is NaN. SQLite stores each of them as NULL, so
+/// this is indistinguishable from [`empty_band`] once written - which is
+/// exactly the equivalence the native writer has to reproduce.
+fn nan_band() -> BandSummary {
+  BandSummary {
+    avg: Some(f32::NAN),
+    max: Some(f32::NAN),
+    min: Some(f32::NAN),
+    sample_minutes: 0,
+  }
+}
+
+fn empty_band() -> BandSummary {
+  BandSummary {
+    avg: None,
+    max: None,
+    min: None,
+    sample_minutes: 0,
+  }
+}
+
+fn fit(n: u32) -> PairedFitStatistics {
+  PairedFitStatistics {
+    n,
+    sum_x: 1.5,
+    sum_y: 2.5,
+    sum_xy: 3.5,
+    sum_xx: 4.5,
+    sum_yy: 5.5,
+  }
+}
+
+/// The seeded SQLite source and the finalized template copied from it.
+///
+/// Deliberately does *not* hold an open `NativeDatabase`: see [`Owned`].
+struct Shared {
+  fixture: NativeFixture,
+}
+
+static SHARED: OnceCell<Shared> = OnceCell::const_new();
+
+async fn shared() -> &'static Shared {
+  SHARED
+    .get_or_init(|| async {
+      let fixture = NativeFixture::new();
+      assert!(db::init(fixture.source.clone()));
+      let pool = fixture.migrated_pool().await;
+      seed_archives().await;
+      seed_projections(&pool).await;
+      pool.close().await;
+
+      fixture.finalize().await;
+      Shared { fixture }
+    })
+    .await
+}
+
+/// A private copy of the finalized fixture, plus the owner serving it.
+///
+/// Every test takes its own copy instead of sharing one open `NativeDatabase`.
+/// On Windows a DuckDB file cannot be read, hashed, or opened by a second
+/// instance while any owner still holds it, so a shared open handle makes
+/// `std::fs::copy` fail with a sharing violation and `read_only` fail with
+/// "File is already open". Finalization - the expensive step - stays shared;
+/// only the copy is per test.
+struct Owned {
+  /// Kept alive so [`Owned::path`] stays valid after the database is closed.
+  _directory: tempfile::TempDir,
+  path: std::path::PathBuf,
+  database: Option<NativeDatabase>,
+}
+
+impl Owned {
+  async fn open(name: &str) -> Self {
+    let shared = shared().await;
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join(name);
+    // Safe because nothing holds the finalized template: `shared` deliberately
+    // does not keep it open.
+    std::fs::copy(&shared.fixture.finalized, &path).unwrap();
+    let database = NativeDatabase::open(
+      &path,
+      NativeDatabaseOptions::new(app_native_schema::NATIVE_SCHEMA_VERSION),
+    )
+    .await
+    .unwrap();
+    Self {
+      _directory: directory,
+      path,
+      database: Some(database),
+    }
+  }
+
+  fn database(&self) -> &NativeDatabase {
+    self.database.as_ref().expect("database already closed")
+  }
+
+  /// Release the file so a second instance can open it. Call before any
+  /// `read_only` on [`Owned::path`].
+  async fn close(&mut self) {
+    if let Some(database) = self.database.take() {
+      database.close().await.unwrap();
+    }
+  }
+}
+
+/// Archive minutes shaped so every branch of the reads has something to do:
+/// a minute with no CPU usage (unclassifiable), a minute with no CPU
+/// temperature, a minute with no power triple, and an ambient source that
+/// stops reporting part way through.
+async fn seed_archives() {
+  let base = at("2026-09-01T00:01:00Z");
+  for minute in 0..12i64 {
+    let tick = base + Duration::minutes(minute);
+    hardware_archive::insert(
+      HardwareArchiveRow {
+        // Minute 4 carries no CPU usage, so it pairs but cannot be
+        // classified into a load band.
+        cpu: if minute == 4 {
+          absent()
+        } else {
+          reading(10.0 + minute as f32 * 7.0)
+        },
+        memory: reading(40.0),
+        cpu_temperature: if minute == 7 {
+          absent()
+        } else {
+          reading(55.0 + minute as f32 * 0.5)
+        },
+        // Minute 9 has only a partial power triple, which the power gate
+        // must refuse on both sides.
+        cpu_power: if minute == 9 {
+          HardwareData {
+            avg: Some(12.0),
+            max: None,
+            min: None,
+          }
+        } else {
+          reading(12.0 + minute as f32)
+        },
+        gpu_power: absent(),
+        ane_power: absent(),
+        package_power: absent(),
+      },
+      tick,
+    )
+    .await
+    .unwrap();
+
+    // Ambient only for the first eight minutes, and the second source only
+    // for the first four.
+    if minute < 8 {
+      let mut rows = vec![AmbientData {
+        source: "Room".to_owned(),
+        temperature: 21.0 + minute as f32 * 0.25,
+        humidity: Some(48.0),
+      }];
+      if minute < 4 {
+        rows.push(AmbientData {
+          source: "Cabinet".to_owned(),
+          temperature: 24.5,
+          humidity: None,
+        });
+      }
+      ambient_archive::insert(rows, tick).await.unwrap();
+    }
+  }
+
+  // An ambient row with no hardware row in its minute: it must never count
+  // as coverage, however often the day is re-rolled.
+  ambient_archive::insert(
+    vec![AmbientData {
+      source: "Room".to_owned(),
+      temperature: 22.0,
+      humidity: None,
+    }],
+    at("2026-09-01T06:30:00Z"),
+  )
+  .await
+  .unwrap();
+}
+
+/// The five summary tables. `cooling_daily_summary` and
+/// `cooling_hourly_summary` go through their own public writers; the other
+/// three have no public single-row writer, so they are seeded with the same
+/// column set their `upsert_with` writes. Provenance does not matter here -
+/// these rows exist so two *readers* can be compared over them.
+async fn seed_projections(pool: &SqlitePool) {
+  for (date, coverage) in [("2026-08-28", 900u32), ("2026-08-29", 1200)] {
+    cooling_daily_summary::upsert(&DailyCoolingSummary {
+      date: day(date),
+      coverage_minutes: coverage,
+      idle: band(41.0, 300),
+      low: band(48.5, 240),
+      // A band with no samples has to come back as absent rather than as a
+      // measured zero.
+      mid: empty_band(),
+      high: band(72.25, 120),
+      power: PowerSummary {
+        avg: Some(13.5),
+        max: Some(28.0),
+        min: Some(4.25),
+        sample_minutes: 660,
+      },
+    })
+    .await
+    .unwrap();
+  }
+  // A day whose every reading is NaN. SQLite has no NaN: the writer's bind is
+  // stored as NULL, so the day reads back as one with no readings at all. It
+  // is seeded here rather than in a test of its own so that every whole-table
+  // comparison below covers it - a native writer that stored the NaN instead
+  // would make all of them disagree.
+  cooling_daily_summary::upsert(&DailyCoolingSummary {
+    date: day("2026-08-31"),
+    coverage_minutes: 0,
+    idle: nan_band(),
+    low: nan_band(),
+    mid: nan_band(),
+    high: nan_band(),
+    power: PowerSummary {
+      avg: Some(f32::NAN),
+      max: Some(f32::NAN),
+      min: Some(f32::NAN),
+      sample_minutes: 0,
+    },
+  })
+  .await
+  .unwrap();
+  cooling_hourly_summary::upsert(&HourlyCoolingSummary {
+    hour_start: hour("2026-08-31 00:00:00"),
+    cpu_usage_avg: Some(f32::NAN),
+    cpu_temperature_avg: Some(f32::NAN),
+    sample_minutes: 0,
+  })
+  .await
+  .unwrap();
+
+  // A day whose bands are all empty: the pairable cursor must skip it while
+  // `max_summarized_date` still sees it.
+  cooling_daily_summary::upsert(&DailyCoolingSummary {
+    date: day("2026-08-30"),
+    coverage_minutes: 0,
+    idle: empty_band(),
+    low: empty_band(),
+    mid: empty_band(),
+    high: empty_band(),
+    power: PowerSummary {
+      avg: None,
+      max: None,
+      min: None,
+      sample_minutes: 0,
+    },
+  })
+  .await
+  .unwrap();
+
+  for offset in 0..4u32 {
+    cooling_hourly_summary::upsert(&HourlyCoolingSummary {
+      hour_start: hour(&format!("2026-08-28 {:02}:00:00", offset * 6)),
+      cpu_usage_avg: Some(12.5 + offset as f32),
+      cpu_temperature_avg: Some(50.0 + offset as f32),
+      sample_minutes: 60 - offset,
+    })
+    .await
+    .unwrap();
+  }
+  // An `hour_start` no format can read: both readers must drop that one row
+  // rather than fail the query.
+  sqlx::query(
+    "INSERT INTO cooling_hourly_summary (hour_start, cpu_usage_avg, cpu_temperature_avg, sample_minutes)
+     VALUES ('2026-08-28 not-an-hour', 1.0, 2.0, 3)",
+  )
+  .execute(pool)
+  .await
+  .unwrap();
+
+  for (date, source, rpm_avg, rpm_max, rpm_min, minutes) in [
+    ("2026-08-28", "Exhaust", 1234.5f64, 1800i64, 900i64, 600i64),
+    ("2026-08-28", "Intake", 0.0, 0, 0, 600),
+    ("2026-08-29", "Exhaust", 1300.0, 1900, 1000, 720),
+  ] {
+    sqlx::query(
+      "INSERT INTO cooling_fan_daily_summary (date, source, rpm_avg, rpm_max, rpm_min, sample_minutes)
+       VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(date)
+    .bind(source)
+    .bind(rpm_avg)
+    .bind(rpm_max)
+    .bind(rpm_min)
+    .bind(minutes)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  for (date, source) in [
+    ("2026-08-28", "Room"),
+    ("2026-08-28", "Cabinet"),
+    ("2026-08-29", "Room"),
+  ] {
+    sqlx::query(
+      "INSERT INTO cooling_thermal_delta_daily_summary (
+         date, source, coverage_minutes,
+         idle_delta_temperature_avg, idle_delta_temperature_max, idle_delta_temperature_min, idle_delta_sample_minutes,
+         low_delta_temperature_avg, low_delta_temperature_max, low_delta_temperature_min, low_delta_sample_minutes,
+         mid_delta_temperature_avg, mid_delta_temperature_max, mid_delta_temperature_min, mid_delta_sample_minutes,
+         high_delta_temperature_avg, high_delta_temperature_max, high_delta_temperature_min, high_delta_sample_minutes)
+       VALUES ($1, $2, 480, 18.5, 20.0, 17.0, 200, 24.0, 26.0, 22.0, 150, NULL, NULL, NULL, 0, 40.5, 44.0, 38.0, 130)",
+    )
+    .bind(date)
+    .bind(source)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  for (date, source, band_key, delta_median, power_median) in [
+    ("2026-08-28", "Room", "idle", Some(18.5f64), Some(9.0f64)),
+    ("2026-08-28", "Room", "high", Some(40.5), None),
+    ("2026-08-28", "Cabinet", "mid", None, Some(15.0)),
+    ("2026-08-29", "Room", "low", Some(24.0), Some(11.0)),
+  ] {
+    sqlx::query(
+      "INSERT INTO cooling_covariate_daily_summary (
+         date, source, band, sample_minutes, band_share, ambient_temperature_median,
+         delta_minutes, delta_temperature_median, power_minutes, cpu_power_median,
+         power_fit_n, power_fit_sum_x, power_fit_sum_y, power_fit_sum_xy, power_fit_sum_xx, power_fit_sum_yy)
+       VALUES ($1, $2, $3, 240, 0.25, 21.5, 200, $4, 180, $5, 7, 1.5, 2.5, 3.5, 4.5, 5.5)",
+    )
+    .bind(date)
+    .bind(source)
+    .bind(band_key)
+    .bind(delta_median)
+    .bind(power_median)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  for (date, source, fan_source, band_key) in [
+    ("2026-08-28", "Room", "Exhaust", "idle"),
+    ("2026-08-28", "Room", "Intake", "high"),
+    ("2026-08-29", "Room", "Exhaust", "low"),
+  ] {
+    sqlx::query(
+      "INSERT INTO cooling_fan_covariate_daily_summary (
+         date, source, fan_source, band, rpm_minutes, rpm_median,
+         fit_n, fit_sum_x, fit_sum_y, fit_sum_xy, fit_sum_xx, fit_sum_yy)
+       VALUES ($1, $2, $3, $4, 210, 1150.5, 9, 1.5, 2.5, 3.5, 4.5, 5.5)",
+    )
+    .bind(date)
+    .bind(source)
+    .bind(fan_source)
+    .bind(band_key)
+    .execute(pool)
+    .await
+    .unwrap();
+  }
+
+  cooling_baseline::insert_established_baseline(&EstablishedBaseline {
+    idle_temperature_avg: 41.25,
+    window_start_date: day("2026-08-28"),
+    window_end_date: day("2026-08-29"),
+    sample_minutes: 540,
+  })
+  .await
+  .unwrap();
+
+  sqlx::query(
+    "INSERT INTO cooling_delta_baseline
+       (id, source, window_start_date, window_end_date, delta_temperature_avg, sample_minutes, established_at)
+     VALUES (1, 'Room', '2026-08-28', '2026-08-29', 18.75, 480, '2026-08-30T00:00:00+00:00')",
+  )
+  .execute(pool)
+  .await
+  .unwrap();
+}
+
+#[tokio::test]
+async fn archive_reads_answer_what_sqlite_answers() {
+  let mut owned = Owned::open("archive-reads.duckdb").await;
+  let (start, end) = (at("2026-09-01T00:00:00Z"), at("2026-09-02T00:00:00Z"));
+
+  let native = native_daily::select_archive_minutes_for_range(
+    owned.database(),
+    cancel(),
+    &start,
+    &end,
+  )
+  .await
+  .unwrap();
+  let sqlite = cooling_daily_summary::select_archive_minutes_for_range(&start, &end)
+    .await
+    .unwrap();
+  assert_eq!(native, sqlite);
+  assert_eq!(native.len(), 12);
+  assert!(native.iter().any(|minute| minute.cpu_usage_avg.is_none()));
+  assert!(
+    native
+      .iter()
+      .any(|minute| minute.cpu_temperature_avg.is_none())
+  );
+
+  assert_eq!(
+    native_daily::earliest_archived_timestamp(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::earliest_archived_timestamp()
+      .await
+      .unwrap()
+  );
+
+  for before in [
+    at("2026-09-01T00:06:00Z"),
+    at("2026-09-01T00:11:00Z"),
+    at("2026-09-02T00:00:00Z"),
+    at("2020-01-01T00:00:00Z"),
+  ] {
+    assert_eq!(
+      native_daily::max_powered_archive_timestamp_before(
+        owned.database(),
+        cancel(),
+        &before
+      )
+      .await
+      .unwrap(),
+      cooling_daily_summary::max_powered_archive_timestamp_before(&before)
+        .await
+        .unwrap(),
+      "before {before}"
+    );
+  }
+  owned.close().await;
+}
+
+#[tokio::test]
+async fn paired_minute_reads_and_cursors_answer_what_sqlite_answers() {
+  let mut owned = Owned::open("paired-minutes.duckdb").await;
+  let (start, end) = (at("2026-09-01T00:00:00Z"), at("2026-09-02T00:00:00Z"));
+
+  let native = native_thermal_delta::select_thermal_delta_minutes_for_range(
+    owned.database(),
+    cancel(),
+    &start,
+    &end,
+  )
+  .await
+  .unwrap();
+  let sqlite =
+    cooling_thermal_delta_daily_summary::select_thermal_delta_minutes_for_range(
+      &start, &end,
+    )
+    .await
+    .unwrap();
+  assert_eq!(native, sqlite);
+  // Four minutes with two sources plus four with one: twelve pairs, and none
+  // for the ambient row whose minute has no hardware row.
+  assert_eq!(native.len(), 12);
+  assert!(native.iter().any(|pair| pair.source == "Cabinet"));
+
+  for before in [
+    at("2026-09-01T00:03:00Z"),
+    at("2026-09-01T00:09:00Z"),
+    at("2026-09-02T00:00:00Z"),
+    at("2020-01-01T00:00:00Z"),
+  ] {
+    assert_eq!(
+      native_thermal_delta::max_pairable_ambient_archive_timestamp_before(
+        owned.database(),
+        cancel(),
+        &before
+      )
+      .await
+      .unwrap(),
+      cooling_thermal_delta_daily_summary::max_pairable_ambient_archive_timestamp_before(
+        &before
+      )
+      .await
+      .unwrap(),
+      "pairable, before {before}"
+    );
+    assert_eq!(
+      native_covariate::max_classifiable_pairable_ambient_archive_timestamp_before(
+        owned.database(),
+        cancel(),
+        &before
+      )
+      .await
+      .unwrap(),
+      cooling_covariate_daily_summary::max_classifiable_pairable_ambient_archive_timestamp_before(
+        &before
+      )
+      .await
+      .unwrap(),
+      "classifiable, before {before}"
+    );
+  }
+
+  // The unclassifiable minute is what makes the two cursors different
+  // questions, so the fixture must actually separate them.
+  let pairable =
+    cooling_thermal_delta_daily_summary::max_pairable_ambient_archive_timestamp_before(
+      &at("2026-09-01T00:06:00Z"),
+    )
+    .await
+    .unwrap();
+  let classifiable =
+    cooling_covariate_daily_summary::max_classifiable_pairable_ambient_archive_timestamp_before(
+      &at("2026-09-01T00:06:00Z"),
+    )
+    .await
+    .unwrap();
+  assert_ne!(pairable, classifiable);
+  owned.close().await;
+}
+
+#[tokio::test]
+async fn every_projection_reads_what_sqlite_reads() {
+  let mut owned = Owned::open("projections.duckdb").await;
+
+  assert_eq!(
+    native_daily::select_all_daily_cooling_summaries(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::select_all_daily_cooling_summaries()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_daily::select_daily_idle_samples(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::select_daily_idle_samples()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_fan_daily::select_all_fan_daily_summaries(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_fan_daily_summary::select_all_fan_daily_summaries()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_thermal_delta::select_all_thermal_delta_daily_summaries(
+      owned.database(),
+      cancel()
+    )
+    .await
+    .unwrap(),
+    cooling_thermal_delta_daily_summary::select_all_thermal_delta_daily_summaries()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_covariate::select_all_covariate_daily_summaries(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_covariate_daily_summary::select_all_covariate_daily_summaries()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_covariate::select_all_fan_covariate_daily_summaries(
+      owned.database(),
+      cancel()
+    )
+    .await
+    .unwrap(),
+    cooling_covariate_daily_summary::select_all_fan_covariate_daily_summaries()
+      .await
+      .unwrap()
+  );
+
+  // The hourly read drops the unreadable `hour_start` on both sides rather
+  // than failing, and keeps the four real hours.
+  let hours = native_hourly::select_hours_in_date_range(
+    owned.database(),
+    cancel(),
+    day("2026-08-28"),
+    day("2026-08-29"),
+  )
+  .await
+  .unwrap();
+  assert_eq!(
+    hours,
+    cooling_hourly_summary::select_hours_in_date_range(
+      day("2026-08-28"),
+      day("2026-08-29")
+    )
+    .await
+    .unwrap()
+  );
+  assert_eq!(hours.len(), 4);
+
+  assert_eq!(
+    native_baseline::select_established_baseline(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_baseline::select_established_baseline()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_delta_baseline::select_established_delta_baseline(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_delta_baseline::select_established_delta_baseline()
+      .await
+      .unwrap()
+  );
+  owned.close().await;
+}
+
+#[tokio::test]
+async fn every_cursor_answers_what_sqlite_answers() {
+  let mut owned = Owned::open("cursors.duckdb").await;
+
+  assert_eq!(
+    native_daily::max_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::max_summarized_date().await.unwrap()
+  );
+  assert_eq!(
+    native_daily::max_pairable_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::max_pairable_summarized_date()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_daily::max_powered_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_daily_summary::max_powered_summarized_date()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_hourly::max_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_hourly_summary::max_summarized_date().await.unwrap()
+  );
+  assert_eq!(
+    native_fan_daily::max_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_fan_daily_summary::max_summarized_date()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_thermal_delta::max_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_thermal_delta_daily_summary::max_summarized_date()
+      .await
+      .unwrap()
+  );
+  assert_eq!(
+    native_covariate::max_summarized_date(owned.database(), cancel())
+      .await
+      .unwrap(),
+    cooling_covariate_daily_summary::max_summarized_date()
+      .await
+      .unwrap()
+  );
+
+  // The empty-band day is what separates `max_summarized_date` from
+  // `max_pairable_summarized_date`; without it the two cursors would agree by
+  // accident and the comparison above would prove nothing.
+  assert_eq!(
+    cooling_daily_summary::max_summarized_date().await.unwrap(),
+    Some(day("2026-08-31"))
+  );
+  assert_eq!(
+    cooling_daily_summary::max_pairable_summarized_date()
+      .await
+      .unwrap(),
+    Some(day("2026-08-29"))
+  );
+  owned.close().await;
+}
+
+fn one_days_rollup(date: NaiveDate) -> DayRollup {
+  DayRollup {
+    summary: Some(DailyCoolingSummary {
+      date,
+      coverage_minutes: 1440,
+      idle: band(40.0, 400),
+      low: band(50.0, 400),
+      mid: band(60.0, 400),
+      high: band(70.0, 240),
+      power: PowerSummary {
+        avg: Some(14.0),
+        max: Some(30.0),
+        min: Some(5.0),
+        sample_minutes: 1440,
+      },
+    }),
+    hours: vec![
+      HourlyCoolingSummary {
+        hour_start: hour("2026-09-05 00:00:00"),
+        cpu_usage_avg: Some(11.0),
+        cpu_temperature_avg: Some(48.0),
+        sample_minutes: 60,
+      },
+      HourlyCoolingSummary {
+        hour_start: hour("2026-09-05 01:00:00"),
+        cpu_usage_avg: None,
+        cpu_temperature_avg: Some(49.0),
+        sample_minutes: 55,
+      },
+    ],
+    fans: vec![FanDailySummary {
+      date,
+      source: "Exhaust".to_owned(),
+      rpm_avg: 1100.5,
+      rpm_max: 1800,
+      rpm_min: 700,
+      sample_minutes: 1400,
+    }],
+    thermal_deltas: vec![ThermalDeltaDailySummary {
+      date,
+      source: "Room".to_owned(),
+      coverage_minutes: 900,
+      idle: band(18.0, 300),
+      low: band(24.0, 300),
+      mid: empty_band(),
+      high: band(40.0, 300),
+    }],
+    covariates: CovariateDaySummary {
+      bands: vec![CovariateDailySummary {
+        date,
+        source: "Room".to_owned(),
+        band: CpuLoadBand::Idle,
+        sample_minutes: 300,
+        band_share: 0.25,
+        ambient_temperature_median: 21.5,
+        delta_minutes: 280,
+        delta_temperature_median: Some(18.0),
+        power_minutes: 260,
+        cpu_power_median: Some(9.5),
+        delta_per_watt: fit(7),
+      }],
+      fans: vec![FanCovariateDailySummary {
+        date,
+        source: "Room".to_owned(),
+        fan_source: "Exhaust".to_owned(),
+        band: CpuLoadBand::Idle,
+        rpm_minutes: 250,
+        rpm_median: 1120.0,
+        delta_per_rpm: fit(5),
+      }],
+    },
+  }
+}
+
+/// One day, six tables, one commit - and the rows read back exactly as
+/// written, through the same readers the projections use.
+#[tokio::test]
+async fn one_days_rollup_commits_all_six_projections_together() {
+  let mut owned = Owned::open("rollup.duckdb").await;
+  let native = owned.database();
+  let date = day("2026-09-05");
+  let rollup = one_days_rollup(date);
+
+  native_rollup::persist_day_rollup(native, cancel(), one_days_rollup(date))
+    .await
+    .unwrap();
+
+  let daily = native_daily::select_all_daily_cooling_summaries(native, cancel())
+    .await
+    .unwrap();
+  assert!(daily.contains(rollup.summary.as_ref().unwrap()));
+  let hours = native_hourly::select_hours_in_date_range(native, cancel(), date, date)
+    .await
+    .unwrap();
+  assert_eq!(hours, rollup.hours);
+  assert!(
+    native_fan_daily::select_all_fan_daily_summaries(native, cancel())
+      .await
+      .unwrap()
+      .contains(&rollup.fans[0])
+  );
+  assert!(
+    native_thermal_delta::select_all_thermal_delta_daily_summaries(native, cancel())
+      .await
+      .unwrap()
+      .contains(&rollup.thermal_deltas[0])
+  );
+  assert!(
+    native_covariate::select_all_covariate_daily_summaries(native, cancel())
+      .await
+      .unwrap()
+      .contains(&rollup.covariates.bands[0])
+  );
+  assert!(
+    native_covariate::select_all_fan_covariate_daily_summaries(native, cancel())
+      .await
+      .unwrap()
+      .contains(&rollup.covariates.fans[0])
+  );
+
+  // Re-rolling the same day updates in place rather than duplicating: the
+  // rollup is idempotent because the catch-up cursor may retry a day.
+  native_rollup::persist_day_rollup(native, cancel(), one_days_rollup(date))
+    .await
+    .unwrap();
+  assert_eq!(
+    native_daily::select_all_daily_cooling_summaries(native, cancel())
+      .await
+      .unwrap()
+      .iter()
+      .filter(|summary| summary.date == date)
+      .count(),
+    1
+  );
+  owned.close().await;
+}
+
+/// A day that fails part way through leaves *nothing* behind. A committed
+/// daily row with its later projections missing is the half-written state the
+/// catch-up cursor cannot tell apart from a day that legitimately had none, so
+/// the whole day has to roll back and be retried.
+///
+/// The failure is induced by removing the last table the transaction writes,
+/// which is the only way to make the sixth statement fail while the first five
+/// succeed.
+#[tokio::test]
+async fn a_day_that_fails_part_way_through_leaves_nothing_behind() {
+  let mut owned = Owned::open("rollback.duckdb").await;
+  // Released before a raw connection touches the file: on Windows a second
+  // DuckDB instance cannot open it while the owner still holds it.
+  owned.close().await;
+  let path = owned.path.clone();
+  duckdb::Connection::open(&path)
+    .unwrap()
+    .execute_batch("DROP TABLE cooling_fan_covariate_daily_summary")
+    .unwrap();
+
+  let native = NativeDatabase::open(
+    &path,
+    NativeDatabaseOptions::new(app_native_schema::NATIVE_SCHEMA_VERSION),
+  )
+  .await
+  .unwrap();
+  let date = day("2026-09-05");
+  let error = native_rollup::persist_day_rollup(&native, cancel(), one_days_rollup(date))
+    .await
+    .unwrap_err();
+  assert!(
+    matches!(error, NativeDatabaseError::DuckDb { .. }),
+    "{error:?}"
+  );
+
+  // None of the five tables that did accept their statement kept the row.
+  assert!(
+    !native_daily::select_all_daily_cooling_summaries(&native, cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|summary| summary.date == date)
+  );
+  assert!(
+    native_hourly::select_hours_in_date_range(&native, cancel(), date, date)
+      .await
+      .unwrap()
+      .is_empty()
+  );
+  for present in [
+    native_fan_daily::select_all_fan_daily_summaries(&native, cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|fan| fan.date == date),
+    native_thermal_delta::select_all_thermal_delta_daily_summaries(&native, cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|delta| delta.date == date),
+    native_covariate::select_all_covariate_daily_summaries(&native, cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|covariate| covariate.date == date),
+  ] {
+    assert!(!present);
+  }
+  // The reopened owner, not `owned`, is what holds the file now.
+  native.close().await.unwrap();
+}
+
+/// The pinned baselines are write-once. A second establishment must change
+/// nothing - not even `established_at` - because replacing the pinned value is
+/// exactly the drift the table exists to prevent.
+#[tokio::test]
+async fn pinning_a_baseline_twice_changes_nothing() {
+  let mut owned = Owned::open("baseline.duckdb").await;
+  let native = owned.database();
+  let before = native_baseline::select_established_baseline(native, cancel())
+    .await
+    .unwrap()
+    .unwrap();
+
+  native_baseline::insert_established_baseline(
+    native,
+    cancel(),
+    &EstablishedBaseline {
+      idle_temperature_avg: 99.0,
+      window_start_date: day("2026-01-01"),
+      window_end_date: day("2026-01-07"),
+      sample_minutes: 1,
+    },
+    at("2027-01-01T00:00:00Z"),
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(
+    native_baseline::select_established_baseline(native, cancel())
+      .await
+      .unwrap(),
+    Some(before)
+  );
+  owned.close().await;
+
+  let connection = native_support::read_only(&owned.path);
+  let established_at: String = connection
+    .query_row(
+      "SELECT established_at FROM cooling_baseline WHERE id = 1",
+      [],
+      |row| row.get(0),
+    )
+    .unwrap();
+  assert!(
+    !established_at.starts_with("2027"),
+    "the second establishment must not touch established_at, got {established_at}"
+  );
+}
+
+/// Retention takes the same rows on both sides, and a preserved window is
+/// exempt on both sides. The cutoff is a local date in both engines, so a
+/// zero-day retention takes everything the window does not protect.
+#[tokio::test]
+async fn retention_preserves_the_pinned_window_the_way_sqlite_does() {
+  let mut owned = Owned::open("retention.duckdb").await;
+  let native = owned.database();
+  let window = [(day("2026-08-29"), day("2026-08-29"))];
+
+  native_daily::delete_old_data(native, cancel(), 0, &window)
+    .await
+    .unwrap();
+  assert_eq!(
+    native_daily::select_all_daily_cooling_summaries(native, cancel())
+      .await
+      .unwrap()
+      .into_iter()
+      .map(|summary| summary.date)
+      .collect::<Vec<_>>(),
+    vec![day("2026-08-29")],
+    "only the preserved window survives a zero-day retention"
+  );
+
+  // The hourly exemption has to cover the protected day's 23:00 row, which is
+  // why its upper bound is suffixed past any hour a day can carry.
+  native_hourly::delete_old_data(
+    native,
+    cancel(),
+    0,
+    &[(day("2026-08-28"), day("2026-08-28"))],
+  )
+  .await
+  .unwrap();
+  assert_eq!(
+    native_hourly::select_hours_in_date_range(
+      native,
+      cancel(),
+      day("2026-08-28"),
+      day("2026-08-28")
+    )
+    .await
+    .unwrap()
+    .len(),
+    4,
+    "every hour of the protected day survives"
+  );
+
+  // The fan projection has no protected window: nothing is derived from it.
+  native_fan_daily::delete_old_data(native, cancel(), 0)
+    .await
+    .unwrap();
+  assert!(
+    native_fan_daily::select_all_fan_daily_summaries(native, cancel())
+      .await
+      .unwrap()
+      .is_empty()
+  );
+
+  // Both co-variate tables age out on one cutoff: a band row whose fan rows
+  // had aged out from under it would be a projection half-present.
+  native_covariate::delete_old_data(native, cancel(), 0, &window)
+    .await
+    .unwrap();
+  let bands = native_covariate::select_all_covariate_daily_summaries(native, cancel())
+    .await
+    .unwrap();
+  let fans = native_covariate::select_all_fan_covariate_daily_summaries(native, cancel())
+    .await
+    .unwrap();
+  assert!(bands.iter().all(|row| row.date == day("2026-08-29")));
+  assert!(fans.iter().all(|row| row.date == day("2026-08-29")));
+  assert!(!bands.is_empty() && !fans.is_empty());
+
+  native_thermal_delta::delete_old_data(native, cancel(), 0, &window)
+    .await
+    .unwrap();
+  let deltas =
+    native_thermal_delta::select_all_thermal_delta_daily_summaries(native, cancel())
+      .await
+      .unwrap();
+  // `all` over an empty collection is vacuously true, so the survivors have to
+  // be shown to exist before their dates mean anything - a delete that took
+  // the protected window too would otherwise pass this assertion.
+  assert!(!deltas.is_empty(), "the preserved window must survive");
+  assert!(deltas.iter().all(|row| row.date == day("2026-08-29")));
+  owned.close().await;
+}
+
+/// SQLite has no NaN. Its writer's bind is stored as NULL, so a day of NaN
+/// readings is indistinguishable from a day with no readings - and the native
+/// writer has to reach the same state, or every whole-table comparison in this
+/// file would disagree on that day.
+///
+/// The seeded NaN day is what makes those comparisons cover this; what is
+/// checked here is the two halves they cannot show on their own: that SQLite
+/// really stored NULL rather than a NaN, so the equivalence is measured rather
+/// than assumed, and that the *native* writer given the same NaN reaches that
+/// same NULL instead of storing a NaN a later `AVG` would propagate.
+#[tokio::test]
+async fn a_nan_summary_reading_is_the_same_absence_in_both_engines() {
+  let shared = shared().await;
+
+  let pool = native_support::open_pool(&shared.fixture.source, false).await;
+  let stored: Vec<String> = sqlx::query_scalar(
+    "SELECT typeof(idle_cpu_temperature_avg) FROM cooling_daily_summary
+     WHERE date = '2026-08-31'",
+  )
+  .fetch_all(&pool)
+  .await
+  .unwrap();
+  pool.close().await;
+  assert_eq!(
+    stored,
+    vec!["null".to_owned()],
+    "SQLite stores a bound NaN as NULL, which is the behaviour being matched"
+  );
+
+  let mut owned = Owned::open("nan.duckdb").await;
+  native_daily::upsert(
+    owned.database(),
+    cancel(),
+    DailyCoolingSummary {
+      date: day("2026-09-07"),
+      coverage_minutes: 0,
+      idle: nan_band(),
+      low: nan_band(),
+      mid: nan_band(),
+      high: nan_band(),
+      power: PowerSummary {
+        avg: Some(f32::NAN),
+        max: Some(f32::NAN),
+        min: Some(f32::NAN),
+        sample_minutes: 0,
+      },
+    },
+  )
+  .await
+  .unwrap();
+  native_hourly::upsert(
+    owned.database(),
+    cancel(),
+    HourlyCoolingSummary {
+      hour_start: hour("2026-09-07 00:00:00"),
+      cpu_usage_avg: Some(f32::NAN),
+      cpu_temperature_avg: Some(f32::NAN),
+      sample_minutes: 0,
+    },
+  )
+  .await
+  .unwrap();
+
+  // Read back through the reader the application uses: a NaN that survived the
+  // bind would come back as `Some(NaN)`, and `Some(NaN) != None`.
+  let written =
+    native_daily::select_all_daily_cooling_summaries(owned.database(), cancel())
+      .await
+      .unwrap()
+      .into_iter()
+      .find(|summary| summary.date == day("2026-09-07"))
+      .unwrap();
+  assert_eq!(written.idle, empty_band());
+  assert_eq!(written.power.avg, None);
+  assert_eq!(
+    native_hourly::select_hours_in_date_range(
+      owned.database(),
+      cancel(),
+      day("2026-09-07"),
+      day("2026-09-07")
+    )
+    .await
+    .unwrap()[0]
+      .cpu_usage_avg,
+    None
+  );
+  owned.close().await;
+
+  // And the column really holds NULL rather than a DuckDB NaN. The typed
+  // reader above cannot tell those apart on its own, because narrowing a
+  // `f64::NAN` to `f32` is still NaN - so the storage itself is checked.
+  let connection = native_support::read_only(&owned.path);
+  let kind: String = connection
+    .query_row(
+      "SELECT CASE WHEN idle_cpu_temperature_avg IS NULL THEN 'null'
+                   WHEN isnan(idle_cpu_temperature_avg) THEN 'nan'
+                   ELSE 'real' END
+       FROM cooling_daily_summary WHERE date = '2026-09-07'",
+      [],
+      |row| row.get(0),
+    )
+    .unwrap();
+  assert_eq!(kind, "null");
+}
+
+/// A `NOT NULL` real column is the case where SQLite does not quietly absorb
+/// the NaN: the insert fails outright. The native writer must fail too, and
+/// must say which column carried it rather than surfacing a DuckDB constraint
+/// message - or, worse, storing a NaN neither engine would have.
+#[tokio::test]
+async fn a_nan_in_a_required_column_is_refused_natively() {
+  let mut owned = Owned::open("nan-required.duckdb").await;
+
+  // Through the rollup, so the refusal is shown where it actually happens -
+  // and the day it was part of rolls back with it.
+  let error = native_rollup::persist_day_rollup(
+    owned.database(),
+    cancel(),
+    DayRollup {
+      summary: Some(DailyCoolingSummary {
+        date: day("2026-09-07"),
+        coverage_minutes: 10,
+        idle: band(40.0, 10),
+        low: empty_band(),
+        mid: empty_band(),
+        high: empty_band(),
+        power: PowerSummary {
+          avg: None,
+          max: None,
+          min: None,
+          sample_minutes: 0,
+        },
+      }),
+      fans: vec![FanDailySummary {
+        date: day("2026-09-07"),
+        source: "Exhaust".to_owned(),
+        rpm_avg: f32::NAN,
+        rpm_max: 1800,
+        rpm_min: 700,
+        sample_minutes: 10,
+      }],
+      ..DayRollup::default()
+    },
+  )
+  .await
+  .unwrap_err();
+  assert!(
+    matches!(
+      error,
+      NativeDatabaseError::NotANumberInRequiredColumn {
+        table: "cooling_fan_daily_summary",
+        column: "rpm_avg"
+      }
+    ),
+    "{error:?}"
+  );
+
+  // The refused fan row left nothing behind - and neither did the daily row
+  // already written in the same transaction.
+  assert!(
+    !native_fan_daily::select_all_fan_daily_summaries(owned.database(), cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|fan| fan.date == day("2026-09-07"))
+  );
+  assert!(
+    !native_daily::select_all_daily_cooling_summaries(owned.database(), cancel())
+      .await
+      .unwrap()
+      .iter()
+      .any(|summary| summary.date == day("2026-09-07"))
+  );
+
+  let error = native_baseline::insert_established_baseline(
+    owned.database(),
+    cancel(),
+    &EstablishedBaseline {
+      idle_temperature_avg: f32::NAN,
+      window_start_date: day("2026-01-01"),
+      window_end_date: day("2026-01-07"),
+      sample_minutes: 1,
+    },
+    at("2027-01-01T00:00:00Z"),
+  )
+  .await
+  .unwrap_err();
+  assert!(
+    matches!(
+      error,
+      NativeDatabaseError::NotANumberInRequiredColumn {
+        table: "cooling_baseline",
+        column: "idle_temperature_avg"
+      }
+    ),
+    "{error:?}"
+  );
+  owned.close().await;
+}

--- a/docs/design/hardware-archive-duckdb.md
+++ b/docs/design/hardware-archive-duckdb.md
@@ -236,6 +236,65 @@ which is bit-identical everywhere. A sum beyond `i64` becomes a query error
 rather than a different number; SQLite abandons exact summation there too, and
 an `i32` `memory_usage` writer cannot reach it within a Retention Period.
 
+**Write-time timestamps and the cooling projections.** A native *writer* faces
+the mirror of the finalizer's problem: it has the `DateTime<Utc>`, but it must
+store the bytes sqlx would have stored (every timestamp comparison in these
+families is a byte-wise text comparison) *and* the key finalization would have
+derived from those bytes. Those two are not the same arithmetic.
+`timestamp_millis()` truncates; SQLite's date parser rounds a fractional second
+to the nearest millisecond, so a `.000500` microsecond stamp diverges from a
+`.000499` one only under SQLite's rule - measured at 1,788,221,700,001 against
+1,788,221,700,000, where `timestamp_millis()` gives both rows 1,788,221,700,000.
+Rather than re-deriving the rounding rule in Rust, where the tie lands on
+whichever side binary64 rounds `s*1000` to, the writer runs the same in-memory
+SQLite oracle the finalizer runs, once per write cycle on a blocking task. The
+key it produces is therefore the value finalization would have computed for the
+row, by construction rather than by agreement. A NULL back from the oracle is
+refused rather than stored: the text being converted is the writer's own
+rendering of a `DateTime<Utc>`, so a NULL would mean the two engines disagreed
+about our own output - a defect, not a missing reading.
+
+Three systematic differences, and nothing else, separate the native cooling and
+ambient/fan queries from their SQLite counterparts. Epoch keys are read from the
+stored `__hv_timestamp_epoch_ms` column instead of recomputed per row, which
+also removes the widened raw-TEXT brackets SQLite carries purely so its
+timestamp index can be range-scanned - a native stored key needs no such hint,
+and the brackets were chosen to be incapable of excluding a row the exact
+predicate keeps. Integer division is spelled `//`, because SQLite's `/` between
+integers truncates toward zero while DuckDB's `/` returns a DOUBLE; the two
+agree on every present-day epoch, so the choice is pinned against SQLite over
+pre-epoch values rather than left to a fixture that could not see it.
+`CAST(cpu_avg AS REAL)` goes through `union_extract` against the tagged
+`UNION(i BIGINT, r DOUBLE)` columns. The one place the native query reproduces a
+SQLite *approximation* on purpose is the pairable-ambient cursor's two-minute
+text bracket: it is the only clause whose answer depends on raw text comparison
+across writers, so it is transcribed rather than dropped, keeping the two
+engines identical even on a database hand-edited into mixed timestamp spellings.
+
+A fourth difference had to be removed rather than described. SQLite has no NaN:
+`sqlite3VdbeMemSetDouble` stores a bound IEEE NaN as NULL, so every SQLite
+writer here silently turns a NaN reading into a gap, and into a `NOT NULL`
+column it fails the insert outright. Both behaviours are measured against sqlx
+rather than taken from the documentation. A native writer binding the NaN
+straight through would change nullness - `AVG` would propagate it, `COUNT` would
+count it, and a lane would draw NaN where the same rows written through SQLite
+draw a break - so every real-valued bind goes through one shared helper that
+returns the absence SQLite would have stored, and a NaN bound for a `NOT NULL`
+column is refused with a typed error naming the column. `±Infinity` is a value
+in both engines and is deliberately left alone. The open question about DuckDB's
+`AVG` above is not confined to Process Stats: the ambient, fan and cooling
+averages read through the same `AVG(DOUBLE)`, so they carry the same binary64
+residue once one bucket's finite `f32` readings span more than about 2^53,
+which no collector this application ships can produce.
+
+One rolled-up day's six projections - daily, hourly, fan, Thermal Delta, and
+both co-variate shapes - are written in a single native transaction, as they are
+in SQLite. A committed daily row with its later projections missing is the
+half-written state the catch-up cursor would have to repair, and it cannot tell
+that case apart from a day that legitimately had none once the archive rows
+behind it age out; failing the day as a whole leaves the cursor unmoved so the
+next pass retries it.
+
 ## Remaining design questions
 
 - [#2089](https://github.com/shm11C3/HardwareVisualizer/issues/2089): native


### PR DESCRIPTION
## Summary

Second #2089 slice, following #2097: the native DuckDB counterparts of the AMBIENT_ARCHIVE and FAN_ARCHIVE families and of the six Cooling Insight projections, each running beside its SQLite module. SQLite stays authoritative; nothing dispatches to these functions yet.

- **Native modules** under `core/src/infrastructure/database/native_database/`: `ambient_archive.rs`, `fan_archive.rs`, `cooling_baseline.rs`, `cooling_delta_baseline.rs`, `cooling_daily_summary.rs`, `cooling_hourly_summary.rs`, `cooling_fan_daily_summary.rs`, `cooling_thermal_delta_daily_summary.rs`, `cooling_covariate_daily_summary.rs`, and `cooling_rollup.rs` (the six-table day rollup in one native transaction, as in SQLite). Each function maps one-to-one to its SQLite original.
- **Write-time stamps** (`write_stamp.rs`): a native writer must store the bytes sqlx would have stored and the `__hv_timestamp_epoch_ms` key finalization would derive from them. Those are not the same arithmetic: `timestamp_millis()` truncates while SQLite's date parser rounds to the nearest millisecond. The writer therefore runs the same in-memory SQLite oracle the finalizer runs, once per write cycle on a blocking task. Measured: `.000500` keys to 1788221700001 where `.000499` keys to 1788221700000, and `timestamp_millis()` gives both 1788221700000. A NULL from the oracle is refused as a defect, never stored.
- **Three systematic query differences and nothing else** (`archive_sql.rs`): epoch keys read from the stored derived column instead of `strftime` per row (which also drops the raw-TEXT index-hint brackets SQLite carries), integer division spelled `//` because DuckDB's `/` returns DOUBLE (pinned against SQLite over pre-epoch values), and `CAST(cpu_avg AS REAL)` through `union_extract` on the tagged columns. The pairable-ambient cursor's two-minute text bracket is transcribed on purpose, since its answer depends on raw text comparison.
- **Stored text decoding** (`stored_text.rs`): a transcription of sqlx's datetime/date decoders so native readers accept exactly the spellings the SQLite readers accept, refusing others with a typed `UndecodableStoredValue`.
- **Upserts and baselines** keep the SQLite semantics (`ON CONFLICT DO UPDATE` column sets, `INSERT OR IGNORE` as `DO NOTHING`, the single-row `CHECK (id = 1)` baselines are write-once).
- Shared-file changes are additive: `archive_queries.rs` widens five items to `pub(crate)` so the native series reuse the one gap-filling definition; `error.rs` gains `UndecodableStoredValue` and `ArchiveSeries`; the Design Doc gains three paragraphs under the compatibility-boundary section.

Not in this PR: DATA_ARCHIVE/GPU (next PR in the stack), Storage Health, dispatch, App changes, reconciliation, selection. Runtime behavior of the shipped application is unchanged.

## Related Issues

Part of #2089. Follows #2097. Base of the stacked PRs for the DATA_ARCHIVE/GPU families and #2090 reconciliation.

## Type of Change

- [ ] Bug fix (`fix/` branch)
- [x] New feature (`feat/` branch)
- [ ] Refactoring (`refactor/` branch)
- [ ] Performance (`perf/` branch)
- [ ] Documentation (`docs/` branch)
- [ ] Dependencies update
- [ ] Other (`chore/` branch)

## Screenshots / Videos

Not applicable.

## Test Plan

- [ ] Manual testing
- [x] Unit tests

Differential tests through the real path (App migrations, #2088 candidate, finalization against `get_native_schema()`, the owner):

- `core/tests/duckdb_ambient_fan.rs` (42): series/cursor/projection parity bit-for-bit against the SQLite functions, retention with preserved windows, insert read-back including the derived key and the `.000499`/`.000500` tie.
- `core/tests/duckdb_cooling.rs` (43): the same rollup inputs through both write paths compared cell-for-cell after reopen, upsert conflict cases, baseline write-once, and a mid-flight failure in the six-table transaction leaving none of the six changed.
- Unit pins for `stored_text` against sqlx and for DuckDB `//` against SQLite `/` over pre-epoch values.

Local validation (macOS arm64, locked bundled DuckDB 1.5.5): `cargo fmt --all -- --check`, `git diff --check`, `cargo clippy -p hardviz-core --features duckdb-archive --all-targets -- -D warnings`, the same without the feature, `cargo clippy -p hardware_visualizer --features duckdb-archive --all-targets -- -D warnings`, and `cargo test -p hardviz-core --features duckdb-archive -- --test-threads=1` (974 passed after rebasing onto develop) all pass.

## Review notes

- Implemented by an Opus 5 subagent lane and reviewed/integrated by the maintainer's Claude session; the cross-lane rule that write-time keys come from the SQLite oracle was confirmed by the next PR in the stack, where a Rust formula was measured wrong on a pre-epoch tie.

## Checklist

- [x] Self-reviewed the code
- [x] Linting and formatting pass (`npm run lint && npm run format` / `cargo tauri-lint && cargo tauri-fmt`)
- [x] Tests pass (`npm test` / `cargo tauri-test`)
- [x] No new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native database support for ambient, fan, and cooling archive data.
  * Added cooling summaries across daily, hourly, fan, thermal, and covariate views.
  * Added persistence for cooling baselines and complete daily rollups.
  * Added archive series aggregation, gap filling, and retention cleanup with preserved historical windows.

* **Bug Fixes**
  * Improved handling and reporting of invalid, missing, and non-finite stored values.
  * Improved timestamp compatibility and archive query consistency.

* **Documentation**
  * Documented database compatibility and atomic rollup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->